### PR TITLE
Add 71 Assay-ready cards to Ixalan

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FavorableWinds.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FavorableWinds.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Favorable Winds
+ * {1}{U}
+ * Enchantment
+ *
+ * Creatures you control with flying get +1/+1.
+ */
+val FavorableWinds = card("Favorable Winds") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control with flying get +1/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Winona Nelson"
+        flavorText = "Long thought to be extinct, flocks of gryffs reappeared with Avacyn's return."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "C16",
+    collectorNumber = "292",
+    scryfallId = "3fb05d9e-24b4-4cc6-bb75-fd801d183b69",
+    artist = "Jon Foster",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3fb05d9e-24b4-4cc6-bb75-fd801d183b69.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DragonskullSummit.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DragonskullSummit.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dragonskull Summit
+ * Land
+ *
+ * This land enters tapped unless you control a Swamp or a Mountain.
+ * {T}: Add {B} or {R}.
+ */
+val DragonskullSummit = card("Dragonskull Summit") {
+    typeLine = "Land"
+    colorIdentity = "BR"
+    oracleText = "This land enters tapped unless you control a Swamp or a Mountain.\n" +
+        "{T}: Add {B} or {R}."
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Swamp")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Mountain"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Jon Foster"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DrownedCatacomb.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DrownedCatacomb.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Drowned Catacomb
+ * Land
+ *
+ * This land enters tapped unless you control an Island or a Swamp.
+ * {T}: Add {U} or {B}.
+ */
+val DrownedCatacomb = card("Drowned Catacomb") {
+    typeLine = "Land"
+    colorIdentity = "BU"
+    oracleText = "This land enters tapped unless you control an Island or a Swamp.\n" +
+        "{T}: Add {U} or {B}."
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Conditions.Any(
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Island")),
+            Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Swamp"))
+        )
+    ))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "224"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "M11",
+    collectorNumber = "223",
+    scryfallId = "11b5408a-0fde-48d4-bcbf-b949a20b79c0",
+    artist = "Jon Foster",
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/11b5408a-0fde-48d4-bcbf-b949a20b79c0.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/DrownedCatacombReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/DrownedCatacombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drowned Catacomb reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownedCatacombReprint = Printing(
+    oracleId = "819fc966-434e-470f-91e9-a38df974ad17",
+    name = "Drowned Catacomb",
+    setCode = "M11",
+    collectorNumber = "224",
+    scryfallId = "ddb09397-c3cc-4ecc-aef7-bee4dfa6957f",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddb09397-c3cc-4ecc-aef7-bee4dfa6957f.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "M12",
+    collectorNumber = "225",
+    scryfallId = "f99375bc-7465-4f20-897c-1bc61f65de61",
+    artist = "Jon Foster",
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f99375bc-7465-4f20-897c-1bc61f65de61.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DrownedCatacombReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DrownedCatacombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drowned Catacomb reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownedCatacombReprint = Printing(
+    oracleId = "819fc966-434e-470f-91e9-a38df974ad17",
+    name = "Drowned Catacomb",
+    setCode = "M12",
+    collectorNumber = "226",
+    scryfallId = "39ad4371-6c81-4b4c-98eb-d5c289c8c0e2",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39ad4371-6c81-4b4c-98eb-d5c289c8c0e2.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "M13",
+    collectorNumber = "222",
+    scryfallId = "5e49c561-570c-43dd-a369-48bc7ad7edac",
+    artist = "Jon Foster",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5e49c561-570c-43dd-a369-48bc7ad7edac.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DrownedCatacombReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DrownedCatacombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drowned Catacomb reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownedCatacombReprint = Printing(
+    oracleId = "819fc966-434e-470f-91e9-a38df974ad17",
+    name = "Drowned Catacomb",
+    setCode = "M13",
+    collectorNumber = "223",
+    scryfallId = "8b41b86b-58e1-4601-b8ed-0ad31f03a78d",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b41b86b-58e1-4601-b8ed-0ad31f03a78d.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/UnknownShoresReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/UnknownShoresReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unknown Shores reprint in OGW. Canonical CardDefinition lives in its earliest set.
+ */
+val UnknownShoresReprint = Printing(
+    oracleId = "82c5ec8e-27be-475a-9921-ad61209fd022",
+    name = "Unknown Shores",
+    setCode = "OGW",
+    collectorNumber = "181",
+    scryfallId = "87db92c1-ac17-4e32-840e-7ccbcef31bc6",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87db92c1-ac17-4e32-840e-7ccbcef31bc6.jpg",
+    releaseDate = "2016-01-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/UnknownShores.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/UnknownShores.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Unknown Shores
+ * Land
+ *
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ */
+val UnknownShores = card("Unknown Shores") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "229"
+        artist = "Seb McKinnon"
+        flavorText = "Philosophers speak of a place where myths wash like tides upon the shores of the real."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/JungleDelverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/JungleDelverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jungle Delver reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val JungleDelverReprint = Printing(
+    oracleId = "2f299e69-d82b-48c9-b7f5-cf07cd9dced2",
+    name = "Jungle Delver",
+    setCode = "ANB",
+    collectorNumber = "99",
+    scryfallId = "57fd403a-397e-423e-979a-69cf7a6096d8",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/57fd403a-397e-423e-979a-69cf7a6096d8.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/OverflowingInsightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/OverflowingInsightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overflowing Insight reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val OverflowingInsightReprint = Printing(
+    oracleId = "ff03a063-9634-4746-a208-9dbcde5c6bdb",
+    name = "Overflowing Insight",
+    setCode = "ANB",
+    collectorNumber = "30",
+    scryfallId = "83443ce0-61d7-484d-b6b2-aaf35fb81fea",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/83443ce0-61d7-484d-b6b2-aaf35fb81fea.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/LightningRigCrewReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/LightningRigCrewReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning-Rig Crew reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val LightningRigCrewReprint = Printing(
+    oracleId = "8e0f93d7-7208-4902-bd92-e7bf66d35fef",
+    name = "Lightning-Rig Crew",
+    setCode = "CMR",
+    collectorNumber = "190",
+    scryfallId = "8fa676ef-3f26-43bb-98f9-9b0b9681a7fe",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8fa676ef-3f26-43bb-98f9-9b0b9681a7fe.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RummagingGoblinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RummagingGoblinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rummaging Goblin reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val RummagingGoblinReprint = Printing(
+    oracleId = "2055eb91-ee36-4752-a6dc-581eaef335c8",
+    name = "Rummaging Goblin",
+    setCode = "CMR",
+    collectorNumber = "198",
+    scryfallId = "254391a3-c12a-4944-9da5-ae166094480f",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/254391a3-c12a-4944-9da5-ae166094480f.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/LegionSJudgmentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/LegionSJudgmentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Legion's Judgment reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val LegionSJudgmentReprint = Printing(
+    oracleId = "dce4d65f-cb91-48a2-a2a7-013e73dfb667",
+    name = "Legion's Judgment",
+    setCode = "M21",
+    collectorNumber = "24",
+    scryfallId = "032f6c5a-8d88-4a55-a54b-28df42d801e1",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/032f6c5a-8d88-4a55-a54b-28df42d801e1.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SureStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SureStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sure Strike reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val SureStrikeReprint = Printing(
+    oracleId = "fb694e7e-f66e-4958-b6ed-aa74bc9ac43e",
+    name = "Sure Strike",
+    setCode = "M21",
+    collectorNumber = "163",
+    scryfallId = "064a6f1c-a058-4cc8-b467-5dbecb5eeb99",
+    artist = "Jakub Kasper",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/064a6f1c-a058-4cc8-b467-5dbecb5eeb99.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/UnknownShoresReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/UnknownShoresReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unknown Shores reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val UnknownShoresReprint = Printing(
+    oracleId = "82c5ec8e-27be-475a-9921-ad61209fd022",
+    name = "Unknown Shores",
+    setCode = "THB",
+    collectorNumber = "249",
+    scryfallId = "492181e4-5825-45d4-b8a1-37f29c32a845",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/492181e4-5825-45d4-b8a1-37f29c32a845.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/IxalanSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/IxalanSet.kt
@@ -22,6 +22,10 @@ object IxalanSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BishopOfRebirth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BishopOfRebirth.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Bishop of Rebirth
+ * {3}{W}{W}
+ * Creature — Vampire Cleric
+ * 3/4
+ *
+ * Vigilance
+ * Whenever this creature attacks, you may return target creature card with mana value 3 or less
+ * from your graveyard to the battlefield.
+ */
+val BishopOfRebirth = card("Bishop of Rebirth") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Cleric"
+    oracleText = "Vigilance\n" +
+        "Whenever this creature attacks, you may return target creature card with mana value 3 " +
+        "or less from your graveyard to the battlefield."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val card = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.manaValueAtMost(3).ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        optional = true
+        effect = Effects.Move(card, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Tommy Arnold"
+        flavorText = "\"In the death of the foe lies the resurrection of the faithful.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BlindingFog.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BlindingFog.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blinding Fog
+ * {2}{G}
+ * Instant
+ *
+ * Prevent all damage that would be dealt to creatures this turn. Creatures you control gain
+ * hexproof until end of turn.
+ */
+val BlindingFog = card("Blinding Fog") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all damage that would be dealt to creatures this turn. Creatures you " +
+        "control gain hexproof until end of turn. (They can't be the targets of spells or " +
+        "abilities your opponents control.)"
+
+    spell {
+        effect = Effects.PreventAllDamageToGroup(GroupFilter(GameObjectFilter.Creature)) then
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.youControl()),
+                Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.Self)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Igor Kieryluk"
+        flavorText = "\"I see you, shiny soldiers, but you won't see me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BlossomDryad.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/BlossomDryad.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blossom Dryad
+ * {2}{G}
+ * Creature — Dryad
+ * 2/2
+ *
+ * {T}: Untap target land.
+ */
+val BlossomDryad = card("Blossom Dryad") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    oracleText = "{T}: Untap target land."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        val land = target("target", Targets.Land)
+        effect = Effects.Untap(land)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Shreya Shetty"
+        flavorText = "The only force on Ixalan not interested in finding the golden city is Ixalan itself."
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CallToTheFeast.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CallToTheFeast.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Call to the Feast
+ * {2}{W}{B}
+ * Sorcery
+ *
+ * Create three 1/1 white Vampire creature tokens with lifelink.
+ */
+val CallToTheFeast = card("Call to the Feast") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Sorcery"
+    oracleText = "Create three 1/1 white Vampire creature tokens with lifelink."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Vampire"),
+            keywords = setOf(Keyword.LIFELINK),
+            count = 3,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Yongjae Choi"
+        flavorText = "By the law of church and crown, vampires feed only on the blood of the guilty—those declared heretics, rebels, or enemies of war."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CarnageTyrant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CarnageTyrant.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carnage Tyrant
+ * {4}{G}{G}
+ * Creature — Dinosaur
+ * 7/6
+ *
+ * This spell can't be countered.
+ * Trample, hexproof
+ */
+val CarnageTyrant = card("Carnage Tyrant") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "This spell can't be countered.\n" +
+        "Trample, hexproof"
+    power = 7
+    toughness = 6
+
+    cantBeCountered = true
+
+    keywords(Keyword.TRAMPLE, Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Yeong-Hao Han"
+        flavorText = "Sun Empire commanders are well versed in advanced martial strategy. Still, the correct maneuver is usually to deploy the giant, implacable death lizard."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ChargingMonstrosaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ChargingMonstrosaur.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charging Monstrosaur
+ * {4}{R}
+ * Creature — Dinosaur
+ * 5/5
+ *
+ * Trample, haste
+ */
+val ChargingMonstrosaur = card("Charging Monstrosaur") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Trample, haste"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Zack Stella"
+        flavorText = "\"I knew I should have stayed with the boat. Always stay with the boat!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ContractKilling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ContractKilling.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Contract Killing
+ * {3}{B}{B}
+ * Sorcery
+ *
+ * Destroy target creature. Create two Treasure tokens.
+ */
+val ContractKilling = card("Contract Killing") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Create two Treasure tokens. (They're artifacts with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        val victim = target("target", Targets.Creature)
+        effect = Effects.Destroy(victim) then Effects.CreateTreasure(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Winona Nelson"
+        flavorText = "For a price, the floating city of High and Dry offers all the amenities a pirate could want: rest, recreation, and revenge."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CrashTheRamparts.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CrashTheRamparts.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crash the Ramparts
+ * {2}{G}
+ * Instant
+ *
+ * Target creature gets +3/+3 and gains trample until end of turn.
+ */
+val CrashTheRamparts = card("Crash the Ramparts") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 and gains trample until end of turn."
+
+    spell {
+        val boosted = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(3, 3, boosted) then
+            Effects.GrantKeyword(Keyword.TRAMPLE, boosted)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Mark Behm"
+        flavorText = "The Legion's conquistadors could endure Ixalan's sun. Their forts could withstand a charging ceratops. But nothing can stop a ceratops strengthened by the sun."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DarkNourishment.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DarkNourishment.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Nourishment
+ * {4}{B}
+ * Instant
+ *
+ * Dark Nourishment deals 3 damage to any target. You gain 3 life.
+ */
+val DarkNourishment = card("Dark Nourishment") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Dark Nourishment deals 3 damage to any target. You gain 3 life."
+
+    spell {
+        val victim = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, victim) then Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Josh Hass"
+        flavorText = "Demons lurk in the shadows of ancient ruins, spreading plague and corruption across the land."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeadeyePlunderers.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeadeyePlunderers.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Deadeye Plunderers
+ * {3}{U}{B}
+ * Creature — Human Pirate
+ * 3/3
+ *
+ * This creature gets +1/+1 for each artifact you control.
+ * {2}{U}{B}: Create a Treasure token.
+ */
+val DeadeyePlunderers = card("Deadeye Plunderers") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "This creature gets +1/+1 for each artifact you control.\n" +
+        "{2}{U}{B}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: " +
+        "Add one mana of any color.\")"
+    power = 3
+    toughness = 3
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+            toughnessBonus = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}{B}")
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Greg Opalinski"
+        flavorText = "\"Keep your friends close and your enemies within range.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeathlessAncient.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeathlessAncient.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deathless Ancient
+ * {4}{B}{B}
+ * Creature — Vampire Knight
+ * 4/4
+ *
+ * Flying
+ * Tap three untapped Vampires you control: Return this card from your graveyard to your hand.
+ *
+ * The ability functions from the graveyard (CR 113.6), so `activateFromZone` is the graveyard;
+ * the tap cost is still paid with Vampires on the battlefield.
+ */
+val DeathlessAncient = card("Deathless Ancient") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Knight"
+    oracleText = "Flying\n" +
+        "Tap three untapped Vampires you control: Return this card from your graveyard to your hand."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.TapPermanents(3, GameObjectFilter.Permanent.withSubtype(Subtype.VAMPIRE))
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.GRAVEYARD)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Nils Hamm"
+        flavorText = "\"Ancient one, we have reached the promised shore. The Immortal Sun is near. Drink and awake.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootChampion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootChampion.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deeproot Champion
+ * {1}{G}
+ * Creature — Merfolk Shaman
+ * 1/1
+ *
+ * Whenever you cast a noncreature spell, put a +1/+1 counter on this creature.
+ */
+val DeeprootChampion = card("Deeproot Champion") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Shaman"
+    oracleText = "Whenever you cast a noncreature spell, put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "185"
+        artist = "Raymond Swanland"
+        flavorText = "\"No good will come from what you seek. Turn back now or suffer an ignoble death far from your home.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootWarrior.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootWarrior.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deeproot Warrior
+ * {1}{G}
+ * Creature — Merfolk Warrior
+ * 2/2
+ *
+ * Whenever this creature becomes blocked, it gets +1/+1 until end of turn.
+ */
+val DeeprootWarrior = card("Deeproot Warrior") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Warrior"
+    oracleText = "Whenever this creature becomes blocked, it gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Slawomir Maniak"
+        flavorText = "\"We breathe from our soul and bones to give strength to the jungle. The jungle breathes from its roots and rivers to give strength to us.\"\n—Shaper Falani"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootWaters.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DeeprootWaters.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deeproot Waters
+ * {2}{U}
+ * Enchantment
+ *
+ * Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof.
+ */
+val DeeprootWaters = card("Deeproot Waters") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token " +
+        "with hexproof. (A creature with hexproof can't be the target of spells or abilities " +
+        "your opponents control.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSubtype(Subtype.MERFOLK)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Merfolk"),
+            keywords = setOf(Keyword.HEXPROOF),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Zezhou Chen"
+        flavorText = "A visit to the Deeproot Tree and its ancient spring replenishes a merfolk's connection to nature."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DepthsOfDesire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DepthsOfDesire.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Depths of Desire
+ * {2}{U}
+ * Instant
+ *
+ * Return target creature to its owner's hand. Create a Treasure token.
+ */
+val DepthsOfDesire = card("Depths of Desire") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature to its owner's hand. Create a Treasure token. " +
+        "(It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        val victim = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(victim) then Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "John Stanko"
+        flavorText = "Pockets full of gold, lungs full of brine."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DinosaurStampede.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DinosaurStampede.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dinosaur Stampede
+ * {2}{R}
+ * Instant
+ *
+ * Attacking creatures get +2/+0 until end of turn. Dinosaurs you control gain trample until end
+ * of turn.
+ */
+val DinosaurStampede = card("Dinosaur Stampede") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +2/+0 until end of turn. Dinosaurs you control gain " +
+        "trample until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.attacking()),
+            Effects.ModifyStats(2, 0, EffectTarget.Self)
+        ) then Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Permanent.withSubtype("Dinosaur").youControl()),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Bram Sels"
+        flavorText = "If you're in the way of a ceratops charge and you're made of mere flesh and bone, then you're not really in the way."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DireFleetHoarder.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DireFleetHoarder.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dire Fleet Hoarder
+ * {1}{B}
+ * Creature — Human Pirate
+ * 2/1
+ *
+ * When this creature dies, create a Treasure token.
+ */
+val DireFleetHoarder = card("Dire Fleet Hoarder") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "When this creature dies, create a Treasure token. (It's an artifact with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Deruchenko Alexander"
+        flavorText = "Among the pirates of the Brazen Coalition, the only thing more dangerous than failure is success."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "XLN",
+    collectorNumber = "252",
+    scryfallId = "91570836-9e36-4774-8d5d-7cbcee0012ba",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91570836-9e36-4774-8d5d-7cbcee0012ba.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DrownedCatacombReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DrownedCatacombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drowned Catacomb reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownedCatacombReprint = Printing(
+    oracleId = "819fc966-434e-470f-91e9-a38df974ad17",
+    name = "Drowned Catacomb",
+    setCode = "XLN",
+    collectorNumber = "253",
+    scryfallId = "8ef728f1-5153-47d6-8f9c-dfd473ee0750",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8ef728f1-5153-47d6-8f9c-dfd473ee0750.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DuskLegionDreadnought.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DuskLegionDreadnought.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Dusk Legion Dreadnought
+ * {5}
+ * Artifact — Vehicle
+ * 4/6
+ *
+ * Vigilance
+ * Crew 2
+ */
+val DuskLegionDreadnought = card("Dusk Legion Dreadnought") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Vigilance\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: " +
+        "This Vehicle becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 6
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Titus Lunter"
+        flavorText = "It loomed up over the horizon, silent and dark as a grave."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/EncampmentKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/EncampmentKeeper.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Encampment Keeper
+ * {W}
+ * Creature — Dog
+ * 1/1
+ *
+ * First strike
+ * {7}{W}, {T}, Sacrifice this creature: Creatures you control get +2/+2 until end of turn.
+ */
+val EncampmentKeeper = card("Encampment Keeper") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    oracleText = "First strike\n" +
+        "{7}{W}, {T}, Sacrifice this creature: Creatures you control get +2/+2 until end of turn."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(2, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Craig J Spearing"
+        flavorText = "Paladins of the Sanctum Seeker order are an adventurous lot, venturing into the wilds with monstrous mastiffs at their side."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FathomFleetFirebrand.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FathomFleetFirebrand.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fathom Fleet Firebrand
+ * {1}{R}
+ * Creature — Human Pirate
+ * 2/2
+ *
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ */
+val FathomFleetFirebrand = card("Fathom Fleet Firebrand") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "{1}{R}: This creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Zezhou Chen"
+        flavorText = "As she charges into battle, her arcane tattoos stir and crawl like fiery serpents."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FavorableWindsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FavorableWindsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Favorable Winds reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val FavorableWindsReprint = Printing(
+    oracleId = "2361ca87-6352-4ba3-8d91-b3d71242914d",
+    name = "Favorable Winds",
+    setCode = "XLN",
+    collectorNumber = "56",
+    scryfallId = "adfe8174-4e75-4e8f-b59c-f80a98492b5f",
+    artist = "Shreya Shetty",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adfe8174-4e75-4e8f-b59c-f80a98492b5f.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GlorifierOfDusk.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GlorifierOfDusk.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glorifier of Dusk
+ * {3}{W}{W}
+ * Creature — Vampire Soldier
+ * 4/4
+ *
+ * Pay 2 life: This creature gains flying until end of turn.
+ * Pay 2 life: This creature gains vigilance until end of turn.
+ */
+val GlorifierOfDusk = card("Glorifier of Dusk") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Soldier"
+    oracleText = "Pay 2 life: This creature gains flying until end of turn.\n" +
+        "Pay 2 life: This creature gains vigilance until end of turn."
+    power = 4
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.PayLife(2)
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.PayLife(2)
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "12"
+        artist = "Viktor Titov"
+        flavorText = "\"The blood of the enemy is a sacrament. The strength it gives is proof that our cause is just.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GrazingWhiptail.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GrazingWhiptail.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grazing Whiptail
+ * {2}{G}{G}
+ * Creature — Dinosaur
+ * 3/4
+ *
+ * Reach
+ */
+val GrazingWhiptail = card("Grazing Whiptail") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Reach"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Gabor Szikszai"
+        flavorText = "Often found browsing on the upper canopies of Ixalan's jungles, whiptails are known to absently bat away anything foolish enough to interrupt their meal."
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/HuatlisSnubhorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/HuatlisSnubhorn.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Huatli's Snubhorn
+ * {1}{W}
+ * Creature — Dinosaur
+ * 2/2
+ *
+ * Vigilance
+ */
+val HuatlisSnubhorn = card("Huatli's Snubhorn") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "286"
+        artist = "Randy Vargas"
+        flavorText = "Don't make the mistake of thinking blunt horns can't kill."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ImperialLancer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ImperialLancer.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Imperial Lancer
+ * {W}
+ * Creature — Human Knight
+ * 1/1
+ *
+ * This creature has double strike as long as you control a Dinosaur.
+ */
+val ImperialLancer = card("Imperial Lancer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "This creature has double strike as long as you control a Dinosaur."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, GroupFilter.source())
+        condition = Conditions.ControlPermanentOfType(Subtype.DINOSAUR)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Viktor Titov"
+        flavorText = "\"Together my mount and I are stronger than either of us apart.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/IxalanBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/IxalanBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Ixalan Basic Lands
+ *
+ * Ixalan contains 4 art variants of each basic land type.
+ * Cards 260-279 (Plains 260-263, Island 264-267, Swamp 268-271, Mountain 272-275, Forest 276-279)
+ */
+
+// =============================================================================
+// Plains (Cards 260-263)
+// =============================================================================
+
+val IxalanPlains260 = basicLand("Plains") {
+    collectorNumber = "260"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/51ff6ee0-01f4-432f-916b-ed771904d64c.jpg?1783935694"
+}
+
+val IxalanPlains261 = basicLand("Plains") {
+    collectorNumber = "261"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed39f11e-a7c4-4a35-aed6-7cd7590723b7.jpg?1783935696"
+}
+
+val IxalanPlains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39965b8e-0ddc-4c9d-9eb1-7536ec4a8723.jpg?1783935695"
+}
+
+val IxalanPlains263 = basicLand("Plains") {
+    collectorNumber = "263"
+    artist = "Min Yum"
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0f9fda9-50b0-4ce4-b351-cd2b5e6409c8.jpg?1783935694"
+}
+
+// =============================================================================
+// Island (Cards 264-267)
+// =============================================================================
+
+val IxalanIsland264 = basicLand("Island") {
+    collectorNumber = "264"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40c840af-9a13-4716-8458-09071239cc26.jpg?1783935694"
+}
+
+val IxalanIsland265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/c/f/cf1bec1a-72cd-4a1f-8386-a228fbbdc04d.jpg?1783935691"
+}
+
+val IxalanIsland266 = basicLand("Island") {
+    collectorNumber = "266"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb839476-63ba-4e17-b97d-4bc282a85648.jpg?1783935692"
+}
+
+val IxalanIsland267 = basicLand("Island") {
+    collectorNumber = "267"
+    artist = "Min Yum"
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9fc35243-3801-4c02-a8df-2ccf6ea71a17.jpg?1783935692"
+}
+
+// =============================================================================
+// Swamp (Cards 268-271)
+// =============================================================================
+
+val IxalanSwamp268 = basicLand("Swamp") {
+    collectorNumber = "268"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db69a637-5770-4eea-9b04-c00e6f90a12a.jpg?1783935691"
+}
+
+val IxalanSwamp269 = basicLand("Swamp") {
+    collectorNumber = "269"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e74c620-a445-46a4-a1aa-b5b8ef657f18.jpg?1783935692"
+}
+
+val IxalanSwamp270 = basicLand("Swamp") {
+    collectorNumber = "270"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1af26e12-8518-4b15-afcd-c44faaebb574.jpg?1783935691"
+}
+
+val IxalanSwamp271 = basicLand("Swamp") {
+    collectorNumber = "271"
+    artist = "Min Yum"
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dcf4e561-d430-432e-8c65-a5a12616f552.jpg?1783935695"
+}
+
+// =============================================================================
+// Mountain (Cards 272-275)
+// =============================================================================
+
+val IxalanMountain272 = basicLand("Mountain") {
+    collectorNumber = "272"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15c96b83-d0b3-4da9-bb2d-249cc18b55e9.jpg?1783935689"
+}
+
+val IxalanMountain273 = basicLand("Mountain") {
+    collectorNumber = "273"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a456b1c-de58-4ba2-ac39-9e0b3e2a9b51.jpg?1783935687"
+}
+
+val IxalanMountain274 = basicLand("Mountain") {
+    collectorNumber = "274"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96328602-bf67-42a5-8cca-1fcea5656b8a.jpg?1783935689"
+}
+
+val IxalanMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Min Yum"
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df190cfa-ebb6-48e8-9980-950a26d0f2d8.jpg?1783935687"
+}
+
+// =============================================================================
+// Forest (Cards 276-279)
+// =============================================================================
+
+val IxalanForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7eef5e5c-27be-45f2-a9c8-4e0a65c984d4.jpg?1783935687"
+}
+
+val IxalanForest277 = basicLand("Forest") {
+    collectorNumber = "277"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/ab82f8e3-6f48-4974-bb5c-39feddc51344.jpg?1783935686"
+}
+
+val IxalanForest278 = basicLand("Forest") {
+    collectorNumber = "278"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/398ee871-7b30-4e8c-b0d0-b85e0a37d3b1.jpg?1783935687"
+}
+
+val IxalanForest279 = basicLand("Forest") {
+    collectorNumber = "279"
+    artist = "Min Yum"
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/1676702c-523a-4e57-9cb3-171405cab782.jpg?1783935688"
+}
+
+/**
+ * All Ixalan basic land variants.
+ */
+val IxalanBasicLands = listOf(
+    IxalanPlains260, IxalanPlains261, IxalanPlains262, IxalanPlains263,
+    IxalanIsland264, IxalanIsland265, IxalanIsland266, IxalanIsland267,
+    IxalanSwamp268, IxalanSwamp269, IxalanSwamp270, IxalanSwamp271,
+    IxalanMountain272, IxalanMountain273, IxalanMountain274, IxalanMountain275,
+    IxalanForest276, IxalanForest277, IxalanForest278, IxalanForest279
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/IxallisKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/IxallisKeeper.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ixalli's Keeper
+ * {1}{G}
+ * Creature — Human Shaman
+ * 2/2
+ *
+ * {7}{G}, {T}, Sacrifice this creature: Target creature gets +5/+5 and gains trample until end
+ * of turn.
+ */
+val IxallisKeeper = card("Ixalli's Keeper") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "{7}{G}, {T}, Sacrifice this creature: Target creature gets +5/+5 and gains " +
+        "trample until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        val boosted = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(5, 5, boosted) then
+            Effects.GrantKeyword(Keyword.TRAMPLE, boosted)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Lake Hurwitz"
+        flavorText = "The people of the Sun Empire worship the sun in three aspects. Ixalli is the Verdant Sun, who fosters growth in all things."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/JadeGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/JadeGuardian.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Jade Guardian
+ * {3}{G}
+ * Creature — Merfolk Shaman
+ * 2/2
+ *
+ * Hexproof
+ * When this creature enters, put a +1/+1 counter on target Merfolk you control.
+ */
+val JadeGuardian = card("Jade Guardian") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Shaman"
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your " +
+        "opponents control.)\n" +
+        "When this creature enters, put a +1/+1 counter on target Merfolk you control."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.HEXPROOF)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val merfolk = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK).youControl())
+            )
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, merfolk)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Chris Seaman"
+        flavorText = "The River Heralds believe that jade gives weight to their magic."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/JungleDelver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/JungleDelver.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jungle Delver
+ * {G}
+ * Creature — Merfolk Warrior
+ * 1/1
+ *
+ * {3}{G}: Put a +1/+1 counter on this creature.
+ */
+val JungleDelver = card("Jungle Delver") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Warrior"
+    oracleText = "{3}{G}: Put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Kieran Yanner"
+        flavorText = "\"There is no power too great to be used in the defense of our ancestral lands.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/KinjallisCaller.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/KinjallisCaller.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Kinjalli's Caller
+ * {W}
+ * Creature — Human Cleric
+ * 0/3
+ *
+ * Dinosaur spells you cast cost {1} less to cast.
+ */
+val KinjallisCaller = card("Kinjalli's Caller") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Dinosaur spells you cast cost {1} less to cast."
+    power = 0
+    toughness = 3
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withSubtype(Subtype.DINOSAUR)),
+            modification = CostModification.ReduceGeneric(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Sara Winters"
+        flavorText = "The people of the Sun Empire worship the sun in three aspects. Kinjalli is the Wakening Sun, who created humans from clay and baked them in the sun's warmth."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LegionsJudgment.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LegionsJudgment.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Legion's Judgment
+ * {2}{W}
+ * Sorcery
+ *
+ * Destroy target creature with power 4 or greater.
+ */
+val LegionsJudgment = card("Legion's Judgment") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature with power 4 or greater."
+
+    spell {
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(4)))
+        )
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Lucas Graciano"
+        flavorText = "\"My lance was once wielded by Venerable Tarrian. In his name and by his might, I cast you down!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LightningRigCrew.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LightningRigCrew.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning-Rig Crew
+ * {2}{R}
+ * Creature — Goblin Pirate
+ * 0/5
+ *
+ * {T}: This creature deals 1 damage to each opponent.
+ * Whenever you cast a Pirate spell, untap this creature.
+ */
+val LightningRigCrew = card("Lightning-Rig Crew") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Pirate"
+    oracleText = "{T}: This creature deals 1 damage to each opponent.\n" +
+        "Whenever you cast a Pirate spell, untap this creature."
+    power = 0
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSubtype(Subtype.PIRATE)
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Filip Burburan"
+        flavorText = "A pirate ship in battle is a storm of activity."
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OtepecHuntmaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OtepecHuntmaster.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Otepec Huntmaster
+ * {1}{R}
+ * Creature — Human Shaman
+ * 1/2
+ *
+ * Dinosaur spells you cast cost {1} less to cast.
+ * {T}: Target Dinosaur gains haste until end of turn.
+ */
+val OtepecHuntmaster = card("Otepec Huntmaster") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "Dinosaur spells you cast cost {1} less to cast.\n" +
+        "{T}: Target Dinosaur gains haste until end of turn."
+    power = 1
+    toughness = 2
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withSubtype(Subtype.DINOSAUR)),
+            modification = CostModification.ReduceGeneric(1)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val dino = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype(Subtype.DINOSAUR)))
+        )
+        effect = Effects.GrantKeyword(Keyword.HASTE, dino)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "153"
+        artist = "Daarken"
+        flavorText = "\"Forward! Let the Burning Sun's light guide you to deserving prey!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OverflowingInsight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OverflowingInsight.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overflowing Insight
+ * {4}{U}{U}{U}
+ * Sorcery
+ *
+ * Target player draws seven cards.
+ */
+val OverflowingInsight = card("Overflowing Insight") {
+    manaCost = "{4}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Target player draws seven cards."
+
+    spell {
+        val player = target("target", Targets.Player)
+        effect = Effects.DrawCards(7, player)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "66"
+        artist = "Lucas Graciano"
+        flavorText = "The truth came to Kumena like the Great River's torrent: the only way to keep his enemies away from the hidden city was to claim its power for himself."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PaladinOfTheBloodstained.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PaladinOfTheBloodstained.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Paladin of the Bloodstained
+ * {3}{W}
+ * Creature — Vampire Knight
+ * 3/2
+ *
+ * When this creature enters, create a 1/1 white Vampire creature token with lifelink.
+ */
+val PaladinOfTheBloodstained = card("Paladin of the Bloodstained") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Knight"
+    oracleText = "When this creature enters, create a 1/1 white Vampire creature token with lifelink."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Vampire"),
+            keywords = setOf(Keyword.LIFELINK),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Bastien L. Deharme"
+        flavorText = "Closely linked to the Church of Dusk, the paladins of the Bloodstained order are devout to the point of fanaticism."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PiratesPrize.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PiratesPrize.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pirate's Prize
+ * {3}{U}
+ * Sorcery
+ *
+ * Draw two cards. Create a Treasure token.
+ */
+val PiratesPrize = card("Pirate's Prize") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw two cards. Create a Treasure token. (It's an artifact with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        effect = Effects.DrawCards(2) then Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Deruchenko Alexander"
+        flavorText = "Nothing warms the heart like plunder."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PterodonKnight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PterodonKnight.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Pterodon Knight
+ * {3}{W}
+ * Creature — Human Knight
+ * 3/3
+ *
+ * This creature has flying as long as you control a Dinosaur.
+ */
+val PterodonKnight = card("Pterodon Knight") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "This creature has flying as long as you control a Dinosaur."
+    power = 3
+    toughness = 3
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.source())
+        condition = Conditions.ControlPermanentOfType(Subtype.DINOSAUR)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Anthony Palumbo"
+        flavorText = "\"To rise like the sun—there is no greater feeling.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/QueensCommission.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/QueensCommission.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Queen's Commission
+ * {2}{W}
+ * Sorcery
+ *
+ * Create two 1/1 white Vampire creature tokens with lifelink.
+ */
+val QueensCommission = card("Queen's Commission") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 white Vampire creature tokens with lifelink."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Vampire"),
+            keywords = setOf(Keyword.LIFELINK),
+            count = 2,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Mark Behm"
+        flavorText = "\"Let the blood of the impure flow through you. Only the blessings of the golden city will purge its acrid taste from your mouth.\"\n—High Marshal Arguel"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RaptorHatchling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RaptorHatchling.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raptor Hatchling
+ * {1}{R}
+ * Creature — Dinosaur
+ * 1/1
+ *
+ * Enrage — Whenever this creature is dealt damage, create a 3/3 green Dinosaur creature token
+ * with trample.
+ */
+val RaptorHatchling = card("Raptor Hatchling") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Enrage — Whenever this creature is dealt damage, create a 3/3 green Dinosaur " +
+        "creature token with trample."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Dinosaur"),
+            keywords = setOf(Keyword.TRAMPLE),
+        )
+        description = "Enrage — Whenever this creature is dealt damage, create a 3/3 green " +
+            "Dinosaur creature token with trample."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Even Amundsen"
+        flavorText = "\"Every little hatchling has a parent's claws to guard it.\"\n—Sun Empire saying"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RavenousDaggertooth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RavenousDaggertooth.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Daggertooth
+ * {2}{G}
+ * Creature — Dinosaur
+ * 3/2
+ *
+ * Enrage — Whenever this creature is dealt damage, you gain 2 life.
+ */
+val RavenousDaggertooth = card("Ravenous Daggertooth") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Enrage — Whenever this creature is dealt damage, you gain 2 life."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.GainLife(2)
+        description = "Enrage — Whenever this creature is dealt damage, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "202"
+        artist = "Jakub Kasper"
+        flavorText = "A daggertooth's triumphant roar makes all the sounds of jungle life fall silent."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RegisaurAlpha.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RegisaurAlpha.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Regisaur Alpha
+ * {3}{R}{G}
+ * Creature — Dinosaur
+ * 4/4
+ *
+ * Other Dinosaurs you control have haste.
+ * When this creature enters, create a 3/3 green Dinosaur creature token with trample.
+ */
+val RegisaurAlpha = card("Regisaur Alpha") {
+    manaCost = "{3}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Other Dinosaurs you control have haste.\n" +
+        "When this creature enters, create a 3/3 green Dinosaur creature token with trample."
+    power = 4
+    toughness = 4
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype("Dinosaur").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Dinosaur"),
+            keywords = setOf(Keyword.TRAMPLE),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Jonathan Kuo"
+        flavorText = "\"Seeing a pack of these monsters hunt together, I'm at a loss to imagine the size of their prey.\"\n—Adrian Adanto of Lujio"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RipjawRaptor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RipjawRaptor.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ripjaw Raptor
+ * {2}{G}{G}
+ * Creature — Dinosaur
+ * 4/5
+ *
+ * Enrage — Whenever this creature is dealt damage, draw a card.
+ *
+ * "Enrage" is an ability word (CR 207.2c) — no rules meaning, so it lives in the trigger's
+ * description rather than as a keyword.
+ */
+val RipjawRaptor = card("Ripjaw Raptor") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Enrage — Whenever this creature is dealt damage, draw a card."
+    power = 4
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.DrawCards(1)
+        description = "Enrage — Whenever this creature is dealt damage, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "203"
+        artist = "Ryan Pancoast"
+        flavorText = "Raptors are clever enough to tear away a hard metal shell to get at the tasty morsel inside."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RummagingGoblinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RummagingGoblinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rummaging Goblin reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val RummagingGoblinReprint = Printing(
+    oracleId = "2055eb91-ee36-4752-a6dc-581eaef335c8",
+    name = "Rummaging Goblin",
+    setCode = "XLN",
+    collectorNumber = "160",
+    scryfallId = "8342ad27-f2cd-47c3-bc30-6fae8523f250",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/8342ad27-f2cd-47c3-bc30-6fae8523f250.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShelteringLight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShelteringLight.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sheltering Light
+ * {W}
+ * Instant
+ *
+ * Target creature gains indestructible until end of turn. Scry 1.
+ */
+val ShelteringLight = card("Sheltering Light") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gains indestructible until end of turn. Scry 1. " +
+        "(Damage and effects that say \"destroy\" don't destroy the creature.)"
+
+    spell {
+        val protege = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, protege) then Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Gabor Szikszai"
+        flavorText = "Those who wield the power of the sun protect the Empire from darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShiningAerosaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShiningAerosaur.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shining Aerosaur
+ * {4}{W}
+ * Creature — Dinosaur
+ * 3/4
+ *
+ * Flying
+ */
+val ShiningAerosaur = card("Shining Aerosaur") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Flying"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"The invaders cloak themselves in the shadows of dusk. Aerosaurs hide in the brilliance of the noonday sun.\"\n—Caparocti Sunborn"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShoreKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ShoreKeeper.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shore Keeper
+ * {U}
+ * Creature — Trilobite
+ * 0/3
+ *
+ * {7}{U}, {T}, Sacrifice this creature: Draw three cards.
+ */
+val ShoreKeeper = card("Shore Keeper") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Trilobite"
+    oracleText = "{7}{U}, {T}, Sacrifice this creature: Draw three cards."
+    power = 0
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "YW Tang"
+        flavorText = "Over their long life spans, the larger trilobites accumulate vast treasure troves in their guts."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkitteringHeartstopper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkitteringHeartstopper.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skittering Heartstopper
+ * {B}
+ * Creature — Insect
+ * 1/2
+ *
+ * {B}: This creature gains deathtouch until end of turn.
+ */
+val SkitteringHeartstopper = card("Skittering Heartstopper") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    oracleText = "{B}: This creature gains deathtouch until end of turn."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Aaron Miller"
+        flavorText = "It flows like water over the forest floor, as deadly as the swiftest current."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkyTerror.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkyTerror.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sky Terror
+ * {R}{W}
+ * Creature — Dinosaur
+ * 2/2
+ *
+ * Flying, menace
+ */
+val SkyTerror = card("Sky Terror") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Flying, menace"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Johann Bodin"
+        flavorText = "\"Wherever the Threefold Sun shines, great wings may go.\"\n—Emperor Apatzec Intli III"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkybladeOfTheLegion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SkybladeOfTheLegion.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyblade of the Legion
+ * {1}{W}
+ * Creature — Vampire Soldier
+ * 1/3
+ *
+ * Flying
+ */
+val SkybladeOfTheLegion = card("Skyblade of the Legion") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Soldier"
+    oracleText = "Flying"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Daarken"
+        flavorText = "Vampires call the gift of flight \"exultation.\" For their enemies, it brings only sorrow."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SlashOfTalons.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SlashOfTalons.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Slash of Talons
+ * {W}
+ * Instant
+ *
+ * Slash of Talons deals 2 damage to target attacking or blocking creature.
+ */
+val SlashOfTalons = card("Slash of Talons") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Slash of Talons deals 2 damage to target attacking or blocking creature."
+
+    spell {
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.attackingOrBlocking()))
+        )
+        effect = Effects.DealDamage(2, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Magali Villeneuve"
+        flavorText = "\"The amber sun smokes with fury, gazing on foes that gather like ants invading our home. We are ready! Blade and claw strike as one.\"\n—Huatli"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SleekSchooner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SleekSchooner.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Sleek Schooner
+ * {3}
+ * Artifact — Vehicle
+ * 4/3
+ *
+ * Crew 1
+ */
+val SleekSchooner = card("Sleek Schooner") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Crew 1 (Tap any number of creatures you control with total power 1 or more: " +
+        "This Vehicle becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 3
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "247"
+        artist = "Mark Winters"
+        flavorText = "The pirates had left the open sea behind, but they were still in their element: reckless adventure."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SnappingSailback.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SnappingSailback.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snapping Sailback
+ * {4}{G}
+ * Creature — Dinosaur
+ * 4/4
+ *
+ * Flash
+ * Enrage — Whenever this creature is dealt damage, put a +1/+1 counter on it.
+ */
+val SnappingSailback = card("Snapping Sailback") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Flash\n" +
+        "Enrage — Whenever this creature is dealt damage, put a +1/+1 counter on it. " +
+        "(It must survive the damage to get the counter.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Enrage — Whenever this creature is dealt damage, put a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Dan Murayama Scott"
+        flavorText = "Lurking beneath the murky waters of Ixalan's rivers, sailbacks can rip a meal off the shore in the blink of an eye."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SunCrownedHunters.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SunCrownedHunters.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sun-Crowned Hunters
+ * {4}{R}{R}
+ * Creature — Dinosaur
+ * 5/4
+ *
+ * Enrage — Whenever this creature is dealt damage, it deals 3 damage to target opponent or
+ * planeswalker.
+ */
+val SunCrownedHunters = card("Sun-Crowned Hunters") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Enrage — Whenever this creature is dealt damage, it deals 3 damage to target " +
+        "opponent or planeswalker."
+    power = 5
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        val victim = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.DealDamage(3, victim)
+        description = "Enrage — Whenever this creature is dealt damage, it deals 3 damage to " +
+            "target opponent or planeswalker."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Aaron Miller"
+        flavorText = "One alone is dangerous, and they are never alone."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SureStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SureStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sure Strike reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val SureStrikeReprint = Printing(
+    oracleId = "fb694e7e-f66e-4958-b6ed-aa74bc9ac43e",
+    name = "Sure Strike",
+    setCode = "XLN",
+    collectorNumber = "166",
+    scryfallId = "5370060a-653b-453d-8daf-bef46f9bb4d5",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/5370060a-653b-453d-8daf-bef46f9bb4d5.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/Swashbuckling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/Swashbuckling.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Swashbuckling
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has haste.
+ */
+val Swashbuckling = card("Swashbuckling") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 and has haste."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Josu Hernaiz"
+        flavorText = "The pirates of the Brazen Coalition are the descendants of those displaced by the Legion of Dusk, and they are eager for vengeance."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/TerritorialHammerskull.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/TerritorialHammerskull.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Territorial Hammerskull
+ * {2}{W}
+ * Creature — Dinosaur
+ * 2/3
+ *
+ * Whenever this creature attacks, tap target creature an opponent controls.
+ */
+val TerritorialHammerskull = card("Territorial Hammerskull") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Whenever this creature attacks, tap target creature an opponent controls."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.opponentControls()))
+        )
+        effect = Effects.Tap(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Lars Grant-West"
+        flavorText = "From the eyes up, it's solid bone and stubbornness."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/TilonallisKnight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/TilonallisKnight.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tilonalli's Knight
+ * {1}{R}
+ * Creature — Human Knight
+ * 2/2
+ *
+ * Whenever this creature attacks, if you control a Dinosaur, this creature gets +1/+1 until end
+ * of turn.
+ */
+val TilonallisKnight = card("Tilonalli's Knight") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Whenever this creature attacks, if you control a Dinosaur, this creature gets " +
+        "+1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        interveningIf = Conditions.ControlPermanentOfType(Subtype.DINOSAUR)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Lius Lasahido"
+        flavorText = "The people of the Sun Empire worship the sun in three aspects. Tilonalli is the Burning Sun, associated with ferocity, fire, and passion."
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/UnfriendlyFire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/UnfriendlyFire.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unfriendly Fire
+ * {4}{R}
+ * Instant
+ *
+ * Unfriendly Fire deals 4 damage to any target.
+ */
+val UnfriendlyFire = card("Unfriendly Fire") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Unfriendly Fire deals 4 damage to any target."
+
+    spell {
+        val victim = target("target", Targets.Any)
+        effect = Effects.DealDamage(4, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Josu Hernaiz"
+        flavorText = "Disputes within the Brazen Coalition can escalate from insult to broadside in the blink of an eye."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/UnknownShoresReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/UnknownShoresReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unknown Shores reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val UnknownShoresReprint = Printing(
+    oracleId = "82c5ec8e-27be-475a-9921-ad61209fd022",
+    name = "Unknown Shores",
+    setCode = "XLN",
+    collectorNumber = "259",
+    scryfallId = "517315dc-591f-4af4-a319-542ad9a2e4b8",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/517315dc-591f-4af4-a319-542ad9a2e4b8.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ViciousConquistador.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ViciousConquistador.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vicious Conquistador
+ * {B}
+ * Creature — Vampire Soldier
+ * 1/2
+ *
+ * Whenever this creature attacks, each opponent loses 1 life.
+ */
+val ViciousConquistador = card("Vicious Conquistador") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Soldier"
+    oracleText = "Whenever this creature attacks, each opponent loses 1 life."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "128"
+        artist = "Kieran Yanner"
+        flavorText = "\"He is ambitious. Tireless. And utterly ruthless. Ideal for the frontier.\"\n—Viceroy Elia Sotonores, report to the queen"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VonaButcherOfMagan.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VonaButcherOfMagan.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Vona, Butcher of Magan
+ * {3}{W}{B}
+ * Legendary Creature — Vampire Knight
+ * 4/4
+ *
+ * Vigilance, lifelink
+ * {T}, Pay 7 life: Destroy target nonland permanent. Activate only during your turn.
+ */
+val VonaButcherOfMagan = card("Vona, Butcher of Magan") {
+    manaCost = "{3}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Legendary Creature — Vampire Knight"
+    oracleText = "Vigilance, lifelink\n" +
+        "{T}, Pay 7 life: Destroy target nonland permanent. Activate only during your turn."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE, Keyword.LIFELINK)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(7))
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Nonland and GameObjectFilter.Permanent))
+        )
+        effect = Effects.Destroy(victim)
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "231"
+        artist = "Volkan Baǵa"
+        flavorText = "\"For four hundred years, I have led armies of conquest. These lands hold nothing that can stand against me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VraskasContempt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VraskasContempt.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vraska's Contempt
+ * {2}{B}{B}
+ * Instant
+ *
+ * Exile target creature or planeswalker. You gain 2 life.
+ */
+val VraskasContempt = card("Vraska's Contempt") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature or planeswalker. You gain 2 life."
+
+    spell {
+        val victim = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Move(victim, Zone.EXILE) then Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "129"
+        artist = "Clint Cearley"
+        flavorText = "It wasn't long before the taverns of High and Dry were full of whispers about the new captain who could turn a person to stone with a glance."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WalkThePlank.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WalkThePlank.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Walk the Plank
+ * {B}{B}
+ * Sorcery
+ *
+ * Destroy target non-Merfolk creature.
+ */
+val WalkThePlank = card("Walk the Plank") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target non-Merfolk creature."
+
+    spell {
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.notSubtype(Subtype.MERFOLK)))
+        )
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Kieran Yanner"
+        flavorText = "When Captain Thorn adds a new ship to his fleet, he gives the crew a simple choice: follow me, or fall in the sea."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WilyGoblin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WilyGoblin.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wily Goblin
+ * {R}{R}
+ * Creature — Goblin Pirate
+ * 1/1
+ *
+ * When this creature enters, create a Treasure token.
+ */
+val WilyGoblin = card("Wily Goblin") {
+    manaCost = "{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Pirate"
+    oracleText = "When this creature enters, create a Treasure token. (It's an artifact with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Steve Prescott"
+        flavorText = "Goblins climb and swing with ease, whether through a pirate ship's rigging or a tree's branches."
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WindStrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WindStrider.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wind Strider
+ * {4}{U}
+ * Creature — Merfolk Wizard
+ * 3/3
+ *
+ * Flash
+ * Flying
+ */
+val WindStrider = card("Wind Strider") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Flying"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Magali Villeneuve"
+        flavorText = "\"Currents are currents, whether in sea or sky.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/DragonskullSummitReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/DragonskullSummitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonskull Summit reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonskullSummitReprint = Printing(
+    oracleId = "63398c02-6fb1-481d-9d9f-81063532fbc0",
+    name = "Dragonskull Summit",
+    setCode = "MSC",
+    collectorNumber = "238",
+    scryfallId = "d20e433a-eb62-4301-bc20-bfe27468b033",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d20e433a-eb62-4301-bc20-bfe27468b033.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/DrownedCatacombReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/DrownedCatacombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drowned Catacomb reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownedCatacombReprint = Printing(
+    oracleId = "819fc966-434e-470f-91e9-a38df974ad17",
+    name = "Drowned Catacomb",
+    setCode = "MSC",
+    collectorNumber = "239",
+    scryfallId = "ebea49ab-e5cf-46d9-ae35-226a7321ede0",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/ebea49ab-e5cf-46d9-ae35-226a7321ede0.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -1221,6 +1221,36 @@
     ]
 }
 
+// Favorable Winds
+{
+    "name": "Favorable Winds",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control with flying get +1/+1.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "Long thought to be extinct, flocks of gryffs reappeared with Avacyn's return.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ghostform
 {
     "name": "Ghostform",

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -153,6 +153,134 @@
     ]
 }
 
+// Dragonskull Summit
+{
+    "name": "Dragonskull Summit",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control a Swamp or a Mountain.\n{T}: Add {B} or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "land Swamp"
+                        },
+                        {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "land Mountain"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "RARE",
+        "artist": "Jon Foster",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d4998db-13c0-412f-b02c-9f041cc45c7e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Drowned Catacomb
+{
+    "name": "Drowned Catacomb",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control an Island or a Swamp.\n{T}: Add {U} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "land Island"
+                        },
+                        {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "land Swamp"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "RARE",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdc6e950-38dd-46da-a1c3-58dc7495a9f9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Elite Vanguard
 {
     "name": "Elite Vanguard",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -831,6 +831,57 @@
     ]
 }
 
+// Unknown Shores
+{
+    "name": "Unknown Shores",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "artist": "Seb McKinnon",
+        "flavorText": "Philosophers speak of a place where myths wash like tides upon the shores of the real.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/fff118a5-765b-4ba1-8f12-ce6f24b2459b.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Voyage's End
 {
     "name": "Voyage's End",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -18,6 +18,60 @@
     ]
 }
 
+// Bishop of Rebirth
+{
+    "name": "Bishop of Rebirth",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Vigilance\nWhenever this creature attacks, you may return target creature card with mana value 3 or less from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Tommy Arnold",
+        "flavorText": "\"In the death of the foe lies the resurrection of the faithful.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Bishop's Soldier
 {
     "name": "Bishop's Soldier",
@@ -39,6 +93,190 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Blinding Fog
+{
+    "name": "Blinding Fog",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all damage that would be dealt to creatures this turn. Creatures you control gain hexproof until end of turn. (They can't be the targets of spells or abilities your opponents control.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "PreventDamageShield",
+                    "recipientGroup": {
+                        "baseFilter": "creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HEXPROOF",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"I see you, shiny soldiers, but you won't see me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bae7d501-72a1-43c2-9f72-d768ac5e9320.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Blossom Dryad
+{
+    "name": "Blossom Dryad",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "{T}: Untap target land.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Shreya Shetty",
+        "flavorText": "The only force on Ixalan not interested in finding the golden city is Ixalan itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66a3645f-2b71-4816-a1f2-6cd4e987882f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Call to the Feast
+{
+    "name": "Call to the Feast",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create three 1/1 white Vampire creature tokens with lifelink.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Vampire"
+            ],
+            "keywords": [
+                "LIFELINK"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Yongjae Choi",
+        "flavorText": "By the law of church and crown, vampires feed only on the blood of the guilty—those declared heretics, rebels, or enemies of war.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7226de1-0e05-4baf-8c2f-54297fee43c1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Carnage Tyrant
+{
+    "name": "Carnage Tyrant",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "This spell can't be countered.\nTrample, hexproof",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HEXPROOF"
+    ],
+    "script": {
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "MYTHIC",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Sun Empire commanders are well versed in advanced martial strategy. Still, the correct maneuver is usually to deploy the giant, implacable death lizard.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Charging Monstrosaur
+{
+    "name": "Charging Monstrosaur",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample, haste",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Zack Stella",
+        "flavorText": "\"I knew I should have stayed with the boat. Always stay with the boat!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5222448-95d1-4b63-ab76-d5060febcf38.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -155,6 +393,109 @@
     ]
 }
 
+// Contract Killing
+{
+    "name": "Contract Killing",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. Create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Winona Nelson",
+        "flavorText": "For a price, the floating city of High and Dry offers all the amenities a pirate could want: rest, recreation, and revenge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1f20feb-b1ed-4d80-bef9-f3cc44ffb7b0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Crash the Ramparts
+{
+    "name": "Crash the Ramparts",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Mark Behm",
+        "flavorText": "The Legion's conquistadors could endure Ixalan's sun. Their forts could withstand a charging ceratops. But nothing can stop a ceratops strengthened by the sun.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20b52d17-7efb-4c6e-9e6a-4763d1ef1daa.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Crushing Canopy
 {
     "name": "Crushing Canopy",
@@ -218,6 +559,440 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Dark Nourishment
+{
+    "name": "Dark Nourishment",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Dark Nourishment deals 3 damage to any target. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "flavorText": "Demons lurk in the shadows of ancient ruins, spreading plague and corruption across the land.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/053c4cf0-992b-4f76-b8d1-cd67f894172c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deadeye Plunderers
+{
+    "name": "Deadeye Plunderers",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "This creature gets +1/+1 for each artifact you control.\n{2}{U}{B}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "toughnessBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Opalinski",
+        "flavorText": "\"Keep your friends close and your enemies within range.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63a7a1a4-aec2-467d-91a1-1a2605718c7c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Deathless Ancient
+{
+    "name": "Deathless Ancient",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "Flying\nTap three untapped Vampires you control: Return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "permanent Vampire"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Ancient one, we have reached the promised shore. The Immortal Sun is near. Drink and awake.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8adc1cd9-22ff-4263-856b-0aaa990a3893.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deeproot Champion
+{
+    "name": "Deeproot Champion",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Merfolk Shaman",
+    "oracleText": "Whenever you cast a noncreature spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"No good will come from what you seek. Turn back now or suffer an ignoble death far from your home.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Deeproot Warrior
+{
+    "name": "Deeproot Warrior",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "oracleText": "Whenever this creature becomes blocked, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"We breathe from our soul and bones to give strength to the jungle. The jungle breathes from its roots and rivers to give strength to us.\"\n—Shaper Falani",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c1a1963-ec46-4ed3-9be1-e4cc09687922.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Deeproot Waters
+{
+    "name": "Deeproot Waters",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a Merfolk spell, create a 1/1 blue Merfolk creature token with hexproof. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Merfolk"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Merfolk"
+                    ],
+                    "keywords": [
+                        "HEXPROOF"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Zezhou Chen",
+        "flavorText": "A visit to the Deeproot Tree and its ancient spring replenishes a merfolk's connection to nature.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24bec3b7-5dfc-4b48-ae8f-5bf49470d030.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Depths of Desire
+{
+    "name": "Depths of Desire",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature to its owner's hand. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "John Stanko",
+        "flavorText": "Pockets full of gold, lungs full of brine.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63420437-76a9-40cf-aedc-0ca1e73fcc0b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dinosaur Stampede
+{
+    "name": "Dinosaur Stampede",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +2/+0 until end of turn. Dinosaurs you control gain trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Dinosaur ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "If you're in the way of a ceratops charge and you're made of mere flesh and bone, then you're not really in the way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a31bda74-8455-45ab-8142-65fbde2f39c3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Dire Fleet Hoarder
+{
+    "name": "Dire Fleet Hoarder",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Among the pirates of the Brazen Coalition, the only thing more dangerous than failure is success.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fcd719e-fa21-42bb-968b-ccc0cd3829c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -327,6 +1102,150 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Dusk Legion Dreadnought
+{
+    "name": "Dusk Legion Dreadnought",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Vigilance\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Titus Lunter",
+        "flavorText": "It loomed up over the horizon, silent and dark as a grave.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aec26144-9acf-43b7-8614-1a2952df613d.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Encampment Keeper
+{
+    "name": "Encampment Keeper",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "First strike\n{7}{W}, {T}, Sacrifice this creature: Creatures you control get +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Craig J Spearing",
+        "flavorText": "Paladins of the Sanctum Seeker order are an adventurous lot, venturing into the wilds with monstrous mastiffs at their side.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6fe64569-c1b6-4bd4-a742-6ee46ea5181c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Fathom Fleet Firebrand
+{
+    "name": "Fathom Fleet Firebrand",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Zezhou Chen",
+        "flavorText": "As she charges into battle, her arcane tattoos stir and crawl like fiery serpents.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52280963-ba5b-4735-b5cb-67866f8624c9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -500,6 +1419,86 @@
     ]
 }
 
+// Glorifier of Dusk
+{
+    "name": "Glorifier of Dusk",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Pay 2 life: This creature gains flying until end of turn.\nPay 2 life: This creature gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 2
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 2
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "UNCOMMON",
+        "artist": "Viktor Titov",
+        "flavorText": "\"The blood of the enemy is a sacrament. The strength it gives is proof that our cause is just.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aaf87f95-1c77-455a-8feb-57bfd4d159c9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Grazing Whiptail
+{
+    "name": "Grazing Whiptail",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Gabor Szikszai",
+        "flavorText": "Often found browsing on the upper canopies of Ixalan's jungles, whiptails are known to absently bat away anything foolish enough to interrupt their meal.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75cbd690-4d6e-49a7-bded-e6ecee2c76b6.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Growing Rites of Itlimoc
 {
     "name": "Growing Rites of Itlimoc",
@@ -666,6 +1665,73 @@
     ]
 }
 
+// Huatli's Snubhorn
+{
+    "name": "Huatli's Snubhorn",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "286",
+        "artist": "Randy Vargas",
+        "flavorText": "Don't make the mistake of thinking blunt horns can't kill.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2d88e6c-4aa8-4175-9f5d-a4c0182cdf74.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Imperial Lancer
+{
+    "name": "Imperial Lancer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "This creature has double strike as long as you control a Dinosaur.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dinosaur"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Viktor Titov",
+        "flavorText": "\"Together my mount and I are stronger than either of us apart.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ed3784a-2dc0-4626-aa6a-268c1e2ac83c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Inspiring Cleric
 {
     "name": "Inspiring Cleric",
@@ -704,6 +1770,313 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Ixalli's Keeper
+{
+    "name": "Ixalli's Keeper",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{7}{G}, {T}, Sacrifice this creature: Target creature gets +5/+5 and gains trample until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Lake Hurwitz",
+        "flavorText": "The people of the Sun Empire worship the sun in three aspects. Ixalli is the Verdant Sun, who fosters growth in all things.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5b98537-abf4-46cb-853f-9561811ab439.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jade Guardian
+{
+    "name": "Jade Guardian",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Merfolk Shaman",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nWhen this creature enters, put a +1/+1 counter on target Merfolk you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent Merfolk ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Chris Seaman",
+        "flavorText": "The River Heralds believe that jade gives weight to their magic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/aca83e48-6e32-477f-8714-6103e77c06df.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jungle Delver
+{
+    "name": "Jungle Delver",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "oracleText": "{3}{G}: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"There is no power too great to be used in the defense of our ancestral lands.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be0e3547-d8cb-4b68-a396-8c8fbc3b2b1c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kinjalli's Caller
+{
+    "name": "Kinjalli's Caller",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Dinosaur spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "Dinosaur"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Sara Winters",
+        "flavorText": "The people of the Sun Empire worship the sun in three aspects. Kinjalli is the Wakening Sun, who created humans from clay and baked them in the sun's warmth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/625211d4-c89c-4aee-a0b0-4bfabd3509ad.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Legion's Judgment
+{
+    "name": "Legion's Judgment",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature with power 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow>=4"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"My lance was once wielded by Venerable Tarrian. In his name and by his might, I cast you down!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/385bea20-c196-4da8-bc3e-36f8d50dcc17.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lightning-Rig Crew
+{
+    "name": "Lightning-Rig Crew",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Pirate",
+    "oracleText": "{T}: This creature deals 1 damage to each opponent.\nWhenever you cast a Pirate spell, untap this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Pirate"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "A pirate ship in battle is a storm of activity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb4a34ce-94d5-4e4d-97cc-1326cf5241f5.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -925,6 +2298,149 @@
     ]
 }
 
+// Otepec Huntmaster
+{
+    "name": "Otepec Huntmaster",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Dinosaur spells you cast cost {1} less to cast.\n{T}: Target Dinosaur gains haste until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Dinosaur"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "Dinosaur"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"Forward! Let the Burning Sun's light guide you to deserving prey!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c334e6f3-1378-4429-b4f1-fa8ed7ab7123.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Overflowing Insight
+{
+    "name": "Overflowing Insight",
+    "manaCost": "{4}{U}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player draws seven cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 7
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "MYTHIC",
+        "artist": "Lucas Graciano",
+        "flavorText": "The truth came to Kumena like the Great River's torrent: the only way to keep his enemies away from the hidden city was to claim its power for himself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Paladin of the Bloodstained
+{
+    "name": "Paladin of the Bloodstained",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "When this creature enters, create a 1/1 white Vampire creature token with lifelink.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Vampire"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "Closely linked to the Church of Dusk, the paladins of the Bloodstained order are devout to the point of fanaticism.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a0385d5-d0f4-40b8-af28-6557ffdfb625.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Pirate's Cutlass
 {
     "name": "Pirate's Cutlass",
@@ -1001,6 +2517,41 @@
     }
 }
 
+// Pirate's Prize
+{
+    "name": "Pirate's Prize",
+    "manaCost": "{3}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw two cards. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Nothing warms the heart like plunder.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48d97373-9b55-4eb7-99b6-8912f09bd0bb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Prosperous Pirates
 {
     "name": "Prosperous Pirates",
@@ -1038,6 +2589,48 @@
     ]
 }
 
+// Pterodon Knight
+{
+    "name": "Pterodon Knight",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "This creature has flying as long as you control a Dinosaur.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dinosaur"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Anthony Palumbo",
+        "flavorText": "\"To rise like the sun—there is no greater feeling.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41f00a04-1336-4830-a6c2-514848afefd2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Queen's Bay Soldier
 {
     "name": "Queen's Bay Soldier",
@@ -1058,6 +2651,43 @@
     ]
 }
 
+// Queen's Commission
+{
+    "name": "Queen's Commission",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 1/1 white Vampire creature tokens with lifelink.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Vampire"
+            ],
+            "keywords": [
+                "LIFELINK"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Mark Behm",
+        "flavorText": "\"Let the blood of the impure flow through you. Only the blessings of the golden city will purge its acrid taste from your mouth.\"\n—High Marshal Arguel",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f06c0007-299e-4d71-99c3-f905d942759d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Raptor Companion
 {
     "name": "Raptor Companion",
@@ -1075,6 +2705,184 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Raptor Hatchling
+{
+    "name": "Raptor Hatchling",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Enrage — Whenever this creature is dealt damage, create a 3/3 green Dinosaur creature token with trample.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Dinosaur"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ]
+                },
+                "descriptionOverride": "Enrage — Whenever this creature is dealt damage, create a 3/3 green Dinosaur creature token with trample."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Even Amundsen",
+        "flavorText": "\"Every little hatchling has a parent's claws to guard it.\"\n—Sun Empire saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/8093e88d-fd3c-43d3-a025-9ebb9f02a84f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ravenous Daggertooth
+{
+    "name": "Ravenous Daggertooth",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Enrage — Whenever this creature is dealt damage, you gain 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "Enrage — Whenever this creature is dealt damage, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "artist": "Jakub Kasper",
+        "flavorText": "A daggertooth's triumphant roar makes all the sounds of jungle life fall silent.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/309b204b-774a-47bc-aead-c78db90f3be2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Regisaur Alpha
+{
+    "name": "Regisaur Alpha",
+    "manaCost": "{3}{R}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Other Dinosaurs you control have haste.\nWhen this creature enters, create a 3/3 green Dinosaur creature token with trample.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Dinosaur"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "permanent Dinosaur ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "RARE",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"Seeing a pack of these monsters hunt together, I'm at a loss to imagine the size of their prey.\"\n—Adrian Adanto of Lujio",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6a322c5-aa4c-4a99-a3ca-48c1353104f0.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Ripjaw Raptor
+{
+    "name": "Ripjaw Raptor",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Enrage — Whenever this creature is dealt damage, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Enrage — Whenever this creature is dealt damage, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "flavorText": "Raptors are clever enough to tear away a hard metal shell to get at the tasty morsel inside.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c5368c6-87e0-4f83-aaf7-f4af96d2bf30.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1347,6 +3155,165 @@
     ]
 }
 
+// Sheltering Light
+{
+    "name": "Sheltering Light",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains indestructible until end of turn. Scry 1. (Damage and effects that say \"destroy\" don't destroy the creature.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Gabor Szikszai",
+        "flavorText": "Those who wield the power of the sun protect the Empire from darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0c945c7-6c31-4c4f-9203-3dc2aef50820.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shining Aerosaur
+{
+    "name": "Shining Aerosaur",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"The invaders cloak themselves in the shadows of dusk. Aerosaurs hide in the brilliance of the noonday sun.\"\n—Caparocti Sunborn",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e900d0d-6f35-4e5d-9365-6ade227d218d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shore Keeper
+{
+    "name": "Shore Keeper",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Trilobite",
+    "oracleText": "{7}{U}, {T}, Sacrifice this creature: Draw three cards.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "YW Tang",
+        "flavorText": "Over their long life spans, the larger trilobites accumulate vast treasure troves in their guts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/135d1145-8640-44e1-8079-45832fa2556d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Skittering Heartstopper
+{
+    "name": "Skittering Heartstopper",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "{B}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Aaron Miller",
+        "flavorText": "It flows like water over the forest floor, as deadly as the swiftest current.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/0722fbdf-c092-4e80-913f-29390177cdcb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Skulduggery
 {
     "name": "Skulduggery",
@@ -1414,6 +3381,179 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Sky Terror
+{
+    "name": "Sky Terror",
+    "manaCost": "{R}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Flying, menace",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "flavorText": "\"Wherever the Threefold Sun shines, great wings may go.\"\n—Emperor Apatzec Intli III",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/167ed739-2953-47af-841f-bc1a092b3aa6.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Skyblade of the Legion
+{
+    "name": "Skyblade of the Legion",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Daarken",
+        "flavorText": "Vampires call the gift of flight \"exultation.\" For their enemies, it brings only sorrow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67e788e2-12e9-4041-8210-753aaef2576c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Slash of Talons
+{
+    "name": "Slash of Talons",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Slash of Talons deals 2 damage to target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"The amber sun smokes with fury, gazing on foes that gather like ants invading our home. We are ready! Blade and claw strike as one.\"\n—Huatli",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a97d474e-83b6-4969-81b4-51f5315057d7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sleek Schooner
+{
+    "name": "Sleek Schooner",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Winters",
+        "flavorText": "The pirates had left the open sea behind, but they were still in their element: reckless adventure.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/767e2bfb-bcf5-442c-b092-bdb1f4f13561.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Snapping Sailback
+{
+    "name": "Snapping Sailback",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Flash\nEnrage — Whenever this creature is dealt damage, put a +1/+1 counter on it. (It must survive the damage to get the counter.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Enrage — Whenever this creature is dealt damage, put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Lurking beneath the murky waters of Ixalan's rivers, sailbacks can rip a meal off the shore in the blink of an eye.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0af1eadf-f7ea-40be-a0cc-b79e4161db34.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1503,6 +3643,51 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sun-Crowned Hunters
+{
+    "name": "Sun-Crowned Hunters",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Enrage — Whenever this creature is dealt damage, it deals 3 damage to target opponent or planeswalker.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponentOrPlaneswalker",
+                    "id": "target"
+                },
+                "descriptionOverride": "Enrage — Whenever this creature is dealt damage, it deals 3 damage to target opponent or planeswalker."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Aaron Miller",
+        "flavorText": "One alone is dangerous, and they are never alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cab793e-0e17-4940-9cab-a30d62df5c20.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1624,6 +3809,85 @@
     ]
 }
 
+// Swashbuckling
+{
+    "name": "Swashbuckling",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Josu Hernaiz",
+        "flavorText": "The pirates of the Brazen Coalition are the descendants of those displaced by the Legion of Dusk, and they are eager for vengeance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01ed59b1-968b-4297-9e98-42d940f9478c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Territorial Hammerskull
+{
+    "name": "Territorial Hammerskull",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Whenever this creature attacks, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Lars Grant-West",
+        "flavorText": "From the eyes up, it's solid bone and stubbornness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af5a237a-31e7-43ee-8d47-3eb12dd1a60c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thundering Spineback
 {
     "name": "Thundering Spineback",
@@ -1683,6 +3947,53 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Tilonalli's Knight
+{
+    "name": "Tilonalli's Knight",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever this creature attacks, if you control a Dinosaur, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dinosaur"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Lius Lasahido",
+        "flavorText": "The people of the Sun Empire worship the sun in three aspects. Tilonalli is the Burning Sun, associated with ferocity, fire, and passion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b25c2f33-1707-4ff3-a22e-58f51936b733.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1829,6 +4140,42 @@
     }
 }
 
+// Unfriendly Fire
+{
+    "name": "Unfriendly Fire",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Unfriendly Fire deals 4 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Josu Hernaiz",
+        "flavorText": "Disputes within the Brazen Coalition can escalate from insult to broadside in the blink of an eye.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a61b274-0499-4cb6-a2e4-f5e18ad7fd2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vanquish the Weak
 {
     "name": "Vanquish the Weak",
@@ -1863,5 +4210,268 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vicious Conquistador
+{
+    "name": "Vicious Conquistador",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Whenever this creature attacks, each opponent loses 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"He is ambitious. Tireless. And utterly ruthless. Ideal for the frontier.\"\n—Viceroy Elia Sotonores, report to the queen",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a4b6ced-e8d3-47e9-bd27-3e0cb644afe4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vona, Butcher of Magan
+{
+    "name": "Vona, Butcher of Magan",
+    "manaCost": "{3}{W}{B}",
+    "typeLine": "Legendary Creature — Vampire Knight",
+    "oracleText": "Vigilance, lifelink\n{T}, Pay 7 life: Destroy target nonland permanent. Activate only during your turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "LIFELINK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 7
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"For four hundred years, I have led armies of conquest. These lands hold nothing that can stand against me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1fd4101-d531-43aa-9cb6-79e36a8121d8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Vraska's Contempt
+{
+    "name": "Vraska's Contempt",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature or planeswalker. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "RARE",
+        "artist": "Clint Cearley",
+        "flavorText": "It wasn't long before the taverns of High and Dry were full of whispers about the new captain who could turn a person to stone with a glance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Walk the Plank
+{
+    "name": "Walk the Plank",
+    "manaCost": "{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target non-Merfolk creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Merfolk"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "flavorText": "When Captain Thorn adds a new ship to his fleet, he gives the crew a simple choice: follow me, or fall in the sea.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/0038ac6a-318f-44fb-bb64-7ae172c4aca3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wily Goblin
+{
+    "name": "Wily Goblin",
+    "manaCost": "{R}{R}",
+    "typeLine": "Creature — Goblin Pirate",
+    "oracleText": "When this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "Goblins climb and swing with ease, whether through a pirate ship's rigging or a tree's branches.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a175b24c-c256-45a8-b24a-6b83e42d5efa.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wind Strider
+{
+    "name": "Wind Strider",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"Currents are currents, whether in sea or sky.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/613a8ab1-9c5e-4b56-aa51-daeb8c1983b9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }


### PR DESCRIPTION
Sweeps the whole ⚡ Assay-ready tail for **XLN — Ixalan**: every card Argentum Assay reads whole that the set had not authored yet. Each card was authored against `assay compile`'s JSON rather than the printed Oracle text.

## The four-way split (71 Assay-ready)

| Bucket | Count | Work |
|---|---|---|
| `original` | 60 | canonical authored in XLN |
| `elsewhere` | 4 | canonical authored in the earlier set, `Printing` row in XLN |
| `row-only` | 2 | `Printing` row in XLN only |
| `basic` | 5 | `basicLand(...)` vals (20 art variants) + the `basicLands` override |

**`elsewhere` placements:** Dragonskull Summit → M10, Drowned Catacomb → M10, Favorable Winds → AVR, Unknown Shores → THS.
**`row-only`:** Rummaging Goblin (canonical M13), Sure Strike (canonical BFZ).

## The reprint tail

Authoring the four `elsewhere` canonicals made 17 further `Printing` rows visible in 10 other scaffolded sets — invisible to `check-card-printing` until the canonical existed, so they land here:

`ANB` 2 · `CMR` 2 · `M11` 2 · `M12` 2 · `M13` 2 · `M21` 2 · `MSC` 2 · `C16` 1 · `OGW` 1 · `THB` 1

23 `Printing` rows in total (6 of them in XLN itself).

## Verification

| Gate | Result |
|---|---|
| `just build` | green |
| `just rebless-cards` | AVR / M10 / THS / XLN goldens moved — **additions only**, no existing card's tree changed |
| `just assay-differential` | **5225 compared / 5177 confirmed / 48 divergent**, against a **5161 / 5113 / 48** baseline taken on `main` with the same freshly-built binary. +64 compared, +64 confirmed, **zero new divergences** |
| `just check-card-printing` | clean for all 66 canonicals (64 new + the 2 row-only) |
| `just assay-ready XLN` | **71 → 0** on the branch |

XLN now reads 154 missing, all of them declines (`LINE_DECLINED` 143, `MULTI_FACE` 8, `LINES_DO_NOT_FOLD` 3) — the rest of this set's tail is grammar work, not authoring work.

## Notes

- **Enrage is an ability word** (CR 207.2c), so the five enrage cards (Raptor Hatchling, Ravenous Daggertooth, Ripjaw Raptor, Snapping Sailback, Sun-Crowned Hunters) spell it as `Triggers.TakesDamage` with the word carried on the trigger's `description`, following the Red Hulk / Raphael precedent.
- **Crew is engine-live** (`CrewEnumerator` + `CrewVehicleHandler` both read `Keyword.CREW`), so Sleek Schooner and Dusk Legion Dreadnought declare `KeywordAbility.Numeric(Keyword.CREW, n)` rather than spelling the ability out — checked before authoring, per the capability pre-flight.
- **No token `imageUri`s.** XLN's whole token sheet (Vampire, Merfolk, Dinosaur, Treasure, …) is already in `tokens.json`, so `MtgSet.tokenArt` resolves the art and passing one by hand would only diverge from Assay.
- `IxalanSet.incomplete` stays `true` — 154 cards remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)