### PR TITLE
Add 74 Assay-ready cards to Modern Horizons

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/cards/Pillage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/cards/Pillage.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.all.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Pillage — Alliances #76
+ * {1}{R}{R} · Sorcery
+ *
+ * Destroy target artifact or land. It can't be regenerated.
+ *
+ * `noRegenerate` composes the "can't be regenerated" marker *before* the destroy, so the marker
+ * is on the permanent by the time it is moved to the graveyard.
+ */
+val Pillage = card("Pillage") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or land. It can't be regenerated."
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Land))
+        )
+        effect = Effects.Destroy(t, noRegenerate = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Richard Kane Ferguson"
+        flavorText = "\"Were they to reduce us to ash, we would clog their throats and sting their eyes in payment.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg?1783947176"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jud/cards/Genesis.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jud/cards/Genesis.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.jud.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Genesis
+ * {4}{G}
+ * Creature — Incarnation
+ * 4/4
+ * At the beginning of your upkeep, if this creature is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand.
+ *
+ * The Judgment incarnation cycle: the upkeep ability functions from the graveyard, which is
+ * `triggerZone = Zone.GRAVEYARD` (the "if this creature is in your graveyard" clause *is* the zone
+ * declaration, not a separate intervening-if). Same shape as Pyre Zombie and Ghastly Remains.
+ */
+val Genesis = card("Genesis") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Incarnation"
+    power = 4
+    toughness = 4
+    oracleText = "At the beginning of your upkeep, if this creature is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerZone = Zone.GRAVEYARD
+        val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}{G}"),
+            effect = Effects.ReturnToHand(t),
+        )
+        description = "At the beginning of your upkeep, if this creature is in your graveyard, " +
+            "you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "Mark Zug"
+        flavorText = "\"First through the Riftstone was Genesis—and the world was lifeless no more.\"\n—*Scroll of Beginnings*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg?1783945111"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/NimbleMongoose.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/NimbleMongoose.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Nimble Mongoose — Odyssey #258
+ * {G} · Creature — Mongoose · 1 / 1
+ *
+ * Shroud (This creature can't be the target of spells or abilities.)
+ * Threshold — This creature gets +2/+2 as long as there are seven or more cards in your graveyard.
+ *
+ * "Threshold" is an ability word, not a keyword — nothing in the engine reads it. It lives only in
+ * [oracleText]; the ability it labels is a plain [ConditionalStaticAbility] re-evaluated during
+ * layer projection, so the bonus appears and disappears the instant the graveyard crosses seven
+ * cards (CR 702.21a — a static ability, never a trigger). [GroupFilter.source] scopes the
+ * [ModifyStats] to this permanent only.
+ */
+val NimbleMongoose = card("Nimble Mongoose") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Mongoose"
+    power = 1
+    toughness = 1
+    oracleText = "Shroud (This creature can't be the target of spells or abilities.)\n" +
+        "Threshold — This creature gets +2/+2 as long as there are seven or more cards in your graveyard."
+
+    keywords(Keyword.SHROUD)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.CardsInGraveyardAtLeast(7),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "Terese Nielsen"
+        flavorText = "Faster than a cobra's bite."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg?1783945213"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/QuakefootCyclopsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/QuakefootCyclopsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quakefoot Cyclops reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val QuakefootCyclopsReprint = Printing(
+    oracleId = "cbb6139f-827f-490b-b9b7-e8c3ef714d44",
+    name = "Quakefoot Cyclops",
+    setCode = "J22",
+    collectorNumber = "583",
+    scryfallId = "d23538c0-ef71-4bbe-b500-7d61aa8b269b",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d23538c0-ef71-4bbe-b500-7d61aa8b269b.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/LlanowarTribeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/LlanowarTribeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Llanowar Tribe reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val LlanowarTribeReprint = Printing(
+    oracleId = "cfd0f0e6-1bbf-4450-97d2-c54907abb7e4",
+    name = "Llanowar Tribe",
+    setCode = "KHC",
+    collectorNumber = "66",
+    scryfallId = "407c1b95-dc0c-4154-a441-fe25537df45c",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/407c1b95-dc0c-4154-a441-fe25537df45c.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/RainOfRevelationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/RainOfRevelationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rain of Revelation reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val RainOfRevelationReprint = Printing(
+    oracleId = "7d5dfa6b-f685-4925-b93a-ae5815a3c0a7",
+    name = "Rain of Revelation",
+    setCode = "M21",
+    collectorNumber = "61",
+    scryfallId = "da367981-9d6f-419f-9f58-f969b6183336",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/da367981-9d6f-419f-9f58-f969b6183336.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/AyulasInfluence.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/AyulasInfluence.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ayula's Influence
+ * {G}{G}{G}
+ * Enchantment
+ * Discard a land card: Create a 2/2 green Bear creature token.
+ *
+ * The discard is the whole activation cost — a typed cost atom ([Costs.Discard] over
+ * [GameObjectFilter.Land]), not an effect, and there is no mana component beside it. Same shape as
+ * Trade Routes' second ability; see
+ * [com.wingedsheep.mtg.sets.definitions.mmq.cards.TradeRoutes].
+ */
+val AyulasInfluence = card("Ayula's Influence") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Discard a land card: Create a 2/2 green Bear creature token."
+
+    activatedAbility {
+        cost = Costs.Discard(GameObjectFilter.Land)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Bear"),
+        )
+        description = "Discard a land card: Create a 2/2 green Bear creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "156"
+        artist = "Kari Christensen"
+        flavorText = "Ayula's runic clawmarks ensure her territories are never left defenseless."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg?1783933100"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/AzraSmokeshaper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/AzraSmokeshaper.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.ninjutsu
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Azra Smokeshaper
+ * {3}{B}
+ * Creature — Azra Ninja
+ * 3/3
+ * Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)
+ * When this creature enters, target creature you control gains indestructible until end of turn.
+ */
+val AzraSmokeshaper = card("Azra Smokeshaper") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Azra Ninja"
+    power = 3
+    toughness = 3
+    oracleText = "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\n" +
+        "When this creature enters, target creature you control gains indestructible until end of turn."
+
+    ninjutsu("{1}{B}")
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg?1783933132"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BarrenMoorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BarrenMoorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barren Moor reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val BarrenMoorReprint = Printing(
+    oracleId = "326ba371-124c-4949-a048-3a0c8962e567",
+    name = "Barren Moor",
+    setCode = "MH1",
+    collectorNumber = "236",
+    scryfallId = "de4d8706-1b2f-41e9-8329-d0186b401227",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de4d8706-1b2f-41e9-8329-d0186b401227.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BazaarTrademage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BazaarTrademage.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bazaar Trademage
+ * {2}{U}
+ * Creature — Human Wizard
+ * 3/4
+ * Flying
+ * When this creature enters, draw two cards, then discard three cards.
+ *
+ * "Draw two, then discard three" is Bazaar of Baghdad's shape on an enters trigger: the draw runs
+ * first and the discard is the Gather → Select → Move hand pipeline behind [Effects.Discard], so the
+ * three cards are chosen after the two are in hand. The discard is mandatory — with fewer than
+ * three cards you discard as many as you can.
+ */
+val BazaarTrademage = card("Bazaar Trademage") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, draw two cards, then discard three cards."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(2).then(Effects.Discard(3))
+        description = "When this creature enters, draw two cards, then discard three cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "41"
+        artist = "Christopher Moeller"
+        flavorText = "He traded a lamp for a scepter, the scepter for a ruby, and the ruby for a simple rug."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1783933150"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BirthingBoughs.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/BirthingBoughs.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Birthing Boughs
+ * {3}
+ * Artifact
+ * {4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling. (It is every creature type.)
+ *
+ * The Boughs itself has no changeling — only the token does, and a token's copy of the keyword is
+ * its own grant, so [Keyword.CHANGELING] rides [Effects.CreateToken]'s `keywords` rather than the
+ * card. Same token as Irregular Cohort's; see
+ * [com.wingedsheep.mtg.sets.definitions.mh1.cards.IrregularCohort].
+ */
+val BirthingBoughs = card("Birthing Boughs") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling. (It is every creature type.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            creatureTypes = setOf("Shapeshifter"),
+            keywords = setOf(Keyword.CHANGELING),
+        )
+        description = "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Mike Bierek"
+        flavorText = "Changelings can't remember where they came from. They just know it wasn't a cradle."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg?1783933075"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CarrionFeederReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CarrionFeederReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carrion Feeder reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val CarrionFeederReprint = Printing(
+    oracleId = "a1cc5e37-b09a-4b7f-afd5-77c1c35aa425",
+    name = "Carrion Feeder",
+    setCode = "MH1",
+    collectorNumber = "81",
+    scryfallId = "0a19da90-880e-4eca-8cf7-6d7baf090d53",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0a19da90-880e-4eca-8cf7-6d7baf090d53.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CaveOfTemptation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CaveOfTemptation.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Cave of Temptation
+ * Land
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ * {4}, {T}, Sacrifice this land: Put two +1/+1 counters on target creature. Activate only as a sorcery.
+ *
+ * "Activate only as a sorcery" is [TimingRule.SorcerySpeed], not a separate restriction. The third
+ * ability targets, so it is not a mana ability even though the land's other two are.
+ */
+val CaveOfTemptation = card("Cave of Temptation") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}: Add one mana of any color.\n" +
+        "{4}, {T}, Sacrifice this land: Put two +1/+1 counters on target creature. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, creature)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "237"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg?1783933069"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ChokingTethersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ChokingTethersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Choking Tethers reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val ChokingTethersReprint = Printing(
+    oracleId = "a60348fa-b182-4667-9e38-15bdf3511f82",
+    name = "Choking Tethers",
+    setCode = "MH1",
+    collectorNumber = "44",
+    scryfallId = "eb0d0c81-8698-41db-a687-47af028e910e",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb0d0c81-8698-41db-a687-47af028e910e.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CleavingSliver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CleavingSliver.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Cleaving Sliver
+ * {3}{R}
+ * Creature — Sliver
+ * 2/2
+ * Sliver creatures you control get +2/+0.
+ *
+ * A plain Sliver lord: [ModifyStats] over every Sliver creature you control. The printed noun is
+ * "Sliver **creatures**", so the filter is [GameObjectFilter.Creature] with the subtype rather than
+ * the bare-tribal-noun `Permanent` form, and the lord counts itself (no `excludeSelf`).
+ */
+val CleavingSliver = card("Cleaving Sliver") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control get +2/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "David Gaillet"
+        flavorText = "When it wriggled closer to a thrum of slivers, their talons hardened and glinted in the sun. One took a playful swipe at a tree trunk, and its new blade cut clean through."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg?1783933115"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CrashingFootfalls.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CrashingFootfalls.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Crashing Footfalls — Modern Horizons #160
+ * (no mana cost) · Sorcery
+ *
+ * Suspend 4—{G}
+ * Create two 4/4 green Rhino creature tokens with trample.
+ *
+ * Printed with **no mana cost** — CR 202.1b/118.6 make that an unpayable cost, so suspend is the
+ * only way to put this on the stack (barring another free-cast effect). `manaCost = ""` is what
+ * `CardBuilder.build()` reads to set `hasNoManaCost`; `"{0}"` would parse to a payable zero cost
+ * and leave the card castable for free, which is a different card. Same shape as
+ * [com.wingedsheep.mtg.sets.definitions.mh2.cards.SolTalisman].
+ *
+ * Green is a printed **color indicator** (CR 204), not derived from a mana cost that doesn't
+ * exist, so `colorIndicator` carries it alongside `colorIdentity` — exactly as Ancestral Vision
+ * does for blue. Without it the card would be colorless everywhere but the deckbuilder.
+ *
+ * The display-only `Keyword.SUSPEND` is derived from the parameterized [KeywordAbility.Suspend]
+ * by `CardBuilder.build()`, so only the ability is declared here.
+ */
+val CrashingFootfalls = card("Crashing Footfalls") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Sorcery"
+    oracleText = "Suspend 4—{G} (Rather than cast this card from your hand, pay {G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n" +
+        "Create two 4/4 green Rhino creature tokens with trample."
+
+    keywordAbility(KeywordAbility.suspend("{G}", 4))
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Rhino"),
+            keywords = setOf(Keyword.TRAMPLE),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "160"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg?1783933099"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CunningEvasion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/CunningEvasion.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cunning Evasion
+ * {1}{U}
+ * Enchantment
+ * Whenever a creature you control becomes blocked, you may return it to its owner's hand.
+ *
+ * The trigger watches every creature its controller controls, so it is
+ * [Triggers.becomesBlocked] with an ANY binding — the enchantment itself is never the blocked
+ * creature. "It" is the creature that became blocked, i.e. [EffectTarget.TriggeringEntity].
+ */
+val CunningEvasion = card("Cunning Evasion") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control becomes blocked, you may return it to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayEffect(Effects.ReturnToHand(EffectTarget.TriggeringEntity))
+        description = "Whenever a creature you control becomes blocked, you may return it to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Steve Argyle"
+        flavorText = "\"Begin with your escape and work backward.\"\n—*Way of Secrets*"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg?1783933148"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FarmsteadGleaner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FarmsteadGleaner.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Farmstead Gleaner
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 2/2
+ * This creature doesn't untap during your untap step.
+ * {2}, {Q}: Put a +1/+1 counter on this creature. ({Q} is the untap symbol.)
+ *
+ * The two halves are one engine: [AbilityFlag.DOESNT_UNTAP] is the self-suppression flag the untap
+ * step filters on (cf. Basalt Monolith), and `{Q}` — [Costs.Untap] — is the only way the Gleaner
+ * ever untaps, so every counter costs it a turn's worth of attacking or blocking. `{Q}` is a cost
+ * atom like `{T}`, not an effect: it can only be paid while the creature is untapped.
+ */
+val FarmsteadGleaner = card("Farmstead Gleaner") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 2
+    oracleText = "This creature doesn't untap during your untap step.\n" +
+        "{2}, {Q}: Put a +1/+1 counter on this creature. ({Q} is the untap symbol.)"
+
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Untap)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "{2}, {Q}: Put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Josh Hass"
+        flavorText = "When it finishes the harvest, you'll have nowhere to hide."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg?1783933074"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FeasterOfFools.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FeasterOfFools.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Feaster of Fools
+ * {4}{B}{B}
+ * Creature — Demon
+ * 3/3
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Flying
+ * Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)
+ *
+ * Convoke and flying are bare keywords the engine already reads; devour is the odd one out and takes
+ * two declarations, exactly as `ala/cards/ThunderThrashElder.kt` spells it. [KeywordAbility.devour]
+ * gives the printed line, while the [EntersWithDevour] replacement effect is what actually offers
+ * the sacrifice and stamps `2 ×` that many +1/+1 counters as the Demon enters. Its defaults — the
+ * plain creature sacrifice filter and the unnamed variant — are the printed "devour 2".
+ */
+val FeasterOfFools = card("Feaster of Fools") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 3
+    toughness = 3
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Flying\n" +
+        "Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)"
+
+    keywords(Keyword.CONVOKE, Keyword.FLYING, Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(2))
+
+    replacementEffect(EntersWithDevour(multiplier = 2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "John Severin Brassell"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg?1783933128"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FieryIslet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FieryIslet.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiery Islet
+ * Land
+ * {T}, Pay 1 life: Add {U} or {R}.
+ * {1}, {T}, Sacrifice this land: Draw a card.
+ *
+ * One of the five Modern Horizons "horizon lands". The printed "Add {U} or {R}" line is two
+ * separate mana abilities — one per colour — because each is its own activation with its own
+ * cost payment; the engine has no single "add one of these two colours" mana ability.
+ */
+val FieryIslet = card("Fiery Islet") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life: Add {U} or {R}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Richard Wright"
+        flavorText = "Where water is the canvas and lava the paint."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg?1783933068"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FireboltReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FireboltReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Firebolt reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val FireboltReprint = Printing(
+    oracleId = "7aa31280-12c3-479d-a6dd-f1c669043083",
+    name = "Firebolt",
+    setCode = "MH1",
+    collectorNumber = "122",
+    scryfallId = "882b8f98-ee51-4c94-a3eb-c79eb2b50d78",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/882b8f98-ee51-4c94-a3eb-c79eb2b50d78.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ForgottenCaveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ForgottenCaveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forgotten Cave reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val ForgottenCaveReprint = Printing(
+    oracleId = "394c6de5-7957-4a0b-a6b9-ee0c707cd022",
+    name = "Forgotten Cave",
+    setCode = "MH1",
+    collectorNumber = "239",
+    scryfallId = "9d41b5e4-6b9a-419a-ba49-611c4699eda2",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d41b5e4-6b9a-419a-ba49-611c4699eda2.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/GenesisReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/GenesisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Genesis reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val GenesisReprint = Printing(
+    oracleId = "15afdd88-05fc-4335-8a55-c6ee702f3bef",
+    name = "Genesis",
+    setCode = "MH1",
+    collectorNumber = "166",
+    scryfallId = "9b741d88-513a-4f47-a4fd-af42c5e44b6d",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Graveshifter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Graveshifter.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.ecl.cards
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
@@ -41,9 +41,9 @@ val Graveshifter = card("Graveshifter") {
 
     metadata {
         rarity = Rarity.UNCOMMON
-        collectorNumber = "104"
-        artist = "Deborah Garcia"
-        flavorText = "We'll see a changeling at their funeral\n—Kithkin saying meaning \"they won't be forgotten\""
-        imageUri = "https://cards.scryfall.io/normal/front/d/a/dadb02b9-d3a0-4b51-bbc3-53b2316cd70d.jpg?1767873656"
+        collectorNumber = "94"
+        artist = "Jakub Kasper"
+        flavorText = "\"Why throw away a perfectly good identity?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg"
     }
 }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/HollowheadSliver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/HollowheadSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Hollowhead Sliver
+ * {2}{R}
+ * Creature — Sliver
+ * 2/2
+ * Sliver creatures you control have "{T}, Discard a card: Draw a card."
+ *
+ * The quoted-ability Sliver lord: [GrantActivatedAbility] hands the same looting ability to every
+ * Sliver creature you control, this one included. The cost is the composite of [Costs.Tap] and
+ * [Costs.DiscardCard] — a plain "discard a card", no filter and no randomness.
+ */
+val HollowheadSliver = card("Hollowhead Sliver") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Composite(Costs.Tap, Costs.DiscardCard),
+                effect = Effects.DrawCards(1)
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "132"
+        artist = "Johan Grenier"
+        flavorText = "\"Brilliant! They evolved away from energy-taxing brains and respond only to spinal reflex arcs from the hive mind.\"\n—Rukarumel, field journal"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg?1783933111"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ImpostorOfTheSixthPride.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ImpostorOfTheSixthPride.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impostor of the Sixth Pride
+ * {1}{W}
+ * Creature — Shapeshifter
+ * 3/1
+ * Changeling (This card is every creature type.)
+ */
+val ImpostorOfTheSixthPride = card("Impostor of the Sixth Pride") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Shapeshifter"
+    power = 3
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)"
+
+    keywords(Keyword.CHANGELING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Chris Seaman"
+        flavorText = "The tribe was as strong as his longing, their territory as vast as his isolation. The changeling knew he had found a home, and a form."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg?1783933161"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/IngeniousInfiltrator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/IngeniousInfiltrator.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.ninjutsu
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ingenious Infiltrator
+ * {2}{U}{B}
+ * Creature — Vedalken Ninja
+ * 2/3
+ * Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)
+ * Whenever a Ninja you control deals combat damage to a player, draw a card.
+ *
+ * The second line is a *lord-shaped* grant, not a trigger of this creature's own: every Ninja you
+ * control — this one included — has "whenever this deals combat damage to a player, draw a card",
+ * so it fires once per Ninja that connects. [GrantTriggeredAbility] over a battlefield-scoped
+ * [GroupFilter] is how `TriggerDetector` sees that.
+ */
+val IngeniousInfiltrator = card("Ingenious Infiltrator") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Vedalken Ninja"
+    power = 2
+    toughness = 3
+    oracleText = "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\n" +
+        "Whenever a Ninja you control deals combat damage to a player, draw a card."
+
+    ninjutsu("{U}{B}")
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.DrawCards(1),
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Ninja").youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "Jason Rainville"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg?1783933081"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LancerSliver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LancerSliver.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Lancer Sliver
+ * {2}{W}
+ * Creature — Sliver
+ * 2/2
+ * Sliver creatures you control have first strike.
+ *
+ * The keyword-granting half of the Sliver lord shape — [GrantKeyword] over the same
+ * "Sliver creatures you control" [GroupFilter] that [CleavingSliver] pumps.
+ */
+val LancerSliver = card("Lancer Sliver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have first strike."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FIRST_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Lucas Graciano"
+        flavorText = "\"These polearms were supposed to help!\"\n—Merrik Aidar, Benalish patrol"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg?1783933160"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LesserMasticore.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LesserMasticore.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lesser Masticore
+ * {2}
+ * Artifact Creature — Masticore
+ * 2/2
+ * As an additional cost to cast this spell, discard a card.
+ * {4}: This creature deals 1 damage to target creature.
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)
+ *
+ * Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ * alone carries the reminder text's behaviour and no triggered ability is authored for it.
+ */
+val LesserMasticore = card("Lesser Masticore") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Masticore"
+    power = 2
+    toughness = 2
+    oracleText = "As an additional cost to cast this spell, discard a card.\n" +
+        "{4}: This creature deals 1 damage to target creature.\n" +
+        "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.PERSIST)
+
+    additionalCost(Costs.additional.DiscardCards(1))
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(1, t)
+        description = "{4}: This creature deals 1 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Wisnu Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg?1783933074"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LlanowarTribe.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LlanowarTribe.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Llanowar Tribe
+ * {G}{G}{G}
+ * Creature — Elf Druid
+ * 3/3
+ * {T}: Add {G}{G}{G}.
+ *
+ * A Llanowar Elves that adds three at once: one [Effects.AddMana] of [Color.GREEN] for 3, not three
+ * separate additions. `manaAbility = true` plus [TimingRule.ManaAbility] is what keeps it off the
+ * stack (CR 605.1a) — the same pair Basalt Monolith carries.
+ */
+val LlanowarTribe = card("Llanowar Tribe") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 3
+    toughness = 3
+    oracleText = "{T}: Add {G}{G}{G}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 3)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {G}{G}{G}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Scott Murphy"
+        flavorText = "\"Llanowar remembers the Ice Age, the Phyrexian Invasion, and the Rift Era. So long as we draw breath, we will ensure such disasters never threaten our world again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg?1783933094"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LonelySandbarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/LonelySandbarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lonely Sandbar reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val LonelySandbarReprint = Printing(
+    oracleId = "765863c8-1be0-4bb1-9e9c-db7701cffde3",
+    name = "Lonely Sandbar",
+    setCode = "MH1",
+    collectorNumber = "242",
+    scryfallId = "54e0fcc2-2409-4e00-95d5-418ffa161c20",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54e0fcc2-2409-4e00-95d5-418ffa161c20.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MagmaticSinkhole.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MagmaticSinkhole.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magmatic Sinkhole
+ * {5}{R}
+ * Instant
+ * Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)
+ * Magmatic Sinkhole deals 5 damage to target creature or planeswalker.
+ *
+ * Murderous Cut's shape in red: [Keyword.DELVE] is read by the cast-time cost payment, so the bare
+ * keyword is the whole of the first line, and the body is one [Effects.DealDamage] over
+ * [Targets.CreatureOrPlaneswalker].
+ */
+val MagmaticSinkhole = card("Magmatic Sinkhole") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n" +
+        "Magmatic Sinkhole deals 5 damage to target creature or planeswalker."
+
+    keywords(Keyword.DELVE)
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Mark Behm"
+        flavorText = "Opening like the maw of a hellion, the earth swallowed the traveler whole."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg?1783933110"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ManOWarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ManOWarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Man-o'-War reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val ManOWarReprint = Printing(
+    oracleId = "67a3541c-8408-40c8-b44f-90035b860f57",
+    name = "Man-o'-War",
+    setCode = "MH1",
+    collectorNumber = "55",
+    scryfallId = "5eaa4199-df9b-494a-af7a-2491e8b0ef70",
+    artist = "Jon J Muth",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5eaa4199-df9b-494a-af7a-2491e8b0ef70.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Mob.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Mob.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mob
+ * {4}{B}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Destroy target creature.
+ *
+ * Devouring Light's convoke, on the plainest possible body: [Keyword.CONVOKE] is read by the cast
+ * enumerator when the total cost is calculated, so the reminder line needs no script of its own.
+ */
+val Mob = card("Mob") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Destroy target creature."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "Not all monsters fight with teeth and claws."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg?1783933124"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MoonbladeShinobi.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MoonbladeShinobi.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.ninjutsu
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moonblade Shinobi
+ * {3}{U}
+ * Creature — Human Ninja
+ * 3/2
+ * Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)
+ * Whenever this creature deals combat damage to a player, create a 1/1 blue Illusion creature token with flying.
+ */
+val MoonbladeShinobi = card("Moonblade Shinobi") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Ninja"
+    power = 3
+    toughness = 2
+    oracleText = "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\n" +
+        "Whenever this creature deals combat damage to a player, create a 1/1 blue Illusion creature token with flying."
+
+    ninjutsu("{2}{U}")
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Illusion"),
+            keywords = setOf(Keyword.FLYING),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Taylor Ingvarsson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg?1783933141"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MoxTantalite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/MoxTantalite.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Mox Tantalite — Modern Horizons #226
+ * (no mana cost) · Artifact
+ *
+ * Suspend 3—{0}
+ * {T}: Add one mana of any color.
+ *
+ * The Sol Talisman shape two years earlier: printed with **no mana cost**, which CR 202.1b/118.6
+ * make unpayable, so suspend is the only route onto the battlefield. `manaCost = ""` is what
+ * `CardBuilder.build()` reads to set `hasNoManaCost` — `"{0}"` would parse to a payable zero cost
+ * and leave it castable for free, a different card. Note that suspending it still costs {0}, which
+ * is a real (if trivial) payment, and the three-turn wait is the whole price.
+ *
+ * Genuinely colorless (CR 202.2), so no `colorIndicator`: unlike Ancestral Vision or Crashing
+ * Footfalls there is no printed color the missing mana cost is hiding.
+ *
+ * Suspend is card-type agnostic (CR 702.62a); the display-only `Keyword.SUSPEND` is derived from
+ * the parameterized [KeywordAbility.Suspend] by the builder.
+ *
+ * "Add one mana of any color" is [Effects.AddManaOfChoice]'s default shape — all five colors, one
+ * mana — and `manaAbility = true` derives `TimingRule.ManaAbility`.
+ */
+val MoxTantalite = card("Mox Tantalite") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n" +
+        "{T}: Add one mana of any color."
+
+    keywordAbility(KeywordAbility.suspend("{0}", 3))
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "226"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg?1783933074"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NaturesChant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NaturesChant.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Nature's Chant — Modern Horizons #210
+ * {1}{G/W} · Instant
+ *
+ * Destroy target artifact or enchantment.
+ *
+ * A hybrid-cost Naturalize: the "artifact or enchantment" target is one filter with a single
+ * `or`-ed card predicate, so both halves share the (default) battlefield scope.
+ */
+val NaturesChant = card("Nature's Chant") {
+    manaCost = "{1}{G/W}"
+    colorIdentity = "GW"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment."
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Enchantment))
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Raoul Vitale"
+        flavorText = "\"Plant every sword. Embrace every soul.\"\n—Trostani"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg?1783933080"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NimbleMongooseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NimbleMongooseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nimble Mongoose reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val NimbleMongooseReprint = Printing(
+    oracleId = "1059f089-2693-4c89-92c5-39fe49beebb3",
+    name = "Nimble Mongoose",
+    setCode = "MH1",
+    collectorNumber = "174",
+    scryfallId = "8a6374ad-71be-422e-bd76-4f08fbf43048",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a6374ad-71be-422e-bd76-4f08fbf43048.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NinjaOfTheNewMoon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NinjaOfTheNewMoon.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.ninjutsu
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ninja of the New Moon
+ * {3}{B}{B}
+ * Creature — Spirit Ninja
+ * 6/3
+ * Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)
+ */
+val NinjaOfTheNewMoon = card("Ninja of the New Moon") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit Ninja"
+    power = 6
+    toughness = 3
+    oracleText = "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)"
+
+    ninjutsu("{3}{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Greg Opalinski"
+        flavorText = "The night is the greatest ally of all."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg?1783933124"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NurturingPeatland.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/NurturingPeatland.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nurturing Peatland
+ * Land
+ * {T}, Pay 1 life: Add {B} or {G}.
+ * {1}, {T}, Sacrifice this land: Draw a card.
+ *
+ * One of the five Modern Horizons "horizon lands". The printed "Add {B} or {G}" line is two
+ * separate mana abilities — one per colour — because each is its own activation with its own
+ * cost payment; the engine has no single "add one of these two colours" mana ability.
+ */
+val NurturingPeatland = card("Nurturing Peatland") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life: Add {B} or {G}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "243"
+        artist = "Noah Bradley"
+        flavorText = "New life is born within its shadows."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg?1783933066"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/OreScaleGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/OreScaleGuardian.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Ore-Scale Guardian
+ * {5}{R}{R}
+ * Creature — Dragon
+ * 4/4
+ * This spell costs {1} less to cast for each land card in your graveyard.
+ * Flying, haste
+ *
+ * A self-cast [ModifySpellCost] / [CostModification.ReduceGenericBy] over
+ * [CostReductionSource.CardsInGraveyardMatchingFilter] — the graveyard is base state, so the
+ * filter is the plain [GameObjectFilter.Land] with no controller predicate ("your graveyard" is
+ * the source's own, not a filter clause). Like affinity this only shaves generic mana, so the
+ * {R}{R} always has to be paid and the mana value stays 7 in every zone.
+ */
+val OreScaleGuardian = card("Ore-Scale Guardian") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "This spell costs {1} less to cast for each land card in your graveyard.\n" +
+        "Flying, haste"
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = GameObjectFilter.Land
+                )
+            )
+        )
+    }
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Aaron Miller"
+        flavorText = "A dragon's loyalty cannot be earned, but it can be bought."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg?1783933108"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PashalikMons.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PashalikMons.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Pashalik Mons
+ * {2}{R}
+ * Legendary Creature — Goblin Warrior
+ * 2/2
+ * Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.
+ * {3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.
+ *
+ * "This or another Goblin you control" is the ANY binding — Pashalik Mons is inside its own
+ * trigger's scope. The bare tribal noun "Goblin" names every *permanent* with the subtype, in the
+ * trigger filter and in the sacrifice cost alike (cf. Sling-Gang Lieutenant).
+ */
+val PashalikMons = card("Pashalik Mons") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Goblin Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n" +
+        "{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Goblin").youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+        description = "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{R}"),
+            Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype("Goblin"))
+        )
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474",
+        )
+        description = "{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "138"
+        artist = "Even Amundsen"
+        flavorText = "The thunderhead that leads in the storm."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg?1783933110"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PhantomNinja.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PhantomNinja.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phantom Ninja — Modern Horizons #62
+ * {1}{U}{U} · Creature — Illusion Ninja · 2 / 2
+ *
+ * This creature can't be blocked.
+ *
+ * Unconditional evasion, so it is the [AbilityFlag.CANT_BE_BLOCKED] static flag rather than a
+ * granted keyword.
+ */
+val PhantomNinja = card("Phantom Ninja") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion Ninja"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't be blocked."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Joe Slucher"
+        flavorText = "\"Ninjas can run across water, pull ladders from pockets, kill with a kiss, and slip between bricks. Pack of lies, I say.\"\n—Benden, teahouse gossip"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg?1783933140"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PillageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PillageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pillage reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val PillageReprint = Printing(
+    oracleId = "0b137853-7cb9-424b-8285-12938991eafb",
+    name = "Pillage",
+    setCode = "MH1",
+    collectorNumber = "139",
+    scryfallId = "bdd06d55-a40f-4b0e-905b-3cd0ce12eb82",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bdd06d55-a40f-4b0e-905b-3cd0ce12eb82.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PonderingMage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PonderingMage.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+
+/**
+ * Pondering Mage
+ * {3}{U}{U}
+ * Creature — Human Wizard
+ * 3/4
+ * When this creature enters, look at the top three cards of your library, then put them back in any order. You may shuffle. Draw a card.
+ *
+ * Ponder stapled to a body, and it composes exactly Ponder's three parts: the look-and-reorder
+ * pipeline, an optional shuffle, then the draw. The shuffle comes *after* the reorder, so saying
+ * yes throws the chosen order away — see
+ * [com.wingedsheep.mtg.sets.definitions.lrw.cards.Ponder].
+ */
+val PonderingMage = card("Pondering Mage") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, look at the top three cards of your library, then put them back in any order. You may shuffle. Draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.lookAtTopAndReorder(count = 3),
+            MayEffect(ShuffleLibraryEffect()),
+            Effects.DrawCards(1),
+        )
+        description = "When this creature enters, look at the top three cards of your library, then put them back in any order. You may shuffle. Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Tommy Arnold"
+        flavorText = "\"Never leave the future to fate.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg?1783933139"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PrismaticVista.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PrismaticVista.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Prismatic Vista
+ * Land
+ * {T}, Pay 1 life, Sacrifice this land: Search your library for a basic land card, put it onto
+ * the battlefield, then shuffle.
+ *
+ * A fetch land in the Onslaught mould, but fetching any *basic* land rather than two named
+ * basic land types — hence [GameObjectFilter.BasicLand] rather than a subtype disjunction.
+ * The fetched land isn't revealed and doesn't enter tapped.
+ */
+val PrismaticVista = card("Prismatic Vista") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1), Costs.SacrificeSelf)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = false,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "244"
+        artist = "Sam Burley"
+        flavorText = "There is beauty in the uncertainty of potential."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg?1783933066"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PutridGoblin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/PutridGoblin.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Putrid Goblin
+ * {1}{B}
+ * Creature — Zombie Goblin
+ * 2/2
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)
+ *
+ * Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ * alone carries the whole behaviour. No triggered ability is authored for the reminder text.
+ */
+val PutridGoblin = card("Putrid Goblin") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Goblin"
+    power = 2
+    toughness = 2
+    oracleText = "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.PERSIST)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Winona Nelson"
+        flavorText = "Too stupid to survive, too dumb to die."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg?1783933123"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/QuakefootCyclops.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/QuakefootCyclops.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Quakefoot Cyclops — Modern Horizons #142
+ * {4}{R} · Creature — Cyclops · 4/4
+ *
+ * When this creature enters, up to two target creatures can't block this turn.
+ * Cycling {1}{R}
+ * When you cycle this card, target creature can't block this turn.
+ *
+ * "Up to two target creatures" is one requirement with `count = 2, optional = true` (CR 601.2c —
+ * the minimum drops to zero), not two separate slots, so the restriction is applied through
+ * [ForEachTargetEffect] with [EffectTarget.ContextTarget]`(0)`: each chosen target gets its own
+ * iteration, and the number of iterations is owned by the requirement rather than duplicated in
+ * the effect. The cycling trigger targets exactly one creature and can name it directly.
+ *
+ * The cycling trigger is a real triggered ability that goes on the stack from the graveyard-bound
+ * discard (CR 702.29b), so it resolves — and its target is chosen — even though the Cyclops itself
+ * never reaches the battlefield.
+ */
+val QuakefootCyclops = card("Quakefoot Cyclops") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cyclops"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, up to two target creatures can't block this turn.\n" +
+        "Cycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, target creature can't block this turn."
+
+    keywordAbility(KeywordAbility.cycling("{1}{R}"))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(listOf(Effects.CantBlock(EffectTarget.ContextTarget(0))))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.CantBlock(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Mike Bierek"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg?1783933105"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RainOfRevelation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RainOfRevelation.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rain of Revelation — Modern Horizons #65
+ * {3}{U} · Instant
+ *
+ * Draw three cards, then discard a card.
+ *
+ * `Effects.Discard` expands to the Gather → Select → Move(Discard) hand pipeline, so the
+ * discard is a real choice made on resolution after the three cards have been drawn.
+ */
+val RainOfRevelation = card("Rain of Revelation") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw three cards, then discard a card."
+
+    spell {
+        effect = Effects.DrawCards(3) then Effects.Discard(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Nils Hamm"
+        flavorText = "\"As the sky opened up, we ran for shelter. Halfway there I came to the sudden realization that, already soaked, there might be more to gain from experiencing the rain than running from it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg?1783933138"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RansackTheLab.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RansackTheLab.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ransack the Lab — Modern Horizons #103
+ * {1}{B} · Sorcery
+ *
+ * Look at the top three cards of your library. Put one of them into your hand and the rest
+ * into your graveyard.
+ *
+ * The stock Gather → Select → Move(kept) → Move(rest) library recipe; the hand/graveyard
+ * destinations are the pattern's defaults, so the selection labels derive from them.
+ */
+val RansackTheLab = card("Ransack the Lab") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(count = 3, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Chris Seaman"
+        flavorText = "\"I think someone is stealing from my laboratory. It had better not be you!\"\n—Geralf, letter to Gisa"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg?1783933123"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RecklessChargeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RecklessChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reckless Charge reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val RecklessChargeReprint = Printing(
+    oracleId = "45bee121-0beb-4901-9473-20e4704ba6dc",
+    name = "Reckless Charge",
+    setCode = "MH1",
+    collectorNumber = "144",
+    scryfallId = "1754a8db-060e-470f-94c0-37f12d82978a",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/1754a8db-060e-470f-94c0-37f12d82978a.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RegrowthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/RegrowthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Regrowth reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val RegrowthReprint = Printing(
+    oracleId = "e6e4a8bd-5c40-4654-8de1-0da9afed90fd",
+    name = "Regrowth",
+    setCode = "MH1",
+    collectorNumber = "175",
+    scryfallId = "d771fc5d-b9a1-4637-8241-3f54616b64af",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d771fc5d-b9a1-4637-8241-3f54616b64af.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScourAllPossibilities.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScourAllPossibilities.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Scour All Possibilities — Modern Horizons #67
+ * {1}{U} · Sorcery
+ *
+ * Scry 2, then draw a card.
+ * Flashback {4}{U}
+ *
+ * The "then" is ordering, not a gate: the scry fully resolves before the draw, which is the whole
+ * point of the card — you get to decide what the drawn card will be. [Effects.Scry] is the compact
+ * macro node the engine expands into the shared Gather → Select → Move pipeline at resolution, so
+ * it stays one step inside [Effects.Composite].
+ *
+ * Flashback is declared as the parameterized [KeywordAbility.Flashback]; the display-only
+ * `Keyword.FLASHBACK` is derived from it by `CardBuilder.build()`. The engine's graveyard-cast path
+ * and the exile-on-resolution rider (CR 702.34a) both hang off that ability, so no extra wiring is
+ * needed here.
+ */
+val ScourAllPossibilities = card("Scour All Possibilities") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Scry 2, then draw a card.\n" +
+        "Flashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    keywordAbility(KeywordAbility.flashback("{4}{U}"))
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Scry(2),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Mitchell Malloy"
+        flavorText = "Searching the future for answers often leads to further questions."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg?1783933138"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScrapyardRecombiner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScrapyardRecombiner.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Scrapyard Recombiner
+ * {3}
+ * Artifact Creature — Construct
+ * 0/0
+ * Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)
+ * {T}, Sacrifice an artifact: Search your library for a Construct card, reveal it, put it into your hand, then shuffle.
+ *
+ * **Modular is lowered here, not handled by the engine** — the same two-declaration shape
+ * `mh2/cards/ArcboundMouser.kt` uses. [KeywordAbility.modular] is display-only vocabulary (nothing
+ * in the rules engine reads `Keyword.MODULAR`), so the two halves the reminder text spells out are
+ * wired explicitly:
+ *
+ *  - the ETB half is an [EntersWithCounters] replacement (`selfOnly`, two +1/+1 counters). That is
+ *    why the printed box is 0/0: a Recombiner on the battlefield is a 2/2 made entirely of counters.
+ *  - the death half is an *optional* dies trigger reading
+ *    [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the live entity — the
+ *    counters cease to exist the moment the Recombiner changes zones, so the count must come from
+ *    last-known information (CR 603.10 / 608.2h).
+ *
+ * That last point is also why this uses [Effects.AddDynamicCounters] with an explicit +1/+1 count
+ * rather than the neighbouring `Effects.MoveAllLastKnownCounters` shape (Servant of the Scale):
+ * moving *all* last-known counters would hand the target any leftover -1/-1 counters too, and
+ * modular only ever moves the +1/+1 ones.
+ *
+ * The tutor is the plain [Patterns.Library.searchLibrary] recipe — a bare "Construct card" is any
+ * permanent card with the subtype, not a creature card, so the filter is
+ * [GameObjectFilter.Permanent] narrowed by subtype.
+ */
+val ScrapyardRecombiner = card("Scrapyard Recombiner") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 0
+    toughness = 0
+    oracleText = "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\n" +
+        "{T}, Sacrifice an artifact: Search your library for a Construct card, reveal it, put it into your hand, then shuffle."
+
+    keywordAbility(KeywordAbility.modular(2))
+
+    // Modular, half one: "This creature enters with two +1/+1 counters on it."
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    // Modular, half two: "When it dies, you may put its +1/+1 counters on target artifact creature."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Artifact))
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.CONSTRUCT),
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg?1783933073"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScuttlingSliver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ScuttlingSliver.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scuttling Sliver
+ * {2}{U}
+ * Creature — Sliver Trilobite
+ * 2/2
+ * Sliver creatures you control have "{2}: Untap this creature."
+ *
+ * Same [GrantActivatedAbility] shape as [HollowheadSliver]. "This creature" inside the granted
+ * quote is the creature that has the ability, so the effect targets [EffectTarget.Self] — the
+ * grantee, not this Sliver.
+ */
+val ScuttlingSliver = card("Scuttling Sliver") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sliver Trilobite"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have \"{2}: Untap this creature.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Mana("{2}"),
+                effect = Effects.Untap(EffectTarget.Self)
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "68"
+        artist = "Mike Bierek"
+        flavorText = "A living fossil active after eons of dormancy."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg?1783933137"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SecludedSteppeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SecludedSteppeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Secluded Steppe reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SecludedSteppeReprint = Printing(
+    oracleId = "8dec6fcf-1254-4b1b-ba23-7a3e492a7241",
+    name = "Secluded Steppe",
+    setCode = "MH1",
+    collectorNumber = "245",
+    scryfallId = "cb40724c-62ca-43ab-b4cd-b5fd8e454bfe",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb40724c-62ca-43ab-b4cd-b5fd8e454bfe.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SegovianAngel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SegovianAngel.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Segovian Angel — Modern Horizons #25
+ * {W} · Creature — Angel · 1 / 1
+ *
+ * Flying, vigilance
+ */
+val SegovianAngel = card("Segovian Angel") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, vigilance"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Simon Dominic"
+        flavorText = "When Worzel summoned Segovian angels to fight Thomil's Gargantikari gnats, the ensuing battle numbered among the Multiverse's least destructive."
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg?1783933157"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SilentClearing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SilentClearing.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silent Clearing
+ * Land
+ * {T}, Pay 1 life: Add {W} or {B}.
+ * {1}, {T}, Sacrifice this land: Draw a card.
+ *
+ * One of the five Modern Horizons "horizon lands". The printed "Add {W} or {B}" line is two
+ * separate mana abilities — one per colour — because each is its own activation with its own
+ * cost payment; the engine has no single "add one of these two colours" mana ability.
+ */
+val SilentClearing = card("Silent Clearing") {
+    manaCost = ""
+    colorIdentity = "BW"
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life: Add {W} or {B}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "246"
+        artist = "Seb McKinnon"
+        flavorText = "The expedition's end began the marsh's story."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg?1783933066"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SmitingHelix.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SmitingHelix.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Smiting Helix — Modern Horizons #109
+ * {3}{B} · Sorcery
+ *
+ * Smiting Helix deals 3 damage to any target and you gain 3 life.
+ * Flashback {R}{W}
+ *
+ * One of the set's off-color flashback cards: a black sorcery whose flashback cost is
+ * {R}{W}, so its color identity is all three (Lightning Helix's effect, cast from the
+ * graveyard on Boros mana). The flashback cost is not a second face — the card is black in
+ * every zone; only the *cost* changes colors.
+ *
+ * "Any target" is one requirement (CR 115.4) covering creature, player, battle and planeswalker,
+ * and the life gain is a separate step in the same [Effects.Composite] — it happens even if the
+ * damage target has become illegal, because the whole spell only fizzles when *every* target does.
+ * No `damageSource` is passed: the spell is its own source, which is the default.
+ */
+val SmitingHelix = card("Smiting Helix") {
+    manaCost = "{3}{B}"
+    colorIdentity = "BRW"
+    typeLine = "Sorcery"
+    oracleText = "Smiting Helix deals 3 damage to any target and you gain 3 life.\n" +
+        "Flashback {R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    keywordAbility(KeywordAbility.flashback("{R}{W}"))
+
+    spell {
+        val victim = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(3, victim),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Evan Shipard"
+        flavorText = "Malice is appropriate when vengeance is called for."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg?1783933120"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredForestReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredForestReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Forest reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredForestReprint = Printing(
+    oracleId = "5f0d3be8-e63e-4ade-ae58-6b0c14f2ce6d",
+    name = "Snow-Covered Forest",
+    setCode = "MH1",
+    collectorNumber = "254",
+    scryfallId = "1c59fc48-704b-4187-b9d3-2a2cff6dd54b",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c59fc48-704b-4187-b9d3-2a2cff6dd54b.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredIslandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredIslandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Island reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredIslandReprint = Printing(
+    oracleId = "5b2460a5-6ae5-4cad-ba94-1a9e98e6e4c0",
+    name = "Snow-Covered Island",
+    setCode = "MH1",
+    collectorNumber = "251",
+    scryfallId = "8ac1fceb-8427-409c-98a4-9a5c1ff980b4",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8ac1fceb-8427-409c-98a4-9a5c1ff980b4.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredMountainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredMountainReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Mountain reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredMountainReprint = Printing(
+    oracleId = "ca9f660b-e07d-4f42-a46e-abd0ca72510c",
+    name = "Snow-Covered Mountain",
+    setCode = "MH1",
+    collectorNumber = "253",
+    scryfallId = "d2209e6f-1d9d-43bb-a314-a8fefc509e78",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d2209e6f-1d9d-43bb-a314-a8fefc509e78.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredPlainsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredPlainsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Plains reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredPlainsReprint = Printing(
+    oracleId = "ac8cc74d-e43b-4118-bba0-dfa8b9c04d45",
+    name = "Snow-Covered Plains",
+    setCode = "MH1",
+    collectorNumber = "250",
+    scryfallId = "7a961768-6166-4852-b518-23eb4cced47d",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a961768-6166-4852-b518-23eb4cced47d.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredSwampReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SnowCoveredSwampReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Swamp reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredSwampReprint = Printing(
+    oracleId = "d8239a86-7184-4005-ba1e-2dddcd756c47",
+    name = "Snow-Covered Swamp",
+    setCode = "MH1",
+    collectorNumber = "252",
+    scryfallId = "c835f235-4196-4281-9788-13e5d54a92d0",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c835f235-4196-4281-9788-13e5d54a92d0.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SporeFrogReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SporeFrogReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spore Frog reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val SporeFrogReprint = Printing(
+    oracleId = "97db6c39-e690-49b6-93a6-e51b8dfad10b",
+    name = "Spore Frog",
+    setCode = "MH1",
+    collectorNumber = "180",
+    scryfallId = "6d42fd52-34ea-4d1b-80dc-58fb0593bb5b",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d42fd52-34ea-4d1b-80dc-58fb0593bb5b.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SunbakedCanyon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SunbakedCanyon.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunbaked Canyon
+ * Land
+ * {T}, Pay 1 life: Add {R} or {W}.
+ * {1}, {T}, Sacrifice this land: Draw a card.
+ *
+ * One of the five Modern Horizons "horizon lands". The printed "Add {R} or {W}" line is two
+ * separate mana abilities — one per colour — because each is its own activation with its own
+ * cost payment; the engine has no single "add one of these two colours" mana ability.
+ */
+val SunbakedCanyon = card("Sunbaked Canyon") {
+    manaCost = ""
+    colorIdentity = "RW"
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life: Add {R} or {W}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Yeong-Hao Han"
+        flavorText = "Since the river ran dry, travelers wander where fish once swam."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg?1783933065"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Thornado.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Thornado.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thornado — Modern Horizons #184
+ * {2}{G} · Instant
+ *
+ * Destroy target creature with flying.
+ * Cycling {1}{G}
+ *
+ * "With flying" is a restriction on the *target*, not a condition on the effect, so it lives in
+ * the target requirement — [Targets.CreatureWithKeyword] — and is rechecked at resolution
+ * (CR 608.2b): a creature that loses flying in response is no longer a legal target and the spell
+ * fizzles rather than destroying it.
+ *
+ * The keyword check must read projected characteristics, which is what
+ * `GameObjectFilter.Creature.withKeyword` gives it — a creature granted flying by an Aura or a
+ * lord is a legal target, and one whose flying was removed is not.
+ *
+ * Green removal with a mode-like escape hatch: cycling costs less than the spell, so an opponent
+ * with no fliers doesn't leave you holding a dead card. Cycling contributes no simple keyword to
+ * `keywords` — it is purely the parameterized ability.
+ */
+val Thornado = card("Thornado") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with flying.\n" +
+        "Cycling {1}{G} ({1}{G}, Discard this card: Draw a card.)"
+
+    keywordAbility(KeywordAbility.cycling("{1}{G}"))
+
+    spell {
+        val flier = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.Destroy(flier)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Volkan Baǵa"
+        flavorText = "Every bough, branch, and bramble lashed out in defense of the forest."
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg?1783933090"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TranquilThicketReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TranquilThicketReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Thicket reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilThicketReprint = Printing(
+    oracleId = "9f8fe514-77ed-41b4-a6f3-c6f095bb97be",
+    name = "Tranquil Thicket",
+    setCode = "MH1",
+    collectorNumber = "248",
+    scryfallId = "b73571bd-b6e5-4338-a9b1-d847a8ad43d1",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b73571bd-b6e5-4338-a9b1-d847a8ad43d1.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TreetopAmbusher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TreetopAmbusher.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Treetop Ambusher
+ * {1}{G}
+ * Creature — Elf Berserker
+ * 2/1
+ * Dash {1}{G} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ * Whenever this creature attacks, target creature you control gets +1/+1 until end of turn.
+ *
+ * Mardu Strike Leader's shape in green: `dash` is a builder property rather than a keyword constant,
+ * and setting it is what adds the `KeywordAbility.Dash` the cast enumerator reads. The printed body
+ * is one [Triggers.Attacks] trigger whose target the Elf can pick itself — "target creature you
+ * control" is unrestricted, so a dashed Ambusher normally pumps the attacker that paid for it.
+ */
+val TreetopAmbusher = card("Treetop Ambusher") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Berserker"
+    power = 2
+    toughness = 1
+    oracleText = "Dash {1}{G} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)\n" +
+        "Whenever this creature attacks, target creature you control gets +1/+1 until end of turn."
+
+    dash = "{1}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(1, 1, t)
+        description = "Whenever this creature attacks, target creature you control gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg?1783933088"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TrumpetingHerd.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TrumpetingHerd.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trumpeting Herd
+ * {2}{G}{G}
+ * Sorcery
+ * Create a 3/3 green Elephant creature token.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Unlike cascade and suspend, [Keyword.REBOUND] has a real consumer — `StackResolver` reads it off
+ * `cardDef.keywords` when the spell resolves — so the bare keyword is the whole of the second line,
+ * and the two Elephants arrive a turn apart from one [Effects.CreateToken]. The token's art comes
+ * from the set's token sheet, so no image is spelled here.
+ */
+val TrumpetingHerd = card("Trumpeting Herd") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a 3/3 green Elephant creature token.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elephant")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Lars Grant-West"
+        flavorText = "An elephant never forgives."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg?1783933088"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TwinSilkSpider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/TwinSilkSpider.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Twin-Silk Spider
+ * {2}{G}
+ * Creature — Spider
+ * 1/2
+ * Reach
+ * When this creature enters, create a 1/2 green Spider creature token with reach.
+ *
+ * The token is a copy of the printed body in everything the text names — 1/2, green, Spider, reach
+ * — but it is a plain token, not a copy effect, so [Keyword.REACH] is repeated in
+ * [Effects.CreateToken]'s `keywords` as its own grant.
+ */
+val TwinSilkSpider = card("Twin-Silk Spider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 1
+    toughness = 2
+    oracleText = "Reach\n" +
+        "When this creature enters, create a 1/2 green Spider creature token with reach."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH),
+        )
+        description = "When this creature enters, create a 1/2 green Spider creature token with reach."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Ben Maier"
+        flavorText = "A forest-wide network of webs brings a hungry couple to captured prey."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg?1783933088"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UmezawasCharm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UmezawasCharm.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Umezawa's Charm — Modern Horizons #111
+ * {1}{B} · Instant
+ *
+ * Choose one —
+ * • Target creature gets +2/+2 until end of turn.
+ * • Target creature gets -1/-1 until end of turn.
+ * • You gain 2 life.
+ *
+ * Each pump mode carries its own target requirement, so the target is chosen for the mode that
+ * was picked; the life-gain mode has none.
+ */
+val UmezawasCharm = card("Umezawa's Charm") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target creature gets +2/+2 until end of turn.\n" +
+        "• Target creature gets -1/-1 until end of turn.\n" +
+        "• You gain 2 life."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target creature gets +2/+2 until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.ModifyStats(2, 2, t)
+            }
+            mode("Target creature gets -1/-1 until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.ModifyStats(-1, -1, t)
+            }
+            mode("You gain 2 life") {
+                effect = Effects.GainLife(2)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Eric Deschamps"
+        flavorText = "\"Be ever loyal to your own best interests.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg?1783933118"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UnearthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UnearthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unearth reprint in MH1. Canonical CardDefinition lives in its earliest set.
+ */
+val UnearthReprint = Printing(
+    oracleId = "4e0b647a-6e1a-421b-bca9-8d5e346bda80",
+    name = "Unearth",
+    setCode = "MH1",
+    collectorNumber = "113",
+    scryfallId = "b62abd0c-ec3e-45d7-989d-da269812aeef",
+    artist = "Jehan Choo",
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b62abd0c-ec3e-45d7-989d-da269812aeef.jpg",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/VenomousChangeling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/VenomousChangeling.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Venomous Changeling
+ * {2}{B}
+ * Creature — Shapeshifter
+ * 1/3
+ * Changeling (This card is every creature type.)
+ * Deathtouch
+ */
+val VenomousChangeling = card("Venomous Changeling") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 3
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Deathtouch"
+
+    keywords(Keyword.CHANGELING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Aaron Miller"
+        flavorText = "It doesn't contain venom. It is venom."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg?1783933117"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Vesperlark.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/Vesperlark.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Vesperlark
+ * {2}{W}
+ * Creature — Elemental
+ * 2/1
+ * Flying
+ * When this creature leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield.
+ * Evoke {1}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+ *
+ * The trigger is a plain leaves-the-battlefield ([Triggers.LeavesBattlefield], SELF, any
+ * destination) — evoke's sacrifice is one of the ways it fires, which is the card's whole point.
+ */
+val Vesperlark = card("Vesperlark") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield.\n" +
+        "Evoke {1}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)"
+
+    keywords(Keyword.FLYING)
+
+    evoke = "{1}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard.powerAtMost(1))
+        )
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+        description = "When this creature leaves the battlefield, return target creature card with " +
+            "power 1 or less from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Raoul Vitale"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg?1783933151"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WarteyeWitch.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WarteyeWitch.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Warteye Witch
+ * {2}{B}
+ * Creature — Goblin Shaman
+ * 3/2
+ * Whenever this creature or another creature you control dies, scry 1.
+ *
+ * "This creature or another creature you control" is the ANY binding — Warteye Witch is inside its
+ * own trigger's scope, so its own death fires it too.
+ */
+val WarteyeWitch = card("Warteye Witch") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Shaman"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature or another creature you control dies, scry 1."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Scry(1)
+        description = "Whenever this creature or another creature you control dies, scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Steve Prescott"
+        flavorText = "Eyeballs that portend unpleasant futures become slimy snacks instead."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg?1783933117"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WaterloggedGrove.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WaterloggedGrove.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Waterlogged Grove
+ * Land
+ * {T}, Pay 1 life: Add {G} or {U}.
+ * {1}, {T}, Sacrifice this land: Draw a card.
+ *
+ * One of the five Modern Horizons "horizon lands". The printed "Add {G} or {U}" line is two
+ * separate mana abilities — one per colour — because each is its own activation with its own
+ * cost payment; the engine has no single "add one of these two colours" mana ability.
+ */
+val WaterloggedGrove = card("Waterlogged Grove") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Land"
+    oracleText = "{T}, Pay 1 life: Add {G} or {U}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "249"
+        artist = "John Avon"
+        flavorText = "The trees pull water from deep underground, filling the forest for miles."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg?1783933063"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WeatherTheStorm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WeatherTheStorm.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weather the Storm
+ * {1}{G}
+ * Instant
+ * You gain 3 life.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn.)
+ *
+ * Sprouting Vines' shape: [Keyword.STORM] is read by the cast pipeline, which puts the copies on
+ * the stack, so the bare keyword is the whole of the second line and the body is one
+ * [Effects.GainLife] whose default target is the controller.
+ */
+val WeatherTheStorm = card("Weather the Storm") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "You gain 3 life.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn.)"
+
+    keywords(Keyword.STORM)
+
+    spell {
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "191"
+        artist = "Magali Villeneuve"
+        flavorText = "\"Quell your ego and anywhere can be as calm as a hurricane's eye.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg?1783933087"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WebweaverChangeling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WebweaverChangeling.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Webweaver Changeling
+ * {3}{G}{G}
+ * Creature — Shapeshifter
+ * 3/5
+ * Changeling (This card is every creature type.)
+ * Reach
+ * When this creature enters, if there are three or more creature cards in your graveyard, you gain 5 life.
+ */
+val WebweaverChangeling = card("Webweaver Changeling") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Shapeshifter"
+    power = 3
+    toughness = 5
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Reach\n" +
+        "When this creature enters, if there are three or more creature cards in your graveyard, you gain 5 life."
+
+    keywords(Keyword.CHANGELING, Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.CreatureCardsInGraveyardAtLeast(3)
+        effect = Effects.GainLife(5)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "192"
+        artist = "Nicholas Gregory"
+        flavorText = "Eight legs carrying endless phobias."
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg?1783933086"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WindcallerAven.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WindcallerAven.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Windcaller Aven — Modern Horizons #77
+ * {4}{U}{U} · Creature — Bird Wizard · 4/3
+ *
+ * Flying
+ * Cycling {U}
+ * When you cycle this card, target creature gains flying until end of turn.
+ *
+ * The cycling trigger (CR 702.29b) goes on the stack from the discard and resolves from the
+ * graveyard, so the Aven grants flying to something else without ever having been on the
+ * battlefield — a one-blue-mana evasion trick that also replaces itself.
+ *
+ * `Effects.GrantKeyword` defaults to [com.wingedsheep.sdk.scripting.Duration.EndOfTurn], which is
+ * exactly "until end of turn"; the grant is a Layer 6 continuous effect the projection applies, so
+ * a creature that gains flying this way is seen as flying by every blocker check.
+ */
+val WindcallerAven = card("Windcaller Aven") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Wizard"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Cycling {U} ({U}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, target creature gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.cycling("{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Uriah Voth"
+        flavorText = "Every cry lifts her allies toward the thunder."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg?1783933133"
+    }
+}

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SunbakedCanyonReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SunbakedCanyonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunbaked Canyon reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val SunbakedCanyonReprint = Printing(
+    oracleId = "f97fd068-b83a-4621-bf8c-cc96e880ce90",
+    name = "Sunbaked Canyon",
+    setCode = "TLE",
+    collectorNumber = "58",
+    scryfallId = "e9e69236-3a67-449f-8591-094ef78da6e7",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9e69236-3a67-449f-8591-094ef78da6e7.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/GraveshifterReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/GraveshifterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ecl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Graveshifter reprint in ECL. Canonical CardDefinition lives in its earliest set.
+ */
+val GraveshifterReprint = Printing(
+    oracleId = "1eebc02a-9a64-49b0-8322-c5ce671457ce",
+    name = "Graveshifter",
+    setCode = "ECL",
+    collectorNumber = "104",
+    scryfallId = "dadb02b9-d3a0-4b51-bbc3-53b2316cd70d",
+    artist = "Deborah Garcia",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/dadb02b9-d3a0-4b51-bbc3-53b2316cd70d.jpg",
+    releaseDate = "2026-01-23",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ALL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALL.json
@@ -42,6 +42,56 @@
     ]
 }
 
+// Pillage
+{
+    "name": "Pillage",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or land. It can't be regenerated.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBeRegenerated",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "\"Were they to reduce us to ash, we would clog their throats and sting their eyes in payment.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/389ecb50-b007-4086-89fb-ec2daa5afdcf.jpg?1783947176"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Storm Crow
 {
     "name": "Storm Crow",

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -9033,62 +9033,6 @@
     ]
 }
 
-// Graveshifter
-{
-    "name": "Graveshifter",
-    "manaCost": "{3}{B}",
-    "typeLine": "Creature — Shapeshifter",
-    "oracleText": "Changeling (This card is every creature type.)\nWhen this creature enters, you may return target creature card from your graveyard to your hand.",
-    "creatureStats": {
-        "power": 2,
-        "toughness": 2
-    },
-    "keywords": [
-        "CHANGELING"
-    ],
-    "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Gated",
-                    "gate": "Gate.MayDecide",
-                    "then": {
-                        "type": "MoveToZone",
-                        "target": {
-                            "type": "BoundVariable",
-                            "name": "target creature card from your graveyard"
-                        },
-                        "destination": "Hand"
-                    }
-                },
-                "targetRequirement": {
-                    "type": "TargetObject",
-                    "filter": {
-                        "baseFilter": "creature own:you",
-                        "zone": "Graveyard"
-                    },
-                    "id": "target creature card from your graveyard"
-                }
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "104",
-        "rarity": "UNCOMMON",
-        "artist": "Deborah Garcia",
-        "flavorText": "We'll see a changeling at their funeral\n—Kithkin saying meaning \"they won't be forgotten\"",
-        "imageUri": "https://cards.scryfall.io/normal/front/d/a/dadb02b9-d3a0-4b51-bbc3-53b2316cd70d.jpg?1767873656"
-    },
-    "colorIdentityOverride": [
-        "BLACK"
-    ]
-}
-
 // Great Forest Druid
 {
     "name": "Great Forest Druid",

--- a/mtg-sets/src/test/resources/snapshots/cards/JUD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JUD.json
@@ -446,6 +446,70 @@
     ]
 }
 
+// Genesis
+{
+    "name": "Genesis",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Incarnation",
+    "oracleText": "At the beginning of your upkeep, if this creature is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}{G}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "activeZones": [
+                    "Graveyard"
+                ],
+                "descriptionOverride": "At the beginning of your upkeep, if this creature is in your graveyard, you may pay {2}{G}. If you do, return target creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "\"First through the Riftstone was Genesis—and the world was lifeless no more.\"\n—*Scroll of Beginnings*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b43aee5e-b12e-43ea-9fae-16310acdc640.jpg?1783945111"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Giant Warthog
 {
     "name": "Giant Warthog",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH1.json
@@ -1,3 +1,445 @@
+// Ayula's Influence
+{
+    "name": "Ayula's Influence",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Discard a land card: Create a 2/2 green Bear creature token.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "filter": "land"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Bear"
+                    ]
+                },
+                "descriptionOverride": "Discard a land card: Create a 2/2 green Bear creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "RARE",
+        "artist": "Kari Christensen",
+        "flavorText": "Ayula's runic clawmarks ensure her territories are never left defenseless.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg?1783933100"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Azra Smokeshaper
+{
+    "name": "Azra Smokeshaper",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Azra Ninja",
+    "oracleText": "Ninjutsu {1}{B} ({1}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhen this creature enters, target creature you control gains indestructible until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "NINJUTSU"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ninjutsu",
+            "cost": "{1}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Aaron Miller",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f627e521-2b8f-4d0f-a9d3-cc4e331ce57d.jpg?1783933132"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bazaar Trademage
+{
+    "name": "Bazaar Trademage",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Flying\nWhen this creature enters, draw two cards, then discard three cards.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 3 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, draw two cards, then discard three cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "RARE",
+        "artist": "Christopher Moeller",
+        "flavorText": "He traded a lamp for a scepter, the scepter for a ruby, and the ruby for a simple rug.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1783933150"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Birthing Boughs
+{
+    "name": "Birthing Boughs",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling. (It is every creature type.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Shapeshifter"
+                    ],
+                    "keywords": [
+                        "CHANGELING"
+                    ]
+                },
+                "descriptionOverride": "{4}, {T}: Create a 2/2 colorless Shapeshifter creature token with changeling."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Bierek",
+        "flavorText": "Changelings can't remember where they came from. They just know it wasn't a cradle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1345ee24-ffa3-44d1-a983-f25f54cda3f3.jpg?1783933075"
+    },
+    "colorIdentityOverride": []
+}
+
+// Cave of Temptation
+{
+    "name": "Cave of Temptation",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.\n{4}, {T}, Sacrifice this land: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "artist": "Winona Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d86e9149-6fd9-44fc-b765-3e646c7d83d6.jpg?1783933069"
+    },
+    "colorIdentityOverride": []
+}
+
+// Cleaving Sliver
+{
+    "name": "Cleaving Sliver",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control get +2/+0.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "David Gaillet",
+        "flavorText": "When it wriggled closer to a thrum of slivers, their talons hardened and glinted in the sun. One took a playful swipe at a tree trunk, and its new blade cut clean through.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51b657f0-6636-4d8a-9176-81027816e0ec.jpg?1783933115"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crashing Footfalls
+{
+    "name": "Crashing Footfalls",
+    "manaCost": "",
+    "typeLine": "Sorcery",
+    "oracleText": "Suspend 4—{G} (Rather than cast this card from your hand, pay {G} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\nCreate two 4/4 green Rhino creature tokens with trample.",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{G}",
+            "timeCounters": 4
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 4,
+            "toughness": 4,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Rhino"
+            ],
+            "keywords": [
+                "TRAMPLE"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "RARE",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg?1783933099"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "colorIndicator": [
+        "GREEN"
+    ],
+    "hasNoManaCost": true
+}
+
+// Cunning Evasion
+{
+    "name": "Cunning Evasion",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control becomes blocked, you may return it to its owner's hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "TriggeringEntity",
+                        "destination": "Hand"
+                    }
+                },
+                "descriptionOverride": "Whenever a creature you control becomes blocked, you may return it to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Begin with your escape and work backward.\"\n—*Way of Secrets*",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/300a431c-48a9-4d63-8256-cb6bdaa67b4c.jpg?1783933148"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Deep Forest Hermit
 {
     "name": "Deep Forest Hermit",
@@ -101,6 +543,187 @@
         "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg?1783933144"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Farmstead Gleaner
+{
+    "name": "Farmstead Gleaner",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature doesn't untap during your untap step.\n{2}, {Q}: Put a +1/+1 counter on this creature. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{2}, {Q}: Put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "flavorText": "When it finishes the harvest, you'll have nowhere to hide.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edafd52f-2dda-4981-baee-404f47ee8969.jpg?1783933074"
+    },
+    "colorIdentityOverride": []
+}
+
+// Feaster of Fools
+{
+    "name": "Feaster of Fools",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying\nDevour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CONVOKE",
+        "FLYING",
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 2
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "John Severin Brassell",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4472ad84-b548-4ed8-a315-ecf9ba9d49ff.jpg?1783933128"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Fiery Islet
+{
+    "name": "Fiery Islet",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life: Add {U} or {R}.\n{1}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Richard Wright",
+        "flavorText": "Where water is the canvas and lava the paint.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3aab13c-9d9d-4507-ae5d-da979990ae1b.jpg?1783933068"
+    },
+    "colorIdentityOverride": [
+        "RED",
         "BLUE"
     ]
 }
@@ -235,6 +858,194 @@
     ]
 }
 
+// Graveshifter
+{
+    "name": "Graveshifter",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nWhen this creature enters, you may return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card from your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "UNCOMMON",
+        "artist": "Jakub Kasper",
+        "flavorText": "\"Why throw away a perfectly good identity?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/128c516b-7eb1-4f81-8b54-428bd0649d92.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hollowhead Sliver
+{
+    "name": "Hollowhead Sliver",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have \"{T}, Discard a card: Draw a card.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            "CostTap",
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": "AtomDiscard"
+                            }
+                        ]
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "rarity": "UNCOMMON",
+        "artist": "Johan Grenier",
+        "flavorText": "\"Brilliant! They evolved away from energy-taxing brains and respond only to spinal reflex arcs from the hive mind.\"\n—Rukarumel, field journal",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f05b162-90aa-4c95-903f-775a17d20359.jpg?1783933111"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Impostor of the Sixth Pride
+{
+    "name": "Impostor of the Sixth Pride",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Chris Seaman",
+        "flavorText": "The tribe was as strong as his longing, their territory as vast as his isolation. The changeling knew he had found a home, and a form.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83298c8a-02c4-4ada-9a41-4b973bb58ac6.jpg?1783933161"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ingenious Infiltrator
+{
+    "name": "Ingenious Infiltrator",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Creature — Vedalken Ninja",
+    "oracleText": "Ninjutsu {U}{B} ({U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever a Ninja you control deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "NINJUTSU"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ninjutsu",
+            "cost": "{U}{B}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "permanent Ninja ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/919cd266-b796-4a1c-937f-76b565c82495.jpg?1783933081"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Irregular Cohort
 {
     "name": "Irregular Cohort",
@@ -324,6 +1135,1010 @@
     ]
 }
 
+// Lancer Sliver
+{
+    "name": "Lancer Sliver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have first strike.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"These polearms were supposed to help!\"\n—Merrik Aidar, Benalish patrol",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a4f8d9a-3760-449e-b8a6-72b2a641ff23.jpg?1783933160"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lesser Masticore
+{
+    "name": "Lesser Masticore",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Masticore",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\n{4}: This creature deals 1 damage to target creature.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PERSIST"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{4}: This creature deals 1 damage to target creature."
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Wisnu Tan",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4c7cba5-6111-40ce-828a-e811301bb283.jpg?1783933074"
+    },
+    "colorIdentityOverride": []
+}
+
+// Llanowar Tribe
+{
+    "name": "Llanowar Tribe",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add {G}{G}{G}.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {G}{G}{G}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Llanowar remembers the Ice Age, the Phyrexian Invasion, and the Rift Era. So long as we draw breath, we will ensure such disasters never threaten our world again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/723d3d8d-e78b-40b8-aed5-888a2d0baa60.jpg?1783933094"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Magmatic Sinkhole
+{
+    "name": "Magmatic Sinkhole",
+    "manaCost": "{5}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\nMagmatic Sinkhole deals 5 damage to target creature or planeswalker.",
+    "keywords": [
+        "DELVE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Mark Behm",
+        "flavorText": "Opening like the maw of a hellion, the earth swallowed the traveler whole.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94db1674-d72b-4c1f-b436-490e5363bee7.jpg?1783933110"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Mob
+{
+    "name": "Mob",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "Not all monsters fight with teeth and claws.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c216e13-3779-4734-b481-9aad7aba9925.jpg?1783933124"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Moonblade Shinobi
+{
+    "name": "Moonblade Shinobi",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Ninja",
+    "oracleText": "Ninjutsu {2}{U} ({2}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever this creature deals combat damage to a player, create a 1/1 blue Illusion creature token with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "NINJUTSU"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ninjutsu",
+            "cost": "{2}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Illusion"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Taylor Ingvarsson",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4ab7f30-ca75-4656-9738-1d965f18a22d.jpg?1783933141"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Mox Tantalite
+{
+    "name": "Mox Tantalite",
+    "manaCost": "",
+    "typeLine": "Artifact",
+    "oracleText": "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n{T}: Add one mana of any color.",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{0}",
+            "timeCounters": 3
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "MYTHIC",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcd05b01-dc73-4dd2-970a-32ec6e153c86.jpg?1783933074"
+    },
+    "colorIdentityOverride": [],
+    "hasNoManaCost": true
+}
+
+// Nature's Chant
+{
+    "name": "Nature's Chant",
+    "manaCost": "{1}{G/W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Raoul Vitale",
+        "flavorText": "\"Plant every sword. Embrace every soul.\"\n—Trostani",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a17cbf6-3f38-4bc6-8448-881e19cffe06.jpg?1783933080"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Ninja of the New Moon
+{
+    "name": "Ninja of the New Moon",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Spirit Ninja",
+    "oracleText": "Ninjutsu {3}{B} ({3}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 3
+    },
+    "keywords": [
+        "NINJUTSU"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ninjutsu",
+            "cost": "{3}{B}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Greg Opalinski",
+        "flavorText": "The night is the greatest ally of all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08be60eb-15ec-4112-919c-995062a9ed54.jpg?1783933124"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nurturing Peatland
+{
+    "name": "Nurturing Peatland",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life: Add {B} or {G}.\n{1}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "RARE",
+        "artist": "Noah Bradley",
+        "flavorText": "New life is born within its shadows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/2744ac83-a79f-4042-8720-688b5adda382.jpg?1783933066"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Ore-Scale Guardian
+{
+    "name": "Ore-Scale Guardian",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "This spell costs {1} less to cast for each land card in your graveyard.\nFlying, haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "land"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Aaron Miller",
+        "flavorText": "A dragon's loyalty cannot be earned, but it can be bought.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e789333b-21ee-4613-8eba-52a719b0f1e5.jpg?1783933108"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Pashalik Mons
+{
+    "name": "Pashalik Mons",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Goblin Warrior",
+    "oracleText": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target.\n{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Goblin ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever Pashalik Mons or another Goblin you control dies, Pashalik Mons deals 1 damage to any target."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Goblin"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474"
+                },
+                "descriptionOverride": "{3}{R}, Sacrifice a Goblin: Create two 1/1 red Goblin creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "RARE",
+        "artist": "Even Amundsen",
+        "flavorText": "The thunderhead that leads in the storm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11616853-34b1-4bb1-9590-461e12970ec3.jpg?1783933110"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Phantom Ninja
+{
+    "name": "Phantom Ninja",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Illusion Ninja",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Joe Slucher",
+        "flavorText": "\"Ninjas can run across water, pull ladders from pockets, kill with a kiss, and slip between bricks. Pack of lies, I say.\"\n—Benden, teahouse gossip",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a392b557-e809-4371-92d7-6e93caed4f1b.jpg?1783933140"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Pondering Mage
+{
+    "name": "Pondering Mage",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, look at the top three cards of your library, then put them back in any order. You may shuffle. Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    },
+                                    "storeAs": "looked"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "looked",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Top"
+                                    },
+                                    "order": "ControllerChooses"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": "ShuffleLibrary"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, look at the top three cards of your library, then put them back in any order. You may shuffle. Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Tommy Arnold",
+        "flavorText": "\"Never leave the future to fate.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c08c5ac8-5c0b-4c89-8f06-e5aadfccee01.jpg?1783933139"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Prismatic Vista
+{
+    "name": "Prismatic Vista",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life, Sacrifice this land: Search your library for a basic land card, put it onto the battlefield, then shuffle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "RARE",
+        "artist": "Sam Burley",
+        "flavorText": "There is beauty in the uncertainty of potential.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e37da81e-be12-45a2-9128-376f1ad7b3e8.jpg?1783933066"
+    },
+    "colorIdentityOverride": []
+}
+
+// Putrid Goblin
+{
+    "name": "Putrid Goblin",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Goblin",
+    "oracleText": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PERSIST"
+    ],
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Winona Nelson",
+        "flavorText": "Too stupid to survive, too dumb to die.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/333406d5-abcc-4629-a33b-395d0662ba1b.jpg?1783933123"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Quakefoot Cyclops
+{
+    "name": "Quakefoot Cyclops",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Cyclops",
+    "oracleText": "When this creature enters, up to two target creatures can't block this turn.\nCycling {1}{R} ({1}{R}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature can't block this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to two target creatures"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Mike Bierek",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27573ee0-156a-4bf3-95eb-5e7b63c638e7.jpg?1783933105"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rain of Revelation
+{
+    "name": "Rain of Revelation",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw three cards, then discard a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Nils Hamm",
+        "flavorText": "\"As the sky opened up, we ran for shelter. Halfway there I came to the sudden realization that, already soaked, there might be more to gain from experiencing the rain than running from it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42230b38-c81a-4d76-ad17-1166f5f62312.jpg?1783933138"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ransack the Lab
+{
+    "name": "Ransack the Lab",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put in graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Chris Seaman",
+        "flavorText": "\"I think someone is stealing from my laboratory. It had better not be you!\"\n—Geralf, letter to Gisa",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b547513d-8b69-41cd-84c9-4b08b6426f1d.jpg?1783933123"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ravenous Giant
 {
     "name": "Ravenous Giant",
@@ -366,6 +2181,340 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Scour All Possibilities
+{
+    "name": "Scour All Possibilities",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Scry 2, then draw a card.\nFlashback {4}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Mitchell Malloy",
+        "flavorText": "Searching the future for answers often leads to further questions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c6466cb-d1d0-4461-b48d-7497bdc9c474.jpg?1783933138"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Scrapyard Recombiner
+{
+    "name": "Scrapyard Recombiner",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\n{T}, Sacrifice an artifact: Search your library for a Construct card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "MODULAR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "MODULAR",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "ContextProperty",
+                            "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Construct"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8945f5e0-c143-47ca-910e-32ad9ac34487.jpg?1783933073"
+    },
+    "colorIdentityOverride": []
+}
+
+// Scuttling Sliver
+{
+    "name": "Scuttling Sliver",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Sliver Trilobite",
+    "oracleText": "Sliver creatures you control have \"{2}: Untap this creature.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
+                    },
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Bierek",
+        "flavorText": "A living fossil active after eons of dormancy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0e63efe-b5ec-426e-8860-a881c495c39e.jpg?1783933137"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Segovian Angel
+{
+    "name": "Segovian Angel",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Simon Dominic",
+        "flavorText": "When Worzel summoned Segovian angels to fight Thomil's Gargantikari gnats, the ensuing battle numbered among the Multiverse's least destructive.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5dbaec5-502d-48c2-9e71-c12cd0bccc6a.jpg?1783933157"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Silent Clearing
+{
+    "name": "Silent Clearing",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life: Add {W} or {B}.\n{1}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "RARE",
+        "artist": "Seb McKinnon",
+        "flavorText": "The expedition's end began the marsh's story.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac07e230-0297-4e1d-bdfe-119010e0ad8e.jpg?1783933066"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
     ]
 }
 
@@ -467,6 +2616,427 @@
     ]
 }
 
+// Smiting Helix
+{
+    "name": "Smiting Helix",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Smiting Helix deals 3 damage to any target and you gain 3 life.\nFlashback {R}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{R}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "UNCOMMON",
+        "artist": "Evan Shipard",
+        "flavorText": "Malice is appropriate when vengeance is called for.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fa3e132-125a-492f-aab7-c560ea36b779.jpg?1783933120"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Sunbaked Canyon
+{
+    "name": "Sunbaked Canyon",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life: Add {R} or {W}.\n{1}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Since the river ran dry, travelers wander where fish once swam.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c36820fa-ee86-4206-9a0d-737a67cf5208.jpg?1783933065"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Thornado
+{
+    "name": "Thornado",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with flying.\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with flying"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Every bough, branch, and bramble lashed out in defense of the forest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/eadffd6b-d707-4fc5-a600-44eb9124b195.jpg?1783933090"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Treetop Ambusher
+{
+    "name": "Treetop Ambusher",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Berserker",
+    "oracleText": "Dash {1}{G} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)\nWhenever this creature attacks, target creature you control gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever this creature attacks, target creature you control gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Randy Vargas",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1722a55-850c-4924-be98-45539f4676a2.jpg?1783933088"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Trumpeting Herd
+{
+    "name": "Trumpeting Herd",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 3/3 green Elephant creature token.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 3,
+            "toughness": 3,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Elephant"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Lars Grant-West",
+        "flavorText": "An elephant never forgives.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0f3b68e-f616-4687-bc2d-075165162cd1.jpg?1783933088"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Twin-Silk Spider
+{
+    "name": "Twin-Silk Spider",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach\nWhen this creature enters, create a 1/2 green Spider creature token with reach.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create a 1/2 green Spider creature token with reach."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Ben Maier",
+        "flavorText": "A forest-wide network of webs brings a hungry couple to captured prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cf3188c-879b-4b18-88b4-6237d7162271.jpg?1783933088"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Umezawa's Charm
+{
+    "name": "Umezawa's Charm",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Target creature gets +2/+2 until end of turn.\n• Target creature gets -1/-1 until end of turn.\n• You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets +2/+2 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets -1/-1 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"Be ever loyal to your own best interests.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afbbb742-0317-4266-bcf5-cfea8d21f108.jpg?1783933118"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Universal Automaton
 {
     "name": "Universal Automaton",
@@ -487,4 +3057,360 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg?1783933069"
     },
     "colorIdentityOverride": []
+}
+
+// Venomous Changeling
+{
+    "name": "Venomous Changeling",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nDeathtouch",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "CHANGELING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Aaron Miller",
+        "flavorText": "It doesn't contain venom. It is venom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c5a1d73-d102-469b-82ca-ec18f616375e.jpg?1783933117"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vesperlark
+{
+    "name": "Vesperlark",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flying\nWhen this creature leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield.\nEvoke {1}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{1}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature pow<=1 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, return target creature card with power 1 or less from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32776159-3fb6-4a70-be84-837ccd1d54a7.jpg?1783933151"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warteye Witch
+{
+    "name": "Warteye Witch",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "Whenever this creature or another creature you control dies, scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "Whenever this creature or another creature you control dies, scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Steve Prescott",
+        "flavorText": "Eyeballs that portend unpleasant futures become slimy snacks instead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0d4dd61-cc7e-4fc5-afce-73a4b326cfdb.jpg?1783933117"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Waterlogged Grove
+{
+    "name": "Waterlogged Grove",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}, Pay 1 life: Add {G} or {U}.\n{1}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "The trees pull water from deep underground, filling the forest for miles.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ab6bfbd-d2e1-4c4c-9f91-6f69c5b8e3bb.jpg?1783933063"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Weather the Storm
+{
+    "name": "Weather the Storm",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "You gain 3 life.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
+    "keywords": [
+        "STORM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"Quell your ego and anywhere can be as calm as a hurricane's eye.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6a9fa51-78c3-42e6-8c2e-39658f59ed87.jpg?1783933087"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Webweaver Changeling
+{
+    "name": "Webweaver Changeling",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nReach\nWhen this creature enters, if there are three or more creature cards in your graveyard, you gain 5 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "CHANGELING",
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Eight legs carrying endless phobias.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91571765-8da8-49f9-a776-7778d86cfb99.jpg?1783933086"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Windcaller Aven
+{
+    "name": "Windcaller Aven",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Bird Wizard",
+    "oracleText": "Flying\nCycling {U} ({U}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Uriah Voth",
+        "flavorText": "Every cry lifts her allies toward the thunder.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88d26568-be8f-4a04-82b6-4c37b55d4cfd.jpg?1783933133"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -3866,6 +3866,60 @@
     ]
 }
 
+// Nimble Mongoose
+{
+    "name": "Nimble Mongoose",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Mongoose",
+    "oracleText": "Shroud (This creature can't be the target of spells or abilities.)\nThreshold — This creature gets +2/+2 as long as there are seven or more cards in your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "SHROUD"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "flavorText": "Faster than a cobra's bite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99e5ecf5-a662-4df0-a6ba-9177c62b6503.jpg?1783945213"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Overeager Apprentice
 {
     "name": "Overeager Apprentice",


### PR DESCRIPTION
Sweeps Modern Horizons' ⚡ Assay-ready count from **74 to 0** — 56 canonicals authored to `assay compile`'s JSON, plus 26 `Printing` rows placing the reprints.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 52 | canonical authored in MH1 |
| `elsewhere` | 3 | canonical authored in the earlier set + a row here — Genesis → JUD, Nimble Mongoose → ODY, Pillage → ALL |
| `row-only` | 14 | `Printing` row in MH1 only |
| `basic` | 5 | the Snow-Covered basics — see below |
| **reprint tail** | 4 | rows in **other** sets that only became visible once the canonicals existed: J22 (Quakefoot Cyclops), KHC (Llanowar Tribe), M21 (Rain of Revelation), TLE (Sunbaked Canyon) |

## Gates

| Gate | Result |
|---|---|
| `just build` | ✅ green |
| `just rebless-cards` | ✅ only MH1 / ECL / JUD / ODY / ALL moved, and only this batch's cards within them |
| `just assay-differential` | **4971 → 5024 compared, 4923 → 4976 confirmed, 48 → 48 divergent** — +53 cards, **zero** new divergences, and the divergence set is byte-identical to the baseline |
| `just check-card-printing` | ✅ clean for all 56 authored canonicals |
| `just assay-ready MH1` | **74 → 0** (re-run on the branch, not inferred) |

The 2 authored cards that did not enter the compared set are Scrapyard Recombiner and Feaster of Fools, both of which land in `script slot not modelled yet` (105 → 107) because their modular / devour lowerings add abilities no Assay line prints. That is the same treatment `ArcboundMouser` already gets and is by design.

## Findings the sweep surfaced

**Graveshifter's canonical was misplaced.** It was filed in ECL (2026), but MH1 (2019) is its earliest real printing. `generate-reprints.py` refused to write a row for it and named it as needing a human — which is the tell. The canonical moves to MH1 and ECL takes the `Printing` row.

**The `basic` bucket was the wrong job for these five.** `assay-ready`'s `--tail` hint says a basic wants a hand-written `card()` (Snow-Covered basics can't use `basicLand()`, which hardcodes `Basic Land — <type>`). That is only true for the *earliest* printing: the five Snow-Covered canonicals have lived in ICE since #2022, so MH1's are plain `Printing` rows — exactly what J22 already does. Worth a note in the skill: the bucket label describes the card, not the placement.

**`Keyword.MODULAR` remains display-only** — confirmed zero readers in `rules-engine`. Scrapyard Recombiner ships the `ArcboundMouser` lowering (`EntersWithCounters` + a dies trigger carrying `LAST_KNOWN_PLUS_ONE_COUNTER_COUNT`), keeping `KeywordAbility.modular(2)` for the printed line only. Every other mechanic in the batch traced to a live engine consumer.

**`EventPattern.kt:778`'s KDoc refers to `Effects.ShuffleLibrary`, which does not exist** on the `Effects` facade — cards reach past it for `ShuffleLibraryEffect()` (Ponder, Omen, Cathartic Parting, and now Pondering Mage). Not fixed here; naming it because the KDoc has drifted.

**Crashing Footfalls needed `colorIndicator = "G"`** — a suspend card with no mana cost is colorless in every zone without it (CR 204). Ancestral Vision sets it for the same reason; Mox Tantalite correctly does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)