### PR TITLE
Add 74 Assay-ready cards to Legends

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AcidRain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AcidRain.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Acid Rain
+ * {3}{U}
+ * Sorcery
+ *
+ * Destroy all Forests.
+ */
+val AcidRain = card("Acid Rain") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all Forests."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Land.withSubtype(Subtype.FOREST))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "NéNé Thomas"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg?1783948079"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ActiveVolcano.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ActiveVolcano.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Active Volcano
+ * {R}
+ * Instant
+ *
+ * Choose one —
+ * • Destroy target blue permanent.
+ * • Return target Island to its owner's hand.
+ */
+val ActiveVolcano = card("Active Volcano") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target blue permanent.\n" +
+        "• Return target Island to its owner's hand."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target blue permanent") {
+                val permanent = target(
+                    "target blue permanent",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withColor(Color.BLUE))),
+                )
+                effect = Effects.Destroy(permanent)
+            }
+            mode("Return target Island to its owner's hand") {
+                val land = target(
+                    "target Island",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.withSubtype(Subtype.ISLAND))),
+                )
+                effect = Effects.ReturnToHand(land)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Justin Hampton"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg?1783948060"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AdunOakenshield.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AdunOakenshield.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Adun Oakenshield
+ * {B}{R}{G}
+ * Legendary Creature — Human Knight
+ * 1/2
+ *
+ * {B}{R}{G}, {T}: Return target creature card from your graveyard to your hand.
+ *
+ * A **targeted** graveyard return takes plain [Effects.ReturnToHand], not the
+ * `fromZone`-guarded self-return facade: the target requirement's own `zone = GRAVEYARD` is
+ * re-checked on resolution under CR 608.2b, so a card exiled in response simply fizzles.
+ */
+val AdunOakenshield = card("Adun Oakenshield") {
+    manaCost = "{B}{R}{G}"
+    colorIdentity = "BGR"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 1
+    toughness = 2
+    oracleText = "{B}{R}{G}, {T}: Return target creature card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{R}{G}"), Costs.Tap)
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard,
+        )
+        effect = Effects.ReturnToHand(creatureCard)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "216"
+        artist = "Jeff A. Menges"
+        flavorText = "\". . . And at his passing, the bodies of the world's great warriors shall rise from their " +
+            "graves and follow him to battle.\" —*The Anvilonian Grimoire*"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg?1783948042"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AerathiBerserker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AerathiBerserker.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerathi Berserker
+ * {2}{R}{R}{R}
+ * Creature — Human Berserker
+ * 2/4
+ *
+ * Rampage 3 (Whenever this creature becomes blocked, it gets +3/+3 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val AerathiBerserker = card("Aerathi Berserker") {
+    manaCost = "{2}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Berserker"
+    power = 2
+    toughness = 4
+    oracleText = "Rampage 3 (Whenever this creature becomes blocked, it gets +3/+3 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    rampage(3)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "131"
+        artist = "Melissa A. Benson"
+        flavorText = "Ærathi children who show promise are left to survive for a year in the wilderness. Those " +
+            "who return are shown the way of the Berserker."
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg?1783948059"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AlabarasCarpet.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AlabarasCarpet.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.effects.PreventionSourceFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Al-abara's Carpet
+ * {5}
+ * Artifact
+ *
+ * {5}, {T}: Prevent all damage that would be dealt to you this turn by attacking creatures without flying.
+ *
+ * The recipient is the controller alone — [PreventDamageEffect]'s default `target` —
+ * so the printed "dealt to you … by attacking creatures without flying" is one shield with a
+ * source-side group filter, not a second effect shape.
+ */
+val AlabarasCarpet = card("Al-abara's Carpet") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{5}, {T}: Prevent all damage that would be dealt to you this turn by attacking creatures " +
+        "without flying."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        effect = PreventDamageEffect(
+            sourceFilter = PreventionSourceFilter.FromGroup(
+                GroupFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING).attacking()),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "271"
+        artist = "Kaja Foglio"
+        flavorText = "Al-abara simply laughed and lifted one finger, and the carpet carried her high out of our " +
+            "reach."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg?1783948031"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AmrouKithkin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AmrouKithkin.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Amrou Kithkin
+ * {W}{W}
+ * Creature — Kithkin
+ * 1/1
+ *
+ * This creature can't be blocked by creatures with power 3 or greater.
+ */
+val AmrouKithkin = card("Amrou Kithkin") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked by creatures with power 3 or greater."
+
+    staticAbility {
+        ability = CantBeBlockedBy(blockerFilter = GameObjectFilter.Creature.powerAtLeast(3))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Quinton Hoover"
+        flavorText = "Quick and agile, Amrou Kithkin can usually escape from even the most fearsome opponents."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg?1783948088"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AzureDrake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/AzureDrake.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azure Drake
+ * {3}{U}
+ * Creature — Drake
+ * 2/4
+ *
+ * Flying
+ */
+val AzureDrake = card("Azure Drake") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 2
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Dan Frazier"
+        flavorText = "The Azure Drake would be more powerful were it not so easily distracted."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg?1783948078"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CarrionAnts.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CarrionAnts.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Carrion Ants
+ * {2}{B}{B}
+ * Creature — Insect
+ * 0/1
+ *
+ * {1}: This creature gets +1/+1 until end of turn.
+ */
+val CarrionAnts = card("Carrion Ants") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 1
+    oracleText = "{1}: This creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "90"
+        artist = "Richard Thomas"
+        flavorText = "\"'War is no picnic,' my father liked to say. But the Ants seemed to disagree.\" —*General " +
+            "Chanek Valteroth*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg?1783948069"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CatWarriors.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CatWarriors.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cat Warriors
+ * {1}{G}{G}
+ * Creature — Cat Warrior
+ * 2/2
+ *
+ * Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)
+ */
+val CatWarriors = card("Cat Warriors") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Melissa A. Benson"
+        flavorText = "These stealthy felines have survived so many battles that some believe they must possess " +
+            "many lives."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg?1783948049"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Chromium.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Chromium.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Chromium
+ * {2}{W}{W}{U}{U}{B}{B}
+ * Legendary Creature — Elder Dragon
+ * 7/7
+ *
+ * Flying
+ * Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)
+ * At the beginning of your upkeep, sacrifice Chromium unless you pay {W}{U}{B}.
+ *
+ * The upkeep tax is CR 118.3's "unless": [PayOrSufferEffect] asks the controller to
+ * pay on resolution and sacrifices the dragon when they decline or cannot.
+ */
+val Chromium = card("Chromium") {
+    manaCost = "{2}{W}{W}{U}{U}{B}{B}"
+    colorIdentity = "BUW"
+    typeLine = "Legendary Creature — Elder Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying\n" +
+        "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each " +
+        "creature blocking it beyond the first.)\n" +
+        "At the beginning of your upkeep, sacrifice Chromium unless you pay {W}{U}{B}."
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{W}{U}{B}"), suffer = SacrificeSelfEffect)
+    }
+
+    rampage(2)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "224"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg?1783948040"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Cleanse.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Cleanse.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Cleanse
+ * {2}{W}{W}
+ * Sorcery
+ *
+ * Destroy all black creatures.
+ */
+val Cleanse = card("Cleanse") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all black creatures."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Phil Foglio"
+        flavorText = "The clouds broke and the sun's rays burst forth; each foul beast in its turn faltered, and " +
+            "was gone."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg?1783948087"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ConcordantCrossroads.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ConcordantCrossroads.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Concordant Crossroads
+ * {G}
+ * World Enchantment
+ *
+ * All creatures have haste.
+ */
+val ConcordantCrossroads = card("Concordant Crossroads") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "World Enchantment"
+    oracleText = "All creatures have haste."
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter(GameObjectFilter.Creature))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "179"
+        artist = "Amy Weber"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg?1783948049"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrawGiant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrawGiant.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Craw Giant
+ * {3}{G}{G}{G}{G}
+ * Creature — Giant
+ * 6/4
+ *
+ * Trample
+ * Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val CrawGiant = card("Craw Giant") {
+    manaCost = "{3}{G}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Giant"
+    power = 6
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    keywords(Keyword.TRAMPLE)
+    rampage(2)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Christopher Rush"
+        flavorText = "Harthag gave a jolly laugh as he surveyed the army before him. \"Ho ho ho! Midgets! You " +
+            "think you can stand in my way?\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg?1783948049"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrimsonManticore.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrimsonManticore.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Crimson Manticore
+ * {2}{R}{R}
+ * Creature — Manticore
+ * 2/2
+ *
+ * Flying
+ * {R}, {T}: This creature deals 1 damage to target attacking or blocking creature.
+ */
+val CrimsonManticore = card("Crimson Manticore") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Manticore"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n{R}, {T}: This creature deals 1 damage to target attacking or blocking creature."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature),
+        )
+        effect = Effects.DealDamage(1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "140"
+        artist = "Daniel Gelon"
+        flavorText = "Noted neither for their good looks nor their charm, Crimson Manticores can be fearsome " +
+            "allies. As dinner companions, however, they are best left alone."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg?1783948057"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CyclopeanMummy.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CyclopeanMummy.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cyclopean Mummy
+ * {1}{B}
+ * Creature — Zombie
+ * 2/1
+ *
+ * When this creature dies, exile it.
+ *
+ * A dies trigger keeps the default `activeZones = {BATTLEFIELD}`: it looks back in time
+ * (CR 603.10a) and is indexed off the battlefield, so narrowing it to the graveyard with
+ * `triggerZone` would stop `TriggerDetector` from ever indexing it.
+ */
+val CyclopeanMummy = card("Cyclopean Mummy") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, exile it."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Exile(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "The ritual of plucking out an eye to gain future sight is but a curse that enables the " +
+            "living to see their own deaths."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg?1783948068"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DAvenantArcher.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DAvenantArcher.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * D'Avenant Archer
+ * {2}{W}
+ * Creature — Human Soldier Archer
+ * 1/2
+ *
+ * {T}: This creature deals 1 damage to target attacking or blocking creature.
+ */
+val DAvenantArcher = card("D'Avenant Archer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier Archer"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: This creature deals 1 damage to target attacking or blocking creature."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature),
+        )
+        effect = Effects.DealDamage(1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg?1783948087"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DakkonBlackblade.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DakkonBlackblade.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dakkon Blackblade
+ * {2}{W}{U}{U}{B}
+ * Legendary Creature — Human Warrior
+ *
+ * Dakkon Blackblade's power and toughness are each equal to the number of lands you control.
+ *
+ * A characteristic-defining ability (CR 604.3): the `*`/`*` stat box is the P/T slot
+ * itself, not an ability list entry, so it lives in [dynamicStats] and applies in every zone.
+ */
+val DakkonBlackblade = card("Dakkon Blackblade") {
+    manaCost = "{2}{W}{U}{U}{B}"
+    colorIdentity = "BUW"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "Dakkon Blackblade's power and toughness are each equal to the number of lands you control."
+
+    dynamicStats(DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land).count())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Richard Kane Ferguson"
+        flavorText = "\"My power is as vast as the plains, my strength is that of mountains. Each wave that " +
+            "crashes upon the shore thunders like blood in my veins.\" —*Memoirs*"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg?1783948040"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Darkness.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Darkness.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darkness
+ * {B}
+ * Instant
+ *
+ * Prevent all combat damage that would be dealt this turn.
+ */
+val Darkness = card("Darkness") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn."
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Harold McNeill"
+        flavorText = "\"If I must die, I will encounter darkness as a bride,/ And hug it in my arms.\" —William " +
+            "Shakespeare, *Measure for Measure*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg?1783948067"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DevouringDeep.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DevouringDeep.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Devouring Deep
+ * {2}{U}
+ * Creature — Fish
+ * 1/2
+ *
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ */
+val DevouringDeep = card("Devouring Deep") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 1
+    toughness = 2
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
+
+    keywords(Keyword.ISLANDWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Liz Danforth"
+        flavorText = "\"Full fathom five thy father lies;/ Of his bones are coral made;/ Those are pearls that " +
+            "were his eyes;/ Nothing of him that doth fade,/ But doth suffer a sea-change/ Into " +
+            "something rich and strange.\" —William Shakespeare, *The Tempest*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg?1783948077"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DivineTransformation.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DivineTransformation.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Divine Transformation
+ * {2}{W}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +3/+3.
+ */
+val DivineTransformation = card("Divine Transformation") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets +3/+3."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(3, 3)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "10"
+        artist = "NéNé Thomas"
+        flavorText = "Glory surged through her and radiance surrounded her. All things were possible with the " +
+            "blessing of the Divine."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg?1783948086"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/EmeraldDragonfly.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/EmeraldDragonfly.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Emerald Dragonfly
+ * {1}{G}
+ * Creature — Insect
+ * 1/1
+ *
+ * Flying
+ * {G}{G}: This creature gains first strike until end of turn.
+ */
+val EmeraldDragonfly = card("Emerald Dragonfly") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n{G}{G}: This creature gains first strike until end of turn."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Mana("{G}{G}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Quinton Hoover"
+        flavorText = "\"Flittering, wheeling, / darting in to strike, and then / gone just as you blink.\" " +
+            "—\"Dragonfly Haiku,\" poet unknown"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg?1783948048"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/EternalWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/EternalWarrior.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Eternal Warrior
+ * {R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has vigilance.
+ */
+val EternalWarrior = card("Eternal Warrior") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature has vigilance."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "144"
+        artist = "Anson Maddocks"
+        flavorText = "Warriors of the Tsunami-nito School spend years in training to master the way of effortless " +
+            "effort."
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg?1783948056"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FireSprites.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FireSprites.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Fire Sprites
+ * {1}{G}
+ * Creature — Faerie
+ * 1/1
+ *
+ * Flying
+ * {G}, {T}: Add {R}.
+ */
+val FireSprites = card("Fire Sprites") {
+    manaCost = "{1}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Faerie"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n{G}, {T}: Add {R}."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Julie Baroh"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg?1783948048"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FlashCounter.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FlashCounter.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Flash Counter
+ * {1}{U}
+ * Instant
+ *
+ * Counter target instant spell.
+ */
+val FlashCounter = card("Flash Counter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target instant spell."
+
+    spell {
+        target("target instant spell", TargetSpell(filter = TargetFilter.InstantSpellOnStack))
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Harold McNeill"
+        flavorText = "\"She grinned at me—a wicked grin. 'I hope you weren't relying too heavily on that, my " +
+            "dear.'\"\n" +
+            "—Medryn Silverwand, *Diary*"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg?1783948075"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FlashFlood.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FlashFlood.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Flash Flood
+ * {U}
+ * Instant
+ *
+ * Choose one —
+ * • Destroy target red permanent.
+ * • Return target Mountain to its owner's hand.
+ */
+val FlashFlood = card("Flash Flood") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target red permanent.\n" +
+        "• Return target Mountain to its owner's hand."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target red permanent") {
+                val permanent = target(
+                    "target red permanent",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withColor(Color.RED))),
+                )
+                effect = Effects.Destroy(permanent)
+            }
+            mode("Return target Mountain to its owner's hand") {
+                val land = target(
+                    "target Mountain",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.withSubtype(Subtype.MOUNTAIN))),
+                )
+                effect = Effects.ReturnToHand(land)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Tom Wänerstrand"
+        flavorText = "Many people say that no power can bring the mountains low. Many people are fools."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg?1783948076"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FrostGiant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/FrostGiant.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frost Giant
+ * {3}{R}{R}{R}
+ * Creature — Giant
+ * 4/4
+ *
+ * Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val FrostGiant = card("Frost Giant") {
+    manaCost = "{3}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 4
+    oracleText = "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    rampage(2)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Daniel Gelon"
+        flavorText = "The Frost Giants have been out in the cold a long, long time, but they have their rage to " +
+            "keep them warm."
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg?1783948056"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/GhostsOfTheDamned.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/GhostsOfTheDamned.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghosts of the Damned
+ * {1}{B}{B}
+ * Creature — Spirit
+ * 0/2
+ *
+ * {T}: Target creature gets -1/-0 until end of turn.
+ */
+val GhostsOfTheDamned = card("Ghosts of the Damned") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 0
+    toughness = 2
+    oracleText = "{T}: Target creature gets -1/-0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-1, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "The voices of the dead ring in the heart long after they have faded from the ears."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg?1783948067"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HellSwarm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HellSwarm.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hell Swarm
+ * {B}
+ * Instant
+ *
+ * All creatures get -1/-0 until end of turn.
+ */
+val HellSwarm = card("Hell Swarm") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "All creatures get -1/-0 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            Effects.ModifyStats(-1, 0, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Christopher Rush"
+        flavorText = "The brightness of day turned in an instant to dusk as the swarm descended upon the " +
+            "battlefield."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg?1783948066"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HellsCaretaker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HellsCaretaker.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hell's Caretaker
+ * {3}{B}
+ * Creature — Horror
+ * 1/1
+ *
+ * {T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. Activate only during your upkeep.
+ */
+val HellsCaretaker = card("Hell's Caretaker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. " +
+        "Activate only during your upkeep."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Creature))
+        restrictions = listOf(
+            ActivationRestriction.All(
+                ActivationRestriction.OnlyDuringYourTurn,
+                ActivationRestriction.DuringStep(Step.UPKEEP),
+            ),
+        )
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard,
+        )
+        effect = Effects.PutOntoBattlefieldFromGraveyard(creatureCard)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Sandra Everingham"
+        flavorText = "You might leave here, Chenndra, should another take your place . . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg?1783948066"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HornOfDeafening.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HornOfDeafening.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+
+/**
+ * Horn of Deafening
+ * {4}
+ * Artifact
+ *
+ * {2}, {T}: Prevent all combat damage that would be dealt by target creature this turn.
+ */
+val HornOfDeafening = card("Horn of Deafening") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: Prevent all combat damage that would be dealt by target creature this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PreventAllDamageDealtBy(creature, scope = PreventionScope.CombatOnly)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "280"
+        artist = "Dan Frazier"
+        flavorText = "\"A blast, an echo . . . then silence.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg?1783948028"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HornetCobra.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HornetCobra.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hornet Cobra
+ * {1}{G}{G}
+ * Creature — Snake
+ * 2/1
+ *
+ * First strike
+ */
+val HornetCobra = card("Hornet Cobra") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    power = 2
+    toughness = 1
+    oracleText = "First strike"
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Sandra Everingham"
+        flavorText = "\"Then inch by inch out of the grass rose up the head and spread hood of Nag, the big black " +
+            "cobra, and he was five feet long from tongue to tail.\"\n" +
+            "—Rudyard Kipling, *The Jungle Books*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg?1783948047"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HorrorOfHorrors.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HorrorOfHorrors.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Horror of Horrors
+ * {3}{B}{B}
+ * Enchantment
+ *
+ * Sacrifice a Swamp: Regenerate target black creature. (The next time that creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)
+ */
+val HorrorOfHorrors = card("Horror of Horrors") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Sacrifice a Swamp: Regenerate target black creature. (The next time that creature would be " +
+        "destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Land.withSubtype(Subtype.SWAMP))
+        val creature = target(
+            "target black creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withColor(Color.BLACK))),
+        )
+        effect = RegenerateEffect(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Mark Tedin"
+        flavorText = "\"And a horror of outer darkness after,/ And dust returneth to dust again.\"\n" +
+            "—Adam Lindsay Gordon, The Swimmer"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg?1783948064"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HundingGjornersen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HundingGjornersen.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunding Gjornersen
+ * {3}{W}{U}{U}
+ * Legendary Creature — Human Warrior
+ * 5/4
+ *
+ * Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val HundingGjornersen = card("Hunding Gjornersen") {
+    manaCost = "{3}{W}{U}{U}"
+    colorIdentity = "UW"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 5
+    toughness = 4
+    oracleText = "Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    rampage(1)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Richard Thomas"
+        flavorText = "\"You would never guess, at the terrifying sight of the man, that Hunding was as charming a " +
+            "companion as one could wish for.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg?1783948038"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Immolation.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Immolation.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Immolation
+ * {R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/-2.
+ */
+val Immolation = card("Immolation") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets +2/-2."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, -2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Scott Kirschner"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg?1783948055"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/IndestructibleAura.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/IndestructibleAura.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+
+/**
+ * Indestructible Aura
+ * {W}
+ * Instant
+ *
+ * Prevent all damage that would be dealt to target creature this turn.
+ *
+ * No `Effects.*` facade spells the plain "prevent all damage that would be dealt to
+ * target this turn" shield — every parameter is [PreventDamageEffect]'s own default except the
+ * recipient — so the card constructs it directly (it is not one of the facade-boundary types).
+ */
+val IndestructibleAura = card("Indestructible Aura") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all damage that would be dealt to target creature this turn."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = PreventDamageEffect(target = creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Mark Poole"
+        flavorText = "Theodar strode the battle lines, snatching swords with his bare hands and casting them " +
+            "aside until all cowered before him."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg?1783948084"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JacquesLeVert.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JacquesLeVert.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Jacques le Vert
+ * {1}{R}{G}{W}
+ * Legendary Creature — Human Warrior
+ * 3/2
+ *
+ * Green creatures you control get +0/+2.
+ */
+val JacquesLeVert = card("Jacques le Vert") {
+    manaCost = "{1}{R}{G}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Green creatures you control get +0/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN).youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Andi Rusu"
+        flavorText = "Abandoning his sword to return to the lush forest of Pendelhaven, Jacques le Vert devoted " +
+            "his life to protecting the creatures of his homeland."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg?1783948039"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KeiTakahashi.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KeiTakahashi.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kei Takahashi
+ * {2}{G}{W}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ *
+ * {T}: Prevent the next 2 damage that would be dealt to target creature this turn.
+ */
+val KeiTakahashi = card("Kei Takahashi") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Prevent the next 2 damage that would be dealt to target creature this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PreventNextDamage(2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Scott Kirschner"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg?1783948036"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KillerBees.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KillerBees.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Killer Bees
+ * {1}{G}{G}
+ * Creature — Insect
+ * 0/1
+ *
+ * Flying
+ * {G}: This creature gets +1/+1 until end of turn.
+ */
+val KillerBees = card("Killer Bees") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n{G}: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "192"
+        artist = "Phil Foglio"
+        flavorText = "The communal mind produces a savage strategy, yet no one could predict that this vicious " +
+            "crossbreed would unravel the secret of steel."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg?1783948046"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldOverlord.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldOverlord.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Kobold Overlord
+ * {1}{R}
+ * Creature — Kobold
+ * 1/2
+ *
+ * First strike
+ * Other Kobold creatures you control have first strike.
+ */
+val KoboldOverlord = card("Kobold Overlord") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kobold"
+    power = 1
+    toughness = 2
+    oracleText = "First strike\nOther Kobold creatures you control have first strike."
+
+    keywords(Keyword.FIRST_STRIKE)
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FIRST_STRIKE,
+            GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.KOBOLD).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "155"
+        artist = "Julie Baroh"
+        flavorText = "\"One for all, all for one; we strike first, and then you're done!\" —Oath of the Kobold " +
+            "Musketeers"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg?1783948054"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldTaskmaster.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldTaskmaster.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Kobold Taskmaster
+ * {1}{R}
+ * Creature — Kobold
+ * 1/2
+ *
+ * Other Kobold creatures you control get +1/+0.
+ */
+val KoboldTaskmaster = card("Kobold Taskmaster") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kobold"
+    power = 1
+    toughness = 2
+    oracleText = "Other Kobold creatures you control get +1/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.KOBOLD).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "156"
+        artist = "Randy Asplund-Faith"
+        flavorText = "The Taskmaster knows that there is no cure for the common Kobold."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg?1783948054"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyCaleria.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyCaleria.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Lady Caleria
+ * {3}{G}{G}{W}{W}
+ * Legendary Creature — Elf Archer
+ * 3/6
+ *
+ * {T}: Lady Caleria deals 3 damage to target attacking or blocking creature.
+ */
+val LadyCaleria = card("Lady Caleria") {
+    manaCost = "{3}{G}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Elf Archer"
+    power = 3
+    toughness = 6
+    oracleText = "{T}: Lady Caleria deals 3 damage to target attacking or blocking creature."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature),
+        )
+        effect = Effects.DealDamage(3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "239"
+        artist = "Bryon Wackwitz"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg?1783948036"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyEvangela.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyEvangela.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+
+/**
+ * Lady Evangela
+ * {W}{U}{B}
+ * Legendary Creature — Human Cleric
+ * 1/2
+ *
+ * {W}{B}, {T}: Prevent all combat damage that would be dealt by target creature this turn.
+ */
+val LadyEvangela = card("Lady Evangela") {
+    manaCost = "{W}{U}{B}"
+    colorIdentity = "BUW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "{W}{B}, {T}: Prevent all combat damage that would be dealt by target creature this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}{B}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PreventAllDamageDealtBy(creature, scope = PreventionScope.CombatOnly)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Mark Poole"
+        flavorText = "\"When milady was young, the sight of a rainbow would fill her soul with peace. As she " +
+            "grew, she learned to share her rapture with others.\" —*Lady Gabriella*"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg?1783948036"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LostSoul.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LostSoul.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lost Soul
+ * {1}{B}{B}
+ * Creature — Spirit Minion
+ * 2/1
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ */
+val LostSoul = card("Lost Soul") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit Minion"
+    power = 2
+    toughness = 1
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Randy Asplund-Faith"
+        flavorText = "She walks in the twilight, her steps make no sound,/ Her feet leave no tracks on the " +
+            "dew-covered ground./ Her hand gently beckons, she whispers your name—/ But those who go " +
+            "with her are never the same."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg?1783948064"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MarhaultElsdragon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MarhaultElsdragon.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marhault Elsdragon
+ * {3}{R}{R}{G}
+ * Legendary Creature — Elf Warrior
+ * 4/6
+ *
+ * Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val MarhaultElsdragon = card("Marhault Elsdragon") {
+    manaCost = "{3}{R}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Legendary Creature — Elf Warrior"
+    power = 4
+    toughness = 6
+    oracleText = "Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    rampage(1)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Mark Poole"
+        flavorText = "Marhault follows a strict philosophy, never letting emotions cloud his thoughts. No chance " +
+            "observer could imagine the rage in his heart."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg?1783948036"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MoldDemon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MoldDemon.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Mold Demon
+ * {5}{B}{B}
+ * Creature — Fungus Demon
+ * 6/6
+ *
+ * When this creature enters, sacrifice it unless you sacrifice two Swamps.
+ */
+val MoldDemon = card("Mold Demon") {
+    manaCost = "{5}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Fungus Demon"
+    power = 6
+    toughness = 6
+    oracleText = "When this creature enters, sacrifice it unless you sacrifice two Swamps."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = PayOrSufferEffect(
+            cost = Costs.pay.Sacrifice(GameObjectFilter.Land.withSubtype(Subtype.SWAMP), count = 2),
+            suffer = SacrificeSelfEffect,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "Jesper Myrfors"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg?1783948064"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MountainYeti.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/MountainYeti.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Mountain Yeti
+ * {2}{R}{R}
+ * Creature — Yeti
+ * 3/3
+ *
+ * Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)
+ * Protection from white
+ */
+val MountainYeti = card("Mountain Yeti") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Yeti"
+    power = 3
+    toughness = 3
+    oracleText = "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)\n" +
+        "Protection from white"
+
+    keywords(Keyword.MOUNTAINWALK)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Dan Frazier"
+        flavorText = "The Yeti's single greatest asset is its unnerving ability to blend in with its surroundings."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg?1783948054"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PalladiaMors.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PalladiaMors.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Palladia-Mors
+ * {2}{R}{R}{G}{G}{W}{W}
+ * Legendary Creature — Elder Dragon
+ * 7/7
+ *
+ * Flying, trample
+ * At the beginning of your upkeep, sacrifice Palladia-Mors unless you pay {R}{G}{W}.
+ *
+ * The upkeep tax is CR 118.3's "unless": [PayOrSufferEffect] asks the controller to
+ * pay on resolution and sacrifices the dragon when they decline or cannot.
+ */
+val PalladiaMors = card("Palladia-Mors") {
+    manaCost = "{2}{R}{R}{G}{G}{W}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Legendary Creature — Elder Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying, trample\n" +
+        "At the beginning of your upkeep, sacrifice Palladia-Mors unless you pay {R}{G}{W}."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{R}{G}{W}"), suffer = SacrificeSelfEffect)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg?1783948035"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PavelMaliki.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PavelMaliki.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pavel Maliki
+ * {4}{B}{R}
+ * Legendary Creature — Human
+ * 5/3
+ *
+ * {B}{R}: Pavel Maliki gets +1/+0 until end of turn.
+ */
+val PavelMaliki = card("Pavel Maliki") {
+    manaCost = "{4}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human"
+    power = 5
+    toughness = 3
+    oracleText = "{B}{R}: Pavel Maliki gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "248"
+        artist = "Andi Rusu"
+        flavorText = "We all know the legend: Pavel wanders the realms, helping those in greatest need. But is " +
+            "this a measure of his generosity, or of his obligation to atone?"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg?1783948035"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PixieQueen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PixieQueen.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pixie Queen
+ * {2}{G}{G}
+ * Creature — Faerie
+ * 1/1
+ *
+ * Flying
+ * {G}{G}{G}, {T}: Target creature gains flying until end of turn.
+ */
+val PixieQueen = card("Pixie Queen") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Faerie"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n{G}{G}{G}, {T}: Target creature gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{G}{G}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "196"
+        artist = "Quinton Hoover"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg?1783948046"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PlanarGate.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PlanarGate.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Planar Gate
+ * {6}
+ * Artifact
+ *
+ * Creature spells you cast cost {2} less to cast.
+ */
+val PlanarGate = card("Planar Gate") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Creature spells you cast cost {2} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature),
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "290"
+        artist = "Melissa A. Benson"
+        flavorText = "Nireya reached through the Gate, sensing the energies trapped beyond."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg?1783948026"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PradeshGypsies.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PradeshGypsies.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pradesh Gypsies
+ * {2}{G}
+ * Creature — Human Nomad
+ * 1/1
+ *
+ * {1}{G}, {T}: Target creature gets -2/-0 until end of turn.
+ */
+val PradeshGypsies = card("Pradesh Gypsies") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Nomad"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{G}, {T}: Target creature gets -2/-0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Quinton Hoover"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg?1783948046"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PrincessLucrezia.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/PrincessLucrezia.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Princess Lucrezia
+ * {3}{U}{U}{B}
+ * Legendary Creature — Human Wizard
+ * 5/4
+ *
+ * {T}: Add {U}.
+ */
+val PrincessLucrezia = card("Princess Lucrezia") {
+    manaCost = "{3}{U}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 5
+    toughness = 4
+    oracleText = "{T}: Add {U}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "249"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg?1783948035"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Ragnar.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Ragnar.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Ragnar
+ * {G}{W}{U}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ *
+ * {G}{W}{U}, {T}: Regenerate target creature.
+ */
+val Ragnar = card("Ragnar") {
+    manaCost = "{G}{W}{U}"
+    colorIdentity = "GUW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{G}{W}{U}, {T}: Regenerate target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{W}{U}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = RegenerateEffect(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "250"
+        artist = "Melissa A. Benson"
+        flavorText = "\"On the field of honor, a soldier need have no fear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg?1783948034"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RamirezDePietro.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RamirezDePietro.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ramirez DePietro
+ * {3}{U}{B}{B}
+ * Legendary Creature — Human Pirate
+ * 4/3
+ *
+ * First strike
+ */
+val RamirezDePietro = card("Ramirez DePietro") {
+    manaCost = "{3}{U}{B}{B}"
+    colorIdentity = "BU"
+    typeLine = "Legendary Creature — Human Pirate"
+    power = 4
+    toughness = 3
+    oracleText = "First strike"
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "251"
+        artist = "Phil Foglio"
+        flavorText = "Ramirez DePietro is a most flamboyant pirate. Be careful not to believe his tall tales, " +
+            "especially when you ask his age."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg?1783948034"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RighteousAvengers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RighteousAvengers.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Righteous Avengers
+ * {4}{W}
+ * Creature — Human Soldier
+ * 3/1
+ *
+ * Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)
+ */
+val RighteousAvengers = card("Righteous Avengers") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 1
+    oracleText = "Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)"
+
+    keywords(Keyword.PLAINSWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Heather Hudson"
+        flavorText = "Few can withstand the wrath of the righteous."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg?1783948081"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RivenTurnbull.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RivenTurnbull.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Riven Turnbull
+ * {5}{U}{B}
+ * Legendary Creature — Human Advisor
+ * 5/7
+ *
+ * {T}: Add {B}.
+ */
+val RivenTurnbull = card("Riven Turnbull") {
+    manaCost = "{5}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 5
+    toughness = 7
+    oracleText = "{T}: Add {B}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "254"
+        artist = "Richard Kane Ferguson"
+        flavorText = "\"Political violence is a perfectly legitimate answer to the persecution handed down by " +
+            "dignitaries of the state.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg?1783948034"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SegovianLeviathan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SegovianLeviathan.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Segovian Leviathan
+ * {4}{U}
+ * Creature — Leviathan
+ * 3/3
+ *
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ */
+val SegovianLeviathan = card("Segovian Leviathan") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Leviathan"
+    power = 3
+    toughness = 3
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
+
+    keywords(Keyword.ISLANDWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Melissa A. Benson"
+        flavorText = "\"Leviathan, too! Can you catch him with a fish-hook/ or run a line round his tongue?\"\n" +
+            "—*Job 40:25*"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg?1783948071"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ShieldWall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ShieldWall.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shield Wall
+ * {1}{W}
+ * Instant
+ *
+ * Creatures you control get +0/+2 until end of turn.
+ */
+val ShieldWall = card("Shield Wall") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +0/+2 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(0, 2, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg?1783948080"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SolkanarTheSwampKing.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SolkanarTheSwampKing.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sol'kanar the Swamp King
+ * {2}{U}{B}{R}
+ * Legendary Creature — Demon
+ * 5/5
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ * Whenever a player casts a black spell, you gain 1 life.
+ */
+val SolkanarTheSwampKing = card("Sol'kanar the Swamp King") {
+    manaCost = "{2}{U}{B}{R}"
+    colorIdentity = "BRU"
+    typeLine = "Legendary Creature — Demon"
+    power = 5
+    toughness = 5
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n" +
+        "Whenever a player casts a black spell, you gain 1 life."
+
+    keywords(Keyword.SWAMPWALK)
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.BLACK))
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Richard Kane Ferguson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg?1783948032"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SpinalVillain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SpinalVillain.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spinal Villain
+ * {2}{R}
+ * Creature — Beast
+ * 1/2
+ *
+ * {T}: Destroy target blue creature.
+ */
+val SpinalVillain = card("Spinal Villain") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Destroy target blue creature."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target(
+            "target blue creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withColor(Color.BLUE))),
+        )
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Anson Maddocks"
+        flavorText = "\"Striking silent as a dream,/ Cutting short the strangled scream . . .\" —Tobrian, " +
+            "\"Watchdragon\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg?1783948052"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SunastianFalconer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SunastianFalconer.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sunastian Falconer
+ * {3}{R}{G}
+ * Legendary Creature — Human Shaman
+ * 4/4
+ *
+ * {T}: Add {C}{C}.
+ */
+val SunastianFalconer = card("Sunastian Falconer") {
+    manaCost = "{3}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Legendary Creature — Human Shaman"
+    power = 4
+    toughness = 4
+    oracleText = "{T}: Add {C}{C}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "261"
+        artist = "Christopher Rush"
+        flavorText = "Sunastian has roots in both sorcery and swordplay; he has learned never to depend too " +
+            "heavily on the latter."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg?1783948033"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Teleport.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Teleport.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Teleport
+ * {U}{U}{U}
+ * Instant
+ *
+ * Cast this spell only during the declare attackers step.
+ * Target creature can't be blocked this turn.
+ */
+val Teleport = card("Teleport") {
+    manaCost = "{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Cast this spell only during the declare attackers step.\n" +
+        "Target creature can't be blocked this turn."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "80"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg?1783948070"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ThunderSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ThunderSpirit.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunder Spirit
+ * {1}{W}{W}
+ * Creature — Elemental Spirit
+ * 2/2
+ *
+ * Flying, first strike
+ */
+val ThunderSpirit = card("Thunder Spirit") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elemental Spirit"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, first strike"
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Randy Asplund-Faith"
+        flavorText = "\"It was full of fire and smoke and light and . . . it drove between us and the Efrafans " +
+            "like a thousand thunderstorms with lightning.\"\n" +
+            "—Richard Adams, *Watership Down*"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg?1783948079"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TorWauki.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TorWauki.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tor Wauki
+ * {2}{B}{B}{R}
+ * Legendary Creature — Human Archer
+ * 3/3
+ *
+ * {T}: Tor Wauki deals 2 damage to target attacking or blocking creature.
+ */
+val TorWauki = card("Tor Wauki") {
+    manaCost = "{2}{B}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Archer"
+    power = 3
+    toughness = 3
+    oracleText = "{T}: Tor Wauki deals 2 damage to target attacking or blocking creature."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature),
+        )
+        effect = Effects.DealDamage(2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "265"
+        artist = "Randy Asplund-Faith"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg?1783948031"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TuknirDeathlock.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TuknirDeathlock.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tuknir Deathlock
+ * {R}{R}{G}{G}
+ * Legendary Creature — Human Wizard
+ * 2/2
+ *
+ * Flying
+ * {R}{G}, {T}: Target creature gets +2/+2 until end of turn.
+ */
+val TuknirDeathlock = card("Tuknir Deathlock") {
+    manaCost = "{R}{R}{G}{G}"
+    colorIdentity = "GR"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n{R}{G}, {T}: Target creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}{G}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "267"
+        artist = "Liz Danforth"
+        flavorText = "An explorer of the Æther, Tuknir often discovers himself in the most unusual physical " +
+            "realms."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg?1783948030"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/VaevictisAsmadi.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/VaevictisAsmadi.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vaevictis Asmadi
+ * {2}{B}{B}{R}{R}{G}{G}
+ * Legendary Creature — Elder Dragon
+ * 7/7
+ *
+ * Flying
+ * At the beginning of your upkeep, sacrifice Vaevictis Asmadi unless you pay {B}{R}{G}.
+ * {B}: Vaevictis Asmadi gets +1/+0 until end of turn.
+ * {R}: Vaevictis Asmadi gets +1/+0 until end of turn.
+ * {G}: Vaevictis Asmadi gets +1/+0 until end of turn.
+ *
+ * The upkeep tax is CR 118.3's "unless": [PayOrSufferEffect] asks the controller to
+ * pay on resolution and sacrifices the dragon when they decline or cannot.
+ */
+val VaevictisAsmadi = card("Vaevictis Asmadi") {
+    manaCost = "{2}{B}{B}{R}{R}{G}{G}"
+    colorIdentity = "BGR"
+    typeLine = "Legendary Creature — Elder Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, sacrifice Vaevictis Asmadi unless you pay {B}{R}{G}.\n" +
+        "{B}: Vaevictis Asmadi gets +1/+0 until end of turn.\n" +
+        "{R}: Vaevictis Asmadi gets +1/+0 until end of turn.\n" +
+        "{G}: Vaevictis Asmadi gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{B}{R}{G}"), suffer = SacrificeSelfEffect)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "269"
+        artist = "Andi Rusu"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg?1783948030"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WalkingDead.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WalkingDead.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Walking Dead
+ * {1}{B}
+ * Creature — Zombie
+ * 1/1
+ *
+ * {B}: Regenerate this creature.
+ */
+val WalkingDead = card("Walking Dead") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "{B}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Dan Frazier"
+        flavorText = "The Walking Dead are the remains of freakish experiments by the Necromantic Lords."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg?1783948060"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfEarth.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfEarth.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Earth
+ * {1}{R}
+ * Creature — Wall
+ * 0/6
+ *
+ * Defender (This creature can't attack.)
+ */
+val WallOfEarth = card("Wall of Earth") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 6
+    oracleText = "Defender (This creature can't attack.)"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Richard Thomas"
+        flavorText = "The ground shuddered violently and the earth seemed to come to life. The elemental force " +
+            "contained in the vast wall of earth was trapped, bent to its controller's will."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg?1783948051"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfHeat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfHeat.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Heat
+ * {2}{R}
+ * Creature — Wall
+ * 2/6
+ *
+ * Defender (This creature can't attack.)
+ */
+val WallOfHeat = card("Wall of Heat") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    power = 2
+    toughness = 6
+    oracleText = "Defender (This creature can't attack.)"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Richard Thomas"
+        flavorText = "At a distance, we mistook the sound for a waterfall . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg?1783948051"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfLight.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfLight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Wall of Light
+ * {2}{W}
+ * Creature — Wall
+ * 1/5
+ *
+ * Defender (This creature can't attack.)
+ * Protection from black
+ */
+val WallOfLight = card("Wall of Light") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Wall"
+    power = 1
+    toughness = 5
+    oracleText = "Defender (This creature can't attack.)\nProtection from black"
+
+    keywords(Keyword.DEFENDER)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Richard Thomas"
+        flavorText = "As many attackers were dazzled by the wall's beauty as were halted by its force."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg?1783948079"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfOpposition.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WallOfOpposition.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wall of Opposition
+ * {3}{R}{R}
+ * Creature — Wall
+ * 0/6
+ *
+ * Defender (This creature can't attack.)
+ * {1}: This creature gets +1/+0 until end of turn.
+ */
+val WallOfOpposition = card("Wall of Opposition") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 6
+    oracleText = "Defender (This creature can't attack.)\n{1}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.DEFENDER)
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Harold McNeill"
+        flavorText = "Like so many obstacles in life, the Wall of Opposition is but an illusion, held fast by the " +
+            "focus and belief of the one who creates it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg?1783948053"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WolverinePack.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/WolverinePack.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wolverine Pack
+ * {2}{G}{G}
+ * Creature — Wolverine
+ * 2/4
+ *
+ * Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)
+ *
+ * Rampage is wired by the [card] builder's `rampage(n)` helper: the printed keyword
+ * ability is display-only, and the +N/+N-per-extra-blocker behaviour lives in the
+ * "becomes blocked" triggered ability the helper installs alongside it.
+ */
+val WolverinePack = card("Wolverine Pack") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolverine"
+    power = 2
+    toughness = 4
+    oracleText = "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each " +
+        "creature blocking it beyond the first.)"
+
+    rampage(2)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "214"
+        artist = "Jeff A. Menges"
+        flavorText = "\"Give them great meals of beef and iron and steel, they will eat like wolves and fight " +
+            "like devils.\" —William Shakespeare, *King Henry V*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg?1783948042"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/XiraArien.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/XiraArien.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Xira Arien
+ * {B}{R}{G}
+ * Legendary Creature — Insect Wizard
+ * 1/2
+ *
+ * Flying
+ * {B}{R}{G}, {T}: Target player draws a card.
+ */
+val XiraArien = card("Xira Arien") {
+    manaCost = "{B}{R}{G}"
+    colorIdentity = "BGR"
+    typeLine = "Legendary Creature — Insect Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n{B}{R}{G}, {T}: Target player draws a card."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{R}{G}"), Costs.Tap)
+        val player = target("target player", Targets.Player)
+        effect = Effects.DrawCards(1, player)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "270"
+        artist = "Melissa A. Benson"
+        flavorText = "A regular guest at the Royal Masquerade, Arien is the envy of the Court. She appears in a " +
+            "new costume every hour."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg?1783948030"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ZephyrFalcon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/ZephyrFalcon.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zephyr Falcon
+ * {1}{U}
+ * Creature — Bird
+ * 1/1
+ *
+ * Flying, vigilance
+ */
+val ZephyrFalcon = card("Zephyr Falcon") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, vigilance"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Heather Hudson"
+        flavorText = "Although greatly prized among falconers, the Zephyr Falcon is capricious and not easily " +
+            "tamed."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg?1783948069"
+    }
+}

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CyclopeanMummyScenarioTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CyclopeanMummyScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Tests for Cyclopean Mummy (Legends, {1}{B}, 2/1 Zombie).
+ *
+ * Oracle: "When this creature dies, exile it."
+ *
+ * A leaves-the-battlefield trigger "looks back in time" (CR 603.10a) and is indexed off the
+ * battlefield, so the ability keeps `TriggeredAbility`'s default `activeZones = {BATTLEFIELD}`.
+ * Narrowing it to the graveyard with `triggerZone` — which reads plausibly, since the effect
+ * reaches for a card that is *already* in the graveyard when it resolves — replaces that default
+ * rather than adding to it, and `TriggerDetector` then never indexes the trigger at all. This
+ * test is the proof that the mummy's own death actually exiles it.
+ */
+class CyclopeanMummyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("Cyclopean Mummy exiles itself when it dies in combat") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val defender = driver.activePlayer!!
+        val attacker = driver.getOpponent(defender)
+
+        val mummy = driver.putCreatureOnBattlefield(defender, "Cyclopean Mummy")
+        driver.removeSummoningSickness(mummy)
+
+        // A 3/3 kills the 2/1 mummy outright in the combat damage step.
+        val giant = driver.putCreatureOnBattlefield(attacker, "Hill Giant")
+        driver.removeSummoningSickness(giant)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        if (driver.activePlayer != attacker) {
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        }
+
+        driver.declareAttackers(attacker, listOf(giant), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(mummy to listOf(giant)))
+
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // The dies trigger resolved: the mummy is in exile, never left sitting in the graveyard.
+        driver.getExileCardNames(defender) shouldContain "Cyclopean Mummy"
+        driver.getGraveyardCardNames(defender) shouldNotContain "Cyclopean Mummy"
+    }
+})

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/FlashCounterReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/FlashCounterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flash Counter reprint in 8ED. Canonical CardDefinition lives in its earliest set.
+ */
+val FlashCounterReprint = Printing(
+    oracleId = "75b2dd64-a2f5-4032-a19f-5b485dc44b16",
+    name = "Flash Counter",
+    setCode = "8ED",
+    collectorNumber = "78",
+    scryfallId = "dc14e61f-481a-4bfa-aca0-fb63dc952be6",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc14e61f-481a-4bfa-aca0-fb63dc952be6.jpg",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AzureDrakeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AzureDrakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azure Drake reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val AzureDrakeReprint = Printing(
+    oracleId = "15cc068c-f424-433e-b165-8457c62a4b35",
+    name = "Azure Drake",
+    setCode = "M11",
+    collectorNumber = "46",
+    scryfallId = "6653bce7-b0fc-49e3-8f45-f0bfcade8870",
+    artist = "Janine Johnston",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/6653bce7-b0fc-49e3-8f45-f0bfcade8870.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ImmolationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ImmolationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Immolation reprint in MID. Canonical CardDefinition lives in its earliest set.
+ */
+val ImmolationReprint = Printing(
+    oracleId = "9f40ad89-3767-4837-a078-f2dcfaf368df",
+    name = "Immolation",
+    setCode = "MID",
+    collectorNumber = "144",
+    scryfallId = "606b1148-4aa6-4d78-bedd-e31573282921",
+    artist = "Olena Richards",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/606b1148-4aa6-4d78-bedd-e31573282921.jpg",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LEG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEG.json
@@ -1,3 +1,364 @@
+// Acid Rain
+{
+    "name": "Acid Rain",
+    "manaCost": "{3}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all Forests.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "land Forest"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "RARE",
+        "artist": "NéNé Thomas",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba93c50a-2440-4e92-9cba-d97e20b1d29c.jpg?1783948079"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Active Volcano
+{
+    "name": "Active Volcano",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target blue permanent.\n• Return target Island to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target blue permanent"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent blue"
+                            },
+                            "id": "target blue permanent"
+                        }
+                    ],
+                    "description": "Destroy target blue permanent"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target Island"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land Island"
+                            },
+                            "id": "target Island"
+                        }
+                    ],
+                    "description": "Return target Island to its owner's hand"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Justin Hampton",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad402e65-6fac-4005-a2d4-592983df0c30.jpg?1783948060"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Adun Oakenshield
+{
+    "name": "Adun Oakenshield",
+    "manaCost": "{B}{R}{G}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "{B}{R}{G}, {T}: Return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{R}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target creature card from your graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "RARE",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\". . . And at his passing, the bodies of the world's great warriors shall rise from their graves and follow him to battle.\" —*The Anvilonian Grimoire*",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60252226-a102-4d88-9b80-42d021b5184d.jpg?1783948042"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Aerathi Berserker
+{
+    "name": "Aerathi Berserker",
+    "manaCost": "{2}{R}{R}{R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "Rampage 3 (Whenever this creature becomes blocked, it gets +3/+3 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 3
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "Ærathi children who show promise are left to survive for a year in the wilderness. Those who return are shown the way of the Berserker.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06673800-22a7-4ee3-92fa-7c7cd4865d30.jpg?1783948059"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Al-abara's Carpet
+{
+    "name": "Al-abara's Carpet",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "{5}, {T}: Prevent all damage that would be dealt to you this turn by attacking creatures without flying.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "sourceFilter": {
+                        "type": "FromGroup",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ],
+                                "statePredicates": [
+                                    "IsAttacking"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "RARE",
+        "artist": "Kaja Foglio",
+        "flavorText": "Al-abara simply laughed and lifted one finger, and the carpet carried her high out of our reach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d5aae6e-fe20-4363-9589-5a54bcbbb77e.jpg?1783948031"
+    },
+    "colorIdentityOverride": []
+}
+
+// Amrou Kithkin
+{
+    "name": "Amrou Kithkin",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Kithkin",
+    "oracleText": "This creature can't be blocked by creatures with power 3 or greater.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtLeast",
+                            "min": 3
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Quinton Hoover",
+        "flavorText": "Quick and agile, Amrou Kithkin can usually escape from even the most fearsome opponents.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbce1c55-123c-4a05-bde4-18a1601fcc5a.jpg?1783948088"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Azure Drake
+{
+    "name": "Azure Drake",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "flavorText": "The Azure Drake would be more powerful were it not so easily distracted.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb5f13a2-0896-4230-8957-6ad1cb2b895b.jpg?1783948078"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Barbary Apes
 {
     "name": "Barbary Apes",
@@ -76,6 +437,322 @@
     ]
 }
 
+// Carrion Ants
+{
+    "name": "Carrion Ants",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "{1}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "RARE",
+        "artist": "Richard Thomas",
+        "flavorText": "\"'War is no picnic,' my father liked to say. But the Ants seemed to disagree.\" —*General Chanek Valteroth*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg?1783948069"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cat Warriors
+{
+    "name": "Cat Warriors",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Melissa A. Benson",
+        "flavorText": "These stealthy felines have survived so many battles that some believe they must possess many lives.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2187a64-2823-4f58-ad35-70f8913db2dc.jpg?1783948049"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Chromium
+{
+    "name": "Chromium",
+    "manaCost": "{2}{W}{W}{U}{U}{B}{B}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying\nRampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)\nAt the beginning of your upkeep, sacrifice Chromium unless you pay {W}{U}{B}.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{W}{U}{B}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "RARE",
+        "artist": "Edward P. Beard, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cd7d7e1-f928-4429-9a59-ba0590a78e98.jpg?1783948040"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Cleanse
+{
+    "name": "Cleanse",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all black creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature black"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Phil Foglio",
+        "flavorText": "The clouds broke and the sun's rays burst forth; each foul beast in its turn faltered, and was gone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2fbd611b-ac97-4516-bad7-cc9ee4ef74f7.jpg?1783948087"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Concordant Crossroads
+{
+    "name": "Concordant Crossroads",
+    "manaCost": "{G}",
+    "typeLine": "World Enchantment",
+    "oracleText": "All creatures have haste.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "RARE",
+        "artist": "Amy Weber",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3bdcfae4-86c9-4d8a-bcfe-f0a928ec29db.jpg?1783948049"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Craw Giant
+{
+    "name": "Craw Giant",
+    "manaCost": "{3}{G}{G}{G}{G}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Trample\nRampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "Harthag gave a jolly laugh as he surveyed the army before him. \"Ho ho ho! Midgets! You think you can stand in my way?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/707dadf0-735f-445d-9240-e49660913314.jpg?1783948049"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Crimson Kobolds
 {
     "name": "Crimson Kobolds",
@@ -90,6 +767,84 @@
         "artist": "Anson Maddocks",
         "flavorText": "\"Kobolds are harmless.\" —Bearand the Bold, epitaph",
         "imageUri": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg?1783948057"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crimson Manticore
+{
+    "name": "Crimson Manticore",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Manticore",
+    "oracleText": "Flying\n{R}, {T}: This creature deals 1 damage to target attacking or blocking creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "RARE",
+        "artist": "Daniel Gelon",
+        "flavorText": "Noted neither for their good looks nor their charm, Crimson Manticores can be fearsome allies. As dinner companions, however, they are best left alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96f73f9c-1c4e-4343-bfa0-cc5c4a7a562e.jpg?1783948057"
     },
     "colorIdentityOverride": [
         "RED"
@@ -116,6 +871,223 @@
     ]
 }
 
+// Cyclopean Mummy
+{
+    "name": "Cyclopean Mummy",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, exile it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Exile"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "The ritual of plucking out an eye to gain future sight is but a curse that enables the living to see their own deaths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/479ccc50-2d72-4adc-901e-fbd4eef2cf92.jpg?1783948068"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// D'Avenant Archer
+{
+    "name": "D'Avenant Archer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier Archer",
+    "oracleText": "{T}: This creature deals 1 damage to target attacking or blocking creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Douglas Shuler",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b09aee5c-8b9e-46c2-b4d4-508062f8af05.jpg?1783948087"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dakkon Blackblade
+{
+    "name": "Dakkon Blackblade",
+    "manaCost": "{2}{W}{U}{U}{B}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Dakkon Blackblade's power and toughness are each equal to the number of lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "\"My power is as vast as the plains, my strength is that of mountains. Each wave that crashes upon the shore thunders like blood in my veins.\" —*Memoirs*",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbfd1278-1486-4516-8846-007ce1985ee9.jpg?1783948040"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Darkness
+{
+    "name": "Darkness",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Harold McNeill",
+        "flavorText": "\"If I must die, I will encounter darkness as a bride,/ And hug it in my arms.\" —William Shakespeare, *Measure for Measure*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53b04dab-45b7-418b-a0f0-bcf35145fc53.jpg?1783948067"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Devouring Deep
+{
+    "name": "Devouring Deep",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Fish",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Liz Danforth",
+        "flavorText": "\"Full fathom five thy father lies;/ Of his bones are coral made;/ Those are pearls that were his eyes;/ Nothing of him that doth fade,/ But doth suffer a sea-change/ Into something rich and strange.\" —William Shakespeare, *The Tempest*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0855a5a8-8c40-4396-9ad1-8fa0fc6a0c59.jpg?1783948077"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Divine Transformation
+{
+    "name": "Divine Transformation",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +3/+3.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "RARE",
+        "artist": "NéNé Thomas",
+        "flavorText": "Glory surged through her and radiance surrounded her. All things were possible with the blessing of the Divine.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg?1783948086"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Durkwood Boars
 {
     "name": "Durkwood Boars",
@@ -133,6 +1105,81 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Emerald Dragonfly
+{
+    "name": "Emerald Dragonfly",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\n{G}{G}: This creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"Flittering, wheeling, / darting in to strike, and then / gone just as you blink.\" —\"Dragonfly Haiku,\" poet unknown",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3e81250-52c3-49f6-be43-17c34339e177.jpg?1783948048"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Eternal Warrior
+{
+    "name": "Eternal Warrior",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has vigilance.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "UNCOMMON",
+        "artist": "Anson Maddocks",
+        "flavorText": "Warriors of the Tsunami-nito School spend years in training to master the way of effortless effort.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97cdc38e-1d96-4de2-98e2-713f5d4d2180.jpg?1783948056"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -180,6 +1227,280 @@
         "rarity": "UNCOMMON",
         "artist": "Anson Maddocks",
         "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f4174e4-0be8-49b5-8c52-22001790f6eb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Fire Sprites
+{
+    "name": "Fire Sprites",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\n{G}, {T}: Add {R}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Julie Baroh",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d26fa79a-ede8-4c80-98d5-f49696f8104d.jpg?1783948048"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Flash Counter
+{
+    "name": "Flash Counter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target instant spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "instant",
+                    "zone": "Stack"
+                },
+                "id": "target instant spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Harold McNeill",
+        "flavorText": "\"She grinned at me—a wicked grin. 'I hope you weren't relying too heavily on that, my dear.'\"\n—Medryn Silverwand, *Diary*",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c3cd450-f1cd-416b-9271-37d95815c089.jpg?1783948075"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Flash Flood
+{
+    "name": "Flash Flood",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target red permanent.\n• Return target Mountain to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target red permanent"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent red"
+                            },
+                            "id": "target red permanent"
+                        }
+                    ],
+                    "description": "Destroy target red permanent"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target Mountain"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land Mountain"
+                            },
+                            "id": "target Mountain"
+                        }
+                    ],
+                    "description": "Return target Mountain to its owner's hand"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Tom Wänerstrand",
+        "flavorText": "Many people say that no power can bring the mountains low. Many people are fools.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5ae88c06-f28c-4fbc-a28c-5eb203a04722.jpg?1783948076"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Frost Giant
+{
+    "name": "Frost Giant",
+    "manaCost": "{3}{R}{R}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Gelon",
+        "flavorText": "The Frost Giants have been out in the cold a long, long time, but they have their rage to keep them warm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/6955d54f-7b37-4e43-8183-51677fb1ee11.jpg?1783948056"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ghosts of the Damned
+{
+    "name": "Ghosts of the Damned",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{T}: Target creature gets -1/-0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "The voices of the dead ring in the heart long after they have faded from the ears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20275678-3488-43d8-a93b-993e2267ab07.jpg?1783948067"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -289,6 +1610,119 @@
     ]
 }
 
+// Hell Swarm
+{
+    "name": "Hell Swarm",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "All creatures get -1/-0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Christopher Rush",
+        "flavorText": "The brightness of day turned in an instant to dusk as the swarm descended upon the battlefield.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64164d1b-75f4-456e-a717-90ce554dc16c.jpg?1783948066"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hell's Caretaker
+{
+    "name": "Hell's Caretaker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "{T}, Sacrifice a creature: Return target creature card from your graveyard to the battlefield. Activate only during your upkeep.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target creature card from your graveyard"
+                    }
+                ],
+                "restrictions": [
+                    {
+                        "type": "ActivationAll",
+                        "restrictions": [
+                            "OnlyDuringYourTurn",
+                            {
+                                "type": "DuringStep",
+                                "step": "UPKEEP"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Sandra Everingham",
+        "flavorText": "You might leave here, Chenndra, should another take your place . . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/336b3b8f-d104-4f06-ad4f-c92b8a9038ca.jpg?1783948066"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Holy Day
 {
     "name": "Holy Day",
@@ -307,6 +1741,311 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6c95a2b-bf44-4ff2-9c6a-916773346edd.jpg?1591104919"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Horn of Deafening
+{
+    "name": "Horn of Deafening",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: Prevent all combat damage that would be dealt by target creature this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "scope": "CombatOnly",
+                    "direction": "FromTarget"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "280",
+        "rarity": "RARE",
+        "artist": "Dan Frazier",
+        "flavorText": "\"A blast, an echo . . . then silence.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17eff8d9-86de-4f19-bf00-5f20dc1373d4.jpg?1783948028"
+    },
+    "colorIdentityOverride": []
+}
+
+// Hornet Cobra
+{
+    "name": "Hornet Cobra",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "First strike",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Sandra Everingham",
+        "flavorText": "\"Then inch by inch out of the grass rose up the head and spread hood of Nag, the big black cobra, and he was five feet long from tongue to tail.\"\n—Rudyard Kipling, *The Jungle Books*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27180bad-9bbc-462b-8832-626dc403a3fd.jpg?1783948047"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Horror of Horrors
+{
+    "name": "Horror of Horrors",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Sacrifice a Swamp: Regenerate target black creature. (The next time that creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land Swamp"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target black creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature black"
+                        },
+                        "id": "target black creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Tedin",
+        "flavorText": "\"And a horror of outer darkness after,/ And dust returneth to dust again.\"\n—Adam Lindsay Gordon, The Swimmer",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9f68dc2-c048-41ec-b237-c36fdd99c27d.jpg?1783948064"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hunding Gjornersen
+{
+    "name": "Hunding Gjornersen",
+    "manaCost": "{3}{W}{U}{U}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 1
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "\"You would never guess, at the terrifying sight of the man, that Hunding was as charming a companion as one could wish for.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07d8e501-6857-4a52-a3b9-2bf0bee5b08c.jpg?1783948038"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Immolation
+{
+    "name": "Immolation",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/-2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": -2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Scott Kirschner",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b3d34fa-398c-4ea0-a392-6690bd3a615c.jpg?1783948055"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Indestructible Aura
+{
+    "name": "Indestructible Aura",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all damage that would be dealt to target creature this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Mark Poole",
+        "flavorText": "Theodar strode the battle lines, snatching swords with his bare hands and casting them aside until all cowered before him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed2a7333-c9ce-4011-b00e-1304e1eec25e.jpg?1783948084"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Jacques le Vert
+{
+    "name": "Jacques le Vert",
+    "manaCost": "{1}{R}{G}{W}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Green creatures you control get +0/+2.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature green ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Andi Rusu",
+        "flavorText": "Abandoning his sword to return to the lush forest of Pendelhaven, Jacques le Vert devoted his life to protecting the creatures of his homeland.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee5a45b1-169b-468e-9251-424c09cd7f0f.jpg?1783948039"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
         "WHITE"
     ]
 }
@@ -419,6 +2158,179 @@
     ]
 }
 
+// Kei Takahashi
+{
+    "name": "Kei Takahashi",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "{T}: Prevent the next 2 damage that would be dealt to target creature this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Scott Kirschner",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a4a524a-fdc7-432d-994b-953808528349.jpg?1783948036"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Killer Bees
+{
+    "name": "Killer Bees",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\n{G}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "RARE",
+        "artist": "Phil Foglio",
+        "flavorText": "The communal mind produces a savage strategy, yet no one could predict that this vicious crossbreed would unravel the secret of steel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg?1783948046"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kobold Overlord
+{
+    "name": "Kobold Overlord",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Kobold",
+    "oracleText": "First strike\nOther Kobold creatures you control have first strike.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Kobold ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "RARE",
+        "artist": "Julie Baroh",
+        "flavorText": "\"One for all, all for one; we strike first, and then you're done!\" —Oath of the Kobold Musketeers",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg?1783948054"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kobold Taskmaster
+{
+    "name": "Kobold Taskmaster",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Kobold",
+    "oracleText": "Other Kobold creatures you control get +1/+0.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Kobold ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Asplund-Faith",
+        "flavorText": "The Taskmaster knows that there is no cure for the common Kobold.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b9c63eb-8d4e-4d8b-8637-308459ef036b.jpg?1783948054"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Kobolds of Kher Keep
 {
     "name": "Kobolds of Kher Keep",
@@ -436,6 +2348,131 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lady Caleria
+{
+    "name": "Lady Caleria",
+    "manaCost": "{3}{G}{G}{W}{W}",
+    "typeLine": "Legendary Creature — Elf Archer",
+    "oracleText": "{T}: Lady Caleria deals 3 damage to target attacking or blocking creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "RARE",
+        "artist": "Bryon Wackwitz",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6914ed2-9207-4689-9166-11d2f8949fdd.jpg?1783948036"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Lady Evangela
+{
+    "name": "Lady Evangela",
+    "manaCost": "{W}{U}{B}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "{W}{B}, {T}: Prevent all combat damage that would be dealt by target creature this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "scope": "CombatOnly",
+                    "direction": "FromTarget"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Mark Poole",
+        "flavorText": "\"When milady was young, the sight of a rainbow would fill her soul with peace. As she grew, she learned to share her rapture with others.\" —*Lady Gabriella*",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3e122e9-ffa3-48dd-94d6-8f2886668e59.jpg?1783948036"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
     ]
 }
 
@@ -461,6 +2498,151 @@
     ]
 }
 
+// Lost Soul
+{
+    "name": "Lost Soul",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Spirit Minion",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Randy Asplund-Faith",
+        "flavorText": "She walks in the twilight, her steps make no sound,/ Her feet leave no tracks on the dew-covered ground./ Her hand gently beckons, she whispers your name—/ But those who go with her are never the same.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/601eed5c-436d-425b-a45f-07881ad893c8.jpg?1783948064"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Marhault Elsdragon
+{
+    "name": "Marhault Elsdragon",
+    "manaCost": "{3}{R}{R}{G}",
+    "typeLine": "Legendary Creature — Elf Warrior",
+    "oracleText": "Rampage 1 (Whenever this creature becomes blocked, it gets +1/+1 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "keywords": [
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 1
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "Marhault follows a strict philosophy, never letting emotions cloud his thoughts. No chance observer could imagine the rage in his heart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67330004-6720-46d9-9de0-c79230110583.jpg?1783948036"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Mold Demon
+{
+    "name": "Mold Demon",
+    "manaCost": "{5}{B}{B}",
+    "typeLine": "Creature — Fungus Demon",
+    "oracleText": "When this creature enters, sacrifice it unless you sacrifice two Swamps.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land Swamp",
+                            "count": 2
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "Jesper Myrfors",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg?1783948064"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Moss Monster
 {
     "name": "Moss Monster",
@@ -481,6 +2663,332 @@
     ]
 }
 
+// Mountain Yeti
+{
+    "name": "Mountain Yeti",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Yeti",
+    "oracleText": "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)\nProtection from white",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MOUNTAINWALK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "WHITE"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "flavorText": "The Yeti's single greatest asset is its unnerving ability to blend in with its surroundings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09242f08-3bfc-4082-b32f-703c7fed62a0.jpg?1783948054"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Palladia-Mors
+{
+    "name": "Palladia-Mors",
+    "manaCost": "{2}{R}{R}{G}{G}{W}{W}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying, trample\nAt the beginning of your upkeep, sacrifice Palladia-Mors unless you pay {R}{G}{W}.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{R}{G}{W}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Edward P. Beard, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad64874d-ce33-4e0a-bcca-723f129ef415.jpg?1783948035"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Pavel Maliki
+{
+    "name": "Pavel Maliki",
+    "manaCost": "{4}{B}{R}",
+    "typeLine": "Legendary Creature — Human",
+    "oracleText": "{B}{R}: Pavel Maliki gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "UNCOMMON",
+        "artist": "Andi Rusu",
+        "flavorText": "We all know the legend: Pavel wanders the realms, helping those in greatest need. But is this a measure of his generosity, or of his obligation to atone?",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/304f9d39-3ea2-4274-b23e-e4eaabbc1c4b.jpg?1783948035"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Pixie Queen
+{
+    "name": "Pixie Queen",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\n{G}{G}{G}, {T}: Target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{G}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "RARE",
+        "artist": "Quinton Hoover",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg?1783948046"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Planar Gate
+{
+    "name": "Planar Gate",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "Creature spells you cast cost {2} less to cast.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "290",
+        "rarity": "RARE",
+        "artist": "Melissa A. Benson",
+        "flavorText": "Nireya reached through the Gate, sensing the energies trapped beyond.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd27f0fe-c032-4f61-9f3d-98a6d2e2c426.jpg?1783948026"
+    },
+    "colorIdentityOverride": []
+}
+
+// Pradesh Gypsies
+{
+    "name": "Pradesh Gypsies",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Nomad",
+    "oracleText": "{1}{G}, {T}: Target creature gets -2/-0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Quinton Hoover",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0370330d-83d9-44d2-a1ed-c4827edc60fd.jpg?1783948046"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Princess Lucrezia
+{
+    "name": "Princess Lucrezia",
+    "manaCost": "{3}{U}{U}{B}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "{T}: Add {U}.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1dcf48c-2700-4024-807e-9244e4c649ac.jpg?1783948035"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Raging Bull
 {
     "name": "Raging Bull",
@@ -498,6 +3006,92 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ragnar
+{
+    "name": "Ragnar",
+    "manaCost": "{G}{W}{U}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "{G}{W}{U}, {T}: Regenerate target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{W}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "RARE",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"On the field of honor, a soldier need have no fear.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cf6a3a3-4a06-4eb7-981a-b70cf05b2473.jpg?1783948034"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ramirez DePietro
+{
+    "name": "Ramirez DePietro",
+    "manaCost": "{3}{U}{B}{B}",
+    "typeLine": "Legendary Creature — Human Pirate",
+    "oracleText": "First strike",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "UNCOMMON",
+        "artist": "Phil Foglio",
+        "flavorText": "Ramirez DePietro is a most flamboyant pirate. Be careful not to believe his tall tales, especially when you ask his age.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5c66c61-aadf-433b-9958-fc9b44b327b9.jpg?1783948034"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
     ]
 }
 
@@ -570,6 +3164,133 @@
     ]
 }
 
+// Righteous Avengers
+{
+    "name": "Righteous Avengers",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "PLAINSWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "UNCOMMON",
+        "artist": "Heather Hudson",
+        "flavorText": "Few can withstand the wrath of the righteous.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d96b463e-9579-4e7b-87c2-342527b91e7c.jpg?1783948081"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Riven Turnbull
+{
+    "name": "Riven Turnbull",
+    "manaCost": "{5}{U}{B}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "{T}: Add {B}.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "\"Political violence is a perfectly legitimate answer to the persecution handed down by dignitaries of the state.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d11f90e7-ced1-4d80-8083-99acbf459ad7.jpg?1783948034"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Segovian Leviathan
+{
+    "name": "Segovian Leviathan",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Leviathan",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"Leviathan, too! Can you catch him with a fish-hook/ or run a line round his tongue?\"\n—*Job 40:25*",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5a814f1-7f8d-4c2c-b706-ee0ed5892f7b.jpg?1783948071"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Shield Wall
+{
+    "name": "Shield Wall",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +0/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Douglas Shuler",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5032bf0-f9c0-4ef0-8ec2-fe7ccea9bdf3.jpg?1783948080"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sir Shandlar of Eberyn
 {
     "name": "Sir Shandlar of Eberyn",
@@ -614,6 +3335,189 @@
     ]
 }
 
+// Sol'kanar the Swamp King
+{
+    "name": "Sol'kanar the Swamp King",
+    "manaCost": "{2}{U}{B}{R}",
+    "typeLine": "Legendary Creature — Demon",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nWhenever a player casts a black spell, you gain 1 life.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Richard Kane Ferguson",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a20dcb0-5350-40e0-82d3-c8d0186fc9d2.jpg?1783948032"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Spinal Villain
+{
+    "name": "Spinal Villain",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{T}: Destroy target blue creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target blue creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature blue"
+                        },
+                        "id": "target blue creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"Striking silent as a dream,/ Cutting short the strangled scream . . .\" —Tobrian, \"Watchdragon\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg?1783948052"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sunastian Falconer
+{
+    "name": "Sunastian Falconer",
+    "manaCost": "{3}{R}{G}",
+    "typeLine": "Legendary Creature — Human Shaman",
+    "oracleText": "{T}: Add {C}{C}.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "Sunastian has roots in both sorcery and swordplay; he has learned never to depend too heavily on the latter.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/587075f3-a568-4089-83ca-fe1e473c025d.jpg?1783948033"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Teleport
+{
+    "name": "Teleport",
+    "manaCost": "{U}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step.\nTarget creature can't be blocked this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "CANT_BE_BLOCKED",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "RARE",
+        "artist": "Douglas Shuler",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18f86e13-f942-423e-b175-930d768cb811.jpg?1783948070"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // The Lady of the Mountain
 {
     "name": "The Lady of the Mountain",
@@ -633,6 +3537,32 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Thunder Spirit
+{
+    "name": "Thunder Spirit",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "Flying, first strike",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "Randy Asplund-Faith",
+        "flavorText": "\"It was full of fire and smoke and light and . . . it drove between us and the Efrafans like a thousand thunderstorms with lightning.\"\n—Richard Adams, *Watership Down*",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg?1783948079"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -658,6 +3588,69 @@
     ]
 }
 
+// Tor Wauki
+{
+    "name": "Tor Wauki",
+    "manaCost": "{2}{B}{B}{R}",
+    "typeLine": "Legendary Creature — Human Archer",
+    "oracleText": "{T}: Tor Wauki deals 2 damage to target attacking or blocking creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Asplund-Faith",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/241a4854-e62c-4be4-a9cc-1e14db4eede9.jpg?1783948031"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Torsten Von Ursus
 {
     "name": "Torsten Von Ursus",
@@ -677,6 +3670,76 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Tuknir Deathlock
+{
+    "name": "Tuknir Deathlock",
+    "manaCost": "{R}{R}{G}{G}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Flying\n{R}{G}, {T}: Target creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "rarity": "RARE",
+        "artist": "Liz Danforth",
+        "flavorText": "An explorer of the Æther, Tuknir often discovers himself in the most unusual physical realms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dfbcb4d-a9ae-4d76-8dde-7312fbad56b0.jpg?1783948030"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }
 
@@ -758,6 +3821,123 @@
     ]
 }
 
+// Vaevictis Asmadi
+{
+    "name": "Vaevictis Asmadi",
+    "manaCost": "{2}{B}{B}{R}{R}{G}{G}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying\nAt the beginning of your upkeep, sacrifice Vaevictis Asmadi unless you pay {B}{R}{G}.\n{B}: Vaevictis Asmadi gets +1/+0 until end of turn.\n{R}: Vaevictis Asmadi gets +1/+0 until end of turn.\n{G}: Vaevictis Asmadi gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{B}{R}{G}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "269",
+        "rarity": "RARE",
+        "artist": "Andi Rusu",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22ea73ec-1325-4437-a23f-dcda1767c713.jpg?1783948030"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
 // Vampire Bats
 {
     "name": "Vampire Bats",
@@ -814,6 +3994,178 @@
     ]
 }
 
+// Walking Dead
+{
+    "name": "Walking Dead",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Dan Frazier",
+        "flavorText": "The Walking Dead are the remains of freakish experiments by the Necromantic Lords.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7533a72-77d1-40cd-b3a1-7597d566c428.jpg?1783948060"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wall of Earth
+{
+    "name": "Wall of Earth",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Richard Thomas",
+        "flavorText": "The ground shuddered violently and the earth seemed to come to life. The elemental force contained in the vast wall of earth was trapped, bent to its controller's will.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c12e97c1-ca28-432a-8140-3f08bb4485a3.jpg?1783948051"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wall of Heat
+{
+    "name": "Wall of Heat",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Richard Thomas",
+        "flavorText": "At a distance, we mistook the sound for a waterfall . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a38059a8-be69-4cc1-969b-951c610f2f11.jpg?1783948051"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wall of Light
+{
+    "name": "Wall of Light",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\nProtection from black",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "As many attackers were dazzled by the wall's beauty as were halted by its force.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5758e82-f901-42b7-b705-0e68ca7ba59e.jpg?1783948079"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Wall of Opposition
+{
+    "name": "Wall of Opposition",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{1}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Harold McNeill",
+        "flavorText": "Like so many obstacles in life, the Wall of Opposition is but an illusion, held fast by the focus and belief of the one who creates it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg?1783948053"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Winds of Change
 {
     "name": "Winds of Change",
@@ -866,5 +4218,169 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Wolverine Pack
+{
+    "name": "Wolverine Pack",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Wolverine",
+    "oracleText": "Rampage 2 (Whenever this creature becomes blocked, it gets +2/+2 until end of turn for each creature blocking it beyond the first.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "RAMPAGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RAMPAGE",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "Subtract",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "BlockerCount"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "multiplier": 2
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\"Give them great meals of beef and iron and steel, they will eat like wolves and fight like devils.\" —William Shakespeare, *King Henry V*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba5aee52-095e-4c69-93eb-5adac11ed1fc.jpg?1783948042"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Xira Arien
+{
+    "name": "Xira Arien",
+    "manaCost": "{B}{R}{G}",
+    "typeLine": "Legendary Creature — Insect Wizard",
+    "oracleText": "Flying\n{B}{R}{G}, {T}: Target player draws a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{R}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "rarity": "RARE",
+        "artist": "Melissa A. Benson",
+        "flavorText": "A regular guest at the Royal Masquerade, Arien is the envy of the Court. She appears in a new costume every hour.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc6c7d89-32e7-4c3f-ac90-7db3a46eed4b.jpg?1783948030"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Zephyr Falcon
+{
+    "name": "Zephyr Falcon",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Heather Hudson",
+        "flavorText": "Although greatly prized among falconers, the Zephyr Falcon is capricious and not easily tamed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/25a173fd-e10c-45f8-a6e5-ad7a747a8050.jpg?1783948069"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }


### PR DESCRIPTION
Every card Argentum Assay reads whole that Legends had not authored yet, taken from 74 to 0.

## The four-way split

Legends (1994) is the earliest real printing for all 74, so the sweep is pure authoring — no `elsewhere`, `row-only`, `basic` or `unscaffolded` work:

| Bucket | Count |
|---|---|
| `original` | 72 |
| `unknown` (printings endpoint 404s) | 2 — Cleanse, Pradesh Gypsies |
| `elsewhere` / `row-only` / `basic` / `unscaffolded` | 0 |

**Reprint tail: 3 rows in 3 other scaffolded sets**, exactly as `--tail` predicted — Flash Counter (8ED), Azure Drake (M11), Immolation (MID). Generated with `generate-reprints.py --since origin/main` after refreshing the printing caches, and re-run after merging main (0 further rows owed).

## Numbers

| | before | after |
|---|---|---|
| LEG Assay-ready | 74 | **0** |
| differential compared | 4971 | 5108 |
| differential confirmed | 4923 | 5060 |
| differential divergent | 48 | **48** |

Zero new divergences. 67 of the 74 entered the compared set; the 7 rampage cards land in `SCRIPT_NOT_MODELLED`, which is `carriesUnreadAbilities` working as designed — the `rampage(n)` builder lowers the keyword into a becomes-blocked trigger that no printed line spells.

## Notes on the batch

All 74 compose existing primitives; no new SDK vocabulary, so `docs/card-sdk-language-reference.md` is unchanged.

- **Rampage (7 cards)** goes through the `rampage(n)` builder helper, which pairs the display keyword with a real `Triggers.BecomesBlocked` ability. Declaring `Keyword.RAMPAGE` alone would have shipped seven cards that lie.
- **The three Elder Dragons** (Chromium, Palladia-Mors, Vaevictis Asmadi) spell their upkeep tax as `PayOrSufferEffect` + `SacrificeSelfEffect`.
- **Dakkon Blackblade**'s `*`/`*` is a characteristic-defining ability, so it lives in `dynamicStats`, not an ability list.
- **Adun Oakenshield** takes plain `Effects.ReturnToHand`, not the `fromZone`-guarded self-return facade: a *targeted* graveyard return is re-validated at resolution under CR 608.2b, and adding the guard would create a divergence. **Hell's Caretaker** does keep the guard via `Effects.PutOntoBattlefieldFromGraveyard`, matching the asymmetry the facade KDoc documents.
- **Al-abara's Carpet** and **Indestructible Aura** construct `PreventDamageEffect` directly — no `Effects.*` facade spells those two shields, and it is not one of the facade-boundary types.

## The one bug the differential caught

**Cyclopean Mummy** first shipped with `triggerZone = Zone.GRAVEYARD` on its dies trigger, which reads plausibly because "exile it" reaches for a card that is already in the graveyard when the ability resolves. But `triggerZone` **replaces** the default `activeZones = {BATTLEFIELD}` rather than adding to it, and `TriggerDetector` only indexes battlefield triggers when `Zone.BATTLEFIELD in ability.activeZones` — so the trigger was never indexed at all. A leaves-the-battlefield ability looks back in time (CR 603.10a) and is indexed off the battlefield. Fixed, and `CyclopeanMummyScenarioTest` is the behavioural proof.

## Findings not fixed here

- **`check-card-printing` and `missing-reprints.py` cannot see Cleanse or Pradesh Gypsies.** Both 404 on Scryfall's `/cards/named` endpoint (they are among the cards removed from the Oracle database), so `generate-reprints.py` skips them with a warning. Confirmed harmless for this sweep: their only reprint sets (4ED/5ED/6ED/ME3) are unscaffolded, so no rows are owed. A set whose reprints *are* scaffolded would silently lose rows here — the set-search endpoint (`q=!"<name>"`) still returns them.
- **`assay-ready --names` classifies those same two cards as `unknown`** for the same reason, rather than as `original`. Both are in fact `original` (LEG is their earliest printing).

## Verification

- `just build` — green
- `just rebless-cards` — only `snapshots/cards/LEG.json` moved
- `just assay-differential` — 5108 compared / 5060 confirmed / 48 divergent, unchanged from the 48-divergence baseline
- `just check-card-printing` — ok on all 72 fetchable canonicals
- `:mtg-sets:1993-1999:tests:test` (forced re-run) and `FacadeBoundaryTest` — green
- `just assay-ready LEG` on the branch — **0 Assay-ready**

🤖 Generated with [Claude Code](https://claude.com/claude-code)