### PR TITLE
Stop the game log naming face-down objects

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -670,7 +671,11 @@ class TriggerDetector(
                 effect = com.wingedsheep.sdk.dsl.Effects.SacrificeTarget(
                     com.wingedsheep.sdk.scripting.targets.EffectTarget.Self
                 ),
-                descriptionOverride = "Evoke — Sacrifice ${cardComponent.name}"
+                // The name is interpolated into the text, so the mask has to be applied here —
+                // masking AbilityTriggeredEvent.sourceName downstream would leave it in the
+                // description. Evoke can't apply to a face-down cast today; Decayed below can.
+                descriptionOverride =
+                    "Evoke — Sacrifice ${nameVisibleToAll(state, event.entityId, cardComponent.name)}"
             )
             triggers.add(
                 PendingTrigger(
@@ -717,7 +722,8 @@ class TriggerDetector(
                         com.wingedsheep.sdk.scripting.targets.EffectTarget.Self
                     )
                 ),
-                descriptionOverride = "Decayed — When ${cardComponent.name} attacks, " +
+                descriptionOverride = "Decayed — When " +
+                    "${nameVisibleToAll(state, attackerId, cardComponent.name)} attacks, " +
                     "sacrifice it at end of combat."
             )
             triggers.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.mechanics.StateBasedActionChecker
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Step
 import kotlin.reflect.KClass
