### PR TITLE
Add 73 Assay-ready cards to Ikoria: Lair of Behemoths

### DIFF
--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/IvyElemental.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/IvyElemental.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ivy Elemental
+ * {X}{G}
+ * Creature — Elemental
+ * 0/0
+ * This creature enters with X +1/+1 counters on it.
+ *
+ * The counters are an [EntersWithDynamicCounters] replacement (CR 614.1c) rather than an
+ * enters trigger, so the body is never a 0/0 on the battlefield.
+ */
+val IvyElemental = card("Ivy Elemental") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with X +1/+1 counters on it."
+
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Ron Spencer"
+        flavorText = "In the gardens of the centaurs, many travelers have mysteriously vanished while admiring the elaborate topiaries."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GreaterSandwurm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GreaterSandwurm.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Greater Sandwurm
+ * {5}{G}{G}
+ * Creature — Wurm
+ * 7/7
+ * This creature can't be blocked by creatures with power 2 or less.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The evasion is the standard [CantBeBlockedBy] over [GameObjectFilter.Creature.powerAtMost],
+ * which reads projected power so pumped blockers stop qualifying.
+ */
+val GreaterSandwurm = card("Greater Sandwurm") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 7
+    toughness = 7
+    oracleText = "This creature can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2))
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Steven Belledin"
+        flavorText = "A sandwurm can lie in wait beneath the sands for years until the slightest tremor alerts it to the presence of prey."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/UnlikelyAidReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/UnlikelyAidReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unlikely Aid reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val UnlikelyAidReprint = Printing(
+    oracleId = "795e0ffb-fcd9-4cb9-ad18-8a0217229bfe",
+    name = "Unlikely Aid",
+    setCode = "ANB",
+    collectorNumber = "64",
+    scryfallId = "4adf7a3f-35df-4322-a61e-e0e4f47da623",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4adf7a3f-35df-4322-a61e-e0e4f47da623.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/IkoriaSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/IkoriaSet.kt
@@ -21,6 +21,10 @@ object IkoriaSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AdaptiveShimmerer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AdaptiveShimmerer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+
+/**
+ * Adaptive Shimmerer — Ikoria: Lair of Behemoths #1
+ * {5} · Creature — Insect · 0/0
+ *
+ * Flash
+ * This creature enters with three +1/+1 counters on it.
+ *
+ * The printed 0/0 body is only ever a 0/0 in the abstract: the counters arrive as the permanent
+ * enters, so it is a 3/3 the first time state-based actions look at it and never dies on entry.
+ * That "as it enters" wording is a replacement effect (CR 614.1c), not an ETB trigger, which is
+ * why it is an [EntersWithCounters] with `selfOnly = true` rather than a triggered ability.
+ */
+val AdaptiveShimmerer = card("Adaptive Shimmerer") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 0
+    oracleText = "Flash\nThis creature enters with three +1/+1 counters on it."
+
+    keywords(Keyword.FLASH)
+
+    replacementEffect(
+        EntersWithCounters(
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Jason Felix"
+        flavorText = "\"You sure you want to see what emerges? You might not like it. It definitely won't like you.\"\n—Kinnan, bonder prodigy"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AdventurousImpulseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AdventurousImpulseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Adventurous Impulse reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val AdventurousImpulseReprint = Printing(
+    oracleId = "5bf49f39-b3d5-4148-8dc2-b5b5011769d2",
+    name = "Adventurous Impulse",
+    setCode = "IKO",
+    collectorNumber = "142",
+    scryfallId = "30811fb2-5767-4106-9a8d-6091f61969c6",
+    artist = "Victor Adame Minguez",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30811fb2-5767-4106-9a8d-6091f61969c6.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AlmightyBrushwagg.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AlmightyBrushwagg.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Almighty Brushwagg — Ikoria: Lair of Behemoths #143
+ * {G} · Creature — Brushwagg · 1/1
+ *
+ * Trample
+ * {3}{G}: This creature gets +3/+3 until end of turn.
+ *
+ * A pure mana sink: the pump targets nothing, it modifies the source itself
+ * ([EffectTarget.Self]), so it can be activated repeatedly and each activation stacks its own
+ * until-end-of-turn Layer 7c modification. Trample is what turns the extra power into damage
+ * once a chump blocker is in the way.
+ */
+val AlmightyBrushwagg = card("Almighty Brushwagg") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Brushwagg"
+    power = 1
+    toughness = 1
+    oracleText = "Trample\n{3}{G}: This creature gets +3/+3 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.ModifyStats(3, 3, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Dmitry Burmak"
+        flavorText = "Laughed at the brushwagg\n—Hunters' expression meaning \"died unexpectedly\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AnticipateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AnticipateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anticipate reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val AnticipateReprint = Printing(
+    oracleId = "a97da5a9-17fc-4367-81e1-17ff81601a63",
+    name = "Anticipate",
+    setCode = "IKO",
+    collectorNumber = "40",
+    scryfallId = "46b6dfb2-ffe4-44fb-bfd9-df11bc3193df",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46b6dfb2-ffe4-44fb-bfd9-df11bc3193df.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AvianOddity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/AvianOddity.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Avian Oddity — Ikoria: Lair of Behemoths #42
+ * {3}{U} · Creature — Bird · 2/4
+ *
+ * Flying
+ * Cycling {2}{U}
+ * When you cycle this card, put a flying counter on target creature you control.
+ *
+ * The cycling payoff is a *keyword counter* (CR 122.1e / 702.9), not an until-end-of-turn grant:
+ * a `flying` counter stays on the creature for good, so the Oddity trades itself for a permanent
+ * evasion upgrade plus the card cycling draws. [Triggers.YouCycleThis] fires from the discard and
+ * resolves with the card already in the graveyard, so the target is chosen at that point.
+ */
+val AvianOddity = card("Avian Oddity") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Cycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, put a flying counter on target creature you control."
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.cycling("{2}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.FLYING, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "42"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BarrierBreach.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BarrierBreach.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Barrier Breach — Ikoria: Lair of Behemoths #145
+ * {2}{G} · Instant
+ *
+ * Exile up to three target enchantments.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Up to three target" is one requirement with `count = 3, optional = true`, so zero targets is a
+ * legal choice and the spell still resolves. The exile is fanned out with [ForEachTargetEffect] so
+ * each chosen enchantment is moved independently — one illegal target on resolution doesn't take
+ * the others with it.
+ */
+val BarrierBreach = card("Barrier Breach") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Exile up to three target enchantments.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        target("target", TargetPermanent(count = 3, optional = true, filter = TargetFilter.Enchantment))
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Exile(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Mathias Kollros"
+        flavorText = "\"They cast wards, thinking it will protect them, but the biggest monsters find a way through.\"\n—Kinnan, bonder prodigy"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BladeBanish.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BladeBanish.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Blade Banish — Ikoria: Lair of Behemoths #4
+ * {3}{W} · Instant
+ *
+ * Exile target creature with power 4 or greater.
+ *
+ * The power restriction lives in the target filter (`powerAtLeast(4)`), so legality is checked at
+ * announcement and again on resolution — a creature that shrinks below 4 power in response is no
+ * longer a legal target and the spell is countered for having none. Power is read from *projected*
+ * state, so pumps and lords count.
+ */
+val BladeBanish = card("Blade Banish") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target creature with power 4 or greater."
+
+    spell {
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(4)))
+        effect = Effects.Exile(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Lie Setiawan"
+        flavorText = "The Wanderer walks many paths. Her blade travels only one."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BlisterspitGremlin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BlisterspitGremlin.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blisterspit Gremlin — Ikoria: Lair of Behemoths #108
+ * {R} · Creature — Gremlin · 1/1
+ *
+ * {1}, {T}: This creature deals 1 damage to each opponent.
+ * Whenever you cast a noncreature spell, untap this creature.
+ *
+ * The two halves are a loop: the untap trigger refunds the tap cost, so every noncreature spell
+ * cast after an activation lets the Gremlin ping again. The untap is a plain
+ * [Effects.Untap] on [EffectTarget.Self] — it doesn't care whether the Gremlin is actually tapped,
+ * and the trigger still goes on the stack either way (CR 603.2).
+ */
+val BlisterspitGremlin = card("Blisterspit Gremlin") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Gremlin"
+    power = 1
+    toughness = 1
+    oracleText = "{1}, {T}: This creature deals 1 damage to each opponent.\n" +
+        "Whenever you cast a noncreature spell, untap this creature."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Simon Dominic"
+        flavorText = "\"Ah, we have a critic.\"\n—Orthion, Lavabrink captain"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BloodfellCavesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BloodfellCavesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodfell Caves reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodfellCavesReprint = Printing(
+    oracleId = "64e29bfc-9313-4e8c-808c-bc27f6b018a6",
+    name = "Bloodfell Caves",
+    setCode = "IKO",
+    collectorNumber = "243",
+    scryfallId = "0c8269e6-b30c-4fdc-82a7-d503c133afa6",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c8269e6-b30c-4fdc-82a7-d503c133afa6.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BlossomingSandsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BlossomingSandsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blossoming Sands reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val BlossomingSandsReprint = Printing(
+    oracleId = "45429b2c-be3b-4b2e-9bab-a059ccbda8cd",
+    name = "Blossoming Sands",
+    setCode = "IKO",
+    collectorNumber = "244",
+    scryfallId = "828044d6-0f53-4caf-a581-d71919df4175",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/828044d6-0f53-4caf-a581-d71919df4175.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BondersEnclave.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BondersEnclave.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bonders' Enclave
+ * Land
+ *
+ * {T}: Add {C}.
+ * {3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.
+ *
+ * The draw ability's restriction reads projected power through the filter's `powerAtLeast`
+ * predicate, so a pumped or animated permanent turns it on.
+ */
+val BondersEnclave = card("Bonders' Enclave") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Effects.DrawCards(1)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Cliff Childs"
+        flavorText = "There is a sanctuary that reveals itself only to those graced by the *eludha*—the mystical connection between bonder and monster."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BoonOfTheWishGiver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BoonOfTheWishGiver.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Boon of the Wish-Giver
+ * {4}{U}{U}
+ * Sorcery
+ *
+ * Draw four cards.
+ * Cycling {1} ({1}, Discard this card: Draw a card.)
+ */
+val BoonOfTheWishGiver = card("Boon of the Wish-Giver") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw four cards.\nCycling {1} ({1}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.DrawCards(4)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{1}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Chris Rahn"
+        flavorText = "\"There is no law of nature that I have not seen Illuna break. Makes you wonder what is truly possible, does it not?\"\n—Rielle, the Everwise"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BristlingBoarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/BristlingBoarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bristling Boar reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val BristlingBoarReprint = Printing(
+    oracleId = "f4aed3d2-04f5-49a4-a6be-d3cf097903f8",
+    name = "Bristling Boar",
+    setCode = "IKO",
+    collectorNumber = "146",
+    scryfallId = "c3c3243c-e9af-4b7d-8296-f7714436e571",
+    artist = "Zezhou Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3c3243c-e9af-4b7d-8296-f7714436e571.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/CheckpointOfficer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/CheckpointOfficer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Checkpoint Officer
+ * {1}{W}
+ * Creature — Human Soldier
+ * 1/2
+ *
+ * {1}{W}, {T}: Tap target creature.
+ */
+val CheckpointOfficer = card("Checkpoint Officer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "{1}{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Manuel Castañón"
+        flavorText = "After what he viewed as Lukka's shocking betrayal, General Kudro enacted stringent security measures at every entry point into Drannith."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/CoordinatedCharge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/CoordinatedCharge.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Coordinated Charge
+ * {4}{W}
+ * Instant
+ *
+ * Creatures you control get +2/+1 until end of turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * Untargeted: the pump snapshots the battlefield as the spell resolves (CR 611.2c), so
+ * creatures that enter afterwards get nothing.
+ */
+val CoordinatedCharge = card("Coordinated Charge") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(2, 1, Filters.Group.creaturesYouControl)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Zoltan Boros"
+        flavorText = "\"Out here we're nothing but our training.\"\n—Ethuk, Coppercoat mage"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Crystacean.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Crystacean.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crystacean
+ * {3}{U}
+ * Creature — Crab
+ * 1/6
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ */
+val Crystacean = card("Crystacean") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 1
+    toughness = 6
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)"
+
+    keywords(Keyword.FLASH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Mathias Kollros"
+        flavorText = "It loves blending into its environment, ambushing prey, and long scuttles on the beach."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DeadWeightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DeadWeightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dead Weight reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadWeightReprint = Printing(
+    oracleId = "b1804304-fac1-4b19-a48d-6ade9407972a",
+    name = "Dead Weight",
+    setCode = "IKO",
+    collectorNumber = "83",
+    scryfallId = "ecf18476-f67b-46e6-905c-e6808981c58a",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ecf18476-f67b-46e6-905c-e6808981c58a.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DivineArrowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DivineArrowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Arrow reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineArrowReprint = Printing(
+    oracleId = "6add505a-9c0f-42e6-898d-be3194c3df33",
+    name = "Divine Arrow",
+    setCode = "IKO",
+    collectorNumber = "9",
+    scryfallId = "5b29acc2-5749-4e8a-924d-3c82406e6393",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b29acc2-5749-4e8a-924d-3c82406e6393.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DurableCoilbug.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DurableCoilbug.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Durable Coilbug
+ * {1}{B}
+ * Creature — Insect
+ * 2/2
+ *
+ * {4}{B}: Return this card from your graveyard to your hand.
+ *
+ * The ability is activated from the graveyard, and the move carries a `fromZone` guard so a
+ * card that has already left the graveyard in response isn't dragged back from elsewhere.
+ */
+val DurableCoilbug = card("Durable Coilbug") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 2
+    toughness = 2
+    oracleText = "{4}{B}: Return this card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{B}")
+        effect = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Milivoj Ćeran"
+        flavorText = "\"I've seen them survive lava, trampling, and a moloch's digestive system. They just roll out and get on with their lives!\"\n—Gannet, Skysail zoologist"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/EasyPrey.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/EasyPrey.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Easy Prey
+ * {1}{B}
+ * Instant
+ * Destroy target creature with mana value 2 or less.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The mana-value cap is a predicate on the target filter rather than a condition on the effect:
+ * `TargetFilter.Creature.manaValueAtMost(2)` bounds the legal-target set, so an illegal creature
+ * can never be chosen and CR 608.2b re-checks it at resolution for free.
+ */
+val EasyPrey = card("Easy Prey") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with mana value 2 or less.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.manaValueAtMost(2)))
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Ekaterina Burmak"
+        flavorText = "The definition of \"bite-sized treat\" depends on who you ask."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/EssenceScatterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/EssenceScatterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Essence Scatter reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val EssenceScatterReprint = Printing(
+    oracleId = "46665089-aa3d-44c3-964d-6638dfbb5782",
+    name = "Essence Scatter",
+    setCode = "IKO",
+    collectorNumber = "49",
+    scryfallId = "5f79c8a0-291e-4e13-b765-4cf8c726cf30",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f79c8a0-291e-4e13-b765-4cf8c726cf30.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FacetReader.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FacetReader.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Facet Reader
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/2
+ * {1}, {T}: Draw a card, then discard a card.
+ *
+ * The looter shape, [Patterns.Hand.loot]: a draw followed by the Gather → Select → Move discard
+ * pipeline. Gathering the hand *after* the draw resolves is what "then" means here — the
+ * just-drawn card is a legal choice for the discard.
+ */
+val FacetReader = card("Facet Reader") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "{1}, {T}: Draw a card, then discard a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Patterns.Hand.loot()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Matt Stewart"
+        flavorText = "\"Every flaw in the crystal represents a moment where our strategy might go wrong.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Farfinder.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Farfinder.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Farfinder
+ * {3}
+ * Creature — Fox
+ * 1/1
+ * Vigilance
+ * When this creature enters, you may search your library for a basic land card, reveal it, put it
+ * into your hand, then shuffle.
+ *
+ * `optional = true` lowers to the CR 601-style consent gate around the whole search, so a
+ * controller who declines never opens the library — which matters, because searching is a public
+ * act (CR 701.23) and the recipe emits the "a player searched their library" event either way.
+ */
+val Farfinder = card("Farfinder") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Creature — Fox"
+    power = 1
+    toughness = 1
+    oracleText = "Vigilance\n" +
+        "When this creature enters, you may search your library for a basic land card, reveal it, " +
+        "put it into your hand, then shuffle."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Leesha Hannigan"
+        flavorText = "\"Take us home,\" she whispered, and the fox's eyes began to glow."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FightAsOne.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FightAsOne.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Fight as One
+ * {W}
+ * Instant
+ * Choose one or both —
+ * • Target Human creature you control gets +1/+1 and gains indestructible until end of turn.
+ * • Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn.
+ *
+ * "Choose one or both" is a two-mode modal with `chooseCount = 2, minChooseCount = 1`. Each mode
+ * carries its own target requirement, so only the picked modes demand a target — and the two
+ * filters partition your creatures by the Human subtype, which is what makes casting both a
+ * two-creature trick rather than a single doubled pump.
+ */
+val FightAsOne = card("Fight as One") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Target Human creature you control gets +1/+1 and gains indestructible until end of turn.\n" +
+        "• Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Target Human creature you control gets +1/+1 and gains indestructible until end of turn.") {
+                val t = target(
+                    "target",
+                    TargetCreature(
+                        filter = TargetFilter(
+                            GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).youControl()
+                        )
+                    )
+                )
+                effect = Effects.Composite(
+                    Effects.ModifyStats(1, 1, t),
+                    Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+                )
+            }
+            mode("Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn.") {
+                val t = target(
+                    "target",
+                    TargetCreature(
+                        filter = TargetFilter(
+                            GameObjectFilter.Creature.notSubtype(Subtype.HUMAN).youControl()
+                        )
+                    )
+                )
+                effect = Effects.Composite(
+                    Effects.ModifyStats(1, 1, t),
+                    Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "12"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FrondlandFelidar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FrondlandFelidar.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Frondland Felidar
+ * {2}{G}{W}
+ * Creature — Cat Beast
+ * 3/5
+ * Vigilance
+ * Creatures you control with vigilance have "{1}, {T}: Tap target creature."
+ *
+ * A lord-shaped [GrantActivatedAbility]: the granted ability lives on each matching creature, so
+ * its {T} taps *that* creature and it answers to that creature's own summoning sickness. The
+ * Felidar grants to itself too — its printed vigilance puts it inside its own filter — and
+ * vigilance is what makes the pair work, since an attacker that stays untapped can still tap for
+ * the ability afterwards. The filter is re-read live, so a creature that gains or loses vigilance
+ * gains or loses the ability with it.
+ */
+val FrondlandFelidar = card("Frondland Felidar") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Cat Beast"
+    power = 3
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Creatures you control with vigilance have \"{1}, {T}: Tap target creature.\""
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap),
+                effect = Effects.Tap(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(TargetCreature())
+            ),
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withKeyword(Keyword.VIGILANCE).youControl()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "186"
+        artist = "Steve Prescott"
+        flavorText = "\"Fear not the behemoth heard from miles away. Fear the stalking felidar, which reveals itself only for the kill.\"\n—Rielle, the Everwise"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FullyGrown.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FullyGrown.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fully Grown
+ * {2}{G}
+ * Instant
+ * Target creature gets +3/+3 until end of turn. Put a trample counter on it.
+ *
+ * Two halves with different lifetimes on one target: the pump is a floating end-of-turn stat
+ * modifier, while the trample counter is a keyword counter (CR 122.1b / 613.1f) and so stays on
+ * the creature permanently.
+ */
+val FullyGrown = card("Fully Grown") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 until end of turn. Put a trample counter on it."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, t),
+            Effects.AddCounters(Counters.TRAMPLE, 1, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Dmitry Burmak"
+        flavorText = "\"One day I woke up and knew I had nothing left to teach her. So now I ride on her shoulders and follow where she leads.\"\n—Gustin, wildbonder"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Glimmerbell.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Glimmerbell.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glimmerbell
+ * {1}{U}
+ * Creature — Elemental Jellyfish
+ * 1/3
+ * Flying
+ * {1}{U}: Untap this creature.
+ *
+ * A pseudo-vigilance jellyfish: the untap is the plain [Effects.Untap] on [EffectTarget.Self],
+ * bought with a repeatable mana-only [Costs.Mana] activation at instant speed.
+ */
+val Glimmerbell = card("Glimmerbell") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Jellyfish"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n{1}{U}: Untap this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Simon Dominic"
+        flavorText = "\"Their paths aren't random, but they don't float with the wind. Could they be following surges in crystalline energy?\"\n—Naireh, Ketria elementalist"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/GreaterSandwurmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/GreaterSandwurmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greater Sandwurm reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val GreaterSandwurmReprint = Printing(
+    oracleId = "d1dfed64-6e88-44c2-b479-9a2d072e4be7",
+    name = "Greater Sandwurm",
+    setCode = "IKO",
+    collectorNumber = "157",
+    scryfallId = "d90c5650-7eb2-480a-856e-a04406096830",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d90c5650-7eb2-480a-856e-a04406096830.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HeightenedReflexes.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HeightenedReflexes.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Heightened Reflexes
+ * {R}
+ * Instant
+ * Target creature gets +1/+0 until end of turn. Put a first strike counter on it.
+ *
+ * The pump expires, the counter doesn't: [Counters.FIRST_STRIKE] is a keyword counter, so the
+ * creature keeps first strike for as long as the counter sits on it. Both halves read the same
+ * named target so "it" is the creature that was targeted.
+ */
+val HeightenedReflexes = card("Heightened Reflexes") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+0 until end of turn. Put a first strike counter on it."
+
+    spell {
+        val creature = target("target", TargetCreature())
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, creature),
+            Effects.AddCounters(Counters.FIRST_STRIKE, 1, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Caio Monteiro"
+        flavorText = "Some crystals glow in the presence of monsters, forming a convenient warning system. Some monsters have learned to outrun the light."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HoneyMammoth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HoneyMammoth.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Honey Mammoth
+ * {4}{G}{G}
+ * Creature — Elephant
+ * 6/6
+ * When this creature enters, you gain 4 life.
+ */
+val HoneyMammoth = card("Honey Mammoth") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant"
+    power = 6
+    toughness = 6
+    oracleText = "When this creature enters, you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Lars Grant-West"
+        flavorText = "\"And I thought *I* had a big sweet tooth.\"\n—Gannet, Skysail zoologist"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HumbleNaturalist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/HumbleNaturalist.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Humble Naturalist
+ * {1}{G}
+ * Creature — Human Druid
+ * 1/3
+ * {T}: Add one mana of any color. Spend this mana only to cast a creature spell.
+ */
+val HumbleNaturalist = card("Humble Naturalist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 1
+    toughness = 3
+    oracleText = "{T}: Add one mana of any color. Spend this mana only to cast a creature spell."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(restriction = ManaRestriction.CreatureSpellsOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Matt Stewart"
+        flavorText = "\"The key to bonding with monsters, no matter their size, is knowing where they like to be scratched.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IkoriaBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IkoriaBasicLands.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Ikoria: Lair of Behemoths Basic Lands
+ *
+ * Ikoria contains 3 art variants of each basic land type.
+ * Cards 260-274 (Plains 260-262, Island 263-265, Swamp 266-268, Mountain 269-271, Forest 272-274)
+ */
+
+
+// =============================================================================
+// Plains (Cards 260-262)
+// =============================================================================
+
+val Plains260 = basicLand("Plains") {
+    collectorNumber = "260"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16ebbce9-fd10-4c14-b52d-cf82c0c1a58c.jpg"
+}
+
+val Plains261 = basicLand("Plains") {
+    collectorNumber = "261"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e84f2b9b-1412-476f-8739-17d35ea48a51.jpg"
+}
+
+val Plains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a65b379-47a9-48f2-be6e-abb4e7868ad0.jpg"
+}
+
+
+// =============================================================================
+// Island (Cards 263-265)
+// =============================================================================
+
+val Island263 = basicLand("Island") {
+    collectorNumber = "263"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b2ad5b3-7257-4521-8916-6b1cbfb89e27.jpg"
+}
+
+val Island264 = basicLand("Island") {
+    collectorNumber = "264"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b9bbc32-a89a-4bed-ab52-ac6569ec74ce.jpg"
+}
+
+val Island265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Nick Southam"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be169f8c-6472-40ec-9b4a-0edcb63e9e2f.jpg"
+}
+
+
+// =============================================================================
+// Swamp (Cards 266-268)
+// =============================================================================
+
+val Swamp266 = basicLand("Swamp") {
+    collectorNumber = "266"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6c8c3f0e-7af4-410b-a675-9ea84f51e812.jpg"
+}
+
+val Swamp267 = basicLand("Swamp") {
+    collectorNumber = "267"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1d99025-46bc-4848-bcbc-bee858ed906c.jpg"
+}
+
+val Swamp268 = basicLand("Swamp") {
+    collectorNumber = "268"
+    artist = "Svetlin Velinov"
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45991831-1018-4f98-a4ad-0998a9577d97.jpg"
+}
+
+
+// =============================================================================
+// Mountain (Cards 269-271)
+// =============================================================================
+
+val Mountain269 = basicLand("Mountain") {
+    collectorNumber = "269"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae3d2fcd-11e0-4071-8c53-cb3315b7360a.jpg"
+}
+
+val Mountain270 = basicLand("Mountain") {
+    collectorNumber = "270"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb1ba09d-ecdd-48c0-af0b-3dc5ef908f9e.jpg"
+}
+
+val Mountain271 = basicLand("Mountain") {
+    collectorNumber = "271"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e609028b-43b8-4aea-9f9a-25aa127482db.jpg"
+}
+
+
+// =============================================================================
+// Forest (Cards 272-274)
+// =============================================================================
+
+val Forest272 = basicLand("Forest") {
+    collectorNumber = "272"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/9/c/9c348494-f60c-4bd1-9077-bff24f2e634b.jpg"
+}
+
+val Forest273 = basicLand("Forest") {
+    collectorNumber = "273"
+    artist = "Jesper Ejsing"
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb61e54a-646b-4c0a-88fe-f55d514202aa.jpg"
+}
+
+val Forest274 = basicLand("Forest") {
+    collectorNumber = "274"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7cf3bbf-acc0-4fe7-a631-aca698190ce2.jpg"
+}
+
+/**
+ * All Ikoria basic land variants.
+ */
+val IkoriaBasicLands = listOf(
+    Plains260, Plains261, Plains262,
+    Island263, Island264, Island265,
+    Swamp266, Swamp267, Swamp268,
+    Mountain269, Mountain270, Mountain271,
+    Forest272, Forest273, Forest274,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ImposingVantasaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ImposingVantasaur.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Imposing Vantasaur
+ * {5}{W}
+ * Creature — Dinosaur
+ * 3/6
+ * Vigilance
+ * Cycling {1} ({1}, Discard this card: Draw a card.)
+ */
+val ImposingVantasaur = card("Imposing Vantasaur") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    power = 3
+    toughness = 6
+    oracleText = "Vigilance\nCycling {1} ({1}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.cycling("{1}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Jonathan Kuo"
+        flavorText = "Raugrin's coastline can be quite beautiful, as long as you avoid the volcanic dinosaurs, the sea dinosaurs, and the roaming beach dinosaurs."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IndathaCrystal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IndathaCrystal.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Indatha Crystal
+ * {3}
+ * Artifact
+ * {T}: Add {W}, {B}, or {G}.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Add {W}, {B}, or {G}" is three separate mana abilities, one per colour — the player picks
+ * which to activate, so there is no resolution-time choice to model.
+ */
+val IndathaCrystal = card("Indatha Crystal") {
+    manaCost = "{3}"
+    colorIdentity = "BGW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W}, {B}, or {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Raoul Vitale"
+        flavorText = "Crystals nestle in the roots of Indatha's helica trees as if being nurtured by their embrace."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IndathaTriome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IndathaTriome.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Indatha Triome
+ * Land — Plains Swamp Forest
+ * ({T}: Add {W}, {B}, or {G}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * The reminder-text mana ability is intrinsic to the basic land subtypes on the type line, so the
+ * only scripted parts are the tapped entry and the cycling cost.
+ */
+val IndathaTriome = card("Indatha Triome") {
+    colorIdentity = "BGW"
+    typeLine = "Land — Plains Swamp Forest"
+    oracleText = "({T}: Add {W}, {B}, or {G}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "248"
+        artist = "Noah Bradley"
+        flavorText = "\"These lowlands were formed thousands of years ago by the behemoth Indath—its final footsteps before vanishing into the sea.\"\n—*Tales of the Ozolith*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IvyElementalReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/IvyElementalReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ivy Elemental reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val IvyElementalReprint = Printing(
+    oracleId = "38517711-e570-4337-b269-addcf8bfdd74",
+    name = "Ivy Elemental",
+    setCode = "IKO",
+    collectorNumber = "161",
+    scryfallId = "8e8aea71-02aa-4799-86fb-efd2a36efc22",
+    artist = "Uriah Voth",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e8aea71-02aa-4799-86fb-efd2a36efc22.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/JungleHollowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/JungleHollowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jungle Hollow reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val JungleHollowReprint = Printing(
+    oracleId = "6de714e1-446d-4fb9-9e3d-bcd3ec6af9ca",
+    name = "Jungle Hollow",
+    setCode = "IKO",
+    collectorNumber = "249",
+    scryfallId = "01926862-bf2d-4a2b-af94-1ea5e4dd7444",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01926862-bf2d-4a2b-af94-1ea5e4dd7444.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/KetriaCrystal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/KetriaCrystal.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Ketria Crystal
+ * {3}
+ * Artifact
+ * {T}: Add {G}, {U}, or {R}.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * An artifact has no basic land subtypes to derive mana from, so the "or" between the three colors
+ * is spelled as three separate {T} mana abilities.
+ */
+val KetriaCrystal = card("Ketria Crystal") {
+    manaCost = "{3}"
+    colorIdentity = "GRU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G}, {U}, or {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Yeong-Hao Han"
+        flavorText = "The dark of night never truly falls on Ketria, where abundant crystals bathe the land in their glow."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/KetriaTriome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/KetriaTriome.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ketria Triome
+ * Land — Forest Island Mountain
+ * ({T}: Add {G}, {U}, or {R}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * The reminder-text mana ability is intrinsic to the basic land subtypes on the type line, so the
+ * only scripted parts are the tapped entry and the cycling cost.
+ */
+val KetriaTriome = card("Ketria Triome") {
+    colorIdentity = "GRU"
+    typeLine = "Land — Forest Island Mountain"
+    oracleText = "({T}: Add {G}, {U}, or {R}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "250"
+        artist = "Sam Burley"
+        flavorText = "Nowhere on Ikoria are monsters more integral to the landscape than Ketria, where the river itself will stand up and roar."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ManedServal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ManedServal.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maned Serval
+ * {1}{W}
+ * Creature — Cat
+ * 1/4
+ * Vigilance
+ */
+val ManedServal = card("Maned Serval") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 4
+    oracleText = "Vigilance"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Jonathan Kuo"
+        flavorText = "\"Don't search the ruins of Orn during the day. Nethroi's many eyes will spot you instantly. Don't go at night either. You'll be dinner for the servals. Maybe just don't go.\"\n—Rasai, Indatha hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/MosscoatGoriak.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/MosscoatGoriak.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mosscoat Goriak
+ * {2}{G}
+ * Creature — Beast
+ * 2/4
+ * Vigilance
+ */
+val MosscoatGoriak = card("Mosscoat Goriak") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 4
+    oracleText = "Vigilance"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Goriaks are as stubborn and hardy as I'd expect of a large herbivore in a wetland habitat. But I never expected them to have such beautiful voices!\"\n—Vivien Reid"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/PatagiaTiger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/PatagiaTiger.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Patagia Tiger
+ * {4}{W}
+ * Creature — Cat
+ * 3/4
+ * Flying
+ * When this creature enters, target Human you control gets +2/+2 until end of turn.
+ *
+ * "Human you control" is a bare tribal noun, so the filter is [GameObjectFilter.Permanent] with the
+ * subtype — not the creature filter. The pump is not "another", so the tiger itself stays legal.
+ */
+val PatagiaTiger = card("Patagia Tiger") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\nWhen this creature enters, target Human you control gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetObject(
+            filter = TargetFilter(GameObjectFilter.Permanent.youControl().withSubtype("Human"))
+        )
+        effect = Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Micah Epstein"
+        flavorText = "Lukka looked out from the parapet and saw not a monster to be put down, but a fierce kind of beauty."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Pyroceratops.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Pyroceratops.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pyroceratops
+ * {3}{R}
+ * Creature — Elemental Dinosaur
+ * 2/3
+ * Trample
+ * Whenever you cast a noncreature spell, put a +1/+1 counter on this creature.
+ *
+ * The same prowess-shaped payoff as Sprite Dragon, on a trampler: [Triggers.YouCastNoncreature]
+ * is the `Player.You` + noncreature-filtered cast watcher, and the growth is a permanent
+ * [Effects.AddCounters] on itself rather than an until-end-of-turn pump — so every counter it
+ * earns keeps pushing damage past a chump blocker.
+ */
+val Pyroceratops = card("Pyroceratops") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Dinosaur"
+    power = 2
+    toughness = 3
+    oracleText = "Trample\nWhenever you cast a noncreature spell, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Jason A. Engle"
+        flavorText = "\"I always thought wizards were supposed to have owls or one-eyed cats for familiars, but flaming dinosaurs work, too.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RaugrinCrystal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RaugrinCrystal.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Raugrin Crystal
+ * {3}
+ * Artifact
+ * {T}: Add {U}, {R}, or {W}.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Add {U}, {R}, or {W}" is three separate mana abilities that happen to share a tap cost, not one
+ * ability with a choice inside it — the same shape the dual and tri lands use. Each is a
+ * [TimingRule.ManaAbility] ability flagged `manaAbility`, so none of them uses the stack (CR 605.1a).
+ */
+val RaugrinCrystal = card("Raugrin Crystal") {
+    manaCost = "{3}"
+    colorIdentity = "RUW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U}, {R}, or {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Kirsten Zirngibl"
+        flavorText = "The vegetation in Raugrin is dull, but that only makes the towering crystal structures gleam brighter."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RaugrinTriome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RaugrinTriome.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Raugrin Triome
+ * Land — Island Mountain Plains
+ * ({T}: Add {U}, {R}, or {W}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * The mana line is printed in reminder-text parentheses because it isn't an ability the card
+ * grants itself — it comes from the basic land types on the type line (CR 305.6), which the engine
+ * reads intrinsically. So the only scripted parts are the tapped-entry replacement and cycling.
+ */
+val RaugrinTriome = card("Raugrin Triome") {
+    colorIdentity = "RUW"
+    typeLine = "Land — Island Mountain Plains"
+    oracleText = "({T}: Add {U}, {R}, or {W}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Jonas De Ro"
+        flavorText = "Raugrin meets the sea with jaws wide, its coast spiked with teeth of crystal and granite."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ReconnaissanceMission.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ReconnaissanceMission.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Reconnaissance Mission
+ * {2}{U}{U}
+ * Enchantment
+ * Whenever a creature you control deals combat damage to a player, you may draw a card.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Whenever a creature you control deals combat damage to a player" is not a trigger on the
+ * enchantment — it is an ability the enchantment *grants* to every creature you control, so it
+ * fires once per creature that connects. [GrantTriggeredAbility] with a group filter is that
+ * shape; the granted ability keeps the SELF binding of
+ * [Triggers.DealsCombatDamageToPlayer], which resolves against whichever creature it is riding on.
+ *
+ * The printed "you may" is a [MayEffect] consent gate around the draw, not an `optional` flag.
+ */
+val ReconnaissanceMission = card("Reconnaissance Mission") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control deals combat damage to a player, you may draw a card.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = MayEffect(effect = Effects.DrawCards(1))
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Johannes Voss"
+        flavorText = "\"The bonders work with creatures that fly, slink, and burrow. Assume they know everything.\"\n—Jirina Kudro"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RuggedHighlandsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RuggedHighlandsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rugged Highlands reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val RuggedHighlandsReprint = Printing(
+    oracleId = "6c922206-6e68-4dcd-9559-88da1074f2c4",
+    name = "Rugged Highlands",
+    setCode = "IKO",
+    collectorNumber = "252",
+    scryfallId = "9a69fa8f-1c2b-453d-8d54-2748890ce925",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a69fa8f-1c2b-453d-8d54-2748890ce925.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RumblingRockslide.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RumblingRockslide.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.lci.cards
+package com.wingedsheep.mtg.sets.definitions.iko.cards
 
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
@@ -34,9 +34,9 @@ val RumblingRockslide = card("Rumbling Rockslide") {
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "163"
-        artist = "Johann Bodin"
-        flavorText = "Sometimes an expedition reaches a natural conclusion. Sometimes it all just comes crashing down."
-        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1782694478"
+        collectorNumber = "134"
+        artist = "Adam Paquette"
+        flavorText = "\"When monsters walk, the earth knows its place and yields.\"\n—Rielle, the Everwise"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg"
     }
 }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SanctuaryLockdown.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SanctuaryLockdown.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sanctuary Lockdown
+ * {2}{W}
+ * Enchantment
+ * Humans you control get +1/+1.
+ * {2}, Tap two untapped Humans you control: Tap target creature an opponent controls.
+ *
+ * "Tap two untapped Humans you control" is a cost, not an effect: [Costs.TapPermanents] carries the
+ * untapped requirement and the you-control restriction itself, so the filter only has to say
+ * "Human permanent". Note it is a *permanent* filter rather than a creature one — the printed
+ * tribal noun is the whole restriction, and a noncreature Human (an animated Vehicle, say) pays it
+ * just as well.
+ */
+val SanctuaryLockdown = card("Sanctuary Lockdown") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Humans you control get +1/+1.\n{2}, Tap two untapped Humans you control: Tap target creature an opponent controls."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Human").youControl())
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.TapPermanents(
+                count = 2,
+                filter = GameObjectFilter.Permanent.withSubtype("Human")
+            )
+        )
+        val victim = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Lius Lasahido"
+        flavorText = "\"Drannith gives no quarter to traitors.\"\n—General Kudro"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SanctuarySmasher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SanctuarySmasher.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Sanctuary Smasher
+ * {4}{R}{R}
+ * Creature — Rhino Beast
+ * 6/4
+ * First strike
+ * Cycling {2}{R} ({2}{R}, Discard this card: Draw a card.)
+ * When you cycle this card, put a first strike counter on target creature you control.
+ *
+ * The cycling trigger (CR 702.29b) goes on the stack from the discard and resolves from the
+ * graveyard, so the Smasher hands its own first strike to something already on the battlefield
+ * without ever being cast. [Counters.FIRST_STRIKE] is a keyword counter (CR 122.1b / 613.1f), so
+ * unlike a granted keyword it never expires.
+ */
+val SanctuarySmasher = card("Sanctuary Smasher") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Rhino Beast"
+    power = 6
+    toughness = 4
+    oracleText = "First strike\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle this card, put a first strike counter on target creature you control."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    keywordAbility(KeywordAbility.cycling("{2}{R}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.FIRST_STRIKE, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiCrystal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiCrystal.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Savai Crystal
+ * {3}
+ * Artifact
+ * {T}: Add {R}, {W}, or {B}.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The "or" mana line is three separate mana abilities, one per colour — the player picks which
+ * ability to activate rather than choosing inside a single one.
+ */
+val SavaiCrystal = card("Savai Crystal") {
+    manaCost = "{3}"
+    colorIdentity = "BRW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R}, {W}, or {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Daniel Ljunggren"
+        flavorText = "The same crystals that root deep enough to pierce Savai's catacombs also soar high enough to change its weather."
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiTriome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiTriome.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Savai Triome
+ * Land — Mountain Plains Swamp
+ * ({T}: Add {R}, {W}, or {B}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * The mana line is reminder text: the three basic land subtypes grant their mana abilities
+ * intrinsically, so the script carries only the tapped-entry replacement and cycling.
+ */
+val SavaiTriome = card("Savai Triome") {
+    colorIdentity = "BRW"
+    typeLine = "Land — Mountain Plains Swamp"
+    oracleText = "({T}: Add {R}, {W}, or {B}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "253"
+        artist = "Titus Lunter"
+        flavorText = "Broad prairies feed the human sanctuary of Drannith and conceal a network of caverns where giant cats make their dens."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ScouredBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ScouredBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scoured Barrens reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val ScouredBarrensReprint = Printing(
+    oracleId = "d37f858e-03c8-4594-9b92-cd03699a1591",
+    name = "Scoured Barrens",
+    setCode = "IKO",
+    collectorNumber = "254",
+    scryfallId = "2282018a-46c8-41ca-ab93-f7dbf32cd295",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/2282018a-46c8-41ca-ab93-f7dbf32cd295.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SerratedScorpion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SerratedScorpion.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Serrated Scorpion
+ * {B}
+ * Creature — Scorpion
+ * 1/2
+ *
+ * When this creature dies, it deals 2 damage to each opponent and you gain 2 life.
+ *
+ * A single dies trigger carrying both halves as one composite effect — the damage is dealt to
+ * every opponent at once (so it scales in multiplayer) while the life gain is a flat 2 for the
+ * controller regardless of how many opponents were hit.
+ */
+val SerratedScorpion = card("Serrated Scorpion") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Scorpion"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature dies, it deals 2 damage to each opponent and you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Composite(
+            Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Chris Seaman"
+        flavorText = "Each scorpion's venom is unique, thwarting sanctuary healers' attempts to develop an antidote."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SplendorMare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SplendorMare.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Splendor Mare
+ * {2}{W}
+ * Creature — Elk Unicorn
+ * 3/3
+ *
+ * Lifelink
+ * Cycling {1}{W} ({1}{W}, Discard this card: Draw a card.)
+ * When you cycle this card, put a lifelink counter on target creature you control.
+ *
+ * The cycling trigger (CR 702.29b) goes on the stack from the discard and resolves from the
+ * graveyard, so the Mare hands its lifelink to something already on the battlefield without ever
+ * being cast. A lifelink counter is a keyword counter (CR 122.1b / 613.1f) — the projection maps
+ * it to the keyword, so the grant lasts as long as the counter does.
+ */
+val SplendorMare = card("Splendor Mare") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elk Unicorn"
+    power = 3
+    toughness = 3
+    oracleText = "Lifelink\n" +
+        "Cycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, put a lifelink counter on target creature you control."
+
+    keywords(Keyword.LIFELINK)
+
+    keywordAbility(KeywordAbility.cycling("{1}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.LIFELINK, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Lucas Graciano"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpontaneousFlight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpontaneousFlight.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spontaneous Flight
+ * {2}{W}
+ * Instant
+ * Target creature gets +2/+2 until end of turn. Put a flying counter on it.
+ *
+ * Two effects on one target: the pump expires at end of turn, the flying counter does not. A
+ * flying counter is a keyword counter (CR 122.1b / 613.1f) that the projection maps to the
+ * keyword, so the evasion sticks around long after the +2/+2 has worn off.
+ */
+val SpontaneousFlight = card("Spontaneous Flight") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. Put a flying counter on it."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.AddCounters(Counters.FLYING, 1, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Gabor Szikszai"
+        flavorText = "\"Amazing! And I was only trying to teach her to sit!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpringjawTrap.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpringjawTrap.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Springjaw Trap
+ * {1}
+ * Artifact
+ * Flash
+ * {4}, {T}, Sacrifice this artifact: It deals 3 damage to any target.
+ *
+ * Flash lets the trap land during an opponent's turn, but the {T} in the activation cost means it
+ * still has to wait out summoning-sickness-free artifact timing — an artifact isn't summoning
+ * sick, so it can be deployed and fired in the same window as long as the {4} is available.
+ */
+val SpringjawTrap = card("Springjaw Trap") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Flash\n{4}, {T}, Sacrifice this artifact: It deals 3 damage to any target."
+
+    keywords(Keyword.FLASH)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Zoltan Boros"
+        flavorText = "\"Stop trying to pierce the hide. Hit where it's softest: ankle, sole, hamstring.\"\n—Master Hunter Chevill"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SurvivorsBond.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SurvivorsBond.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Survivors' Bond
+ * {1}{G}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Return target Human creature card from your graveyard to your hand.
+ * • Return target non-Human creature card from your graveyard to your hand.
+ *
+ * "Choose one or both" is `modal(chooseCount = 2, minChooseCount = 1)` — `chooseCount` is the
+ * ceiling and `minChooseCount` the floor (CR 700.2). The two modes are deliberately disjoint:
+ * `Human` vs `non-Human` is `HasSubtype` against `NotSubtype` on the same creature-card filter, so
+ * taking both modes always recurs two different cards.
+ *
+ * Ownership, not control, is the axis on both filters: a card in a graveyard is neither a permanent
+ * nor a spell, so it has no controller — only the owner whose graveyard it sits in.
+ */
+val SurvivorsBond = card("Survivors' Bond") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Return target Human creature card from your graveyard to your hand.\n" +
+        "• Return target non-Human creature card from your graveyard to your hand."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Return target Human creature card from your graveyard to your hand") {
+                val t = target(
+                    "target",
+                    TargetObject(
+                        filter = TargetFilter(
+                            GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).ownedByYou(),
+                            zone = Zone.GRAVEYARD,
+                        ),
+                    ),
+                )
+                effect = Effects.ReturnToHand(t)
+            }
+            mode("Return target non-Human creature card from your graveyard to your hand") {
+                val t = target(
+                    "target",
+                    TargetObject(
+                        filter = TargetFilter(
+                            GameObjectFilter.Creature.notSubtype(Subtype.HUMAN).ownedByYou(),
+                            zone = Zone.GRAVEYARD,
+                        ),
+                    ),
+                )
+                effect = Effects.ReturnToHand(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Randy Vargas"
+        flavorText = "\"And what did we learn? Never taunt a porcuparrot!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SwiftwaterCliffsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SwiftwaterCliffsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftwater Cliffs reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val SwiftwaterCliffsReprint = Printing(
+    oracleId = "2f4ad084-2062-44c0-9975-15f100204531",
+    name = "Swiftwater Cliffs",
+    setCode = "IKO",
+    collectorNumber = "255",
+    scryfallId = "7108c071-5f1c-4cf5-90c6-530cee3f7685",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/7108c071-5f1c-4cf5-90c6-530cee3f7685.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ThornwoodFallsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ThornwoodFallsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thornwood Falls reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val ThornwoodFallsReprint = Printing(
+    oracleId = "ec96cde2-f1e6-495c-94e2-3e8ae79e556c",
+    name = "Thornwood Falls",
+    setCode = "IKO",
+    collectorNumber = "256",
+    scryfallId = "8d011b0f-1681-4a51-9f5d-47ad135d03fe",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d011b0f-1681-4a51-9f5d-47ad135d03fe.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/TitanothRex.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/TitanothRex.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Titanoth Rex
+ * {7}{G}{G}
+ * Creature — Dinosaur Beast
+ * 11/11
+ *
+ * Trample
+ * Cycling {1}{G}
+ * When you cycle this card, put a trample counter on target creature you control.
+ *
+ * The cycling payoff is a separate triggered ability from cycling itself (CR 702.29b): it goes on
+ * the stack from the discard and resolves with the Rex already in the graveyard. A trample counter
+ * is a keyword counter (CR 122.1b / 613.1f) — [Counters.TRAMPLE] is wired through the projector's
+ * keyword-counter map, so the creature has trample for as long as the counter is on it, unlike the
+ * end-of-turn grant a "gains trample" clause would give.
+ */
+val TitanothRex = card("Titanoth Rex") {
+    manaCost = "{7}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur Beast"
+    power = 11
+    toughness = 11
+    oracleText = "Trample\n" +
+        "Cycling {1}{G} ({1}{G}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, put a trample counter on target creature you control."
+
+    keywords(Keyword.TRAMPLE)
+
+    keywordAbility(KeywordAbility.cycling("{1}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.TRAMPLE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/UnlikelyAidReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/UnlikelyAidReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unlikely Aid reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val UnlikelyAidReprint = Printing(
+    oracleId = "795e0ffb-fcd9-4cb9-ad18-8a0217229bfe",
+    name = "Unlikely Aid",
+    setCode = "IKO",
+    collectorNumber = "103",
+    scryfallId = "bac3409e-7c24-43b0-9956-5f0cdeae6468",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/bac3409e-7c24-43b0-9956-5f0cdeae6468.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/VoidBeckoner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/VoidBeckoner.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Void Beckoner
+ * {6}{B}{B}
+ * Creature — Nightmare Horror
+ * 8/8
+ *
+ * Deathtouch
+ * Cycling {2}{B}
+ * When you cycle this card, put a deathtouch counter on target creature you control.
+ *
+ * The black half of Ikoria's keyword-counter cycling cycle (see Titanoth Rex). The payoff is a
+ * separate triggered ability from cycling itself (CR 702.29b) and resolves with the Beckoner
+ * already in the graveyard; a deathtouch counter is a keyword counter (CR 122.1b / 613.1f), so the
+ * creature keeps deathtouch for as long as the counter is on it rather than only until end of turn.
+ */
+val VoidBeckoner = card("Void Beckoner") {
+    manaCost = "{6}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare Horror"
+    power = 8
+    toughness = 8
+    oracleText = "Deathtouch\n" +
+        "Cycling {2}{B} ({2}{B}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, put a deathtouch counter on target creature you control."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    keywordAbility(KeywordAbility.cycling("{2}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.DEATHTOUCH, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WeaponizeTheMonsters.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WeaponizeTheMonsters.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Weaponize the Monsters
+ * {R}
+ * Enchantment
+ *
+ * {2}, Sacrifice a creature: This enchantment deals 2 damage to any target.
+ *
+ * The Stormbind shape: a [Costs.Composite] of the mana atom and a sacrifice atom over
+ * [GameObjectFilter.Creature]. The sacrifice is a *cost*, so it happens on activation and can't be
+ * responded to — the creature is already gone by the time the ability resolves, and the ability
+ * still deals its damage if the creature is somehow saved after.
+ */
+val WeaponizeTheMonsters = card("Weaponize the Monsters") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{2}, Sacrifice a creature: This enchantment deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Magali Villeneuve"
+        flavorText = "Revenge is a path inevitably walked alone."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WhirlwindOfThought.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WhirlwindOfThought.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whirlwind of Thought
+ * {1}{U}{R}{W}
+ * Enchantment
+ *
+ * Whenever you cast a noncreature spell, draw a card.
+ *
+ * [Triggers.YouCastNoncreature] already carries both halves of the sentence — the
+ * `GameObjectFilter.Noncreature` spell filter and `Player.You` — so the trigger needs no extra
+ * scoping. It fires on *cast*, not on resolution: the card is drawn even if the spell that caused
+ * it is countered, and the draw trigger goes on the stack above the spell.
+ */
+val WhirlwindOfThought = card("Whirlwind of Thought") {
+    manaCost = "{1}{U}{R}{W}"
+    colorIdentity = "RUW"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a noncreature spell, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Bram Sels"
+        flavorText = "As Narset struggled to meditate, tiny dragonlings spiraled around her, conjuring thoughts of ancient clans."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Wilt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Wilt.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Wilt
+ * {1}{G}
+ * Instant
+ *
+ * Destroy target artifact or enchantment.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The green Naturalize with a floor: [Targets.ArtifactOrEnchantment] is a single `Or` predicate, so
+ * an artifact enchantment satisfies it once and only one target is chosen. Cycling (CR 702.29a) is
+ * an activated ability of the card in hand, which is what makes the card castable-or-not a
+ * non-decision in an artifact-light matchup.
+ */
+val Wilt = card("Wilt") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Volkan Baǵa"
+        flavorText = "Nothing returns from the nightmare nests of Indatha unscathed."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WindScarredCragReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/WindScarredCragReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wind-Scarred Crag reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val WindScarredCragReprint = Printing(
+    oracleId = "b0af0c54-2a59-4075-8543-d41ff20c4c87",
+    name = "Wind-Scarred Crag",
+    setCode = "IKO",
+    collectorNumber = "258",
+    scryfallId = "86367edc-9587-4f3b-aa95-c3a2bfc8c6f4",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86367edc-9587-4f3b-aa95-c3a2bfc8c6f4.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ZagothCrystal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ZagothCrystal.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Zagoth Crystal
+ * {3}
+ * Artifact
+ * {T}: Add {B}, {G}, or {U}.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The "or" mana line is three separate mana abilities, one per colour — the player picks which
+ * ability to activate rather than choosing inside a single one.
+ */
+val ZagothCrystal = card("Zagoth Crystal") {
+    manaCost = "{3}"
+    colorIdentity = "BGU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B}, {G}, or {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "242"
+        artist = "Raoul Vitale"
+        flavorText = "From the fertile muck of Zagoth, everything—animal, botanical, and crystalline—grows with rugged beauty."
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ZagothTriome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ZagothTriome.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Zagoth Triome
+ * Land — Swamp Forest Island
+ * ({T}: Add {B}, {G}, or {U}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * The mana line is reminder text: the three basic land subtypes grant their mana abilities
+ * intrinsically, so the script carries only the tapped-entry replacement and cycling.
+ */
+val ZagothTriome = card("Zagoth Triome") {
+    colorIdentity = "BGU"
+    typeLine = "Land — Swamp Forest Island"
+    oracleText = "({T}: Add {B}, {G}, or {U}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Eytan Zana"
+        flavorText = "Hunters in the primeval wetlands become fluent in reading the ripples to tell when to pursue and when to flee."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlisterspitGremlinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlisterspitGremlinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blisterspit Gremlin reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val BlisterspitGremlinReprint = Printing(
+    oracleId = "cd8a90a7-5502-405f-a49e-ad4252872595",
+    name = "Blisterspit Gremlin",
+    setCode = "J22",
+    collectorNumber = "500",
+    scryfallId = "12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8",
+    artist = "Simon Dominic",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12fed3bc-6ce1-409c-9eac-ce6fd12d9ea8.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BondersEnclaveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BondersEnclaveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bonders' Enclave reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val BondersEnclaveReprint = Printing(
+    oracleId = "f33ce38a-34ec-4b65-a0fc-160484a02007",
+    name = "Bonders' Enclave",
+    setCode = "J22",
+    collectorNumber = "811",
+    scryfallId = "026f06a2-9d89-4cf7-aa4c-fe7ca4163511",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/026f06a2-9d89-4cf7-aa4c-fe7ca4163511.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DurableCoilbugReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DurableCoilbugReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Durable Coilbug reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val DurableCoilbugReprint = Printing(
+    oracleId = "a421582a-f673-4f43-beb5-28ee785da11e",
+    name = "Durable Coilbug",
+    setCode = "J22",
+    collectorNumber = "408",
+    scryfallId = "58725475-ff77-4511-9797-c44b0fa9909d",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58725475-ff77-4511-9797-c44b0fa9909d.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/ReconnaissanceMissionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/ReconnaissanceMissionReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reconnaissance Mission reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val ReconnaissanceMissionReprint = Printing(
+    oracleId = "11bf211c-95a3-4e7f-bd08-13f979d54e73",
+    name = "Reconnaissance Mission",
+    setCode = "VOC",
+    collectorNumber = "111",
+    scryfallId = "b2364119-d764-4ef1-86cf-a0b7a5ae1b38",
+    artist = "Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2364119-d764-4ef1-86cf-a0b7a5ae1b38.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/UnlikelyAid.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/UnlikelyAid.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Unlikely Aid
+ * {1}{B}
+ * Instant
+ * Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and effects
+ * that say "destroy" don't destroy it.)
+ *
+ * One sentence, two effects over the same bound target: the pump and the keyword grant. Both
+ * default to `Duration.EndOfTurn`, which is what the printed "until end of turn" says.
+ */
+val UnlikelyAid = card("Unlikely Aid") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        val t = target("target", TargetCreature())
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, t),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Viktor Titov"
+        flavorText = "\"No one will ever ride me again, Gideon. Expect no further favors.\"\n—Rakdos"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RumblingRockslideReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RumblingRockslideReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rumbling Rockslide reprint in LCI. Canonical CardDefinition lives in its earliest set.
+ */
+val RumblingRockslideReprint = Printing(
+    oracleId = "0909cbce-b4a0-42bb-8a97-47eeb99606c0",
+    name = "Rumbling Rockslide",
+    setCode = "LCI",
+    collectorNumber = "163",
+    scryfallId = "4f06b53f-ec82-4d7f-bee3-6ca04583f023",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg",
+    releaseDate = "2023-11-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ReconnaissanceMissionReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ReconnaissanceMissionReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reconnaissance Mission reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val ReconnaissanceMissionReprint = Printing(
+    oracleId = "11bf211c-95a3-4e7f-bd08-13f979d54e73",
+    name = "Reconnaissance Mission",
+    setCode = "MSC",
+    collectorNumber = "153",
+    scryfallId = "9fdd83d4-b473-498f-b45e-174f025e1259",
+    artist = "Berto Martinez",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9fdd83d4-b473-498f-b45e-174f025e1259.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/WhirlwindOfThoughtReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/WhirlwindOfThoughtReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whirlwind of Thought reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val WhirlwindOfThoughtReprint = Printing(
+    oracleId = "6467cbb7-1e4e-482d-a20f-6cb9fc0f1ad1",
+    name = "Whirlwind of Thought",
+    setCode = "MSC",
+    collectorNumber = "190",
+    scryfallId = "a3069683-0ff5-49e5-b7ae-f5bd40a4a32f",
+    artist = "Viktor Fetsch",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3069683-0ff5-49e5-b7ae-f5bd40a4a32f.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -355,6 +355,49 @@
     ]
 }
 
+// Greater Sandwurm
+{
+    "name": "Greater Sandwurm",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "This creature can't be blocked by creatures with power 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtMost",
+                            "max": 2
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Steven Belledin",
+        "flavorText": "A sandwurm can lie in wait beneath the sands for years until the slightest tremor alerts it to the presence of prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6411d177-45fd-4193-8414-0f7e7846d2b9.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hieroglyphic Illumination
 {
     "name": "Hieroglyphic Illumination",

--- a/mtg-sets/src/test/resources/snapshots/cards/IKO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/IKO.json
@@ -1,3 +1,34 @@
+// Adaptive Shimmerer
+{
+    "name": "Adaptive Shimmerer",
+    "manaCost": "{5}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flash\nThis creature enters with three +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Jason Felix",
+        "flavorText": "\"You sure you want to see what emerges? You might not like it. It definitely won't like you.\"\n—Kinnan, bonder prodigy",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8a2e243-e446-46c6-8a37-e26620951c41.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Aegis Turtle
 {
     "name": "Aegis Turtle",
@@ -12,6 +43,1023 @@
         "artist": "Milivoj Ćeran",
         "flavorText": "\"The endurance of the ancient turtles in a land so harsh makes a strong case for patience, tranquility, and composure.\"\n—Gavi, nest warden",
         "imageUri": "https://cards.scryfall.io/normal/front/e/4/e433e7f0-7417-4dfe-a7a4-3f222b0a835f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Almighty Brushwagg
+{
+    "name": "Almighty Brushwagg",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Brushwagg",
+    "oracleText": "Trample\n{3}{G}: This creature gets +3/+3 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Dmitry Burmak",
+        "flavorText": "Laughed at the brushwagg\n—Hunters' expression meaning \"died unexpectedly\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71f2b7ac-8742-468d-b6a3-87881cb522ff.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Avian Oddity
+{
+    "name": "Avian Oddity",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nCycling {2}{U} ({2}{U}, Discard this card: Draw a card.)\nWhen you cycle this card, put a flying counter on target creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "flying",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f325873b-97de-4701-910f-ec5cdb66de33.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Barrier Breach
+{
+    "name": "Barrier Breach",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Exile up to three target enchantments.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Exile"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"They cast wards, thinking it will protect them, but the biggest monsters find a way through.\"\n—Kinnan, bonder prodigy",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/822f8403-77a7-4e75-88af-60d604632f5d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Blade Banish
+{
+    "name": "Blade Banish",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature with power 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow>=4"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Lie Setiawan",
+        "flavorText": "The Wanderer walks many paths. Her blade travels only one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35a30091-7f68-4a67-b47e-f44318fc93b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blisterspit Gremlin
+{
+    "name": "Blisterspit Gremlin",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Gremlin",
+    "oracleText": "{1}, {T}: This creature deals 1 damage to each opponent.\nWhenever you cast a noncreature spell, untap this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Simon Dominic",
+        "flavorText": "\"Ah, we have a critic.\"\n—Orthion, Lavabrink captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ec65b97-d5c0-4609-8a60-3c4daa3e59c1.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bonders' Enclave
+{
+    "name": "Bonders' Enclave",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}: Draw a card. Activate only if you control a creature with power 4 or greater.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature pow>=4"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "RARE",
+        "artist": "Cliff Childs",
+        "flavorText": "There is a sanctuary that reveals itself only to those graced by the *eludha*—the mystical connection between bonder and monster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fe9388d-b1ee-4f35-9fbd-5f504528b398.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Boon of the Wish-Giver
+{
+    "name": "Boon of the Wish-Giver",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw four cards.\nCycling {1} ({1}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 4
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "\"There is no law of nature that I have not seen Illuna break. Makes you wonder what is truly possible, does it not?\"\n—Rielle, the Everwise",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e790851-f0f7-4f1a-80e6-94be649499b6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Checkpoint Officer
+{
+    "name": "Checkpoint Officer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{1}{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Manuel Castañón",
+        "flavorText": "After what he viewed as Lukka's shocking betrayal, General Kudro enacted stringent security measures at every entry point into Drannith.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a0e12f5-7b15-4a8c-b045-35bcbf1fbb90.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Coordinated Charge
+{
+    "name": "Coordinated Charge",
+    "manaCost": "{4}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+1 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Out here we're nothing but our training.\"\n—Ethuk, Coppercoat mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/129c404b-2c1e-4f0b-bb4e-7e8e627a69a8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Crystacean
+{
+    "name": "Crystacean",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Crab",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Mathias Kollros",
+        "flavorText": "It loves blending into its environment, ambushing prey, and long scuttles on the beach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32afec8a-dbae-446e-919a-3efb556f5cb1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Durable Coilbug
+{
+    "name": "Durable Coilbug",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "{4}{B}: Return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "\"I've seen them survive lava, trampling, and a moloch's digestive system. They just roll out and get on with their lives!\"\n—Gannet, Skysail zoologist",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0cbdfb6-c029-440f-bc07-c95e03c20110.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Easy Prey
+{
+    "name": "Easy Prey",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with mana value 2 or less.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=2"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "The definition of \"bite-sized treat\" depends on who you ask.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/312fb6e4-1eb1-4fbb-b7a4-125829a6e96a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Facet Reader
+{
+    "name": "Facet Reader",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Matt Stewart",
+        "flavorText": "\"Every flaw in the crystal represents a moment where our strategy might go wrong.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1199596-ae77-4192-ae70-3e2ebd009b64.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Farfinder
+{
+    "name": "Farfinder",
+    "manaCost": "{3}",
+    "typeLine": "Creature — Fox",
+    "oracleText": "Vigilance\nWhen this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Leesha Hannigan",
+        "flavorText": "\"Take us home,\" she whispered, and the fox's eyes began to glow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53f63f40-46f1-4b9e-b447-ff9274f2b926.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Fight as One
+{
+    "name": "Fight as One",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Target Human creature you control gets +1/+1 and gains indestructible until end of turn.\n• Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Human ctrl:you"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target Human creature you control gets +1/+1 and gains indestructible until end of turn."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Human"
+                                        }
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
+                                }
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target non-Human creature you control gets +1/+1 and gains indestructible until end of turn."
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "UNCOMMON",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c62ea13-9bd5-46ce-a861-68cf9a2c6f8c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Frondland Felidar
+{
+    "name": "Frondland Felidar",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Creature — Cat Beast",
+    "oracleText": "Vigilance\nCreatures you control with vigilance have \"{1}, {T}: Tap target creature.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "creature kw:vigilance ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Fear not the behemoth heard from miles away. Fear the stalking felidar, which reveals itself only for the kill.\"\n—Rielle, the Everwise",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab220695-e1a9-45ec-a1b1-5a82c9c90a03.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Fully Grown
+{
+    "name": "Fully Grown",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 until end of turn. Put a trample counter on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "trample",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"One day I woke up and knew I had nothing left to teach her. So now I ride on her shoulders and follow where she leads.\"\n—Gustin, wildbonder",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b683d3f-025c-4b8d-89d7-3513488649d5.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Glimmerbell
+{
+    "name": "Glimmerbell",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Elemental Jellyfish",
+    "oracleText": "Flying\n{1}{U}: Untap this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Simon Dominic",
+        "flavorText": "\"Their paths aren't random, but they don't float with the wind. Could they be following surges in crystalline energy?\"\n—Naireh, Ketria elementalist",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54f71f8a-546a-465e-a254-09a3ae873ef4.jpg"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -35,6 +1083,349 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Heightened Reflexes
+{
+    "name": "Heightened Reflexes",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+0 until end of turn. Put a first strike counter on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "first strike",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Caio Monteiro",
+        "flavorText": "Some crystals glow in the presence of monsters, forming a convenient warning system. Some monsters have learned to outrun the light.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f7cc8e7-3002-4ee0-869f-931438d8362d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Honey Mammoth
+{
+    "name": "Honey Mammoth",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Elephant",
+    "oracleText": "When this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"And I thought *I* had a big sweet tooth.\"\n—Gannet, Skysail zoologist",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84b9bee2-b973-4de7-b72d-7f36f8e8153c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Humble Naturalist
+{
+    "name": "Humble Naturalist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": "CreatureSpellsOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Matt Stewart",
+        "flavorText": "\"The key to bonding with monsters, no matter their size, is knowing where they like to be scratched.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f56705d-eb64-4cef-b716-edbeac60bf79.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Imposing Vantasaur
+{
+    "name": "Imposing Vantasaur",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Vigilance\nCycling {1} ({1}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Jonathan Kuo",
+        "flavorText": "Raugrin's coastline can be quite beautiful, as long as you avoid the volcanic dinosaurs, the sea dinosaurs, and the roaming beach dinosaurs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6fa5feb-f5e9-4079-acc9-84e458044769.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Indatha Crystal
+{
+    "name": "Indatha Crystal",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W}, {B}, or {G}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "flavorText": "Crystals nestle in the roots of Indatha's helica trees as if being nurtured by their embrace.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdace59f-f025-4717-8eb4-3d1e13b31d2b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Indatha Triome
+{
+    "name": "Indatha Triome",
+    "manaCost": "",
+    "typeLine": "Land — Plains Swamp Forest",
+    "oracleText": "({T}: Add {W}, {B}, or {G}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "RARE",
+        "artist": "Noah Bradley",
+        "flavorText": "\"These lowlands were formed thousands of years ago by the behemoth Indath—its final footsteps before vanishing into the sea.\"\n—*Tales of the Ozolith*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b74bb81-fb9a-40e5-a941-e517430b52f5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Ketria Crystal
+{
+    "name": "Ketria Crystal",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {G}, {U}, or {R}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "The dark of night never truly falls on Ketria, where abundant crystals bathe the land in their glow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7df435cb-3aeb-490a-8fca-91f3b6936965.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Ketria Triome
+{
+    "name": "Ketria Triome",
+    "manaCost": "",
+    "typeLine": "Land — Forest Island Mountain",
+    "oracleText": "({T}: Add {G}, {U}, or {R}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "RARE",
+        "artist": "Sam Burley",
+        "flavorText": "Nowhere on Ikoria are monsters more integral to the landscape than Ketria, where the river itself will stand up and roar.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a249b1f4-2b22-4b67-a207-e0c4ae95d2e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "BLUE"
     ]
 }
 
@@ -141,6 +1532,54 @@
     ]
 }
 
+// Maned Serval
+{
+    "name": "Maned Serval",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"Don't search the ruins of Orn during the day. Nethroi's many eyes will spot you instantly. Don't go at night either. You'll be dinner for the servals. Maybe just don't go.\"\n—Rasai, Indatha hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5ac51e35-e2c5-4457-981c-e59894584288.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Mosscoat Goriak
+{
+    "name": "Mosscoat Goriak",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Goriaks are as stubborn and hardy as I'd expect of a large herbivore in a wetland habitat. But I never expected them to have such beautiful voices!\"\n—Vivien Reid",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c23139d4-0db5-4683-8d49-f4600fbe29e2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Neutralize
 {
     "name": "Neutralize",
@@ -174,6 +1613,108 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Patagia Tiger
+{
+    "name": "Patagia Tiger",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Flying\nWhen this creature enters, target Human you control gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent Human ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Micah Epstein",
+        "flavorText": "Lukka looked out from the parapet and saw not a monster to be put down, but a fierce kind of beauty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be398100-89e2-432b-8017-74fb7e4dbc26.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pyroceratops
+{
+    "name": "Pyroceratops",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental Dinosaur",
+    "oracleText": "Trample\nWhenever you cast a noncreature spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"I always thought wizards were supposed to have owls or one-eyed cats for familiars, but flaming dinosaurs work, too.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6599645-dbb5-4174-bd26-8556af6d89c3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -219,6 +1760,375 @@
     ]
 }
 
+// Raugrin Crystal
+{
+    "name": "Raugrin Crystal",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {U}, {R}, or {W}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Kirsten Zirngibl",
+        "flavorText": "The vegetation in Raugrin is dull, but that only makes the towering crystal structures gleam brighter.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5bce0fb-53d6-47ee-8c5a-a99e50f67fc9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Raugrin Triome
+{
+    "name": "Raugrin Triome",
+    "manaCost": "",
+    "typeLine": "Land — Island Mountain Plains",
+    "oracleText": "({T}: Add {U}, {R}, or {W}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "flavorText": "Raugrin meets the sea with jaws wide, its coast spiked with teeth of crystal and granite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02138fbb-3962-4348-8d31-faaefba0b8b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Reconnaissance Mission
+{
+    "name": "Reconnaissance Mission",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control deals combat damage to a player, you may draw a card.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "flavorText": "\"The bonders work with creatures that fly, slink, and burrow. Assume they know everything.\"\n—Jirina Kudro",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae9f7efa-d125-4f83-825e-172ea099a62a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Rumbling Rockslide
+{
+    "name": "Rumbling Rockslide",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Adam Paquette",
+        "flavorText": "\"When monsters walk, the earth knows its place and yields.\"\n—Rielle, the Everwise",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96f9aaa7-11c7-4cd0-9803-9471c14ab846.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sanctuary Lockdown
+{
+    "name": "Sanctuary Lockdown",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Humans you control get +1/+1.\n{2}, Tap two untapped Humans you control: Tap target creature an opponent controls.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "count": 2,
+                                "filter": "permanent Human"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Human ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Drannith gives no quarter to traitors.\"\n—General Kudro",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1387b7be-f69e-4919-9070-a89654c656f3.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sanctuary Smasher
+{
+    "name": "Sanctuary Smasher",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Rhino Beast",
+    "oracleText": "First strike\nCycling {2}{R} ({2}{R}, Discard this card: Draw a card.)\nWhen you cycle this card, put a first strike counter on target creature you control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "first strike",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc634c10-42c5-4bdc-bc22-f862ae285492.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Savai Crystal
+{
+    "name": "Savai Crystal",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R}, {W}, or {B}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "The same crystals that root deep enough to pierce Savai's catacombs also soar high enough to change its weather.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/6954a5c1-89b1-4edd-814e-8f88fd49cda3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Savai Sabertooth
 {
     "name": "Savai Sabertooth",
@@ -236,6 +2146,93 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Savai Triome
+{
+    "name": "Savai Triome",
+    "manaCost": "",
+    "typeLine": "Land — Mountain Plains Swamp",
+    "oracleText": "({T}: Add {R}, {W}, or {B}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "RARE",
+        "artist": "Titus Lunter",
+        "flavorText": "Broad prairies feed the human sanctuary of Drannith and conceal a network of caverns where giant cats make their dens.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/748e6a61-9c1f-4225-9f04-e54002f63ac3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Serrated Scorpion
+{
+    "name": "Serrated Scorpion",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Scorpion",
+    "oracleText": "When this creature dies, it deals 2 damage to each opponent and you gain 2 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Chris Seaman",
+        "flavorText": "Each scorpion's venom is unique, thwarting sanctuary healers' attempts to develop an antidote.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc8f0242-35e1-4409-9321-56e742e8fef4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -312,6 +2309,173 @@
     ]
 }
 
+// Splendor Mare
+{
+    "name": "Splendor Mare",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elk Unicorn",
+    "oracleText": "Lifelink\nCycling {1}{W} ({1}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, put a lifelink counter on target creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "lifelink",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/535ccc75-b24e-4071-b6a0-fc5267a454e3.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Spontaneous Flight
+{
+    "name": "Spontaneous Flight",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. Put a flying counter on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "flying",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Gabor Szikszai",
+        "flavorText": "\"Amazing! And I was only trying to teach her to sit!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3dc24dd4-d259-4687-8247-f56aa7abb5b9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Springjaw Trap
+{
+    "name": "Springjaw Trap",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\n{4}, {T}, Sacrifice this artifact: It deals 3 damage to any target.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Stop trying to pierce the hide. Hit where it's softest: ankle, sole, hamstring.\"\n—Master Hunter Chevill",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3741de51-ea92-493a-8058-e0f2000e7701.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Sprite Dragon
 {
     "name": "Sprite Dragon",
@@ -362,6 +2526,191 @@
     ]
 }
 
+// Survivors' Bond
+{
+    "name": "Survivors' Bond",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Return target Human creature card from your graveyard to your hand.\n• Return target non-Human creature card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Human own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target Human creature card from your graveyard to your hand"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Human"
+                                        }
+                                    ],
+                                    "controllerPredicate": "OwnedByYou"
+                                },
+                                "zone": "Graveyard"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target non-Human creature card from your graveyard to your hand"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Randy Vargas",
+        "flavorText": "\"And what did we learn? Never taunt a porcuparrot!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/530ff2a1-6447-4653-a661-d9a39156d6fa.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Titanoth Rex
+{
+    "name": "Titanoth Rex",
+    "manaCost": "{7}{G}{G}",
+    "typeLine": "Creature — Dinosaur Beast",
+    "oracleText": "Trample\nCycling {1}{G} ({1}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, put a trample counter on target creature you control.",
+    "creatureStats": {
+        "power": 11,
+        "toughness": 11
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "trample",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d02e1e8-b85b-4e26-8ab8-ca2f49d05b88.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Void Beckoner
+{
+    "name": "Void Beckoner",
+    "manaCost": "{6}{B}{B}",
+    "typeLine": "Creature — Nightmare Horror",
+    "oracleText": "Deathtouch\nCycling {2}{B} ({2}{B}, Discard this card: Draw a card.)\nWhen you cycle this card, put a deathtouch counter on target creature you control.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "deathtouch",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1523cda-c47d-4419-a5d3-fd6ed9867c56.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Voracious Greatshark
 {
     "name": "Voracious Greatshark",
@@ -403,6 +2752,244 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg?1783931068"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Weaponize the Monsters
+{
+    "name": "Weaponize the Monsters",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "{2}, Sacrifice a creature: This enchantment deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "UNCOMMON",
+        "artist": "Magali Villeneuve",
+        "flavorText": "Revenge is a path inevitably walked alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68bba622-a0ab-4c0e-88b1-9120690ea5a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Whirlwind of Thought
+{
+    "name": "Whirlwind of Thought",
+    "manaCost": "{1}{U}{R}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a noncreature spell, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "RARE",
+        "artist": "Bram Sels",
+        "flavorText": "As Narset struggled to meditate, tiny dragonlings spiraled around her, conjuring thoughts of ancient clans.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0699cbc-b499-44a6-82e1-631491aaaec6.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Wilt
+{
+    "name": "Wilt",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Nothing returns from the nightmare nests of Indatha unscathed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55987bab-c24f-4261-b97e-f0ad4474b0a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zagoth Crystal
+{
+    "name": "Zagoth Crystal",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {B}, {G}, or {U}.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "flavorText": "From the fertile muck of Zagoth, everything—animal, botanical, and crystalline—grows with rugged beauty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/9138a442-8e8b-465f-bb76-b6af7e6dab6f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Zagoth Triome
+{
+    "name": "Zagoth Triome",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Forest Island",
+    "oracleText": "({T}: Add {B}, {G}, or {U}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Eytan Zana",
+        "flavorText": "Hunters in the primeval wetlands become fluent in reading the ripples to tell when to pursue and when to flee.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc520518-2063-4b57-a0d4-10cf62a7175e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
         "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -15355,46 +15355,6 @@
     ]
 }
 
-// Rumbling Rockslide
-{
-    "name": "Rumbling Rockslide",
-    "manaCost": "{3}{R}",
-    "typeLine": "Sorcery",
-    "oracleText": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
-    "script": {
-        "spellEffect": {
-            "type": "DealDamage",
-            "amount": {
-                "type": "AggregateBattlefield",
-                "player": "You",
-                "filter": "land"
-            },
-            "target": {
-                "type": "BoundVariable",
-                "name": "target creature"
-            }
-        },
-        "targetRequirements": [
-            {
-                "type": "TargetObject",
-                "filter": {
-                    "baseFilter": "creature"
-                },
-                "id": "target creature"
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "163",
-        "artist": "Johann Bodin",
-        "flavorText": "Sometimes an expedition reaches a natural conclusion. Sometimes it all just comes crashing down.",
-        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1782694478"
-    },
-    "colorIdentityOverride": [
-        "RED"
-    ]
-}
-
 // Runaway Boulder
 {
     "name": "Runaway Boulder",

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -2913,6 +2913,36 @@
     ]
 }
 
+// Ivy Elemental
+{
+    "name": "Ivy Elemental",
+    "manaCost": "{X}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "This creature enters with X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "RARE",
+        "artist": "Ron Spencer",
+        "flavorText": "In the gardens of the centaurs, many travelers have mysteriously vanished while admiring the elaborate topiaries.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc441d3a-e917-4dd6-b5f9-f99075ec398f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kamahl, Pit Fighter
 {
     "name": "Kamahl, Pit Fighter",

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -1220,3 +1220,59 @@
         "RED"
     ]
 }
+
+// Unlikely Aid
+{
+    "name": "Unlikely Aid",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Viktor Titov",
+        "flavorText": "\"No one will ever ride me again, Gideon. Expect no further favors.\"\n—Rakdos",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c260c5c-e796-4f81-9e15-0c5be75106b9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}


### PR DESCRIPTION
Sweeps IKO's ⚡ Assay-ready tail to zero. Every card was authored to `assay compile`'s JSON rather than to the oracle text; no new SDK vocabulary was needed.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 50 | canonical authored in IKO |
| `elsewhere` | 3 | canonical authored in the earlier set + an IKO `Printing` row — Greater Sandwurm → AKH, Ivy Elemental → ODY, Unlikely Aid → WAR |
| `row-only` | 15 | `Printing` row in IKO only |
| `basic` | 5 | `basicLand(...)` vals (15 art variants, cn 260–274) + a new `basicLands` override on `IkoriaSet` |
| `unscaffolded` | 0 | — |

**Reprint tail:** 8 rows in 5 other sets — J22 (3), MSC (2), ANB (1), VOC (1), LCI (1).

## Before / after

| | before | after |
|---|---:|---:|
| IKO Assay-ready | **73** | **0** |
| IKO missing | 250 | 177 (all `LINE_DECLINED` — grammar work, not authoring work) |
| differential: compared | 5161 | 5214 |
| differential: confirmed | 5113 | 5166 |
| differential: **divergent** | **48** | **48** |

**Zero new divergences.** All 53 authored canonicals entered the compared set and every one agrees with Assay's model; the 48 divergences are the pre-existing set, none of them in IKO/AKH/ODY/WAR.

## Findings the sweep surfaced

- **Rumbling Rockslide's canonical was misplaced.** `assay-ready` badged it `row-only` (canonical in LCI), but LCI is a 2023 reprint — IKO is the card's earliest real printing. `generate-reprints.py` caught it as a *misplaced canonical*. Relocated to `iko/cards/` with IKO metadata (cn 134, Adam Paquette); LCI now carries the `Printing` row. `check-card-printing` is green on it. This is the second time a `row-only` badge has meant "misplaced canonical" rather than "just needs a row".
- **`generate-reprints.py --cards-from` still over-emits.** Scoping by canonical *name* pulls in the pre-existing reprint gaps of `row-only` cards whose canonicals this PR never touched — 26 of the 43 generated rows were unrelated (NEO 8, C16 4, ELD 2, KHC/M20/SOI/J22 1 each, all gain-lands / Dead Weight / Bristling Boar / Adventurous Impulse). Dropped from this PR to keep it scoped; they remain a real backlog item.
- **`AbzanDevotee.kt:43` (TDM) is missing the `fromZone` guard** — writes `Effects.Move(EffectTarget.Self, Zone.HAND)` for "Return this card from your graveyard to your hand" where the other seven such cards use `Effects.ReturnToHandFromGraveyard`. Same shape as the previously-recorded 18-card family. Not touched here.
- **`SpriteDragon.kt` (IKO, pre-existing) sets a triggered-ability `description`** that none of the compile JSONs carry. Harmless today, but it would read as a divergence if that card ever enters the compared set.

## Verification

- `just build` — green.
- `just rebless-cards` — only IKO/AKH/ODY/WAR gained cards and LCI lost one; **no existing card's tree changed** (verified card-by-card, not just by diff shape).
- `just assay-differential` — 5214/5166/48, delta 0 divergent.
- `just check-card-printing` — clean for all 54 authored/relocated canonicals.
- `just assay-ready IKO` re-run **on the branch**: 0.
- Metadata for all 53 authored cards machine-diffed against the Scryfall set payload: 0 discrepancies.

No scenario tests: every construct reuses existing, engine-live vocabulary (cycling, keyword counters, `EntersTapped`, mana abilities, `ActivationRestriction.OnlyIfCondition`, `Costs.TapPermanents`, `EntersWithDynamicCounters`), and the differential is the net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)