### PR TITLE
Add 77 Assay-ready cards to Ravnica Allegiance

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/TowerDefense.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/TowerDefense.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tower Defense — Gatecrash #137
+ * {1}{G} · Instant
+ *
+ * The canonical lives here, in Gatecrash — its earliest real printing — and RNA carries a
+ * Printing row. `pumpAndGrantToAll` names the group **once**: gathering it twice (a pump pass
+ * plus a grant pass) would let a filter the first pass changes match a different set the second
+ * time, which is not what the printed sentence says.
+ */
+val TowerDefense = card("Tower Defense") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +0/+5 and gain reach until end of turn."
+
+    spell {
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 0,
+            toughness = 5,
+            keyword = Keyword.REACH,
+            filter = GroupFilter.AllCreaturesYouControl
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Seb McKinnon"
+        flavorText = "\"The drakes are practice. We may one day need to bring down a sky swallower, or maybe even Rakdos himself.\"\n" +
+        "—Korun Nar, Rubblebelt hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ConcordiaPegasus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ConcordiaPegasus.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Concordia Pegasus — Return to Ravnica #8
+ * {1}{W} · Creature — Pegasus · 1 / 3
+ *
+ * A vanilla flier. The canonical lives here, in Return to Ravnica — its earliest real
+ * printing — and the later sets (RNA, M20, M21) carry Printing rows.
+ */
+val ConcordiaPegasus = card("Concordia Pegasus") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Pegasus"
+    power = 1
+    toughness = 3
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Winona Nelson"
+        flavorText = "\"A kick from its hooves is like a bolt of lightning. I'd know. I've been hit by both.\"\n" +
+        "—Rencz, Izzet chemister's aide"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ImpassionedOratorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ImpassionedOratorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impassioned Orator reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val ImpassionedOratorReprint = Printing(
+    oracleId = "c7107a2d-2dcf-42e9-9ea9-d0fc0d6d2ec6",
+    name = "Impassioned Orator",
+    setCode = "ANB",
+    collectorNumber = "10",
+    scryfallId = "20726907-ee1f-49ef-a694-7d3f53ee1e2d",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20726907-ee1f-49ef-a694-7d3f53ee1e2d.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/StonyStrengthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/StonyStrengthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stony Strength reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val StonyStrengthReprint = Printing(
+    oracleId = "da5a7cb8-1fa7-4b91-abd4-9e766291be63",
+    name = "Stony Strength",
+    setCode = "ANB",
+    collectorNumber = "105",
+    scryfallId = "4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4a0597ce-f91a-43a0-aad6-fbb2a4d9fe57.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/StormStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/StormStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Storm Strike reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val StormStrikeReprint = Printing(
+    oracleId = "f0748ff2-94b1-45a9-8d56-8459bd86704a",
+    name = "Storm Strike",
+    setCode = "ANB",
+    collectorNumber = "86",
+    scryfallId = "ff3da54f-b4ee-4e9a-929e-619094691434",
+    artist = "Dmitry Burmak",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff3da54f-b4ee-4e9a-929e-619094691434.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WindstormDrakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WindstormDrakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windstorm Drake reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val WindstormDrakeReprint = Printing(
+    oracleId = "16977ebd-6384-4c28-b9c3-448563a07807",
+    name = "Windstorm Drake",
+    setCode = "ANB",
+    collectorNumber = "42",
+    scryfallId = "b40dae56-be19-4b64-b99d-f45b7f816287",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b40dae56-be19-4b64-b99d-f45b7f816287.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/GiftOfStrength.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/GiftOfStrength.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gift of Strength — Hour of Devastation #117
+ * {1}{G} · Instant
+ *
+ * The canonical lives here, in Hour of Devastation — its earliest real printing — and RNA and
+ * THB carry Printing rows. One clause about one creature, so the pump and the reach grant are
+ * one composite.
+ */
+val GiftOfStrength = card("Gift of Strength") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 and gains reach until end of turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(listOf(
+            Effects.ModifyStats(3, 3, creature),
+            Effects.GrantKeyword(Keyword.REACH, creature)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "Kieran Yanner"
+        flavorText = "\"What greater testament can there be to Rhonas's lessons?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IllGottenInheritanceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IllGottenInheritanceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ill-Gotten Inheritance reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val IllGottenInheritanceReprint = Printing(
+    oracleId = "84e8ca5e-730e-468b-943c-7c6358ade95c",
+    name = "Ill-Gotten Inheritance",
+    setCode = "J22",
+    collectorNumber = "427",
+    scryfallId = "cc24cd32-e275-4fc1-9fde-834db4564663",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/cc24cd32-e275-4fc1-9fde-834db4564663.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WindstormDrakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WindstormDrakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windstorm Drake reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val WindstormDrakeReprint = Printing(
+    oracleId = "16977ebd-6384-4c28-b9c3-448563a07807",
+    name = "Windstorm Drake",
+    setCode = "JMP",
+    collectorNumber = "195",
+    scryfallId = "82ff4bd1-2b61-46be-b547-38916ea08298",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/82ff4bd1-2b61-46be-b547-38916ea08298.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ConcordiaPegasusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ConcordiaPegasusReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Concordia Pegasus reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val ConcordiaPegasusReprint = Printing(
+    oracleId = "93c35f9e-3346-4269-b1af-df9f216bfd7a",
+    name = "Concordia Pegasus",
+    setCode = "M20",
+    collectorNumber = "304",
+    scryfallId = "55f32ff8-3b49-4ce8-96a0-ba0d99477de1",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55f32ff8-3b49-4ce8-96a0-ba0d99477de1.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/HaazdaOfficerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/HaazdaOfficerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Haazda Officer reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val HaazdaOfficerReprint = Printing(
+    oracleId = "35023c04-ae62-47bf-80a0-faa2d7a67788",
+    name = "Haazda Officer",
+    setCode = "M20",
+    collectorNumber = "305",
+    scryfallId = "f766418a-eb1d-4536-ae51-7f3e8969bb78",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f766418a-eb1d-4536-ae51-7f3e8969bb78.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ImpassionedOratorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ImpassionedOratorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impassioned Orator reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val ImpassionedOratorReprint = Printing(
+    oracleId = "c7107a2d-2dcf-42e9-9ea9-d0fc0d6d2ec6",
+    name = "Impassioned Orator",
+    setCode = "M20",
+    collectorNumber = "306",
+    scryfallId = "696d6c4b-69d7-498b-87d4-0a03b16cc971",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/696d6c4b-69d7-498b-87d4-0a03b16cc971.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ConcordiaPegasusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ConcordiaPegasusReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Concordia Pegasus reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val ConcordiaPegasusReprint = Printing(
+    oracleId = "93c35f9e-3346-4269-b1af-df9f216bfd7a",
+    name = "Concordia Pegasus",
+    setCode = "M21",
+    collectorNumber = "12",
+    scryfallId = "600d3517-e370-47ae-ac4f-c7ef8995a89c",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/600d3517-e370-47ae-ac4f-c7ef8995a89c.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EssenceCaptureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EssenceCaptureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Essence Capture reprint in NEO. Canonical CardDefinition lives in its earliest set.
+ */
+val EssenceCaptureReprint = Printing(
+    oracleId = "0f730bd9-2060-46b1-9208-0ac6562e8b2a",
+    name = "Essence Capture",
+    setCode = "NEO",
+    collectorNumber = "52",
+    scryfallId = "f39bf1fa-b530-4353-a683-843466227109",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f39bf1fa-b530-4353-a683-843466227109.jpg",
+    releaseDate = "2022-02-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/RavnicaAllegianceSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/RavnicaAllegianceSet.kt
@@ -24,6 +24,10 @@ object RavnicaAllegianceSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AppliedBiomancy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AppliedBiomancy.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Applied Biomancy — Ravnica Allegiance #153
+ * {G}{U} · Instant
+ *
+ * "Choose one or both" is the modal *count*, not a third mode: `chooseCount = 2` with
+ * `minChooseCount = 1` (CR 700.2). Each mode carries its own target, so picking both asks for
+ * two creatures — which may be the same creature twice, since the requirements are independent.
+ */
+val AppliedBiomancy = card("Applied Biomancy") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Target creature gets +1/+1 until end of turn.\n" +
+        "• Return target creature to its owner's hand."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Target creature gets +1/+1 until end of turn") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.ModifyStats(1, 1, creature)
+            }
+            mode("Return target creature to its owner's hand") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.ReturnToHand(creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Sidharth Chaturvedi"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azorius Guildgate reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val AzoriusGuildgateReprint = Printing(
+    oracleId = "ad1712d8-809f-410c-8b91-ffe6fb8a69a1",
+    name = "Azorius Guildgate",
+    setCode = "RNA",
+    collectorNumber = "243",
+    scryfallId = "93cf5412-c711-41b4-ab3b-7788a0a22228",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93cf5412-c711-41b4-ab3b-7788a0a22228.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusKnightArbiter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusKnightArbiter.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azorius Knight-Arbiter — Ravnica Allegiance #154
+ * {3}{W}{U} · Creature — Human Knight · 2 / 5
+ *
+ * "This creature can't be blocked" is unconditional evasion with no filter, which is an
+ * [AbilityFlag] rather than a [Keyword] — the block-legality check reads the flag set
+ * directly. Vigilance is an ordinary keyword.
+ */
+val AzoriusKnightArbiter = card("Azorius Knight-Arbiter") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "This creature can't be blocked."
+
+    keywords(Keyword.VIGILANCE)
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Even Amundsen"
+        flavorText = "Thanks to the magic in his Writ of Passage, alms beasts lumbered aside, anarchs bowed their heads, and even Rakdos acrobats rolled their spikewheels out of his way."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AzoriusLocket.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Azorius Locket — Ravnica Allegiance #231
+ * {3} · Artifact
+ *
+ * The RNA half of the Locket cycle, wired exactly like GRN's five: "Add {W} or {U}" is two
+ * separate mana abilities rather than one choice effect, because each is independently
+ * activatable and the engine's mana enumeration walks abilities, not choices. The draw is a
+ * normal activated ability (it does not produce mana, so it uses the stack).
+ */
+val AzoriusLocket = card("Azorius Locket") {
+    manaCost = "{3}"
+    colorIdentity = "UW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W} or {U}.\n" +
+        "{W/U}{W/U}{W/U}{W/U}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W/U}{W/U}{W/U}{W/U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Craig J Spearing"
+        flavorText = "\"Mandatory lockets enable the tracking of all Senate personnel for improved security and efficiency.\"\n" +
+        "—Dovin Baan"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BankruptInBlood.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BankruptInBlood.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bankrupt in Blood — Ravnica Allegiance #62
+ * {1}{B} · Sorcery
+ *
+ * The sacrifice is an *additional cost*, paid on announcement — so the creatures are gone
+ * before anyone can respond, and the spell being countered does not give them back.
+ */
+val BankruptInBlood = card("Bankrupt in Blood") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice two creatures.\n" +
+        "Draw three cards."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature, count = 2))
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Seb McKinnon"
+        flavorText = "\"Your spirits can rest in peace, for your debts are paid.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BasilicaBellHaunt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BasilicaBellHaunt.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basilica Bell-Haunt — Ravnica Allegiance #156
+ * {W}{W}{B}{B} · Creature — Spirit · 3 / 4
+ *
+ * [Patterns.Hand] `eachOpponentDiscards` is the per-opponent gather → select → discard pipeline;
+ * each opponent chooses their own card. The life gain is flat, not per opponent.
+ */
+val BasilicaBellHaunt = card("Basilica Bell-Haunt") {
+    manaCost = "{W}{W}{B}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, each opponent discards a card and you gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(listOf(
+            Patterns.Hand.eachOpponentDiscards(1),
+            Effects.GainLife(3)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "156"
+        artist = "Yeong-Hao Han"
+        flavorText = "You can hear their tolling only when your debt is due."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ChargingWarBoar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ChargingWarBoar.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Charging War Boar — Ravnica Allegiance #271
+ * {1}{R}{G} · Creature — Boar · 3 / 1
+ *
+ * "A Domri planeswalker" is the planeswalker filter narrowed by the planeswalker *subtype*
+ * (CR 205.3j); [Conditions.YouControl] is the battlefield-existence check. The pump and the
+ * trample grant are **two** conditional statics sharing one condition rather than one
+ * [ConditionalStaticAbility] over a composite — they live in different layers (7c and 6), so
+ * keeping them apart is what lets the layer system order them independently.
+ */
+val ChargingWarBoar = card("Charging War Boar") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Boar"
+    power = 3
+    toughness = 1
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "As long as you control a Domri planeswalker, this creature gets +1/+1 and has trample. (It can deal excess damage to the player or planeswalker it's attacking.)"
+
+    keywords(Keyword.HASTE)
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Domri"))
+        )
+    }
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.TRAMPLE, GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Domri"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "271"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CivicStalwart.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CivicStalwart.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Civic Stalwart — Ravnica Allegiance #6
+ * {3}{W} · Creature — Elephant Soldier · 3 / 3
+ *
+ * One group named once: [Patterns.Group] `modifyStatsForAll` gathers the creatures you control
+ * in a single pass, which is the shape the printed sentence describes. The Stalwart is on the
+ * battlefield by the time its own enters trigger resolves, so it pumps itself too.
+ */
+val CivicStalwart = card("Civic Stalwart") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, creatures you control get +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Gabor Szikszai"
+        flavorText = "\"These are your streets. Defend them! This is your neighborhood. Honor it! This is your city. Save it!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ClamorShaman.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ClamorShaman.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Clamor Shaman — Ravnica Allegiance #96
+ * {2}{R} · Creature — Goblin Shaman · 1 / 1
+ *
+ * Riot plus an attack trigger. "Can't block this turn" is [Effects.CantBlock] — a
+ * combat restriction on the targeted creature, not an evasion grant on the attacker, so a
+ * second blocker is unaffected.
+ */
+val ClamorShaman = card("Clamor Shaman") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\n" +
+        "Whenever this creature attacks, target creature an opponent controls can't block this turn."
+
+    riot()
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val victim = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.CantBlock(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "96"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"Little goblin. Big noise.\"\n" +
+        "—Ruric Thar"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ConcordiaPegasusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ConcordiaPegasusReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Concordia Pegasus reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val ConcordiaPegasusReprint = Printing(
+    oracleId = "93c35f9e-3346-4269-b1af-df9f216bfd7a",
+    name = "Concordia Pegasus",
+    setCode = "RNA",
+    collectorNumber = "7",
+    scryfallId = "8a7fdf7b-022c-4900-9344-9b13d41c1604",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a7fdf7b-022c-4900-9344-9b13d41c1604.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CultGuildmage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CultGuildmage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Cult Guildmage — Ravnica Allegiance #164
+ * {B}{R} · Creature — Human Shaman · 2 / 2
+ *
+ * The Rakdos entry in the RNA Guildmage cycle. "Activate only as a sorcery" is
+ * [TimingRule.SorcerySpeed] on that one ability, not a separate restriction; the ping targets
+ * an opponent *or* a planeswalker, which is its own target requirement rather than a filtered
+ * permanent target.
+ */
+val CultGuildmage = card("Cult Guildmage") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{3}{B}, {T}: Target player discards a card. Activate only as a sorcery.\n" +
+        "{R}, {T}: This creature deals 1 damage to target opponent or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.Tap)
+        val player = target("target", Targets.Player)
+        effect = Patterns.Hand.discardCards(1, player)
+        timing = TimingRule.SorcerySpeed
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val victim = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Deface.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Deface.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Deface — Ravnica Allegiance #98
+ * {R} · Sorcery
+ *
+ * An ordinary "choose one" — two modes, one pick. The second mode's target is narrowed to
+ * creatures *with defender*, which the target legality check reads off projected state, so a
+ * creature that lost defender this turn is no longer a legal choice.
+ */
+val Deface = card("Deface") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target creature with defender."
+
+    spell {
+        modal {
+            mode("Destroy target artifact") {
+                val artifact = target("target", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+            mode("Destroy target creature with defender") {
+                val wall = target(
+                    "target",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)))
+                )
+                effect = Effects.Destroy(wall)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "\"Leave no stone unturned.\"\n" +
+        "—Ruric Thar"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/DovinsAutomaton.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/DovinsAutomaton.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Dovin's Automaton — Ravnica Allegiance #268
+ * {4} · Artifact Creature — Homunculus · 3 / 3
+ *
+ * The colourless twin of [ChargingWarBoar]'s shape — two conditional statics over one
+ * "you control a Dovin planeswalker" condition, kept apart so layers 7c and 6 order
+ * independently.
+ */
+val DovinsAutomaton = card("Dovin's Automaton") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Homunculus"
+    power = 3
+    toughness = 3
+    oracleText = "As long as you control a Dovin planeswalker, this creature gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Dovin"))
+        )
+    }
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Dovin"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "268"
+        artist = "Adam Paquette"
+        flavorText = "It was made for battle, but that doesn't mean it's unsophisticated."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EliteArrester.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EliteArrester.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Arrester — Ravnica Allegiance #266
+ * {W} · Creature — Human Soldier · 0 / 3
+ *
+ * A one-drop tapper with an off-colour Azorius activation.
+ */
+val EliteArrester = card("Elite Arrester") {
+    manaCost = "{W}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Soldier"
+    power = 0
+    toughness = 3
+    oracleText = "{1}{U}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "266"
+        artist = "Randy Vargas"
+        flavorText = "\"Hold it! I need to see your papers.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EnragedCeratok.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EnragedCeratok.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Enraged Ceratok — Ravnica Allegiance #125
+ * {2}{G}{G} · Creature — Rhino · 4 / 4
+ *
+ * A *filtered* evasion restriction, so it is a [CantBeBlockedBy] static ability rather than
+ * the blanket `AbilityFlag.CANT_BE_BLOCKED`. The filter reads the blocker's power, which the
+ * block-legality check evaluates against projected state — so a pumped 3-power blocker may
+ * block even though its printed power is 2.
+ */
+val EnragedCeratok = card("Enraged Ceratok") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino"
+    power = 4
+    toughness = 4
+    oracleText = "This creature can't be blocked by creatures with power 2 or less."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Lars Grant-West"
+        flavorText = "\"There's no time to calm it down! Run!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EssenceCapture.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/EssenceCapture.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Essence Capture — Ravnica Allegiance #37
+ * {U}{U} · Instant
+ *
+ * Two targets, the second "up to one" — an [TargetCreature] with `optional = true`, so the
+ * spell is still castable (and still counters) with no creature of yours on the battlefield.
+ * The optional target is declared last, which is where an optional target must sit.
+ */
+val EssenceCapture = card("Essence Capture") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control."
+
+    spell {
+        target("target", Targets.CreatureSpell)
+        val ally = target(
+            "target 1",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.Composite(listOf(
+            Effects.CounterSpell(),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, ally)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "Mathias Kollros"
+        flavorText = "\"It's not enough to defeat our foes. We must learn from them, too.\"\n" +
+        "—Vannifar"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ExposeToDaylight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ExposeToDaylight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Expose to Daylight — Ravnica Allegiance #8
+ * {2}{W} · Instant
+ *
+ * [Targets.ArtifactOrEnchantment] is the shared disjunction rather than a hand-rolled `Or`,
+ * followed by the same scry rider the RNA removal commons share.
+ */
+val ExposeToDaylight = card("Expose to Daylight") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment. Scry 1."
+
+    spell {
+        val permanent = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Composite(listOf(
+            Effects.Destroy(permanent),
+            Effects.Scry(1)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Daniel Ljunggren"
+        flavorText = "\"Lies cannot long withstand the harsh light of day.\"\n" +
+        "—Lavinia"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FaerieDuelist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FaerieDuelist.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Duelist — Ravnica Allegiance #39
+ * {1}{U} · Creature — Faerie Rogue · 1 / 2
+ *
+ * Flash plus flying makes it an ambush blocker; the enters trigger shrinks an attacker's
+ * power. -2/-0 is a stat modification, so a creature already at 0 power simply stays there.
+ */
+val FaerieDuelist = card("Faerie Duelist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 2
+    oracleText = "Flash\n" +
+        "Flying\n" +
+        "When this creature enters, target creature an opponent controls gets -2/-0 until end of turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-2, 0, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Yongjae Choi"
+        flavorText = "Faeries are easily offended and quick to exact a quirky revenge."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FootlightFiend.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FootlightFiend.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Footlight Fiend — Ravnica Allegiance #216
+ * {B/R} · Creature — Devil · 1 / 1
+ *
+ * A dies trigger, so the target is chosen as the ability goes on the stack while the Fiend is
+ * already in the graveyard (CR 603.6c/603.10). The damage source is the Fiend's last known
+ * information, which the engine supplies from the zone-change event.
+ */
+val FootlightFiend = card("Footlight Fiend") {
+    manaCost = "{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Devil"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, it deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val victim = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"This footlight's broken. Get me a stagehand!\"\n" +
+        "—Judith"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FrenziedArynx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FrenziedArynx.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frenzied Arynx — Ravnica Allegiance #173
+ * {2}{R}{G} · Creature — Cat Beast · 3 / 3
+ *
+ * Riot, printed trample, and a repeatable firebreathing-style pump.
+ */
+val FrenziedArynx = card("Frenzied Arynx") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Cat Beast"
+    power = 3
+    toughness = 3
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\n" +
+        "Trample\n" +
+        "{4}{R}{G}: This creature gets +3/+0 until end of turn."
+
+    riot()
+    keywords(Keyword.TRAMPLE)
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}{G}")
+        effect = Effects.ModifyStats(3, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FrilledMystic.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FrilledMystic.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frilled Mystic — Ravnica Allegiance #174
+ * {G}{G}{U}{U} · Creature — Elf Lizard Wizard · 3 / 2
+ *
+ * Flash plus an enters-counter is the Draining Whelk shape: cast it in response, and the
+ * counter resolves from the trigger. `optional = true` is the printed "you may" — the DSL
+ * lowers it to a `Gate.MayDecide` around the counter, asked at resolution, while the target is
+ * still locked in when the trigger goes on the stack (CR 603.3d).
+ */
+val FrilledMystic = card("Frilled Mystic") {
+    manaCost = "{G}{G}{U}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elf Lizard Wizard"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\n" +
+        "When this creature enters, you may counter target spell."
+
+    keywords(Keyword.FLASH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        target("target", Targets.Spell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Randy Vargas"
+        flavorText = "\"Your arrival was expected...and unwelcome.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GetThePoint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GetThePoint.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Get the Point — Ravnica Allegiance #176
+ * {3}{B}{R} · Instant
+ *
+ * Destroy then scry, in that order — the scry happens even if the creature is gone by the time
+ * the spell resolves, because it is a separate step of the same resolution.
+ */
+val GetThePoint = card("Get the Point") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature. Scry 1."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(listOf(
+            Effects.Destroy(creature),
+            Effects.Scry(1)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Steve Argyle"
+        flavorText = "\"Vraska sees the grandeur in death but misses the hilarity.\"\n" +
+        "—Judith"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GhorClanWrecker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GhorClanWrecker.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghor-Clan Wrecker — Ravnica Allegiance #103
+ * {3}{R} · Creature — Human Warrior · 2 / 2
+ *
+ * Riot plus printed menace.
+ */
+val GhorClanWrecker = card("Ghor-Clan Wrecker") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\n" +
+        "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    riot()
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "David Palumbo"
+        flavorText = "\"Today the Rubblebelt is a bit larger. That's a good day's work.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GiftOfStrengthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GiftOfStrengthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gift of Strength reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val GiftOfStrengthReprint = Printing(
+    oracleId = "fe971240-268a-47d4-a14e-3d6352656091",
+    name = "Gift of Strength",
+    setCode = "RNA",
+    collectorNumber = "127",
+    scryfallId = "bb363b1d-0b80-453c-98ca-e9f873bb7add",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb363b1d-0b80-453c-98ca-e9f873bb7add.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GraspingThrull.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GraspingThrull.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grasping Thrull — Ravnica Allegiance #177
+ * {3}{W}{B} · Creature — Thrull · 3 / 3
+ *
+ * The damage half hits every opponent at once via `EffectTarget.PlayerRef(Player.EachOpponent)`,
+ * so in multiplayer it is 2 to each. The life gain is a flat 2 regardless of the opponent count —
+ * the printed line is not "for each".
+ */
+val GraspingThrull = card("Grasping Thrull") {
+    manaCost = "{3}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Thrull"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, it deals 2 damage to each opponent and you gain 2 life."
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(listOf(
+            Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(2)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Seb McKinnon"
+        flavorText = "\"Debt due! Debt due!\" The thrull's screeching makes children flinch and debtors quail. \"Debt due!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GravelHideGoblin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GravelHideGoblin.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gravel-Hide Goblin — Ravnica Allegiance #105
+ * {1}{R} · Creature — Goblin Shaman · 2 / 1
+ *
+ * An off-colour activation ({G} on a red creature) — the mana cost is just a string, so
+ * nothing special is needed to express the Gruul "splash" cycle.
+ */
+val GravelHideGoblin = card("Gravel-Hide Goblin") {
+    manaCost = "{1}{R}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Goblin Shaman"
+    power = 2
+    toughness = 1
+    oracleText = "{3}{G}: This creature gets +2/+2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Jonathan Kuo"
+        flavorText = "\"No peace accord will save Ravnica. You don't build on rot. You burn it down and start again.\"\n" +
+        "—Domri Rade"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GrotesqueDemise.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GrotesqueDemise.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Grotesque Demise — Ravnica Allegiance #75
+ * {2}{B} · Instant
+ *
+ * Exile, not destroy — indestructible and regeneration do not save it. The power restriction
+ * lives on the *target*, so it is checked on announcement and again on resolution (CR 608.2b).
+ */
+val GrotesqueDemise = card("Grotesque Demise") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature with power 3 or less."
+
+    spell {
+        val small = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtMost(3))))
+        effect = Effects.Exile(small)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Ben Wootten"
+        flavorText = "\"A debtor's soul has little value, except as a warning to others who might consider defaulting on their loans.\"\n" +
+        "—Ubea, Orzhov ministrant"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GruulGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GruulGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gruul Guildgate reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val GruulGuildgateReprint = Printing(
+    oracleId = "d38476e9-2e47-4c0c-8129-483c0bd09ec0",
+    name = "Gruul Guildgate",
+    setCode = "RNA",
+    collectorNumber = "249",
+    scryfallId = "33d10573-1695-4a73-b92d-d478572b85ec",
+    artist = "Alexander Forssberg",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/33d10573-1695-4a73-b92d-d478572b85ec.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GruulLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GruulLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Gruul Locket — Ravnica Allegiance #234
+ * {3} · Artifact
+ *
+ * See [AzoriusLocket] for the cycle's wiring — two mana abilities plus the hybrid-cost draw.
+ */
+val GruulLocket = card("Gruul Locket") {
+    manaCost = "{3}"
+    colorIdentity = "GR"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R} or {G}.\n" +
+        "{R/G}{R/G}{R/G}{R/G}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R/G}{R/G}{R/G}{R/G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "234"
+        artist = "Kev Walker"
+        flavorText = "\"In life, it was a cunning survivor, fearless and quick. May its power pass to you as you wear its skull.\"\n" +
+        "—Gna, Gruul shaman"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HaazdaOfficer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HaazdaOfficer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Haazda Officer — Ravnica Allegiance #10
+ * {2}{W} · Creature — Human Soldier · 3 / 2
+ *
+ * An enters-trigger pump on a creature you control.
+ */
+val HaazdaOfficer = card("Haazda Officer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, target creature you control gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val ally = target("target", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(1, 1, ally)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Aaron Miller"
+        flavorText = "\"You two, cover the alley! You, with me! Eyes on windows, balconies, and rooftops. Who knows what a fish-octopus-crab can do!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HeroOfPrecinctOne.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/HeroOfPrecinctOne.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hero of Precinct One — Ravnica Allegiance #11
+ * {1}{W} · Creature — Human Warrior · 2 / 2
+ *
+ * The same multicolour cast trigger as [TomeOfTheGuildpact], paying off in 1/1 white Humans.
+ * Token art resolves through `TokenArtData` from the set code, so no `imageUri` is authored
+ * here.
+ */
+val HeroOfPrecinctOne = card("Hero of Precinct One") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast a multicolored spell, create a 1/1 white Human creature token."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Multicolored)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "11"
+        artist = "Bram Sels"
+        flavorText = "When the established order falters, what remains are ordinary people and their struggle to survive."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Humongulus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Humongulus.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Humongulus — Ravnica Allegiance #41
+ * {4}{U} · Creature — Homunculus · 2 / 5
+ *
+ * Hexproof and nothing else. The reminder text is printed, so it lives in `oracleText`;
+ * the keyword itself is the whole rules content.
+ */
+val Humongulus = card("Humongulus") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Homunculus"
+    power = 2
+    toughness = 5
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Jesper Ejsing"
+        flavorText = "Searching the city for Fblthp felt like sifting the rain for a single drop of blood."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/IllGottenInheritance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/IllGottenInheritance.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ill-Gotten Inheritance — Ravnica Allegiance #77
+ * {3}{B} · Enchantment
+ *
+ * The upkeep drain hits every opponent at once ([Player.EachOpponent]) while the life gain is
+ * flat; the sacrifice ability targets a single opponent instead. Both halves are one composite
+ * per ability, so damage and life gain resolve together.
+ */
+val IllGottenInheritance = card("Ill-Gotten Inheritance") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, this enchantment deals 1 damage to each opponent and you gain 1 life.\n" +
+        "{5}{B}, Sacrifice this enchantment: It deals 4 damage to target opponent and you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(listOf(
+            Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1)
+        ))
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}{B}"), Costs.SacrificeSelf)
+        val victim = target("target", Targets.Opponent)
+        effect = Effects.Composite(listOf(
+            Effects.DealDamage(4, victim),
+            Effects.GainLife(4)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Winona Nelson"
+        flavorText = "\"The suffering of others is not my concern.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ImpassionedOrator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ImpassionedOrator.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Impassioned Orator — Ravnica Allegiance #12
+ * {1}{W} · Creature — Human Cleric · 2 / 2
+ *
+ * "Whenever **another** creature you control enters" is [TriggerBinding.OTHER] over the
+ * creatures-you-control filter — the Orator's own arrival must not trigger it.
+ */
+val ImpassionedOrator = card("Impassioned Orator") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever another creature you control enters, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Mark Zug"
+        flavorText = "In times of unrest, the crowd is eager for the comfort of strong convictions."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/NoxiousGroodion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/NoxiousGroodion.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Noxious Groodion — Ravnica Allegiance #78
+ * {2}{B} · Creature — Beast · 2 / 2
+ *
+ * Vanilla deathtouch.
+ */
+val NoxiousGroodion = card("Noxious Groodion") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "Deathtouch"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Simon Dominic"
+        flavorText = "\"Behold the groodion! Ichor-slurper, oozing fiend. Foulest wonder underground. Grandest vermin of them all!\"\n" +
+        "—Zalin the Gutter Bard"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/OrzhovGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/OrzhovGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orzhov Guildgate reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val OrzhovGuildgateReprint = Printing(
+    oracleId = "57b37df5-fee4-4720-931f-f0cb0a8b338c",
+    name = "Orzhov Guildgate",
+    setCode = "RNA",
+    collectorNumber = "252",
+    scryfallId = "cba5fb67-e161-4e89-be3e-c8021122ff19",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cba5fb67-e161-4e89-be3e-c8021122ff19.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/OrzhovLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/OrzhovLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Orzhov Locket — Ravnica Allegiance #236
+ * {3} · Artifact
+ *
+ * See [AzoriusLocket] for the cycle's wiring — two mana abilities plus the hybrid-cost draw.
+ */
+val OrzhovLocket = card("Orzhov Locket") {
+    manaCost = "{3}"
+    colorIdentity = "BW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W} or {B}.\n" +
+        "{W/B}{W/B}{W/B}{W/B}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W/B}{W/B}{W/B}{W/B}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "236"
+        artist = "Volkan Baǵa"
+        flavorText = "\"It looks expensive, doesn't it? You have no idea...\"\n" +
+        "—Milana, Orzhov prelate"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/PitilessPontiff.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/PitilessPontiff.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pitiless Pontiff — Ravnica Allegiance #194
+ * {W}{B} · Creature — Vampire Cleric · 2 / 2
+ *
+ * "Sacrifice another creature" is [Costs.SacrificeAnother] — the `excludeSelf` sibling of
+ * [Costs.Sacrifice], which is what keeps the Pontiff from eating itself. Both keywords are
+ * granted by the same resolution, so they are one [CompositeEffect] rather than two abilities.
+ */
+val PitilessPontiff = card("Pitiless Pontiff") {
+    manaCost = "{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Vampire Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{1}, Sacrifice another creature: This creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeAnother(GameObjectFilter.Creature))
+        effect = Effects.Composite(listOf(
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Yongjae Choi"
+        flavorText = "\"Pay in gold. Pay in blood. Pay with the servitude of your spirit kin. But pay you must.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Ragefire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Ragefire.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ragefire — Ravnica Allegiance #270
+ * {1}{R} · Sorcery
+ *
+ * A plain burn sorcery.
+ */
+val Ragefire = card("Ragefire") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Ragefire deals 3 damage to target creature."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Randy Vargas"
+        flavorText = "\"Your precious laws can't save you now!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakdos Guildgate reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val RakdosGuildgateReprint = Printing(
+    oracleId = "361f534b-39d1-4421-b5a8-d3813c62f86d",
+    name = "Rakdos Guildgate",
+    setCode = "RNA",
+    collectorNumber = "255",
+    scryfallId = "26f7e55d-d4c9-4755-ab87-a592ba3fb64f",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/26f7e55d-d4c9-4755-ab87-a592ba3fb64f.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Rakdos Locket — Ravnica Allegiance #237
+ * {3} · Artifact
+ *
+ * See [AzoriusLocket] for the cycle's wiring — two mana abilities plus the hybrid-cost draw.
+ */
+val RakdosLocket = card("Rakdos Locket") {
+    manaCost = "{3}"
+    colorIdentity = "BR"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B} or {R}.\n" +
+        "{B/R}{B/R}{B/R}{B/R}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B/R}{B/R}{B/R}{B/R}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "237"
+        artist = "Sung Choi"
+        flavorText = "\"This trinket will gain you admittance to some painfully exclusive gatherings.\"\n" +
+        "—Exava, blood witch"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosTrumpeter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RakdosTrumpeter.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rakdos Trumpeter — Ravnica Allegiance #84
+ * {1}{B} · Creature — Human Shaman · 1 / 3
+ *
+ * Menace is printed with reminder text; the activated ability is the same off-colour pump
+ * as the rest of the RNA "splash" commons.
+ */
+val RakdosTrumpeter = card("Rakdos Trumpeter") {
+    manaCost = "{1}{B}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Human Shaman"
+    power = 1
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "{3}{R}: This creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.MENACE)
+    activatedAbility {
+        cost = Costs.Mana("{3}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Eric Deschamps"
+        flavorText = "\"The louder their performance, the quieter we become in comparison. They are the perfect distractions, for only fools ignore the Rakdos.\"\n" +
+        "—Lazav"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RampagingRendhorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RampagingRendhorn.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rampaging Rendhorn — Ravnica Allegiance #135
+ * {4}{G} · Creature — Beast · 4 / 4
+ *
+ * Riot on a vanilla body — see [ZhurTaaGoblin] for why the [riot] helper is load-bearing.
+ */
+val RampagingRendhorn = card("Rampaging Rendhorn") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)"
+
+    riot()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Ben Wootten"
+        flavorText = "Tumult is its natural habitat."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RavnicaAllegianceBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RavnicaAllegianceBasicLands.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Ravnica Allegiance Basic Lands
+ *
+ * One art per basic land type, cards 260-264.
+ *
+ * A basic land is **not** a `Printing` row: `basicLand(...)` builds a full per-set
+ * `CardDefinition`, which the set's `basicLands` override discovers through
+ * `CardDiscovery.findBasicLandsIn`. (`check-card-printing` flags every basic land in every set
+ * as printing drift for exactly this reason — that class of report is a script limitation, not
+ * a gap here.)
+ */
+
+val RavnicaAllegiancePlains260 = basicLand("Plains") {
+    collectorNumber = "260"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/9433619d-5bd1-41e9-ab7a-364c98347b1d.jpg"
+}
+
+val RavnicaAllegianceIsland261 = basicLand("Island") {
+    collectorNumber = "261"
+    artist = "Eytan Zana"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/197f5bd0-5ab3-4bf4-b20e-1389c0e9527a.jpg"
+}
+
+val RavnicaAllegianceSwamp262 = basicLand("Swamp") {
+    collectorNumber = "262"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/308809ad-c150-49b1-83e3-b78494156d7a.jpg"
+}
+
+val RavnicaAllegianceMountain263 = basicLand("Mountain") {
+    collectorNumber = "263"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54a773e3-93f0-4bf8-ab6a-8cee939d743a.jpg"
+}
+
+val RavnicaAllegianceForest264 = basicLand("Forest") {
+    collectorNumber = "264"
+    artist = "Eytan Zana"
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48764854-d268-462d-a016-27329c8f062d.jpg"
+}
+
+/**
+ * All Ravnica Allegiance basic land variants.
+ */
+val RavnicaAllegianceBasicLands = listOf(
+    RavnicaAllegiancePlains260,
+    RavnicaAllegianceIsland261,
+    RavnicaAllegianceSwamp262,
+    RavnicaAllegianceMountain263,
+    RavnicaAllegianceForest264
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ResoluteWatchdog.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ResoluteWatchdog.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Resolute Watchdog — Ravnica Allegiance #19
+ * {W} · Creature — Dog · 1 / 3
+ *
+ * Sacrificing itself is [Costs.SacrificeSelf]; the indestructible grant is an ordinary
+ * until-end-of-turn keyword grant onto the chosen creature.
+ */
+val ResoluteWatchdog = card("Resolute Watchdog") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    power = 1
+    toughness = 3
+    oracleText = "Defender\n" +
+        "{1}, Sacrifice this creature: Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    keywords(Keyword.DEFENDER)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Milivoj Ćeran"
+        flavorText = "A friend in good times, a guardian in bad times, and a savior when all else fails."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RubbleReading.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RubbleReading.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rubble Reading — Ravnica Allegiance #110
+ * {3}{R} · Sorcery
+ *
+ * Land destruction with a scry 2 rider — the same destroy-then-scry composite as
+ * [GetThePoint].
+ */
+val RubbleReading = card("Rubble Reading") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target land. Scry 2."
+
+    spell {
+        val land = target("target", Targets.Land)
+        effect = Effects.Composite(listOf(
+            Effects.Destroy(land),
+            Effects.Scry(2)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Aaron Miller"
+        flavorText = "Gruul oracles see omens in all forms of destruction: the entrails of a maaka's prey, the flight of vultures over a battlefield, the scattering of toppled stone."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RubbleSlinger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RubbleSlinger.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rubble Slinger — Ravnica Allegiance #217
+ * {2}{R/G} · Creature — Human Warrior · 2 / 3
+ *
+ * Vanilla reach.
+ */
+val RubbleSlinger = card("Rubble Slinger") {
+    manaCost = "{2}{R/G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "Reach"
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Livia Prima"
+        flavorText = "\"Tear down the city, lie by lie. Then throw it back at the liars, stone by stone.\"\n" +
+        "—Domri Rade"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SaruliCaretaker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SaruliCaretaker.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Saruli Caretaker — Ravnica Allegiance #139
+ * {G} · Creature — Dryad · 0 / 3
+ *
+ * "Tap an untapped creature you control" is a [Costs.TapPermanents] atom beside the source's
+ * own {T} — two separate tap costs in one composite. The ability produces mana and targets
+ * nothing, so it is a mana ability ([TimingRule.ManaAbility], `manaAbility = true`) and never
+ * uses the stack.
+ */
+val SaruliCaretaker = card("Saruli Caretaker") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    power = 0
+    toughness = 3
+    oracleText = "Defender\n" +
+        "{T}, Tap an untapped creature you control: Add one mana of any color."
+
+    keywords(Keyword.DEFENDER)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature))
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Howard Lyon"
+        flavorText = "\"I hold the seed of our new beginning.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateCourier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateCourier.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Senate Courier — Ravnica Allegiance #50
+ * {2}{U} · Creature — Bird · 1 / 4
+ *
+ * Flying is printed; vigilance is granted by the activation until end of turn.
+ */
+val SenateCourier = card("Senate Courier") {
+    manaCost = "{2}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 4
+    oracleText = "Flying\n" +
+        "{1}{W}: This creature gains vigilance until end of turn."
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Johann Bodin"
+        flavorText = "\"This Dovin Baan came from nowhere. Watch him. Read his letters. He is more than he appears.\"\n" +
+        "—Lazav"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateGriffin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateGriffin.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Senate Griffin — Ravnica Allegiance #219
+ * {2}{W/U}{W/U} · Creature — Griffin · 3 / 2
+ *
+ * A flier with an enters-scry.
+ */
+val SenateGriffin = card("Senate Griffin") {
+    manaCost = "{2}{W/U}{W/U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Griffin"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, scry 1."
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "219"
+        artist = "Lucas Graciano"
+        flavorText = "\"The Senate griffins overhead used to make people think of order and safety. Not anymore.\"\n" +
+        "—Lavinia"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateGuildmage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SenateGuildmage.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Senate Guildmage — Ravnica Allegiance #204
+ * {W}{U} · Creature — Human Wizard · 2 / 2
+ *
+ * The Azorius entry in the RNA Guildmage cycle. "Draw a card, then discard a card" is one
+ * ordered composite, not two abilities — the discard is chosen after the draw resolves.
+ */
+val SenateGuildmage = card("Senate Guildmage") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{W}, {T}: You gain 2 life.\n" +
+        "{U}, {T}: Draw a card, then discard a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        effect = Effects.GainLife(2)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        effect = Effects.Composite(listOf(
+            Effects.DrawCards(1),
+            Patterns.Hand.discardCards(1)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "G-host Lee"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ShimmerOfPossibility.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ShimmerOfPossibility.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Shimmer of Possibility — Ravnica Allegiance #51
+ * {1}{U} · Sorcery
+ *
+ * [Patterns.Library] `lookAtTopAndKeep` is the gather → select → move-kept → move-rest pipeline;
+ * the printed "in a random order" is its `restOrder`, which matters because the three losers go
+ * under the library in an order the caster does not choose.
+ */
+val ShimmerOfPossibility = card("Shimmer of Possibility") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 4,
+            keepCount = 1,
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Volkan Baǵa"
+        flavorText = "\"There's something peculiar about the rain today.\"\n" +
+        "—Janoc, Tin Street tinker"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SimicGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SimicGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Simic Guildgate reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val SimicGuildgateReprint = Printing(
+    oracleId = "e8705df9-6439-4930-91b6-229f818559af",
+    name = "Simic Guildgate",
+    setCode = "RNA",
+    collectorNumber = "257",
+    scryfallId = "6e73e082-b16a-45d5-bc4a-24c694b0b9af",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e73e082-b16a-45d5-bc4a-24c694b0b9af.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SimicLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SimicLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Simic Locket — Ravnica Allegiance #240
+ * {3} · Artifact
+ *
+ * See [AzoriusLocket] for the cycle's wiring — two mana abilities plus the hybrid-cost draw.
+ */
+val SimicLocket = card("Simic Locket") {
+    manaCost = "{3}"
+    colorIdentity = "GU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G} or {U}.\n" +
+        "{G/U}{G/U}{G/U}{G/U}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G/U}{G/U}{G/U}{G/U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "240"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"Like our guild itself, this locket can stand for many things. You must discern what it means for you.\"\n" +
+        "—Vannifar"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Slimebind.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/Slimebind.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Slimebind — Ravnica Allegiance #54
+ * {1}{U} · Enchantment — Aura
+ *
+ * `auraTarget` carries the "Enchant creature" line — both the cast-time target and the standing
+ * attachment restriction (CR 303.4). The -4/-0 is a *filterless* [ModifyStats] static: with no
+ * filter it applies to whatever the Aura is attached to and follows the attachment automatically.
+ * Flash makes it a combat trick that blanks an attacker's damage without killing it.
+ */
+val Slimebind = card("Slimebind") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets -4/-0."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-4, 0)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Mark Behm"
+        flavorText = "\"Relax. It's quite harmless. And it will dissolve completely in a month or two.\"\n" +
+        "—Navona, Simic field tester"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SpireMangler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SpireMangler.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spire Mangler — Ravnica Allegiance #86
+ * {2}{B} · Creature — Insect · 2 / 1
+ *
+ * The target is narrowed to your own fliers, so it needs a filtered [TargetCreature] rather
+ * than the shared [com.wingedsheep.sdk.dsl.Targets.CreatureYouControl]. The keyword test reads
+ * projected state, so a creature granted flying this turn is a legal target.
+ */
+val SpireMangler = card("Spire Mangler") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 2
+    toughness = 1
+    oracleText = "Flash\n" +
+        "Flying\n" +
+        "When this creature enters, target creature you control with flying gets +2/+0 until end of turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val flier = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl()))
+        )
+        effect = Effects.ModifyStats(2, 0, flier)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Its mandibles can leave a rider in the clouds astride a headless griffin."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SpiritOfTheSpires.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SpiritOfTheSpires.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Spirit of the Spires — Ravnica Allegiance #23
+ * {3}{W} · Creature — Spirit · 2 / 4
+ *
+ * A flying lord. `excludeSelf = true` carries the printed "Other" — without it the Spirit
+ * would pump itself, since it has flying too.
+ */
+val SpiritOfTheSpires = card("Spirit of the Spires") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Other creatures you control with flying get +0/+1."
+
+    keywords(Keyword.FLYING)
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl(), excludeSelf = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Yeong-Hao Han"
+        flavorText = "She breathes fair winds to tired griffins and lifts songbirds beyond the reach of stalking cats."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SteepleCreeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SteepleCreeper.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Steeple Creeper — Ravnica Allegiance #142
+ * {2}{G} · Creature — Frog Snake · 4 / 2
+ *
+ * Off-colour activation granting flying to itself until end of turn.
+ */
+val SteepleCreeper = card("Steeple Creeper") {
+    manaCost = "{2}{G}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Frog Snake"
+    power = 4
+    toughness = 2
+    oracleText = "{3}{U}: This creature gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Svetlin Velinov"
+        flavorText = "\"If the Fin Clade cannot produce a reliable venomous krasis, mobile in both air and water, then the Guardian Project will absorb its resources.\"\n" +
+        "—Vannifar"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/StonyStrength.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/StonyStrength.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stony Strength — Ravnica Allegiance #143
+ * {G} · Instant
+ *
+ * A permanent +1/+1 counter rather than an until-end-of-turn pump, plus an untap — the untap
+ * is what makes it a combat trick on a blocker that has already been tapped for mana.
+ */
+val StonyStrength = card("Stony Strength") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Put a +1/+1 counter on target creature you control. Untap that creature."
+
+    spell {
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(listOf(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+            Effects.Untap(creature)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Chris Seaman"
+        flavorText = "\"What you build, we will destroy . . . and bury you in the rubble!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/StormStrike.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/StormStrike.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Storm Strike — Ravnica Allegiance #119
+ * {R} · Instant
+ *
+ * The pump and the first-strike grant are one clause about one creature, so they nest inside a
+ * single composite; the scry is the separate trailing sentence.
+ */
+val StormStrike = card("Storm Strike") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(listOf(
+            Effects.Composite(listOf(
+                Effects.ModifyStats(1, 0, creature),
+                Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature)
+            )),
+            Effects.Scry(1)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Dmitry Burmak"
+        flavorText = "\"My shout is thunder and my fist is lightning!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SwirlingTorrent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SwirlingTorrent.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swirling Torrent — Ravnica Allegiance #56
+ * {5}{U} · Sorcery
+ *
+ * The same "choose one or both" count as [AppliedBiomancy]. Both modes are tempo rather than
+ * removal, and choosing both on the *same* creature is legal but pointless — the second mode
+ * fizzles on a creature already gone.
+ */
+val SwirlingTorrent = card("Swirling Torrent") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Put target creature on top of its owner's library.\n" +
+        "• Return target creature to its owner's hand."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Put target creature on top of its owner's library") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.PutOnTopOfLibrary(creature)
+            }
+            mode("Return target creature to its owner's hand") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.ReturnToHand(creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Ben Wootten"
+        flavorText = "\"Oops!\"\n" +
+        "—Grupgrup, sluiceway technician"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SyndicateGuildmage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SyndicateGuildmage.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Syndicate Guildmage — Ravnica Allegiance #211
+ * {W}{B} · Creature — Human Cleric · 2 / 2
+ *
+ * The Orzhov entry in the RNA Guildmage cycle. The tapper is restricted to power 4 or
+ * greater, so it needs a filtered [TargetCreature] rather than the shared [Targets.Creature].
+ */
+val SyndicateGuildmage = card("Syndicate Guildmage") {
+    manaCost = "{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{W}, {T}: Tap target creature with power 4 or greater.\n" +
+        "{4}{B}, {T}: This creature deals 2 damage to target opponent or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val big = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(4))))
+        effect = Effects.Tap(big)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{B}"), Costs.Tap)
+        val victim = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.DealDamage(2, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Josh Hass"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TerritorialBoar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TerritorialBoar.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Territorial Boar — Ravnica Allegiance #145
+ * {1}{G} · Creature — Boar · 2 / 2
+ *
+ * [TriggerBinding.ANY] rather than `OTHER`: the printed line has no "another", so a 4-power
+ * Boar-pumping creature that *is* the Boar would still count — it just never is, since the Boar
+ * is a 2/2. The power test reads projected state, so a creature that enters as a 2/2 and is
+ * immediately made 4/4 by a replacement does trigger it.
+ */
+val TerritorialBoar = card("Territorial Boar") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever a creature you control with power 4 or greater enters, this creature gets +1/+1 and gains vigilance until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.powerAtLeast(4).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(listOf(
+            Effects.ModifyStats(1, 1, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"The presence of the strong will make you stronger.\"\n" +
+        "—Yeva, Nature's Herald"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ThirstingShade.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ThirstingShade.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thirsting Shade — Ravnica Allegiance #87
+ * {B} · Creature — Shade · 1 / 1
+ *
+ * The classic Shade firebreathing shape: a repeatable mana-only pump on itself. No {T} in
+ * the cost, so it can be activated any number of times and while attacking.
+ */
+val ThirstingShade = card("Thirsting Shade") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shade"
+    power = 1
+    toughness = 1
+    oracleText = "Lifelink\n" +
+        "{2}{B}: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.LIFELINK)
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Seb McKinnon"
+        flavorText = "\"Your life is a blinding light, your breath a gale, your pulse a deafening drum. Be still. Be still.\"\n" +
+        "—Dahlya Trul, \"Irbitov Lament\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TinStreetDodger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TinStreetDodger.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tin Street Dodger — Ravnica Allegiance #120
+ * {R} · Creature — Goblin Rogue · 1 / 1
+ *
+ * "Can't be blocked … except by creatures with defender" is the *filtered exception* form,
+ * so it is [Effects.GrantCantBeBlockedExceptBy] with a blocker filter rather than the blanket
+ * `AbilityFlag.CANT_BE_BLOCKED` — a defender-having blocker is still legal.
+ */
+val TinStreetDodger = card("Tin Street Dodger") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "{R}: This creature can't be blocked this turn except by creatures with defender."
+
+    keywords(Keyword.HASTE)
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.GrantCantBeBlockedExceptBy(
+            target = EffectTarget.Self,
+            blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"That giant didn't even see me, let alone catch me! And I was close enough to smell him! Of course, that's not saying much.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TomeOfTheGuildpact.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TomeOfTheGuildpact.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Tome of the Guildpact — Ravnica Allegiance #242
+ * {5} · Artifact — Book
+ *
+ * "Whenever you cast a multicolored spell" is [Triggers.youCastSpell] narrowed by
+ * [GameObjectFilter.Multicolored] — the multicolour test reads the spell's *colors*, so a
+ * hybrid card counts only when it actually has two or more. The mana ability is unrestricted
+ * any-colour fixing.
+ */
+val TomeOfTheGuildpact = card("Tome of the Guildpact") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Book"
+    oracleText = "Whenever you cast a multicolored spell, draw a card.\n" +
+        "{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Multicolored)
+        effect = Effects.DrawCards(1)
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "242"
+        artist = "Randy Gallegos"
+        flavorText = "\"Reading it has given me a glimpse of what makes this deeply flawed city so very magnificent.\"\n" +
+        "—Dovin Baan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TowerDefenseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TowerDefenseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower Defense reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val TowerDefenseReprint = Printing(
+    oracleId = "58853200-efbe-41cc-87f1-720841308f4d",
+    name = "Tower Defense",
+    setCode = "RNA",
+    collectorNumber = "147",
+    scryfallId = "195e94a4-a698-4c66-9428-5cc8a40d42c6",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/195e94a4-a698-4c66-9428-5cc8a40d42c6.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TwilightPanther.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/TwilightPanther.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Twilight Panther — Ravnica Allegiance #28
+ * {W} · Creature — Cat Spirit · 1 / 2
+ *
+ * Deathtouch is *granted* by the activation, not printed, so it is an
+ * [Effects.GrantKeyword] on the source rather than a `keywords(...)` line.
+ */
+val TwilightPanther = card("Twilight Panther") {
+    manaCost = "{W}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Cat Spirit"
+    power = 1
+    toughness = 2
+    oracleText = "{B}: This creature gains deathtouch until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Uriah Voth"
+        flavorText = "A pet that can hunt both flesh and spirit is precious in a place where smiling assassins keep company with ghostly shadows."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/VizkopaVampire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/VizkopaVampire.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vizkopa Vampire — Ravnica Allegiance #220
+ * {2}{W/B} · Creature — Vampire · 3 / 1
+ *
+ * A hybrid-cost vanilla lifelinker.
+ */
+val VizkopaVampire = card("Vizkopa Vampire") {
+    manaCost = "{2}{W/B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 1
+    oracleText = "Lifelink"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Winona Nelson"
+        flavorText = "Orzhov vampires look for allies in unlikely places in case their new guildmaster turns on them. The fate of the Obzedat is proof of Kaya's power and her hatred of the living dead."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WatchfulGiant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WatchfulGiant.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Watchful Giant — Ravnica Allegiance #30
+ * {5}{W} · Creature — Giant Soldier · 3 / 6
+ *
+ * An enters-trigger token maker. Token art resolves through `TokenArtData` from the set code,
+ * so no `imageUri` is authored on the [Effects.CreateToken] call.
+ */
+val WatchfulGiant = card("Watchful Giant") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant Soldier"
+    power = 3
+    toughness = 6
+    oracleText = "When this creature enters, create a 1/1 white Human creature token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "Loitering is not only illegal but unwise, since those who stay too long in one place are apt to be stepped on."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WindstormDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WindstormDrake.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Windstorm Drake — Ravnica Allegiance #60
+ * {4}{U} · Creature — Drake · 3 / 3
+ *
+ * The +1/+0 half of the same flying-lord shape as Spirit of the Spires; `excludeSelf`
+ * carries the printed "Other".
+ */
+val WindstormDrake = card("Windstorm Drake") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Other creatures you control with flying get +1/+0."
+
+    keywords(Keyword.FLYING)
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl(), excludeSelf = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Daarken"
+        flavorText = "Drakes become especially voracious as they prepare for their autumn migration, hunting the city's thoroughfares from dawn to dusk."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WreckingBeast.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/WreckingBeast.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wrecking Beast — Ravnica Allegiance #150
+ * {5}{G}{G} · Creature — Beast · 6 / 6
+ *
+ * Riot plus printed trample. [riot] already adds `Keyword.RIOT` to the keyword set, so only
+ * trample is listed here.
+ */
+val WreckingBeast = card("Wrecking Beast") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 6
+    toughness = 6
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\n" +
+        "Trample"
+
+    riot()
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Izzy"
+        flavorText = "\"The best construction makes the most satisfying destruction.\"\n" +
+        "—Domri Rade"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ZhurTaaGoblin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ZhurTaaGoblin.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zhur-Taa Goblin — Ravnica Allegiance #215
+ * {R}{G} · Creature — Goblin Berserker · 2 / 2
+ *
+ * Riot and nothing else. The keyword is display-only in the rules engine, so the mechanic is
+ * wired by the [riot] DSL helper: an `EntersWithChoice(MODE)` recording the pick, a mode-gated
+ * `EntersWithCounters` for the +1/+1 counter, and a mode-gated haste grant (CR 702.136). Never
+ * write `keywordAbility(KeywordAbility.simple(Keyword.RIOT))` beside it — that ships a creature
+ * whose riot does nothing.
+ */
+val ZhurTaaGoblin = card("Zhur-Taa Goblin") {
+    manaCost = "{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Goblin Berserker"
+    power = 2
+    toughness = 2
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)"
+
+    riot()
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Wayne Reynolds"
+        flavorText = "Among the Zhur-Taa Clan, goblins are the first to enter battlefury. When the battle is over, the survivors are still frothing at the mouth, looking for someone to hit."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/GiftOfStrengthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/GiftOfStrengthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gift of Strength reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val GiftOfStrengthReprint = Printing(
+    oracleId = "fe971240-268a-47d4-a14e-3d6352656091",
+    name = "Gift of Strength",
+    setCode = "THB",
+    collectorNumber = "171",
+    scryfallId = "75f5e144-4dd6-441f-b3e2-433aa82bdf7b",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/75f5e144-4dd6-441f-b3e2-433aa82bdf7b.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/AzoriusLocketReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/AzoriusLocketReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azorius Locket reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val AzoriusLocketReprint = Printing(
+    oracleId = "ca13dda2-fbb0-4b6b-9126-3c8df04dee2b",
+    name = "Azorius Locket",
+    setCode = "VOC",
+    collectorNumber = "160",
+    scryfallId = "f893f1e9-1d19-4220-9e0d-3f9c85d33837",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f893f1e9-1d19-4220-9e0d-3f9c85d33837.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -888,3 +888,54 @@
         "BLUE"
     ]
 }
+
+// Tower Defense
+{
+    "name": "Tower Defense",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +0/+5 and gain reach until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "REACH",
+                        "target": "Self"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"The drakes are practice. We may one day need to bring down a sky swallower, or maybe even Rakdos himself.\"\n—Korun Nar, Rubblebelt hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/857e1eb2-f3f2-4c7f-9965-da9d7e385223.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOU.json
@@ -286,6 +286,62 @@
     ]
 }
 
+// Gift of Strength
+{
+    "name": "Gift of Strength",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 and gains reach until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"What greater testament can there be to Rhonas's lessons?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b779620-6bac-445e-a6fe-6d770c0a9c70.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Harrier Naga
 {
     "name": "Harrier Naga",

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -1,3 +1,76 @@
+// Applied Biomancy
+{
+    "name": "Applied Biomancy",
+    "manaCost": "{G}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Target creature gets +1/+1 until end of turn.\n• Return target creature to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets +1/+1 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target creature to its owner's hand"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Sidharth Chaturvedi",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f91ed618-7b0b-4a70-95ad-d9ed46e28692.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Archway Angel
 {
     "name": "Archway Angel",
@@ -63,6 +136,224 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Azorius Knight-Arbiter
+{
+    "name": "Azorius Knight-Arbiter",
+    "manaCost": "{3}{W}{U}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance\nThis creature can't be blocked.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Even Amundsen",
+        "flavorText": "Thanks to the magic in his Writ of Passage, alms beasts lumbered aside, anarchs bowed their heads, and even Rakdos acrobats rolled their spikewheels out of his way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60befc28-2ab8-4b59-a33f-0328c5d2f995.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Azorius Locket
+{
+    "name": "Azorius Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W} or {U}.\n{W/U}{W/U}{W/U}{W/U}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W/U}{W/U}{W/U}{W/U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"Mandatory lockets enable the tracking of all Senate personnel for improved security and efficiency.\"\n—Dovin Baan",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13aed078-9e29-48e7-b145-5252362031a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Bankrupt in Blood
+{
+    "name": "Bankrupt in Blood",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice two creatures.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Your spirits can rest in peace, for your debts are paid.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e635c433-0398-442a-856e-1869f6bf2cfd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Basilica Bell-Haunt
+{
+    "name": "Basilica Bell-Haunt",
+    "manaCost": "{W}{W}{B}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "When this creature enters, each opponent discards a card and you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "EachOpponent"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "You can hear their tolling only when your debt is due.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e72f4329-db6f-4284-b63e-55f22a0a0f6e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
     ]
 }
 
@@ -244,6 +535,214 @@
     ]
 }
 
+// Charging War Boar
+{
+    "name": "Charging War Boar",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nAs long as you control a Domri planeswalker, this creature gets +1/+1 and has trample. (It can deal excess damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Domri"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Domri"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02cef5a4-e8fd-4ebd-b121-67059308c772.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Civic Stalwart
+{
+    "name": "Civic Stalwart",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "oracleText": "When this creature enters, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "Gabor Szikszai",
+        "flavorText": "\"These are your streets. Defend them! This is your neighborhood. Honor it! This is your city. Save it!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa981489-4301-43f6-b1d7-2aa42e00cf75.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Clamor Shaman
+{
+    "name": "Clamor Shaman",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\nWhenever this creature attacks, target creature an opponent controls can't block this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "RIOT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"Little goblin. Big noise.\"\n—Ruric Thar",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3f073d7-f60a-44c1-aec9-cf42bbdb3153.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Coral Commando
 {
     "name": "Coral Commando",
@@ -258,6 +757,510 @@
         "artist": "Alex Konstad",
         "flavorText": "Few Ravnicans are aware of the vast reefs in their world's hidden ocean. Far beneath the great sinkholes, where the light is blue and dim, merfolk tend the coral labyrinths that feed the benthic ecosystem.",
         "imageUri": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg?1783933710"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cult Guildmage
+{
+    "name": "Cult Guildmage",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{3}{B}, {T}: Target player discards a card. Activate only as a sorcery.\n{R}, {T}: This creature deals 1 damage to target opponent or planeswalker.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponentOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "UNCOMMON",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0536c2fa-7402-49a1-9016-dcf5633ca9ef.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Deface
+{
+    "name": "Deface",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Destroy target artifact.\n• Destroy target creature with defender.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:defender"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target creature with defender"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "\"Leave no stone unturned.\"\n—Ruric Thar",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43df9f41-944e-4cf3-ac80-524eadac221d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Dovin's Automaton
+{
+    "name": "Dovin's Automaton",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Homunculus",
+    "oracleText": "As long as you control a Dovin planeswalker, this creature gets +2/+2 and has vigilance. (Attacking doesn't cause it to tap.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Dovin"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Dovin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Paquette",
+        "flavorText": "It was made for battle, but that doesn't mean it's unsophisticated.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a962509-2e77-4655-b397-9625b2f3407a.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Elite Arrester
+{
+    "name": "Elite Arrester",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{1}{U}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "artist": "Randy Vargas",
+        "flavorText": "\"Hold it! I need to see your papers.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/070f0a21-8e06-46ec-9d84-c65067b23893.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Enraged Ceratok
+{
+    "name": "Enraged Ceratok",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Rhino",
+    "oracleText": "This creature can't be blocked by creatures with power 2 or less.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtMost",
+                            "max": 2
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"There's no time to calm it down! Run!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c44fc50f-8958-422f-933f-fd043d642c97.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Essence Capture
+{
+    "name": "Essence Capture",
+    "manaCost": "{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature spell. Put a +1/+1 counter on up to one target creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target 1"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature",
+                    "zone": "Stack"
+                },
+                "id": "target"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"It's not enough to defeat our foes. We must learn from them, too.\"\n—Vannifar",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce137910-0f0e-4f94-9b95-6e0eeeba164e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Expose to Daylight
+{
+    "name": "Expose to Daylight",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment. Scry 1.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "\"Lies cannot long withstand the harsh light of day.\"\n—Lavinia",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/094c2ac3-040f-41fe-9a37-c037d90baec0.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Faerie Duelist
+{
+    "name": "Faerie Duelist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, target creature an opponent controls gets -2/-0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Yongjae Choi",
+        "flavorText": "Faeries are easily offended and quick to exact a quirky revenge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7da9c9b-aeef-4f48-bc8f-39425841cc8c.jpg"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -281,6 +1284,200 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Footlight Fiend
+{
+    "name": "Footlight Fiend",
+    "manaCost": "{B/R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "When this creature dies, it deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"This footlight's broken. Get me a stagehand!\"\n—Judith",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c604697-5c81-4329-9b16-f19bd90ba08c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Frenzied Arynx
+{
+    "name": "Frenzied Arynx",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Cat Beast",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\nTrample\n{4}{R}{G}: This creature gets +3/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "RIOT",
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bce2eef7-03a4-415f-8bb7-a29d50ce1b0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Frilled Mystic
+{
+    "name": "Frilled Mystic",
+    "manaCost": "{G}{G}{U}{U}",
+    "typeLine": "Creature — Elf Lizard Wizard",
+    "oracleText": "Flash\nWhen this creature enters, you may counter target spell.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Counter"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Stack"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "flavorText": "\"Your arrival was expected...and unwelcome.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50595d02-edad-48a6-b10c-6fa859cc88bb.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 
@@ -418,6 +1615,267 @@
     ]
 }
 
+// Get the Point
+{
+    "name": "Get the Point",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature. Scry 1.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Vraska sees the grandeur in death but misses the hilarity.\"\n—Judith",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/821c4ab5-eb75-445a-bbec-e50af54dba7a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Ghor-Clan Wrecker
+{
+    "name": "Ghor-Clan Wrecker",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\nMenace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "RIOT",
+        "MENACE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "David Palumbo",
+        "flavorText": "\"Today the Rubblebelt is a bit larger. That's a good day's work.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4da3969c-1979-4eee-828a-4a7189121eba.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Grasping Thrull
+{
+    "name": "Grasping Thrull",
+    "manaCost": "{3}{W}{B}",
+    "typeLine": "Creature — Thrull",
+    "oracleText": "Flying\nWhen this creature enters, it deals 2 damage to each opponent and you gain 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Debt due! Debt due!\" The thrull's screeching makes children flinch and debtors quail. \"Debt due!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56f82d97-ce50-490c-ad7f-46d70a73e454.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Gravel-Hide Goblin
+{
+    "name": "Gravel-Hide Goblin",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "{3}{G}: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"No peace accord will save Ravnica. You don't build on rot. You burn it down and start again.\"\n—Domri Rade",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/4942068c-ffde-4a6b-849e-8acf05e1d2e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Grotesque Demise
+{
+    "name": "Grotesque Demise",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature with power 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow<=3"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Ben Wootten",
+        "flavorText": "\"A debtor's soul has little value, except as a warning to others who might consider defaulting on their loans.\"\n—Ubea, Orzhov ministrant",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b698c5e1-3816-4f35-8e39-65dc68f5c64f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Growth Spiral
 {
     "name": "Growth Spiral",
@@ -488,6 +1946,199 @@
     ]
 }
 
+// Gruul Locket
+{
+    "name": "Gruul Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R} or {G}.\n{R/G}{R/G}{R/G}{R/G}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R/G}{R/G}{R/G}{R/G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "artist": "Kev Walker",
+        "flavorText": "\"In life, it was a cunning survivor, fearless and quick. May its power pass to you as you wear its skull.\"\n—Gna, Gruul shaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1ec78880-a8ec-4c87-bc3f-e2a79d154884.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Haazda Officer
+{
+    "name": "Haazda Officer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, target creature you control gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Aaron Miller",
+        "flavorText": "\"You two, cover the alley! You, with me! Eyes on windows, balconies, and rooftops. Who knows what a fish-octopus-crab can do!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5ba5f096-c6ea-4db6-966b-617e3454813f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Hero of Precinct One
+{
+    "name": "Hero of Precinct One",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever you cast a multicolored spell, create a 1/1 white Human creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "RARE",
+        "artist": "Bram Sels",
+        "flavorText": "When the established order falters, what remains are ordinary people and their struggle to survive.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87732718-1067-4e5f-a76d-409539c9ef3f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Humongulus
+{
+    "name": "Humongulus",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Homunculus",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Searching the city for Fblthp felt like sifting the rain for a single drop of blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21982dc7-4f79-4251-8382-95cd1f627e0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Hydroid Krasis
 {
     "name": "Hydroid Krasis",
@@ -555,6 +2206,301 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Ill-Gotten Inheritance
+{
+    "name": "Ill-Gotten Inheritance",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, this enchantment deals 1 damage to each opponent and you gain 1 life.\n{5}{B}, Sacrifice this enchantment: It deals 4 damage to target opponent and you gain 4 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Winona Nelson",
+        "flavorText": "\"The suffering of others is not my concern.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d44b342-f611-4836-a9d5-83b00a24318f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Impassioned Orator
+{
+    "name": "Impassioned Orator",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Whenever another creature you control enters, you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Mark Zug",
+        "flavorText": "In times of unrest, the crowd is eager for the comfort of strong convictions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bd746e3-8934-4c86-894e-2cb1738b1d58.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Noxious Groodion
+{
+    "name": "Noxious Groodion",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Deathtouch",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Simon Dominic",
+        "flavorText": "\"Behold the groodion! Ichor-slurper, oozing fiend. Foulest wonder underground. Grandest vermin of them all!\"\n—Zalin the Gutter Bard",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6cb3d78-1a60-4e9b-b387-afeb58677536.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Orzhov Locket
+{
+    "name": "Orzhov Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W} or {B}.\n{W/B}{W/B}{W/B}{W/B}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W/B}{W/B}{W/B}{W/B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"It looks expensive, doesn't it? You have no idea...\"\n—Milana, Orzhov prelate",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/761e7188-bad1-4775-84a2-15da9a42a57c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Pitiless Pontiff
+{
+    "name": "Pitiless Pontiff",
+    "manaCost": "{W}{B}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "{1}, Sacrifice another creature: This creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DEATHTOUCH",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"Pay in gold. Pay in blood. Pay with the servitude of your spirit kin. But pay you must.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98f66c03-cf79-4de0-be55-b921cbdc5038.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
     ]
 }
 
@@ -644,6 +2590,365 @@
     ]
 }
 
+// Ragefire
+{
+    "name": "Ragefire",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Ragefire deals 3 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Randy Vargas",
+        "flavorText": "\"Your precious laws can't save you now!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb13420d-d295-4000-9c38-fa5d10e06ece.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rakdos Locket
+{
+    "name": "Rakdos Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {B} or {R}.\n{B/R}{B/R}{B/R}{B/R}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B/R}{B/R}{B/R}{B/R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "artist": "Sung Choi",
+        "flavorText": "\"This trinket will gain you admittance to some painfully exclusive gatherings.\"\n—Exava, blood witch",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fd60d9b-2282-4b32-9bff-efb2bcf87d22.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Rakdos Trumpeter
+{
+    "name": "Rakdos Trumpeter",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\n{3}{R}: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"The louder their performance, the quieter we become in comparison. They are the perfect distractions, for only fools ignore the Rakdos.\"\n—Lazav",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/2822aff3-9985-424b-9f19-b49e987c25e4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Rampaging Rendhorn
+{
+    "name": "Rampaging Rendhorn",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "RIOT"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Ben Wootten",
+        "flavorText": "Tumult is its natural habitat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12c1b820-0f06-41f6-804f-5c98f60c1529.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Resolute Watchdog
+{
+    "name": "Resolute Watchdog",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Defender\n{1}, Sacrifice this creature: Target creature you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "A friend in good times, a guardian in bad times, and a savior when all else fails.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56d86909-b7f3-4a46-9904-e173853b79f1.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rubble Reading
+{
+    "name": "Rubble Reading",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target land. Scry 2.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Scry",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Aaron Miller",
+        "flavorText": "Gruul oracles see omens in all forms of destruction: the entrails of a maaka's prey, the flight of vultures over a battlefield, the scattering of toppled stone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ace095a-3ea9-4121-8ffb-5b3612b96985.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rubble Slinger
+{
+    "name": "Rubble Slinger",
+    "manaCost": "{2}{R/G}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "217",
+        "artist": "Livia Prima",
+        "flavorText": "\"Tear down the city, lie by lie. Then throw it back at the liars, stone by stone.\"\n—Domri Rade",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f006255f-b18d-4d52-b97a-17909b67decc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
 // Sage's Row Savant
 {
     "name": "Sage's Row Savant",
@@ -675,6 +2980,739 @@
         "artist": "Bastien L. Deharme",
         "flavorText": "The streets of Ravnica are full of former guild members now using their institutional skills for personal gain.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg?1783933705"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Saruli Caretaker
+{
+    "name": "Saruli Caretaker",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "Defender\n{T}, Tap an untapped creature you control: Add one mana of any color.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Howard Lyon",
+        "flavorText": "\"I hold the seed of our new beginning.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef3358cb-714c-49bf-b7e9-a69d02d7799e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Senate Courier
+{
+    "name": "Senate Courier",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\n{1}{W}: This creature gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Johann Bodin",
+        "flavorText": "\"This Dovin Baan came from nowhere. Watch him. Read his letters. He is more than he appears.\"\n—Lazav",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da8dc5c8-4eb7-4e41-8431-b41251f7814e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Senate Griffin
+{
+    "name": "Senate Griffin",
+    "manaCost": "{2}{W/U}{W/U}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\nWhen this creature enters, scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"The Senate griffins overhead used to make people think of order and safety. Not anymore.\"\n—Lavinia",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/465adbb4-4c64-44eb-8323-61d23282c6b8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Senate Guildmage
+{
+    "name": "Senate Guildmage",
+    "manaCost": "{W}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{W}, {T}: You gain 2 life.\n{U}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "G-host Lee",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/913b3a2a-e3fd-4095-ab2a-5e356ea179df.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Shimmer of Possibility
+{
+    "name": "Shimmer of Possibility",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"There's something peculiar about the rain today.\"\n—Janoc, Tin Street tinker",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76e3092d-2422-438c-b5dd-bf8eca33a76e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Simic Locket
+{
+    "name": "Simic Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {G} or {U}.\n{G/U}{G/U}{G/U}{G/U}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G/U}{G/U}{G/U}{G/U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "\"Like our guild itself, this locket can stand for many things. You must discern what it means for you.\"\n—Vannifar",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/29c65978-e5b0-428e-aace-f99768ca6106.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Slimebind
+{
+    "name": "Slimebind",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets -4/-0.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -4,
+                "toughnessBonus": 0
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Mark Behm",
+        "flavorText": "\"Relax. It's quite harmless. And it will dissolve completely in a month or two.\"\n—Navona, Simic field tester",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6263410-20c5-43b4-8183-3c02c10d07fb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Spire Mangler
+{
+    "name": "Spire Mangler",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, target creature you control with flying gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature kw:flying ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "Its mandibles can leave a rider in the clouds astride a headless griffin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3ce548d-764a-4397-bae3-d348dca78421.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Spirit of the Spires
+{
+    "name": "Spirit of the Spires",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nOther creatures you control with flying get +0/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "She breathes fair winds to tired griffins and lifts songbirds beyond the reach of stalking cats.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbd11910-58e2-4233-a18c-e97413126597.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Steeple Creeper
+{
+    "name": "Steeple Creeper",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Frog Snake",
+    "oracleText": "{3}{U}: This creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"If the Fin Clade cannot produce a reliable venomous krasis, mobile in both air and water, then the Guardian Project will absorb its resources.\"\n—Vannifar",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4afafb4-3fc0-4ccf-a942-e4bd2f146d89.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Stony Strength
+{
+    "name": "Stony Strength",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Put a +1/+1 counter on target creature you control. Untap that creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Chris Seaman",
+        "flavorText": "\"What you build, we will destroy . . . and bury you in the rubble!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bbab274-69dd-44a9-9310-a15779c35cad.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Storm Strike
+{
+    "name": "Storm Strike",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"My shout is thunder and my fist is lightning!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8de24cba-545a-438b-9516-1c19a50ca78c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Swirling Torrent
+{
+    "name": "Swirling Torrent",
+    "manaCost": "{5}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Put target creature on top of its owner's library.\n• Return target creature to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Put target creature on top of its owner's library"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target creature to its owner's hand"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Wootten",
+        "flavorText": "\"Oops!\"\n—Grupgrup, sluiceway technician",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8dbb3d2f-4ee4-46e2-98aa-4aa388bd5375.jpg"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -721,6 +3759,412 @@
     ]
 }
 
+// Syndicate Guildmage
+{
+    "name": "Syndicate Guildmage",
+    "manaCost": "{W}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{1}{W}, {T}: Tap target creature with power 4 or greater.\n{4}{B}, {T}: This creature deals 2 damage to target opponent or planeswalker.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=4"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponentOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e82d3c8d-849a-445b-bc7c-365514d1511f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Territorial Boar
+{
+    "name": "Territorial Boar",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "Whenever a creature you control with power 4 or greater enters, this creature gets +1/+1 and gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow>=4 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"The presence of the strong will make you stronger.\"\n—Yeva, Nature's Herald",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e9ddae7-7e7c-46c7-ad7d-9a686c256b9d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thirsting Shade
+{
+    "name": "Thirsting Shade",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Shade",
+    "oracleText": "Lifelink\n{2}{B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Your life is a blinding light, your breath a gale, your pulse a deafening drum. Be still. Be still.\"\n—Dahlya Trul, \"Irbitov Lament\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a920c2e6-4a1f-487c-ad3f-b772443f0633.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Tin Street Dodger
+{
+    "name": "Tin Street Dodger",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "Haste\n{R}: This creature can't be blocked this turn except by creatures with defender.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantCantBeBlockedExceptBy",
+                    "target": "Self",
+                    "blockerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasKeyword",
+                                "keyword": "DEFENDER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "\"That giant didn't even see me, let alone catch me! And I was close enough to smell him! Of course, that's not saying much.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3815ab6-87cd-4310-8068-ec721ee10a24.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tome of the Guildpact
+{
+    "name": "Tome of the Guildpact",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Book",
+    "oracleText": "Whenever you cast a multicolored spell, draw a card.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"Reading it has given me a glimpse of what makes this deeply flawed city so very magnificent.\"\n—Dovin Baan",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95e307d4-7e5f-4f00-869e-da0e7abbf27f.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Twilight Panther
+{
+    "name": "Twilight Panther",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Cat Spirit",
+    "oracleText": "{B}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Uriah Voth",
+        "flavorText": "A pet that can hunt both flesh and spirit is precious in a place where smiling assassins keep company with ghostly shadows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fb149cc-74ca-4bc3-8efc-10ce872b59fb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Vizkopa Vampire
+{
+    "name": "Vizkopa Vampire",
+    "manaCost": "{2}{W/B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Winona Nelson",
+        "flavorText": "Orzhov vampires look for allies in unlikely places in case their new guildmaster turns on them. The fate of the Obzedat is proof of Kaya's power and her hatred of the living dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61245466-694f-4a80-b556-4e7f876aedca.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Watchful Giant
+{
+    "name": "Watchful Giant",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Giant Soldier",
+    "oracleText": "When this creature enters, create a 1/1 white Human creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "Loitering is not only illegal but unwise, since those who stay too long in one place are apt to be stepped on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61a38f24-1eb3-4914-be1f-0b5f6d4b09d5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Wilderness Reclamation
 {
     "name": "Wilderness Reclamation",
@@ -762,5 +4206,186 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Windstorm Drake
+{
+    "name": "Windstorm Drake",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nOther creatures you control with flying get +1/+0.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature kw:flying ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "Drakes become especially voracious as they prepare for their autumn migration, hunting the city's thoroughfares from dawn to dusk.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/120aa3b3-d358-4df3-be39-9b7ce926673a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wrecking Beast
+{
+    "name": "Wrecking Beast",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\nTrample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "RIOT",
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Izzy",
+        "flavorText": "\"The best construction makes the most satisfying destruction.\"\n—Domri Rade",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74e6f7be-4493-4081-ac67-d782ab2b3723.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zhur-Taa Goblin
+{
+    "name": "Zhur-Taa Goblin",
+    "manaCost": "{R}{G}",
+    "typeLine": "Creature — Goblin Berserker",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "RIOT"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "flavorText": "Among the Zhur-Taa Clan, goblins are the first to enter battlefury. When the battle is over, the survivors are still frothing at the mouth, looking for someone to hit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13070db2-cf89-4552-8b6c-76426274321a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -212,6 +212,30 @@
     ]
 }
 
+// Concordia Pegasus
+{
+    "name": "Concordia Pegasus",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Winona Nelson",
+        "flavorText": "\"A kick from its hooves is like a bolt of lightning. I'd know. I've been hit by both.\"\n—Rencz, Izzet chemister's aide",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0333d0b-ae42-48aa-83d8-a4f2c7483a46.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Desecration Demon
 {
     "name": "Desecration Demon",


### PR DESCRIPTION
Sweeps RNA's ⚡ Assay-ready tail to zero: **77 → 0**. Every card was authored to `assay compile`'s JSON rather than to its oracle text, so the differential formalises the result rather than finding bugs in it.

## The four-way split

| bucket | n | work |
|---|---|---|
| `original` | 64 | canonical authored in RNA |
| `elsewhere` | 3 | canonical authored in the earlier set + a `Printing` row here |
| `row-only` | 5 | `Printing` row only (the five Guildgates) |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override — never `Printing` rows |

The `elsewhere` three: **Concordia Pegasus** → RTR, **Gift of Strength** → HOU, **Tower Defense** → GTC.

**Reprint tail: 21 `Printing` rows in all** — 8 into RNA and 13 into eight other sets (ANB 4, M20 3, J22/JMP/M21/NEO/THB/VOC 1 each), the rows that only became visible to `check-card-printing` once these canonicals existed. Printing caches were refreshed before generating, so nothing was silently dropped to a stale TTL.

## Riot is the one mechanic, and it is not a keyword

Six cards carry riot (Clamor Shaman, Frenzied Arynx, Ghor-Clan Wrecker, Rampaging Rendhorn, Wrecking Beast, Zhur-Taa Goblin). Assay's grammar spells it `KeywordAbility.Simple(RIOT)` — which is **display-only**: nothing in `rules-engine` reads `Keyword.RIOT` on a printed card. All six use the `riot()` DSL instead, which composes CR 702.136 out of live primitives: an `EntersWithChoice(MODE)` recording the pick, a mode-gated `EntersWithCounters` for the +1/+1 counter, and a mode-gated haste grant (the same wiring `mh2/ArcboundSlasher` uses).

That is exactly why RNA's scoped differential reports **6** cards in "script slot not modelled yet" rather than comparing them — authoring them the way Assay spells them would have shipped six creatures whose riot does nothing.

## Verification

- `just build` — green.
- `just rebless-cards` — only GTC/HOU/RNA/RTR goldens moved; **additions only, no removals** (RNA +64 canonicals, GTC/RTR/HOU +1 each).
- `just assay-differential`:
  - before: **5161 compared / 5113 confirmed / 48 divergent**
  - after: **5222 compared / 5174 confirmed / 48 divergent**
  - The delta is +61 compared, +61 confirmed, **0 new divergences and 0 resolved** — name-for-name the same 48 cards as the baseline. (+61 rather than +67 is the six riot cards leaving the compared set, as above.)
  - RNA-scoped: **69/69 confirmed, 0 divergent (100.0%)**.
- `just assay-ready RNA` **on the branch**: `0 Assay-ready` (161 declined remain — all grammar work, `LINE_DECLINED` 151 / `MULTI_FACE` 10).
- `scripts/check-card-printing.py` clean for all 67 authored canonicals.

## Findings surfaced, not fixed

- **`lrw/KithkinGreatheart` is a standing differential divergence** for a shape this PR also contains. It folds "gets +1/+1 and has first strike" into one `ConditionalStaticAbility(CompositeStaticAbility(...))`, while Assay emits **two** conditional statics sharing one condition. Charging War Boar and Dovin's Automaton — the same printed sentence — are written the two-static way here, which is also the layer-correct form: the pump is layer 7c and the keyword grant is layer 6, so keeping them apart lets the layer system order them independently. Worth a follow-up to reshape Kithkin Greatheart (and any sibling) rather than teaching the grammar to fold.
- `check-card-printing` flags every basic land in every set as printing drift, because it wants a `Printing` row where the repo uses `basicLand(...)`. Pre-existing script limitation; the new RNA basics are in that class and were not "fixed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)