@@ -359,8 +360,11 @@ class SubmitDecisionHandler(
             }
 
             pending is ChooseTargetsDecision && response is TargetsResponse -> {
+                // A face-down permanent or spell has no name (CR 708.2a / 708.4) — naming it here
+                // would leak a morphed or disguised card the moment somebody targeted it.
                 val targetNames = response.selectedTargets.values.flatten().mapNotNull { targetId ->
                     state.getEntity(targetId)?.get<CardComponent>()?.name
+                        ?.let { nameVisibleToAll(state, targetId, it) }
                         ?: if (state.turnOrder.contains(targetId)) "player" else null
                 }
                 if (targetNames.isNotEmpty()) {
@@ -371,6 +375,7 @@ class SubmitDecisionHandler(
             pending is DistributeDecision && response is DistributionResponse -> {
                 val parts = response.distribution.mapNotNull { (targetId, amount) ->
                     val name = state.getEntity(targetId)?.get<CardComponent>()?.name
+                        ?.let { nameVisibleToAll(state, targetId, it) }
                         ?: if (state.turnOrder.contains(targetId)) "player" else null
                     name?.let { "$amount to $it" }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantHexproofFromChosenColorExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantHexproofFromChosenColorExecutor.kt
@@ -8,8 +8,8 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.scripting.effects.GrantHexproofFromChosenColorEffect
 import kotlin.reflect.KClass
 
@@ -47,7 +47,7 @@ class GrantHexproofFromChosenColorExecutor : EffectExecutor<GrantHexproofFromCho
             context = context
         )
 
-        val displayName = if (container.has<FaceDownComponent>()) "Face-down creature" else cardComponent.name
+        val displayName = nameVisibleToAll(state, targetId, cardComponent.name)
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
         val events = listOf(
             KeywordGrantedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantProtectionFromChosenColorExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/protection/GrantProtectionFromChosenColorExecutor.kt
@@ -8,8 +8,8 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.scripting.effects.GrantProtectionFromChosenColorEffect
 import kotlin.reflect.KClass
 
@@ -47,7 +47,7 @@ class GrantProtectionFromChosenColorExecutor : EffectExecutor<GrantProtectionFro
             context = context
         )
 
-        val displayName = if (container.has<FaceDownComponent>()) "Face-down creature" else cardComponent.name
+        val displayName = nameVisibleToAll(state, targetId, cardComponent.name)
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
         val events = listOf(
             KeywordGrantedEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -38,6 +38,8 @@ import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.handlers.effects.library.ChooseCreatureTypePipelineExecutor
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -470,17 +472,25 @@ class StackResolver(
         } else {
             cardComponent.name
         }
-        // For face-down creatures, use a generic name in the event
-        val eventName = if (castFaceDown) "Face-down creature" else spellName
+        // For face-down creatures, use a generic name in the event (CR 708.2a)
+        val eventName = if (castFaceDown) FACE_DOWN_DISPLAY_NAME else spellName
 
         // Collect target names for the cast event log
         val targetNames = effectiveTargets.mapNotNull { target ->
             when (target) {
+                // A face-down permanent is no more nameable as a *target* than as a source —
+                // "cast Igneous Inspiration targeting Aurelia's Vindicator" gave away a disguised
+                // creature just as completely as the enters line did.
                 is ChosenTarget.Permanent -> newState.getEntity(target.entityId)?.get<CardComponent>()?.name
+                    ?.let { nameVisibleToAll(newState, target.entityId, it) }
                 is ChosenTarget.Player -> if (target.playerId == casterId) "themselves" else "opponent"
                 is ChosenTarget.Spell -> newState.getEntity(target.spellEntityId)?.get<CardComponent>()?.name
+                    ?.let { nameVisibleToAll(newState, target.spellEntityId, it) }
                     ?: "spell"
+                // A card lying face down in exile is hidden too, and reads as "Face-down card"
+                // rather than "Face-down creature" — it has no characteristics to show.
                 is ChosenTarget.Card -> newState.getEntity(target.cardId)?.get<CardComponent>()?.name
+                    ?.let { nameVisibleToAll(newState, target.cardId, it) }
             }
         }
 
@@ -660,10 +670,15 @@ class StackResolver(
         newState = newState.pushToStack(abilityId)
             .copy(priorityPassedBy = emptySet())
 
+        // The only ability a face-down permanent can put on the stack is the ward its face-down
+        // mode grants (CR 702.168a disguise / 701.58a cloak), and reporting `ability.sourceName`
+        // for it announced exactly which card had just refused to be targeted.
+        val sourceDisplayName = nameVisibleToAll(state, ability.sourceId, ability.sourceName)
+
         val events = mutableListOf<GameEvent>(
             AbilityTriggeredEvent(
                 ability.sourceId,
-                ability.sourceName,
+                sourceDisplayName,
                 ability.controllerId,
                 ability.description,
                 abilityEntityId = abilityId,
@@ -672,12 +687,12 @@ class StackResolver(
         )
 
         if (CrimeDetector.isCrime(newState, ability.controllerId, targets)) {
-            events.add(CommitCrimeEvent(ability.controllerId, abilityId, ability.sourceName))
+            events.add(CommitCrimeEvent(ability.controllerId, abilityId, sourceDisplayName))
             newState = recordCrime(newState, ability.controllerId)
         }
 
         if (targets.isNotEmpty()) {
-            events.add(TargetsChosenEvent(ability.controllerId, abilityId, ability.sourceName))
+            events.add(TargetsChosenEvent(ability.controllerId, abilityId, sourceDisplayName))
         }
 
         // Emit BecomesTargetEvent for each permanent, spell, or player target
@@ -989,7 +1004,13 @@ class StackResolver(
             }
             newState = permanentResult.state
             events.addAll(permanentResult.events)
-            val permanentName = cardComponent?.name ?: "Unknown"
+            // CR 708.2a — a permanent that entered face down has no name, so neither the
+            // "resolved" line nor the "entered the battlefield" line may carry the printed one.
+            // The cast line was already masked at `eventName` above; leaving these two unmasked
+            // made the log contradict it and told the opponent exactly what they were looking at.
+            // Read the resolved entity rather than `spellComponent.castFaceDown` so every route
+            // that lands a permanent face down is covered, not only a face-down cast.
+            val permanentName = nameVisibleToAll(newState, spellId, cardComponent?.name ?: "Unknown")
             events.add(ResolvedEvent(spellId, permanentName))
             events.add(
                 ZoneChangeEvent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.state
+
+import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * What a face-down permanent or a face-down spell is called instead of the card underneath it.
+ *
+ * CR 708.2a — a face-down permanent is a 2/2 creature with "no text, no name, no subtypes, and no
+ * mana cost". CR 708.4 gives a face-down *spell* the same characteristics while it is on the stack.
+ */
+const val FACE_DOWN_DISPLAY_NAME: String = "Face-down creature"
+
+/**
+ * What a card lying face down in exile is called. Deliberately not [FACE_DOWN_DISPLAY_NAME]: an
+ * exiled face-down card (a foretold card, an "exile face down" rider) is not a creature and has no
+ * characteristics to show, which is why [com.wingedsheep.engine.view.ClientStateTransformer] draws
+ * it with a different, smaller card view.
+ */
+const val FACE_DOWN_CARD_DISPLAY_NAME: String = "Face-down card"
+
+/**
+ * The name [entityId] may be shown under to *any* viewer, its controller included.
+ *
+ * Use this for flat strings with no audience attached — a game-log line, a decision summary. Those
+ * reach both players, and [com.wingedsheep.engine.view.ClientEventTransformer] cannot redact them
+ * downstream: it maps engine events to text with no `GameState` in hand, so it cannot tell a
+ * face-down object from a face-up one. The decision has to be made where the event is emitted.
+ *
+ * Where the text *does* have an audience, prefer [nameVisibleTo] — a player may look at a
+ * face-down object they control (CR 708.5).
+ */
+fun nameVisibleToAll(state: GameState, entityId: EntityId, fallback: String): String =
+    faceDownDisplayName(state, entityId) ?: fallback
+
+/**
+ * The name [entityId] may be shown under to [viewingPlayerId] specifically.
+ *
+ * Same masking as [nameVisibleToAll], except that a player may look at a face-down object they
+ * control (CR 708.5) and so keeps [fallback] for their own. A spectator never may — matching the
+ * gate [com.wingedsheep.engine.view.ClientStateTransformer] applies to card views, so a per-viewer
+ * label and the card it labels always agree.
+ */
+fun nameVisibleTo(
+    state: GameState,
+    entityId: EntityId,
+    fallback: String,
+    viewingPlayerId: EntityId,
+    isSpectator: Boolean = false,
+): String {
+    val masked = faceDownDisplayName(state, entityId) ?: return fallback
+    val mayLook = !isSpectator && viewingPlayerId == playerWhoMayLookAt(state, entityId)
+    return if (mayLook) fallback else masked
+}
+
+/**
+ * The masked name for [entityId] if it is a face-down object in a zone where its identity is
+ * hidden, or null if it has a name everyone may read.
+ *
+ * The three zones answer differently, which is the whole reason this lives in one place:
+ *
+ * - **Stack** — a spell cast face down carries no [FaceDownComponent]; that is stamped as it
+ *   resolves. Its face-down status rides [SpellOnStackComponent.castFaceDown] instead. This is the
+ *   same pair `ClientStateTransformer` tests when deciding whether to mask a card view.
+ * - **Battlefield** — [FaceDownComponent], but checked against the *physical* zone. [GameState
+ *   .getBattlefield] deliberately hides phased-out permanents, and a phased-out face-down permanent
+ *   is still a face-down permanent whose identity must not leak.
+ * - **Exile** — [FaceDownComponent] again, but the object is not a creature, so it gets
+ *   [FACE_DOWN_CARD_DISPLAY_NAME].
+ *
+ * Anything else keeps its name, including a face-down object that has already left all three: its
+ * owner reveals it to every player as it goes (CR 708.9).
+ */
+private fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
+    val container = state.getEntity(entityId) ?: return null
+
+    if (entityId in state.stack) {
+        val faceDown = container.has<FaceDownComponent>() ||
+            container.get<SpellOnStackComponent>()?.castFaceDown == true
+        return if (faceDown) FACE_DOWN_DISPLAY_NAME else null
+    }
+
+    if (!container.has<FaceDownComponent>()) return null
+
+    if (entityId in state.getBattlefield()) return FACE_DOWN_DISPLAY_NAME
+    // Only phased-out permanents are missing from the memoized accessor above, so the unmemoized
+    // physical-zone scan is reached only for them.
+    if (container.has<PhasedOutComponent>() && entityId in state.allBattlefieldEntities()) {
+        return FACE_DOWN_DISPLAY_NAME
+    }
+
+    val ownerId = container.get<CardComponent>()?.ownerId ?: container.get<OwnerComponent>()?.playerId
+    if (ownerId != null && entityId in state.getExile(ownerId)) return FACE_DOWN_CARD_DISPLAY_NAME
+
+    return null
+}
+
+/** The one player entitled to read [entityId]'s real name off the table (CR 708.5). */
+private fun playerWhoMayLookAt(state: GameState, entityId: EntityId): EntityId? {
+    val container = state.getEntity(entityId) ?: return null
+    return state.projectedState.getController(entityId)
+        ?: container.get<SpellOnStackComponent>()?.casterId
+        ?: container.get<ControllerComponent>()?.playerId
+        ?: container.get<CardComponent>()?.ownerId
+        ?: container.get<OwnerComponent>()?.playerId
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -20,7 +20,10 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantChosenColor
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.nameVisibleTo
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.*
 import com.wingedsheep.engine.state.components.battlefield.*
@@ -190,7 +193,7 @@ class ClientStateTransformer(
             for (entityId in state.stack) {
                 if (entityId !in cards) {
                     val clientCard = transformCard(state, entityId, stackZoneKey, projectedState, viewingPlayerId, isSpectator)
-                        ?: transformAbilityOnStack(state, entityId, viewingPlayerId)
+                        ?: transformAbilityOnStack(state, entityId, viewingPlayerId, isSpectator)
                     if (clientCard != null) {
                         cards[entityId] = clientCard
                     }
@@ -531,7 +534,8 @@ class ClientStateTransformer(
     private fun transformAbilityOnStack(
         state: GameState,
         entityId: EntityId,
-        viewingPlayerId: EntityId
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean
     ): ClientCard? {
         val container = state.getEntity(entityId) ?: return null
 
@@ -641,7 +645,8 @@ class ClientStateTransformer(
                         triggeredAbility.chosenModes,
                         triggeredAbility.modeTargetsOrdered,
                         triggeredModeDescriptions,
-                        viewingPlayerId
+                        viewingPlayerId,
+                        isSpectator
                     )
                 } else emptyList()
 
@@ -853,7 +858,7 @@ class ClientStateTransformer(
             if (zoneKey.zoneType == Zone.EXILE) {
                 return ClientCard(
                     id = entityId,
-                    name = "Face-down card",
+                    name = FACE_DOWN_CARD_DISPLAY_NAME,
                     manaCost = "",
                     manaValue = 0,
                     typeLine = "",
@@ -914,7 +919,7 @@ class ClientStateTransformer(
             val faceDownKeywordsWithProtection = if (faceDownProtections.isNotEmpty()) faceDownKeywords + Keyword.PROTECTION else faceDownKeywords
             return ClientCard(
                 id = entityId,
-                name = "Face-down creature",
+                name = FACE_DOWN_DISPLAY_NAME,
                 manaCost = "",
                 manaValue = 0,
                 typeLine = "Creature",
@@ -1055,7 +1060,8 @@ class ClientStateTransformer(
                 spellOnStack.chosenModes,
                 spellOnStack.modeTargetsOrdered,
                 chosenModeDescriptions,
-                viewingPlayerId
+                viewingPlayerId,
+                isSpectator
             )
         } else emptyList()
 
@@ -1739,14 +1745,17 @@ class ClientStateTransformer(
     /**
      * Build per-mode target groups for a modal spell on the stack, aligned with
      * [SpellOnStackComponent.modeTargetsOrdered]. Hidden-zone targets are redacted to a generic
-     * "a card in X's hand/library" string when the viewer does not own the zone.
+     * "a card in X's hand/library" string when the viewer does not own the zone, and a face-down
+     * object is redacted for every viewer but the one who may look at it (see
+     * [resolveTargetDisplayName]).
      */
     private fun buildPerModeTargetGroups(
         state: GameState,
         chosenModes: List<Int>,
         modeTargetsOrdered: List<List<ChosenTarget>>,
         modeDescriptions: List<String>,
-        viewingPlayerId: EntityId
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean
     ): List<ClientPerModeTargetGroup> {
         if (chosenModes.isEmpty()) return emptyList()
         return chosenModes.mapIndexed { index, modeIndex ->
@@ -1760,7 +1769,7 @@ class ClientStateTransformer(
                 }
             }
             val targetNames = rawTargets.map { target ->
-                resolveTargetDisplayName(state, target, viewingPlayerId)
+                resolveTargetDisplayName(state, target, viewingPlayerId, isSpectator)
             }
             ClientPerModeTargetGroup(
                 modeIndex = modeIndex,
@@ -1778,14 +1787,24 @@ class ClientStateTransformer(
     private fun resolveTargetDisplayName(
         state: GameState,
         target: ChosenTarget,
-        viewingPlayerId: EntityId
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean
     ): String = when (target) {
         is ChosenTarget.Player -> state.getEntity(target.playerId)
             ?.get<PlayerComponent>()?.name ?: "a player"
+        // A face-down object is nameless (CR 708.2a / 708.4), but this label has an audience, so
+        // it is masked per viewer rather than for everyone: a player may look at a face-down
+        // object they control (CR 708.5). That also keeps modal spells consistent with non-modal
+        // ones, whose targets ship as bare entity ids and are named client-side from the card
+        // view — which applies exactly this gate.
         is ChosenTarget.Permanent -> state.getEntity(target.entityId)
-            ?.get<CardComponent>()?.name ?: "a permanent"
+            ?.get<CardComponent>()?.name
+            ?.let { nameVisibleTo(state, target.entityId, it, viewingPlayerId, isSpectator) }
+            ?: "a permanent"
         is ChosenTarget.Spell -> state.getEntity(target.spellEntityId)
-            ?.get<CardComponent>()?.name ?: "a spell"
+            ?.get<CardComponent>()?.name
+            ?.let { nameVisibleTo(state, target.spellEntityId, it, viewingPlayerId, isSpectator) }
+            ?: "a spell"
         is ChosenTarget.Card -> {
             val hiddenZone = target.zone == Zone.HAND || target.zone == Zone.LIBRARY
             if (hiddenZone && target.ownerId != viewingPlayerId) {
@@ -1793,7 +1812,9 @@ class ClientStateTransformer(
                     ?.get<PlayerComponent>()?.name ?: "opponent"
                 "a card in ${ownerName}'s ${target.zone.name.lowercase()}"
             } else {
-                state.getEntity(target.cardId)?.get<CardComponent>()?.name ?: "a card"
+                state.getEntity(target.cardId)?.get<CardComponent>()?.name
+                    ?.let { nameVisibleTo(state, target.cardId, it, viewingPlayerId, isSpectator) }
+                    ?: "a card"
             }
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -1,0 +1,311 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.nameVisibleTo
+import com.wingedsheep.engine.state.nameVisibleToAll
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The game log must never print the name of a card that is face down on the battlefield.
+ *
+ * CR 708.2a: a face-down permanent has no name. The cast line was masked from the start, but the
+ * three lines that follow it were not, so a disguised creature announced itself the moment it
+ * resolved:
+ *
+ * ```
+ * Opponent cast Face-down creature
+ * Aurelia's Vindicator resolved                                      <- leak
+ * Opponent's Aurelia's Vindicator entered the battlefield            <- leak
+ * You cast Igneous Inspiration targeting Aurelia's Vindicator        <- leak
+ * Opponent's Aurelia's Vindicator triggered: ... unless ... pays {2} <- leak
+ * ```
+ *
+ * [ClientEventTransformer] cannot fix this downstream — it maps engine events to log text with no
+ * `GameState` in hand, so it cannot tell a face-down permanent from a face-up one. Every one of
+ * these is therefore masked where the event is emitted, in `StackResolver`.
+ *
+ * The mask applies to *both* players' logs, as the cast line already did: the object genuinely has
+ * no name, and a controller who wants to know what their own face-down permanent is looks at the
+ * card (CR 708.5) — [ClientStateTransformer] keeps the real name in their card view, which is what
+ * [FaceDownHelperCardVisibilityTest] covers.
+ */
+class FaceDownGameLogMaskingTest : FunSpec({
+
+    val disguisedAngel = card("Disguised Angel") {
+        manaCost = "{2}{W}{W}"
+        typeLine = "Creature — Angel"
+        power = 4
+        toughness = 2
+        disguise = "{3}{W}"
+    }
+
+    // A targeted *trigger* is the reachable path to a ChooseTargetsDecision: a non-modal spell
+    // declares its targets at cast time and never prompts.
+    val tapper = card("Test Tapper") {
+        manaCost = "{2}{B}"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            target("target creature", TargetCreature())
+            effect = Effects.Tap(EffectTarget.ContextTarget(0))
+            description = "When this creature enters, tap target creature."
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(disguisedAngel, tapper))
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Every log line this game has produced, as [viewingPlayerId] would read it. */
+    fun GameTestDriver.logAsSeenBy(viewingPlayerId: EntityId): List<String> =
+        ClientEventTransformer.transform(events, viewingPlayerId).map { it.description }
+
+    /** Put [cardName] onto the battlefield face down under [mode], as a real face-down entry does. */
+    fun GameTestDriver.putFaceDown(playerId: EntityId, cardName: String, mode: FaceDownMode): EntityId {
+        val id = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(mode))
+                FaceDownTurnUp.dataFor(cardDef, cardName, mode)?.let { c = c.with(it) }
+                c
+            }
+        )
+        return id
+    }
+
+    test("a creature cast face down is not named as it resolves or as it enters") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+
+        val cardId = d.putCardInHand(caster, "Disguised Angel")
+        d.giveMana(caster, Color.BLACK, 3)
+        d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        d.bothPass()
+
+        val opponentLog = d.logAsSeenBy(opponent)
+        withClue("opponent's log: $opponentLog") {
+            opponentLog.forEach { it shouldNotContain "Disguised Angel" }
+            opponentLog.contains("Face-down creature resolved") shouldBe true
+            opponentLog.contains("Opponent's Face-down creature entered the battlefield") shouldBe true
+        }
+
+        val casterLog = d.logAsSeenBy(caster)
+        withClue("caster's own log: $casterLog") {
+            casterLog.forEach { it shouldNotContain "Disguised Angel" }
+            casterLog.contains("Your Face-down creature entered the battlefield") shouldBe true
+        }
+    }
+
+    test("the ward a disguised permanent triggers is not attributed to the hidden card") {
+        val d = driver()
+        val activePlayer = d.activePlayer!!
+        val opponent = d.getOpponent(activePlayer)
+
+        // The face-down permanent's ward {2} comes from disguise (CR 702.168a), not from any
+        // printed ability — a face-down permanent has none (CR 708.2).
+        val hidden = d.putFaceDown(opponent, "Disguised Angel", FaceDownMode.DISGUISE)
+
+        // Exactly {R} for Bolt and nothing left for the ward, so it counters without a prompt.
+        d.giveMana(activePlayer, Color.RED, 1)
+        val bolt = d.putCardInHand(activePlayer, "Lightning Bolt")
+        d.castSpellWithTargets(
+            activePlayer, bolt, listOf(ChosenTarget.Permanent(hidden))
+        ).isSuccess shouldBe true
+
+        d.bothPass()
+
+        val log = d.logAsSeenBy(activePlayer)
+        withClue("targeting player's log: $log") {
+            log.forEach { it shouldNotContain "Disguised Angel" }
+            // The spell that targeted it must not name it either — this is the line that gave the
+            // Vindicator away in the transcript this test was written from.
+            log.contains("You cast Lightning Bolt targeting Face-down creature") shouldBe true
+            log.any { it.startsWith("Opponent's Face-down creature triggered:") } shouldBe true
+        }
+    }
+
+    test("a spell that answers a face-down spell does not name it either") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+
+        val cardId = d.putCardInHand(caster, "Disguised Angel")
+        d.giveMana(caster, Color.BLACK, 3)
+        d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+
+        // A face-down *spell* is nameless too (CR 708.4), so the counter that answers it on the
+        // stack must not name it — the leak is the same one, a zone earlier.
+        d.passPriority(caster)
+        d.giveMana(opponent, Color.BLUE, 2)
+        val counter = d.putCardInHand(opponent, "Counterspell")
+        d.castSpellWithTargets(
+            opponent, counter, listOf(ChosenTarget.Spell(cardId))
+        ).isSuccess shouldBe true
+
+        val log = d.logAsSeenBy(caster)
+        withClue("log: $log") {
+            log.forEach { it shouldNotContain "Disguised Angel" }
+            log.contains("Opponent cast Counterspell targeting Face-down creature") shouldBe true
+        }
+    }
+
+    context("which zone the mask applies in") {
+
+        test("battlefield and stack are masked; a face-down card in hand is not") {
+            val d = driver()
+            val player = d.activePlayer!!
+
+            // A card in hand is hidden by the zone itself; calling it "Face-down creature" would
+            // be a different claim, not a safer one.
+            val inHand = d.putCardInHand(player, "Disguised Angel")
+            d.replaceState(d.state.updateEntity(inHand) { it.with(FaceDownComponent) })
+            nameVisibleToAll(d.state, inHand, "Disguised Angel") shouldBe "Disguised Angel"
+
+            val onBattlefield = d.putFaceDown(player, "Disguised Angel", FaceDownMode.DISGUISE)
+            nameVisibleToAll(d.state, onBattlefield, "Disguised Angel") shouldBe "Face-down creature"
+        }
+
+        test("a phased-out face-down permanent is still masked") {
+            val d = driver()
+            val player = d.activePlayer!!
+            val hidden = d.putFaceDown(player, "Disguised Angel", FaceDownMode.DISGUISE)
+
+            // GameState.getBattlefield() deliberately hides phased-out permanents, so a naive
+            // battlefield check unmasks them. Phasing never changes zones (CR 702.26d) — the
+            // permanent is still on the battlefield, and its identity is still hidden.
+            d.replaceState(
+                d.state.updateEntity(hidden) { it.with(PhasedOutComponent(phasedOutByController = player)) }
+            )
+            d.state.getBattlefield() shouldNotContain hidden
+            nameVisibleToAll(d.state, hidden, "Disguised Angel") shouldBe "Face-down creature"
+        }
+
+        test("a card face down in exile reads as a card, not a creature") {
+            val d = driver()
+            val player = d.activePlayer!!
+
+            val exiled = d.putCardInExile(player, "Disguised Angel")
+            d.replaceState(d.state.updateEntity(exiled) { it.with(FaceDownComponent) })
+
+            // Not "Face-down creature" — an exiled face-down card has no characteristics to show
+            // and is not a creature.
+            nameVisibleToAll(d.state, exiled, "Disguised Angel") shouldBe "Face-down card"
+        }
+    }
+
+    test("a face-down permanent's controller may still read its name where the text has an audience") {
+        val d = driver()
+        val controller = d.activePlayer!!
+        val opponent = d.getOpponent(controller)
+        val hidden = d.putFaceDown(controller, "Disguised Angel", FaceDownMode.DISGUISE)
+
+        // CR 708.5 — you may look at a face-down permanent you control. Per-viewer text honours
+        // that; the flat game-log strings cannot and mask for everyone.
+        nameVisibleTo(d.state, hidden, "Disguised Angel", controller) shouldBe "Disguised Angel"
+        nameVisibleTo(d.state, hidden, "Disguised Angel", opponent) shouldBe "Face-down creature"
+        withClue("a spectator is never the player who may look") {
+            nameVisibleTo(d.state, hidden, "Disguised Angel", controller, isSpectator = true) shouldBe
+                "Face-down creature"
+        }
+    }
+
+    test("a decision summary does not name the face-down permanent it targeted") {
+        val d = driver()
+        val chooser = d.activePlayer!!
+        val opponent = d.getOpponent(chooser)
+
+        val hidden = d.putFaceDown(opponent, "Disguised Angel", FaceDownMode.DISGUISE)
+
+        // A second legal target, so the choice is a genuine prompt rather than an auto-select.
+        d.putCreatureOnBattlefield(chooser, "Grizzly Bears")
+
+        d.giveMana(chooser, Color.BLACK, 3)
+        val tapperCard = d.putCardInHand(chooser, "Test Tapper")
+        d.submitSuccess(
+            CastSpell(
+                playerId = chooser,
+                cardId = tapperCard,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        d.bothPass()
+
+        d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        d.submitTargetSelection(chooser, listOf(hidden))
+
+        val log = d.logAsSeenBy(chooser)
+        withClue("chooser's log: $log") {
+            log.forEach { it shouldNotContain "Disguised Angel" }
+            log.contains("You: (Test Tapper) Targeting Face-down creature") shouldBe true
+        }
+    }
+
+    test("a face-up permanent is still named normally") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+
+        val cardId = d.putCardInHand(caster, "Disguised Angel")
+        d.giveMana(caster, Color.WHITE, 4)
+        d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        d.bothPass()
+
+        val opponentLog = d.logAsSeenBy(opponent)
+        withClue("opponent's log: $opponentLog") {
+            opponentLog.contains("Disguised Angel resolved") shouldBe true
+            opponentLog.contains("Opponent's Disguised Angel entered the battlefield") shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
# Stop the game log naming face-down objects

A creature cast with disguise announced itself the moment it resolved. The cast line was
masked; the four lines around it were not:

```
Opponent cast Face-down creature
Aurelia's Vindicator resolved                                       <- leak
Opponent's Aurelia's Vindicator entered the battlefield             <- leak
You cast Igneous Inspiration targeting Aurelia's Vindicator         <- leak
Opponent's Aurelia's Vindicator triggered: ... unless ... pays {2}  <- leak
```

That transcript is from a real playtest game. By the time the Vindicator's ward countered
the removal spell, the log had named the card four times.

A face-down permanent has no name (CR 708.2a) and neither does a face-down spell
(CR 708.4), so none of those lines may carry the printed name of the card underneath.

## Why the fix is where the text is built

`ClientEventTransformer` is where log text is assembled, and it is already per-viewer — but it
maps engine events to strings with no `GameState` in hand, so it cannot tell a face-down object
from a face-up one. Every decision therefore has to be made where the text is built, which is what
the pre-existing cast-line mask already did.

Those scattered decisions now route through one predicate in `state/FaceDownNaming.kt`. That
matters more than it looks, because **all three public zones answer differently**:

- **Stack** — a spell cast face down carries no `FaceDownComponent`; that is stamped as the spell
  resolves. Its status rides `SpellOnStackComponent.castFaceDown` instead. My first attempt checked
  only the component and left the stack case leaking; the test caught it.
- **Battlefield** — `FaceDownComponent`, but checked against the *physical* zone.
  `GameState.getBattlefield()` deliberately hides phased-out permanents, and phasing never moves a
  permanent out of the zone (CR 702.26d), so a phased-out face-down permanent must stay masked.
  The memoized accessor still handles the fast path; the unmemoized physical scan is reached only
  for phased-out entities.
- **Exile** — `FaceDownComponent` again, but the object is not a creature, so it reads
  **"Face-down card"** — the name its own card view already uses.

Anything that has left all three keeps its real name: its owner reveals it to every player as it
goes (CR 708.9).

## Who the mask applies to

**Text with no audience** — game-log lines, decision summaries — masks for both players, as the
cast line always has. The object genuinely has no name, and a controller who wants to know what
their own face-down permanent is looks at the card (CR 708.5).

**Text with an audience** uses `nameVisibleTo`, which lets a player read their own face-down object
and treats a spectator as never entitled to. This is the gate `ClientStateTransformer` already
applies to card views, so a label and the card it labels always agree — and it keeps modal spells
consistent with non-modal ones, whose targets ship as bare entity ids and are named client-side off
that same per-viewer card view. Threading it through cost one extra parameter on
`transformAbilityOnStack` and `buildPerModeTargetGroups`.

## Sites

| File | Text it fixes |
|---|---|
| `StackResolver` `targetNames` (permanent, spell, card) | `cast X targeting <face-down object>` |
| `StackResolver` `ResolvedEvent` | `Aurelia's Vindicator resolved` |
| `StackResolver` `ZoneChangeEvent` | `Opponent's ... entered the battlefield` |
| `StackResolver` `putTriggeredAbility` | `Opponent's ... triggered: ...` |
| `TriggerDetector` `descriptionOverride` ×2 | names interpolated into Evoke / Decayed trigger text |
| `SubmitDecisionHandler` ×2 | `Targeting X`, `Distributed: N to X` |
| `ClientStateTransformer.resolveTargetDisplayName` | stack-view per-mode target labels |
| `Grant{Hexproof,Protection}FromChosenColorExecutor` | keyword-granted event target names |

The two `TriggerDetector` sites are worth calling out: they interpolate the card name *into the
description string*, so masking `AbilityTriggeredEvent.sourceName` downstream would have left the
name sitting in the text beside it. Evoke can't apply to a face-down cast; Decayed can.

No new SDK vocabulary — this is one internal predicate plus a shared constant, no `Effect`,
trigger, or DSL surface.

## Blast radius

Every field touched is display-only. `CommitCrimeEvent`'s matcher
(`TriggerMatcher.kt:377`) reads only `playerId`, never `sourceName`, and both
`CommitCrimeEvent` and `TargetsChosenEvent` map to `null` in `ClientEventTransformer` — so
those two edits change nothing observable today and are defensive only. `SpellCastEvent
.targetNames` has no consumer outside the log. No trigger, matcher, or state read touches
any of it.

The one client-side check keyed on the literal `'Face-down creature'`
(`web-client/src/store/slices/handlers/gameplayHandlers.ts:238`) is gated on
`type === 'spellCast'` — the one line this PR does not change.

## Rules cited

Verified against `MagicCompRules_20260808.txt`, not from memory:

- **708.2a** — a face-down permanent is a 2/2 with "no text, no name, no subtypes, and no
  mana cost". This is the rule for *no name*; 708.2 is the general characteristics rule.
- **708.4** — objects cast face down are turned face down before going on the stack, so
  effects see only the face-down spell's characteristics.
- **708.5** — you may look at a face-down permanent you control.
- **708.9** — a face-down permanent moving off the battlefield is revealed to all players.
- **702.168a / 701.58a** — disguise and cloak both list ward {2} among the face-down
  characteristics. This is why the Vindicator's ward fired at all: the printed ward {2} is
  a face-*up* keyword and does not apply. `TriggerAbilityResolver.getWardTriggeredAbilities`
  already took the right branch; that behavior was correct before this PR and is unchanged.

## Verification

`scripts/gradle-locked :rules-engine:test` — **3116 test cases, 0 failures, 1m 37s.** Confirmed the
suite actually ran rather than being served up-to-date: all 532 result XMLs rewritten at the run
timestamp.

Gate chosen by what the diff reaches: all nine files are under `rules-engine/`. `test-rules` would
add the `:mtg-sets:scenarioTest` fan-out, which nothing here can affect — of the 19 scenario tests
that use `castFaceDown`, not one references `ClientEvent` or `ClientEventTransformer`; they assert
on state, not log strings.

Nine tests in `FaceDownGameLogMaskingTest` cover: the four original log lines, a counterspell
naming a face-down spell, the decision summary, the per-viewer split (controller / opponent /
spectator), and three zone-boundary cases — battlefield, phased-out battlefield, exile, and a
face-down card in hand that must *keep* its name so the mask can't drift into over-masking.

**What this does not cover:**

- **No TypeScript ran.** `node_modules` is absent and the network is firewalled, so the web-client
  is unverified by any tool. The reasoning below about `gameplayHandlers.ts` is a code read, not a
  test result.
- **No game-server run.** `ClientStateTransformer` is used by `:game-server`, and this PR changes
  two of its private signatures (adding `isSpectator`). Both are private with call sites inside the
  same file, so nothing outside the class can break — but `:game-server:test` was not run.

## Deliberately left out

Nothing from the review round remains open. The earlier draft of this PR deferred face-down cards
in exile, the three duplicated string literals, and the helper's placement; all three are now in.
