### PR TITLE
Add the Mirrodin Besieged Zenith cycle

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -9131,6 +9131,23 @@ composite abilities).
     `manaCost == ManaCost.ZERO` — a printed `{0}` parses to a non-empty one-symbol cost and stays normally castable,
     and plenty of engine test fixtures construct `ManaCost.ZERO` directly as shorthand for "free," which must not
     trip this gate.
+- `selfShuffleIntoLibrary()` — `spell { effect = …; selfShuffleIntoLibrary() }` for a card that prints
+  "Shuffle <card name> into its owner's library." (the Mirrodin Besieged Zenith cycle: Green Sun's Zenith,
+  Blue/White/Black/Red Sun's Zenith). Sets `CardScript.selfShuffleIntoLibraryOnResolve`, the sibling of
+  `selfExileOnResolve`: both replace the destination of **CR 608.2n** ("as the final part of an instant or
+  sorcery spell's resolution, the spell is put into its owner's graveyard"), and `StackResolver` reads them
+  at the same seam on both the full-resolve and paused-resolve paths. The card is added to its owner's
+  library and the library is then shuffled, emitting `LibraryShuffledEvent` — the same tail the Omen face
+  uses. A card prints one clause or the other, so don't set both (this one wins if you do — it is checked
+  first). Deliberately **not** a zone-change replacement (`RedirectZoneChange` is that, and applies to any
+  card heading to a graveyard from anywhere), and **not** `AfterResolveDestination.BOTTOM_OF_LIBRARY` (which
+  also lands in `Zone.LIBRARY` but does not shuffle). It is also **not** the cast-this-way rider
+  `AfterResolveDestination` — and it *outranks* one, uniquely among the card-intrinsic destinations: those
+  riders read "if that spell would be put into a graveyard, [somewhere] instead" (Kylox's Voltstrider), and a
+  spell that shuffles itself in never would be, so the rider has nothing to replace. On the countered and
+  fizzled paths, where the card really is put into a graveyard, the rider still wins. Because it is read at resolution-destination
+  time it is correctly inert when the spell is countered or fizzles — those paths never reach CR 608.2n, so
+  the card goes to its owner's graveyard as usual.
 - `Paradigm` (Secrets of Strixhaven) — `spell { effect = …; paradigm() }` on a Lesson spell. An **exile-zone
   recurrence** mechanic, modelled exactly like Suspend (a marker the engine reads off an exiled card), differing
   only in that it casts a **copy** rather than the card itself, so the original recurs forever. Oracle: "[effect]

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -9138,16 +9138,22 @@ composite abilities).
   sorcery spell's resolution, the spell is put into its owner's graveyard"), and `StackResolver` reads them
   at the same seam on both the full-resolve and paused-resolve paths. The card is added to its owner's
   library and the library is then shuffled, emitting `LibraryShuffledEvent` — the same tail the Omen face
-  uses. A card prints one clause or the other, so don't set both (this one wins if you do — it is checked
-  first). Deliberately **not** a zone-change replacement (`RedirectZoneChange` is that, and applies to any
+  uses. A card prints one clause or the other, and setting both is **rejected at card-construction time**
+  (in the DSL, with a message naming the card, and again in `CardScript`'s own `init` for scripts built
+  directly). Deliberately **not** a zone-change replacement (`RedirectZoneChange` is that, and applies to any
   card heading to a graveyard from anywhere), and **not** `AfterResolveDestination.BOTTOM_OF_LIBRARY` (which
   also lands in `Zone.LIBRARY` but does not shuffle). It is also **not** the cast-this-way rider
-  `AfterResolveDestination` — and it *outranks* one, uniquely among the card-intrinsic destinations: those
-  riders read "if that spell would be put into a graveyard, [somewhere] instead" (Kylox's Voltstrider), and a
-  spell that shuffles itself in never would be, so the rider has nothing to replace. On the countered and
-  fizzled paths, where the card really is put into a graveyard, the rider still wins. Because it is read at resolution-destination
+  `AfterResolveDestination` — and it *outranks* one: those riders read "if that spell would be put into a
+  graveyard, [somewhere] instead" (Kylox's Voltstrider), and a spell that shuffles itself in never would be,
+  so the rider has nothing to replace. On the countered and fizzled paths, where the card really is put into
+  a graveyard, the rider still wins. Because it is read at resolution-destination
   time it is correctly inert when the spell is countered or fizzles — those paths never reach CR 608.2n, so
   the card goes to its owner's graveyard as usual.
+  **It does not outrank flashback (CR 702.34a) or harmonize (CR 702.180a)**, printed or granted. Every other
+  clause at this seam — the rider, rebound, Adventure, Omen — is worded "instead of putting it into its
+  owner's *graveyard*", which is why the printed clause beats them; those two are worded "exile this card
+  instead of putting it *anywhere else* any time it would leave the stack", which covers the library move,
+  so they still apply. A Blue Sun's Zenith flashbacked off Snapcaster Mage is exiled, not shuffled in.
 - `Paradigm` (Secrets of Strixhaven) — `spell { effect = …; paradigm() }` on a Lesson spell. An **exile-zone
   recurrence** mechanic, modelled exactly like Suspend (a marker the engine reads off an exiled card), differing
   only in that it casts a **copy** rather than the card itself, so the original recurs forever. Oracle: "[effect]

--- a/manual-scenarios/cards/b/black-suns-zenith.json
+++ b/manual-scenarios/cards/b/black-suns-zenith.json
@@ -1,0 +1,41 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Black Sun's Zenith"],
+    "battlefield": [
+      {"name": "Birds of Paradise"},
+      {"name": "Craw Wurm"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Grizzly Bears", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Llanowar Elves"},
+      {"name": "Grizzly Bears"},
+      {"name": "Hill Giant"},
+      {"name": "Elder Gargaroth"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Grizzly Bears", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/b/blue-suns-zenith.json
+++ b/manual-scenarios/cards/b/blue-suns-zenith.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Blue Sun's Zenith"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Air Elemental", "Island", "Island", "Grizzly Bears", "Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Hill Giant", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/cards/g/green-suns-zenith.json
+++ b/manual-scenarios/cards/g/green-suns-zenith.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Green Sun's Zenith", "Green Sun's Zenith"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Dryad Arbor", "Llanowar Elves", "Grizzly Bears", "Elder Gargaroth", "Craw Wurm", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Hill Giant", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/cards/r/red-suns-zenith.json
+++ b/manual-scenarios/cards/r/red-suns-zenith.json
@@ -1,0 +1,39 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Red Sun's Zenith", "Red Sun's Zenith"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Craw Wurm"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Llanowar Elves", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/cards/w/white-suns-zenith.json
+++ b/manual-scenarios/cards/w/white-suns-zenith.json
@@ -1,0 +1,40 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["White Sun's Zenith"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Serra Angel", "Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Craw Wurm"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Hill Giant", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -948,6 +948,7 @@ class CardBuilder(private val name: String) {
             classLevels = classLevelsList.toList(),
             sagaChapters = sagaChaptersList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
+            selfShuffleIntoLibraryOnResolve = spellBuilder?.shufflesIntoLibraryOnResolve ?: false,
             paradigm = spellBuilder?.isParadigm ?: false,
             returnTransformedFromGraveyardOnResolve = spellBuilder?.returnTransformedFromGraveyardMarker,
             selfAlternativeCost = selfAlternativeCost,
@@ -1070,6 +1071,21 @@ class SpellBuilder {
     }
 
     internal val exilesOnResolve: Boolean get() = selfExileOnResolve
+
+    private var selfShuffleIntoLibraryOnResolve: Boolean = false
+
+    /**
+     * Mark this spell to shuffle itself into its owner's library on resolution instead of going to
+     * the graveyard. Used for cards that say "Shuffle <card name> into its owner's library."
+     *
+     * The sibling of [selfExile]; both replace the CR 608.2n destination. A card prints one clause
+     * or the other, so don't set both.
+     */
+    fun selfShuffleIntoLibrary() {
+        selfShuffleIntoLibraryOnResolve = true
+    }
+
+    internal val shufflesIntoLibraryOnResolve: Boolean get() = selfShuffleIntoLibraryOnResolve
 
     private var paradigm: Boolean = false
 
@@ -2123,6 +2139,7 @@ class CardFaceBuilder(private val name: String) {
             staticAbilities = staticAbilities.toList(),
             additionalCosts = additionalCostsList.toList(),
             selfExileOnResolve = spellBuilder?.exilesOnResolve ?: false,
+            selfShuffleIntoLibraryOnResolve = spellBuilder?.shufflesIntoLibraryOnResolve ?: false,
             paradigm = spellBuilder?.isParadigm ?: false,
         )
         return CardFace(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1080,7 +1080,11 @@ class SpellBuilder {
      * the graveyard. Used for cards that say "Shuffle <card name> into its owner's library."
      *
      * The sibling of [selfExile]; both replace the CR 608.2n destination. A card prints one clause
-     * or the other, so don't set both.
+     * or the other, so don't set both — setting both is rejected at card-construction time.
+     *
+     * Does not outrank flashback (CR 702.34a) or harmonize (CR 702.180a): those replace "anywhere
+     * else any time it would leave the stack" rather than naming the graveyard, so a flashbacked
+     * spell with this clause is exiled. See [com.wingedsheep.sdk.model.CardScript.selfShuffleIntoLibraryOnResolve].
      */
     fun selfShuffleIntoLibrary() {
         selfShuffleIntoLibraryOnResolve = true
@@ -1094,6 +1098,9 @@ class SpellBuilder {
      * card-authoring mistake, and without this it resolves silently to whichever clause
      * `StackResolver` happens to check first. Order-independent, so it also catches
      * [paradigm] (which implies [selfExile]) paired with [selfShuffleIntoLibrary] either way round.
+     *
+     * [com.wingedsheep.sdk.model.CardScript]'s own `init` rejects the same pair; this one runs first
+     * for anything built through the DSL, purely so the message can name the offending card.
      */
     internal fun validateResolutionDestination(cardName: String) {
         require(!(selfExileOnResolve && selfShuffleIntoLibraryOnResolve)) {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -925,6 +925,7 @@ class CardBuilder(private val name: String) {
         } else {
             rawSpellEffect
         }
+        spellBuilder?.validateResolutionDestination(name)
         val script = CardScript(
             spellEffect = spellEffect,
             targetRequirements = spellBuilder?.targetRequirements ?: emptyList(),
@@ -1086,6 +1087,20 @@ class SpellBuilder {
     }
 
     internal val shufflesIntoLibraryOnResolve: Boolean get() = selfShuffleIntoLibraryOnResolve
+
+    /**
+     * A card prints "Exile <card name>." or "Shuffle <card name> into its owner's library.", never
+     * both — they are two spellings of the same slot, the CR 608.2n destination. Setting both is a
+     * card-authoring mistake, and without this it resolves silently to whichever clause
+     * `StackResolver` happens to check first. Order-independent, so it also catches
+     * [paradigm] (which implies [selfExile]) paired with [selfShuffleIntoLibrary] either way round.
+     */
+    internal fun validateResolutionDestination(cardName: String) {
+        require(!(selfExileOnResolve && selfShuffleIntoLibraryOnResolve)) {
+            "$cardName sets both selfExile() and selfShuffleIntoLibrary(); a spell has one " +
+                "CR 608.2n destination, so pick the clause the card actually prints"
+        }
+    }
 
     private var paradigm: Boolean = false
 
@@ -2130,6 +2145,7 @@ class CardFaceBuilder(private val name: String) {
         } else {
             rawSpellEffect
         }
+        spellBuilder?.validateResolutionDestination(name)
         val script = CardScript(
             spellEffect = spellEffect,
             targetRequirements = spellBuilder?.targetRequirements ?: emptyList(),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -279,8 +279,8 @@ data class CardScript(
      * The sibling of [selfExileOnResolve], and the same seam: both replace the destination of
      * CR 608.2n ("as the final part of an instant or sorcery spell's resolution, the spell is put
      * into its owner's graveyard"). The two are mutually exclusive — a card prints one clause or the
-     * other, never both — and this one wins if a card somehow sets both, because `StackResolver`
-     * checks it first (see the precedence note below).
+     * other, never both — and setting both is **rejected**, by the `init` block below and again in
+     * the DSL, where the message can name the offending card.
      *
      * Three things this deliberately is **not**:
      *  - not a zone-change replacement — [com.wingedsheep.sdk.scripting.ReplacementEffect] shapes
@@ -288,16 +288,21 @@ data class CardScript(
      *    this is one printed instruction about the spell's own resolution;
      *  - not the cast-this-way rider
      *    ([com.wingedsheep.sdk.scripting.effects.AfterResolveDestination]), which another effect
-     *    stamps onto a spell *it* is casting — and which this **outranks**, uniquely among the
-     *    card-intrinsic destinations: those riders are written "if that spell *would be put into a
-     *    graveyard*, [somewhere] instead" (Kylox's Voltstrider), and a spell that shuffles itself
-     *    into its owner's library never would be, so the rider has nothing to replace. On the
-     *    countered and fizzled paths, where the card really is put into a graveyard, the rider
-     *    still wins;
+     *    stamps onto a spell *it* is casting — and which this **outranks**: those riders are
+     *    written "if that spell *would be put into a graveyard*, [somewhere] instead" (Kylox's
+     *    Voltstrider), and a spell that shuffles itself into its owner's library never would be, so
+     *    the rider has nothing to replace. On the countered and fizzled paths, where the card really
+     *    is put into a graveyard, the rider still wins;
      *  - not "put it on the bottom of its owner's library" — the card is shuffled in, so the
      *    library is randomized and a `LibraryShuffledEvent` is emitted (contrast
      *    [com.wingedsheep.sdk.scripting.effects.AfterResolveDestination.BOTTOM_OF_LIBRARY], which
      *    does not shuffle).
+     *
+     * It does **not** outrank flashback (CR 702.34a) or harmonize (CR 702.180a), printed or granted.
+     * Those two are worded "exile this card instead of putting it anywhere else any time it would
+     * leave the stack" rather than naming the graveyard, so unlike every other clause at this seam
+     * they still apply to a spell that shuffles itself in: a flashbacked Blue Sun's Zenith is
+     * exiled, not shuffled into its owner's library.
      *
      * Read at resolution-destination time, so — like [selfExileOnResolve] — it is correctly inert
      * when the spell is countered or fizzles: those paths never reach CR 608.2n, and the card goes
@@ -382,6 +387,18 @@ data class CardScript(
      */
     val castTimeCaptures: List<CastTimeCapture> = emptyList()
 ) {
+    init {
+        // "Exile <card name>." and "Shuffle <card name> into its owner's library." are two
+        // spellings of one slot — the CR 608.2n destination — so a script that sets both has no
+        // answer, only whichever clause `StackResolver` happens to test first. The DSL rejects it
+        // too, with a message that names the card; this backstop covers the paths that build a
+        // CardScript directly (test fixtures, the Assay compiler), where the DSL guard never runs.
+        require(!(selfExileOnResolve && selfShuffleIntoLibraryOnResolve)) {
+            "A CardScript sets both selfExileOnResolve and selfShuffleIntoLibraryOnResolve; a " +
+                "spell has one CR 608.2n destination, so pick the clause the card actually prints"
+        }
+    }
+
     /**
      * Whether this card has any scripted behavior.
      * Vanilla creatures and basic lands return false.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardScript.kt
@@ -272,6 +272,40 @@ data class CardScript(
     val selfExileOnResolve: Boolean = false,
 
     /**
+     * Whether this spell shuffles itself into its owner's library on resolution instead of going to
+     * the graveyard. Used for cards that say "Shuffle <card name> into its owner's library." — the
+     * Mirrodin Besieged Zenith cycle (Green Sun's Zenith and its four siblings).
+     *
+     * The sibling of [selfExileOnResolve], and the same seam: both replace the destination of
+     * CR 608.2n ("as the final part of an instant or sorcery spell's resolution, the spell is put
+     * into its owner's graveyard"). The two are mutually exclusive — a card prints one clause or the
+     * other, never both — and this one wins if a card somehow sets both, because `StackResolver`
+     * checks it first (see the precedence note below).
+     *
+     * Three things this deliberately is **not**:
+     *  - not a zone-change replacement — [com.wingedsheep.sdk.scripting.ReplacementEffect] shapes
+     *    such as `RedirectZoneChange` apply to any card heading to a graveyard from anywhere, while
+     *    this is one printed instruction about the spell's own resolution;
+     *  - not the cast-this-way rider
+     *    ([com.wingedsheep.sdk.scripting.effects.AfterResolveDestination]), which another effect
+     *    stamps onto a spell *it* is casting — and which this **outranks**, uniquely among the
+     *    card-intrinsic destinations: those riders are written "if that spell *would be put into a
+     *    graveyard*, [somewhere] instead" (Kylox's Voltstrider), and a spell that shuffles itself
+     *    into its owner's library never would be, so the rider has nothing to replace. On the
+     *    countered and fizzled paths, where the card really is put into a graveyard, the rider
+     *    still wins;
+     *  - not "put it on the bottom of its owner's library" — the card is shuffled in, so the
+     *    library is randomized and a `LibraryShuffledEvent` is emitted (contrast
+     *    [com.wingedsheep.sdk.scripting.effects.AfterResolveDestination.BOTTOM_OF_LIBRARY], which
+     *    does not shuffle).
+     *
+     * Read at resolution-destination time, so — like [selfExileOnResolve] — it is correctly inert
+     * when the spell is countered or fizzles: those paths never reach CR 608.2n, and the card goes
+     * to its owner's graveyard as usual.
+     */
+    val selfShuffleIntoLibraryOnResolve: Boolean = false,
+
+    /**
      * Paradigm (Secrets of Strixhaven). When true, this spell exiles itself on resolution
      * (implies [selfExileOnResolve]) and is tagged with the paradigm marker as it lands in
      * exile, so the engine synthesizes the recurring free-recast triggered ability

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BlueSunsZenithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BlueSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blue Sun's Zenith reprint in C13 (Commander 2013). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val BlueSunsZenithReprint = Printing(
+    oracleId = "613a41b8-0b4f-4995-bf1e-ca41f96e6438",
+    name = "Blue Sun's Zenith",
+    setCode = "C13",
+    collectorNumber = "32",
+    scryfallId = "1ed91aab-9009-4cab-9dd8-b595648df011",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1ed91aab-9009-4cab-9dd8-b595648df011.jpg?1783939686",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BlackSunsZenithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BlackSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Black Sun's Zenith reprint in C14 (Commander 2014). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val BlackSunsZenithReprint = Printing(
+    oracleId = "038c0165-32b6-4e81-8180-604b49905207",
+    name = "Black Sun's Zenith",
+    setCode = "C14",
+    collectorNumber = "136",
+    scryfallId = "90b217bf-9a62-4239-be24-e23c106b8212",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90b217bf-9a62-4239-be24-e23c106b8212.jpg?1783938845",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/WhiteSunsZenithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/WhiteSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * White Sun's Zenith reprint in C14 (Commander 2014). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val WhiteSunsZenithReprint = Printing(
+    oracleId = "ea4a9299-c2b3-4092-89dd-28142b203d60",
+    name = "White Sun's Zenith",
+    setCode = "C14",
+    collectorNumber = "95",
+    scryfallId = "fc78c528-b481-493f-aa24-747e86a54272",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc78c528-b481-493f-aa24-747e86a54272.jpg?1783938854",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BlueSunsZenithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BlueSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blue Sun's Zenith reprint in C15 (Commander 2015). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val BlueSunsZenithReprint = Printing(
+    oracleId = "613a41b8-0b4f-4995-bf1e-ca41f96e6438",
+    name = "Blue Sun's Zenith",
+    setCode = "C15",
+    collectorNumber = "88",
+    scryfallId = "8287b55b-ed12-4a86-b2ca-e462457570f4",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/8287b55b-ed12-4a86-b2ca-e462457570f4.jpg?1783938095",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlackSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlackSunsZenith.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Black Sun's Zenith — Mirrodin Besieged #39 (canonical / earliest real printing, 2011)
+ * {X}{B}{B} · Sorcery
+ *
+ * Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.
+ *
+ * Darkness Descends' shape (`ForEachInGroup` over `GroupFilter.AllCreatures`, `EffectTarget.Self`
+ * rebound to each creature in turn) with the fixed count swapped for the dynamic one. Counters
+ * rather than a -X/-X effect is the whole point of the card: they stick past end of turn, and a
+ * creature reduced to 0 toughness dies to state-based actions.
+ */
+val BlackSunsZenith = card("Black Sun's Zenith") {
+    manaCost = "{X}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its " +
+        "owner's library."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreatures,
+            effect = AddDynamicCountersEffect(
+                counterType = Counters.MINUS_ONE_MINUS_ONE,
+                amount = DynamicAmount.XValue,
+                target = EffectTarget.Self,
+            ),
+        )
+        selfShuffleIntoLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Daniel Ljunggren"
+        flavorText = "\"Under the suns, Mirrodin kneels and begs us for perfection.\"\n" +
+            "—Geth, Lord of the Vault"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg?1783941385"
+        ruling(
+            "2011-06-01",
+            "If this spell doesn't resolve, none of its effects occur. In particular, it will go " +
+                "to the graveyard rather than to its owner's library."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlackSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlackSunsZenith.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -30,7 +29,7 @@ val BlackSunsZenith = card("Black Sun's Zenith") {
     spell {
         effect = Effects.ForEachInGroup(
             filter = GroupFilter.AllCreatures,
-            effect = AddDynamicCountersEffect(
+            effect = Effects.AddDynamicCounters(
                 counterType = Counters.MINUS_ONE_MINUS_ONE,
                 amount = DynamicAmount.XValue,
                 target = EffectTarget.Self,

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlueSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/BlueSunsZenith.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Blue Sun's Zenith — Mirrodin Besieged #20 (canonical / earliest real printing, 2011)
+ * {X}{U}{U}{U} · Instant
+ *
+ * Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.
+ *
+ * Note the target is a *player*, not "you" — the card is as happy decking an opponent as refilling
+ * your own hand. `selfShuffleIntoLibrary()` replaces the CR 608.2n destination; if the spell is
+ * countered or its target becomes illegal it goes to the graveyard as usual.
+ */
+val BlueSunsZenith = card("Blue Sun's Zenith") {
+    manaCost = "{X}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library."
+
+    spell {
+        target("target player", Targets.Player)
+        effect = Effects.DrawCards(DynamicAmount.XValue, EffectTarget.ContextTarget(0))
+        selfShuffleIntoLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Izzy"
+        flavorText = "\"The Origin Query will wait. We must ensure we survive to return to it.\"\n" +
+            "—Pelyus, vedalken ordinar"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg?1783941389"
+        ruling(
+            "2011-06-01",
+            "If this spell doesn't resolve, none of its effects occur. In particular, it will go " +
+                "to the graveyard rather than to its owner's library."
+        )
+        ruling(
+            "2018-03-16",
+            "Because you follow the spell's instructions in order, you won't be able to draw the " +
+                "same Blue Sun's Zenith that you cast."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/GreenSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/GreenSunsZenith.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Green Sun's Zenith — Mirrodin Besieged #81 (canonical / earliest real printing, 2011)
+ * {X}{G} · Sorcery
+ *
+ * Search your library for a green creature card with mana value X or less, put it onto the
+ * battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.
+ *
+ * The search is the stock `Patterns.Library.searchLibrary` recipe pointed at the battlefield;
+ * `count = 1` is how many cards are found, while the {X} paid lives in the *filter*
+ * (`manaValueAtMostX()` → `CardPredicate.ManaValueAtMostX`, read off this spell's own cast at
+ * resolution). Searching never compels a find (CR 701.23b), so X = 0 legitimately finds nothing —
+ * except for Dryad Arbor, the one green creature card with mana value 0.
+ *
+ * The trailing clause is `selfShuffleIntoLibrary()`, which replaces this spell's CR 608.2n
+ * destination. Note it fires only on resolution: countered or fizzled, the card goes to the
+ * graveyard like any other spell. Of the five Zeniths this is the only one whose effect *pauses*
+ * mid-resolution (for the library-search decision), so it is the cycle's one exercise of
+ * `StackResolver`'s paused-resolve path.
+ */
+val GreenSunsZenith = card("Green Sun's Zenith") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a green creature card with mana value X or less, put it " +
+        "onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library."
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature.withColor(Color.GREEN).manaValueAtMostX(),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+        )
+        selfShuffleIntoLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "81"
+        artist = "David Rapoza"
+        flavorText = "As the green sun crowned, Phyrexian prophecies glowed on the Tree of Tales."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg?1783941375"
+        ruling(
+            "2011-06-01",
+            "If this spell doesn't resolve, none of its effects occur. In particular, it will go " +
+                "to the graveyard rather than to its owner's library."
+        )
+        ruling(
+            "2016-06-08",
+            "If Green Sun's Zenith is countered, none of its effects will happen. Notably, it " +
+                "will be put into its owner's graveyard rather than shuffled into its owner's library."
+        )
+        ruling(
+            "2016-06-08",
+            "In most cases, if you own Green Sun's Zenith and cast it, you'll shuffle your " +
+                "library twice. In practice, shuffling once is sufficient, but effects that care " +
+                "about you shuffling your library (like Psychogenic Probe, for example) will see " +
+                "that you've shuffled twice."
+        )
+        ruling(
+            "2016-06-08",
+            "If you own Green Sun's Zenith, but an opponent casts it (due to Knowledge Pool's " +
+                "effect, for example), that opponent searches their library for an appropriate " +
+                "creature card, then shuffles that library. That opponent then shuffles Green " +
+                "Sun's Zenith into your library. You won't shuffle any library in this case."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/RedSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/RedSunsZenith.kt
@@ -1,9 +1,11 @@
 package com.wingedsheep.mtg.sets.definitions.mbs.cards
 
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
-import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.targets.AnyTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
@@ -14,11 +16,20 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Red Sun's Zenith deals X damage to any target. If a creature dealt damage this way would die
  * this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.
  *
- * Carbonize's shape exactly: `AnyTarget()` plus [MarkExileOnDeathEffect], the CR 614 death
+ * Carbonize's shape plus a gate: `AnyTarget()` and [Effects.MarkExileOnDeath], the CR 614 death
  * replacement that lasts the turn. The mark goes on *before* the damage, as on Carbonize, so a
  * creature killed by this very spell is exiled rather than merely a creature that survives it and
- * dies later. Marking a player or planeswalker is a no-op — "a creature dealt damage this way" is
- * the only thing the clause speaks to.
+ * dies later.
+ *
+ * The gate is what Carbonize doesn't need. Carbonize deals a fixed 3, but this is an {X} spell and
+ * X = 0 is a legal, {R}-cheap cast — and CR 120.8 says a source that would deal 0 damage deals none
+ * at all. With no creature "dealt damage this way" there is nothing to exile, so an ungated mark
+ * would quietly exile a creature that died to something else later in the turn. `X > 0` is the
+ * condition the card's own wording implies.
+ *
+ * Not gated on the target being a creature: marking a player is a no-op in the executor, and
+ * marking a planeswalker is a no-op because the loyalty state-based action never consults the
+ * marker — "a creature dealt damage this way" is the only thing the clause speaks to.
  */
 val RedSunsZenith = card("Red Sun's Zenith") {
     manaCost = "{X}{R}"
@@ -29,7 +40,15 @@ val RedSunsZenith = card("Red Sun's Zenith") {
 
     spell {
         val t = target("any target", AnyTarget())
-        effect = MarkExileOnDeathEffect(t) then DealDamageEffect(DynamicAmount.XValue, t)
+        effect = ConditionalEffect(
+            // CR 120.8 — X = 0 deals no damage, so nothing was "dealt damage this way".
+            condition = Conditions.CompareAmounts(
+                DynamicAmount.XValue,
+                ComparisonOperator.GT,
+                DynamicAmount.Fixed(0),
+            ),
+            effect = Effects.MarkExileOnDeath(t),
+        ) then Effects.DealDamage(DynamicAmount.XValue, t)
         selfShuffleIntoLibrary()
     }
 

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/RedSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/RedSunsZenith.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Red Sun's Zenith — Mirrodin Besieged #74 (canonical / earliest real printing, 2011)
+ * {X}{R} · Sorcery
+ *
+ * Red Sun's Zenith deals X damage to any target. If a creature dealt damage this way would die
+ * this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.
+ *
+ * Carbonize's shape exactly: `AnyTarget()` plus [MarkExileOnDeathEffect], the CR 614 death
+ * replacement that lasts the turn. The mark goes on *before* the damage, as on Carbonize, so a
+ * creature killed by this very spell is exiled rather than merely a creature that survives it and
+ * dies later. Marking a player or planeswalker is a no-op — "a creature dealt damage this way" is
+ * the only thing the clause speaks to.
+ */
+val RedSunsZenith = card("Red Sun's Zenith") {
+    manaCost = "{X}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Red Sun's Zenith deals X damage to any target. If a creature dealt damage this " +
+        "way would die this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library."
+
+    spell {
+        val t = target("any target", AnyTarget())
+        effect = MarkExileOnDeathEffect(t) then DealDamageEffect(DynamicAmount.XValue, t)
+        selfShuffleIntoLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "74"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg?1783941377"
+        ruling(
+            "2011-06-01",
+            "If this spell doesn't resolve, none of its effects occur. In particular, it will go " +
+                "to the graveyard rather than to its owner's library."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/WhiteSunsZenith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/WhiteSunsZenith.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * White Sun's Zenith — Mirrodin Besieged #19 (canonical / earliest real printing, 2011)
+ * {X}{W}{W}{W} · Instant
+ *
+ * Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.
+ *
+ * The dynamic-count `Effects.CreateToken` overload, with X read off this spell's cast. Mirrodin
+ * Besieged printed no Cat token of its own, so the art is the one Scryfall links from this
+ * printing (`all_parts`).
+ */
+val WhiteSunsZenith = card("White Sun's Zenith") {
+    manaCost = "{X}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its " +
+        "owner's library."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.XValue,
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Cat"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/d/7d400b41-813d-4a63-848f-5eb4db4bf3bb.jpg?1783903575",
+        )
+        selfShuffleIntoLibrary()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Mike Bierek"
+        flavorText = "After the Battle of Liet Field, the white sun crested above Taj-Nar, " +
+            "bringing hope to all who survived the carnage."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg?1783941389"
+        ruling(
+            "2011-06-01",
+            "If this spell doesn't resolve, none of its effects occur. In particular, it will go " +
+                "to the graveyard rather than to its owner's library."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlueSunsZenithScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlueSunsZenithScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.LibraryShuffledEvent
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.cards.SnapcasterMage
+import com.wingedsheep.mtg.sets.definitions.mbs.cards.BlueSunsZenith
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blue Sun's Zenith — "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's
+ * library."
+ *
+ * The cycle's only instant, which is what makes it the card that meets **Snapcaster Mage**: the
+ * printed "shuffle this into its owner's library" clause and flashback both want to say where the
+ * card goes as it resolves, and flashback wins. CR 702.34a is worded "exile this card instead of
+ * putting it **anywhere else** any time it would leave the stack" — not "instead of putting it into
+ * its owner's graveyard", which is how the cast-this-way rider, rebound, Adventure and Omen are all
+ * worded and why the printed clause beats *those*. Getting this backwards turns Snapcaster plus this
+ * card into a repeatable draw-X loop, so it is worth a card-level test and not only the engine one
+ * (`SelfShuffleIntoLibraryOnResolveScenarioTest`).
+ */
+class BlueSunsZenithScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BlueSunsZenith)
+        driver.registerCard(SnapcasterMage)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (guard++ < 30) {
+            when {
+                isPaused -> autoResolveDecision()
+                state.stack.isNotEmpty() -> bothPass()
+                else -> break
+            }
+        }
+    }
+
+    test("target player draws X, then the spell shuffles itself into its owner's library") {
+        val driver = newDriver()
+        val you = driver.player1
+        val handBefore = driver.getHand(you).size
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+
+        val zenith = driver.putCardInHand(you, "Blue Sun's Zenith")
+        driver.giveMana(you, Color.BLUE, 8)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Player(you)),
+                xValue = 3,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("three cards drawn — the Zenith itself left the hand to be cast") {
+            driver.getHand(you).size shouldBe handBefore + 3 - 1 + 1
+        }
+        withClue("three cards left the library and the Zenith came back into it") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore - 3 + 1
+            driver.getGraveyardCardNames(you).contains("Blue Sun's Zenith") shouldBe false
+        }
+    }
+
+    test("it can deck an opponent — the target is a player, not 'you'") {
+        val driver = newDriver()
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+        val opponentHandBefore = driver.getHand(opponent).size
+
+        val zenith = driver.putCardInHand(you, "Blue Sun's Zenith")
+        driver.giveMana(you, Color.BLUE, 8)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                xValue = 2,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("the opponent drew, and the card went back into *its owner's* library — yours") {
+            driver.getHand(opponent).size shouldBe opponentHandBefore + 2
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+        }
+    }
+
+    test("flashbacked off Snapcaster Mage it is exiled, not shuffled in — CR 702.34a") {
+        val driver = newDriver()
+        val you = driver.player1
+        val zenith = driver.putCardInGraveyard(you, "Blue Sun's Zenith")
+
+        // Cast Snapcaster Mage so its enters trigger actually fires, and point it at the Zenith.
+        val snapcaster = driver.putCardInHand(you, "Snapcaster Mage")
+        driver.giveMana(you, Color.BLUE, 2)
+        driver.submit(
+            CastSpell(you, snapcaster, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+        if (driver.isPaused) driver.submitTargetSelection(you, listOf(zenith))
+        driver.settle()
+
+        withClue("the grant landed on the card in the graveyard") {
+            driver.state.grantedKeywordAbilities.any { it.entityId == zenith } shouldBe true
+        }
+
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+
+        // Flashback cost is the card's mana cost, {X}{U}{U}{U}; X = 1 makes that four mana.
+        driver.giveMana(you, Color.BLUE, 4)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Player(you)),
+                xValue = 1,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("flashback replaces 'anywhere else', which covers the library the printed clause " +
+            "asks for — otherwise this is an infinite Snapcaster loop") {
+            driver.getExile(you).contains(zenith) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe false
+        }
+        withClue("one card drawn, and no shuffle at all — the card never reached the library") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore - 1
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore
+        }
+    }
+})

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GreenSunsZenithScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GreenSunsZenithScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fut.cards.DryadArbor
+import com.wingedsheep.mtg.sets.definitions.mbs.cards.GreenSunsZenith
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Green Sun's Zenith — "Search your library for a green creature card with mana value X or less,
+ * put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library."
+ *
+ * The cycle's headline card and the one that exercises `selfShuffleIntoLibrary()`'s **paused**
+ * resolve path, because the library search stops for a decision before the spell leaves the stack.
+ * (The vocabulary itself is covered in the engine by `SelfShuffleIntoLibraryOnResolveScenarioTest`;
+ * this file is about the card.)
+ *
+ * The X = 0 case is the famous one: searching never compels a find (CR 701.23b), and Dryad Arbor
+ * is the one green creature card with mana value 0, so `{G}` alone puts a land-creature onto the
+ * battlefield.
+ */
+class GreenSunsZenithScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GreenSunsZenith)
+        driver.registerCard(DryadArbor)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (guard++ < 30) {
+            when {
+                isPaused -> autoResolveDecision()
+                state.stack.isNotEmpty() -> bothPass()
+                else -> break
+            }
+        }
+    }
+
+    test("finds a green creature within X and shuffles itself back into its owner's library") {
+        val driver = createDriver()
+        val you = driver.player1
+        val bears = driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        val zenith = driver.putCardInHand(you, "Green Sun's Zenith")
+        driver.giveMana(you, Color.GREEN, 6)
+        driver.submit(
+            CastSpell(you, zenith, xValue = 2, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(bears))
+        driver.settle()
+
+        withClue("the {G}{G} 2/2 is within X = 2 and goes straight onto the battlefield") {
+            driver.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(bears) shouldBe true
+        }
+        withClue("the spell shuffles itself in rather than going to the graveyard — and it is the " +
+            "*owner's* library, which here is also the caster's") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+            driver.getGraveyardCardNames(you).contains("Green Sun's Zenith") shouldBe false
+        }
+    }
+
+    test("X = 0 finds Dryad Arbor, the only green creature card with mana value 0") {
+        val driver = createDriver()
+        val you = driver.player1
+        val arbor = driver.putCardOnTopOfLibrary(you, "Dryad Arbor")
+
+        val zenith = driver.putCardInHand(you, "Green Sun's Zenith")
+        driver.giveMana(you, Color.GREEN, 4)
+        driver.submit(
+            CastSpell(you, zenith, xValue = 0, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(arbor))
+        driver.settle()
+
+        withClue("mana value 0 is 'X or less' for X = 0, so the search may find it") {
+            driver.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(arbor) shouldBe true
+        }
+        withClue("and the Zenith still returns to the library") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+        }
+    }
+
+    test("a creature above X can't be taken, and the spell still shuffles itself in") {
+        val driver = createDriver()
+        val you = driver.player1
+        // Grizzly Bears is {1}{G} — mana value 2, out of reach of X = 1. Nothing in the library
+        // matches the filter, so there is nothing for the search to offer.
+        driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        val zenith = driver.putCardInHand(you, "Green Sun's Zenith")
+        driver.giveMana(you, Color.GREEN, 4)
+        driver.submit(
+            CastSpell(you, zenith, xValue = 1, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        // CR 701.23b — a search need not find anything. With an empty candidate pool the engine
+        // doesn't stop to ask; if it ever does, declining is the same answer.
+        if (driver.isPaused) driver.submitCardSelection(you, emptyList())
+        driver.settle()
+
+        withClue("the out-of-range creature stayed in the library") {
+            driver.findPermanent(you, "Grizzly Bears") shouldBe null
+        }
+        withClue("finding nothing is still a resolution, so the clause applies — this is the " +
+            "case that would regress if the shuffle were wired into the search rather than into " +
+            "the spell's own resolution") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+            driver.getGraveyardCardNames(you).contains("Green Sun's Zenith") shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RedSunsZenithScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RedSunsZenithScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mbs.cards.RedSunsZenith
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Red Sun's Zenith — "Red Sun's Zenith deals X damage to any target. If a creature dealt damage
+ * this way would die this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's
+ * library."
+ *
+ * The cycle's one card with behaviour beyond "do a thing, then shuffle": the exile rider is a
+ * CR 614 death replacement that outlives the spell, so it has to be marked before the damage and
+ * has to be scoped to creatures the spell actually damaged.
+ *
+ * **X = 0 is the case worth a test.** This is an {X} spell, so `{R}` alone is a legal cast, and
+ * CR 120.8 — "if a source would deal 0 damage, it does not deal damage at all" — means no creature
+ * was "dealt damage this way". An unconditional mark would quietly exile a creature that died to
+ * something else later in the turn, which is why the card gates the marker on `X > 0` rather than
+ * copying Carbonize's ungated shape (Carbonize deals a fixed 3 and can't reach this).
+ */
+class RedSunsZenithScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RedSunsZenith)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (guard++ < 30) {
+            when {
+                isPaused -> autoResolveDecision()
+                state.stack.isNotEmpty() -> bothPass()
+                else -> break
+            }
+        }
+    }
+
+    test("a creature killed by the damage is exiled, not put into its owner's graveyard") {
+        val driver = newDriver()
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val zenith = driver.putCardInHand(you, "Red Sun's Zenith")
+        driver.giveMana(you, Color.RED, 6)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                xValue = 2,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("X = 2 is lethal to a 2/2, and the death replacement sends it to exile") {
+            driver.getExile(opponent).contains(bear) shouldBe true
+            driver.getGraveyardCardNames(opponent).contains("Grizzly Bears") shouldBe false
+        }
+        withClue("and the spell still shuffles itself in") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+        }
+    }
+
+    test("X = 0 deals no damage, so a creature that dies later still goes to the graveyard") {
+        val driver = newDriver()
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val zenith = driver.putCardInHand(you, "Red Sun's Zenith")
+        driver.giveMana(you, Color.RED, 4)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                xValue = 0,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("0 damage is no damage at all (CR 120.8), so the 2/2 is untouched") {
+            driver.state.getZone(ZoneKey(opponent, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        }
+
+        // Kill it with something else, still this turn — the window the marker would have covered.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.submit(
+            CastSpell(
+                you, bolt,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("no creature was 'dealt damage this way', so the exile clause never applied — " +
+            "an ungated marker would have swallowed this creature into exile") {
+            driver.getGraveyardCardNames(opponent).contains("Grizzly Bears") shouldBe true
+            driver.getExile(opponent).contains(bear) shouldBe false
+        }
+    }
+
+    test("the spell shuffles itself into its owner's library on resolution") {
+        val driver = newDriver()
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+
+        val zenith = driver.putCardInHand(you, "Red Sun's Zenith")
+        driver.giveMana(you, Color.RED, 6)
+        driver.submit(
+            CastSpell(
+                you, zenith,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                xValue = 3,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("X damage to a player, and the card returns to the library rather than the bin") {
+            driver.getLifeTotal(opponent) shouldBe 17
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenith) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore + 1
+            driver.getGraveyardCardNames(you).contains("Red Sun's Zenith") shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/WhiteSunsZenithReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/WhiteSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * White Sun's Zenith reprint in C17 (Commander 2017). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val WhiteSunsZenithReprint = Printing(
+    oracleId = "ea4a9299-c2b3-4092-89dd-28142b203d60",
+    name = "White Sun's Zenith",
+    setCode = "C17",
+    collectorNumber = "78",
+    scryfallId = "cebb57f0-8401-4429-b2b4-bed37ff9ce6d",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/cebb57f0-8401-4429-b2b4-bed37ff9ce6d.jpg?1783935921",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/WhiteSunsZenithReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/WhiteSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * White Sun's Zenith reprint in CMR (Commander Legends). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val WhiteSunsZenithReprint = Printing(
+    oracleId = "ea4a9299-c2b3-4092-89dd-28142b203d60",
+    name = "White Sun's Zenith",
+    setCode = "CMR",
+    collectorNumber = "391",
+    scryfallId = "029e0450-ceb1-484d-8a18-e769defac428",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg?1783928723",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/BlackSunsZenithReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/BlackSunsZenithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Black Sun's Zenith reprint in TLE (Avatar: The Last Airbender Eternal). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS, the card's earliest real printing.
+ */
+val BlackSunsZenithReprint = Printing(
+    oracleId = "038c0165-32b6-4e81-8180-604b49905207",
+    name = "Black Sun's Zenith",
+    setCode = "TLE",
+    collectorNumber = "22",
+    scryfallId = "5dbb0c4b-c5f1-4860-aa2c-8ee55a7564e8",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5dbb0c4b-c5f1-4860-aa2c-8ee55a7564e8.jpg?1783904856",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MBS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MBS.json
@@ -1,3 +1,174 @@
+// Black Sun's Zenith
+{
+    "name": "Black Sun's Zenith",
+    "manaCost": "{X}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put X -1/-1 counters on each creature. Shuffle Black Sun's Zenith into its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "AddDynamicCounters",
+                "counterType": "-1/-1",
+                "amount": "XValue",
+                "target": "Self"
+            }
+        },
+        "selfShuffleIntoLibraryOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "\"Under the suns, Mirrodin kneels and begs us for perfection.\"\n—Geth, Lord of the Vault",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03bdcf52-50b8-42c0-9665-931d83f5f314.jpg?1783941385",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blue Sun's Zenith
+{
+    "name": "Blue Sun's Zenith",
+    "manaCost": "{X}{U}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target player draws X cards. Shuffle Blue Sun's Zenith into its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": "XValue",
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ],
+        "selfShuffleIntoLibraryOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "flavorText": "\"The Origin Query will wait. We must ensure we survive to return to it.\"\n—Pelyus, vedalken ordinar",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8150f78-e187-4949-9746-fec64d1675d1.jpg?1783941389",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
+            },
+            {
+                "date": "2018-03-16",
+                "text": "Because you follow the spell's instructions in order, you won't be able to draw the same Blue Sun's Zenith that you cast."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Green Sun's Zenith
+{
+    "name": "Green Sun's Zenith",
+    "manaCost": "{X}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a green creature card with mana value X or less, put it onto the battlefield, then shuffle. Shuffle Green Sun's Zenith into its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasColor",
+                                    "color": "GREEN"
+                                },
+                                "ManaValueAtMostX"
+                            ]
+                        }
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        },
+        "selfShuffleIntoLibraryOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "RARE",
+        "artist": "David Rapoza",
+        "flavorText": "As the green sun crowned, Phyrexian prophecies glowed on the Tree of Tales.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02335747-54e3-4827-ae19-4e362863da9b.jpg?1783941375",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
+            },
+            {
+                "date": "2016-06-08",
+                "text": "If Green Sun's Zenith is countered, none of its effects will happen. Notably, it will be put into its owner's graveyard rather than shuffled into its owner's library."
+            },
+            {
+                "date": "2016-06-08",
+                "text": "In most cases, if you own Green Sun's Zenith and cast it, you'll shuffle your library twice. In practice, shuffling once is sufficient, but effects that care about you shuffling your library (like Psychogenic Probe, for example) will see that you've shuffled twice."
+            },
+            {
+                "date": "2016-06-08",
+                "text": "If you own Green Sun's Zenith, but an opponent casts it (due to Knowledge Pool's effect, for example), that opponent searches their library for an appropriate creature card, then shuffles that library. That opponent then shuffles Green Sun's Zenith into your library. You won't shuffle any library in this case."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hexplate Golem
 {
     "name": "Hexplate Golem",
@@ -154,6 +325,58 @@
     ]
 }
 
+// Red Sun's Zenith
+{
+    "name": "Red Sun's Zenith",
+    "manaCost": "{X}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Red Sun's Zenith deals X damage to any target. If a creature dealt damage this way would die this turn, exile it instead. Shuffle Red Sun's Zenith into its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MarkExileOnDeath",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ],
+        "selfShuffleIntoLibraryOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg?1783941377",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Slagstorm
 {
     "name": "Slagstorm",
@@ -276,4 +499,44 @@
         ]
     },
     "colorIdentityOverride": []
+}
+
+// White Sun's Zenith
+{
+    "name": "White Sun's Zenith",
+    "manaCost": "{X}{W}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Create X 2/2 white Cat creature tokens. Shuffle White Sun's Zenith into its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": "XValue",
+            "power": 2,
+            "toughness": 2,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Cat"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d400b41-813d-4a63-848f-5eb4db4bf3bb.jpg?1783903575"
+        },
+        "selfShuffleIntoLibraryOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "RARE",
+        "artist": "Mike Bierek",
+        "flavorText": "After the Battle of Liet Field, the white sun crested above Taj-Nar, bringing hope to all who survived the carnage.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a879940e-6632-47c5-a30e-d29a82d16e9d.jpg?1783941389",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard rather than to its owner's library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MBS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MBS.json
@@ -336,10 +336,25 @@
             "type": "Composite",
             "effects": [
                 {
-                    "type": "MarkExileOnDeath",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "any target"
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "XValue",
+                            "operator": "GT",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 0
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "MarkExileOnDeath",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
                     }
                 },
                 {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2255,19 +2255,23 @@ class StackResolver(
                 val pausedSelfShuffleIntoLibrary = pausedResolvedScript?.selfShuffleIntoLibraryOnResolve == true
                 val pausedReboundExile = spellComponent.castFromZone == Zone.HAND &&
                     spellHasRebound(effectResult.state, spellId, pausedCardDef)
+                // See the resolved twin below for why this isn't a plain priority order.
                 val pausedIntended = when {
-                    // Above the rider, unlike every other clause here: the cast-this-way riders are
-                    // written "if that spell *would be put into a graveyard*, [somewhere] instead"
-                    // (Kylox's Voltstrider), and a spell that shuffles itself in never would be — so
-                    // the rider has nothing to replace and the printed clause stands. The countered
-                    // and fizzled paths, which really do put the card into a graveyard, don't read
-                    // this flag at all, so the rider still wins there, as it should.
-                    pausedSelfShuffleIntoLibrary -> Zone.LIBRARY
                     // The cast-this-way rider is the most specific instruction on this one spell,
                     // so it outranks the card-intrinsic exile reasons below rather than being
                     // OR'd into them — it is the only one that can name a zone other than exile.
-                    pausedExileAfterResolveComp != null -> pausedExileAfterResolveComp.zone
-                    pausedSelfExile || pausedFlashbackExile || pausedAdventureFaceExile || pausedReboundExile -> Zone.EXILE
+                    // It replaces "would be put into a graveyard", though (Kylox's Voltstrider),
+                    // and a spell that shuffles itself into its owner's library never would be —
+                    // hence the guard, which hands that case to the printed clause below.
+                    pausedExileAfterResolveComp != null && !pausedSelfShuffleIntoLibrary ->
+                        pausedExileAfterResolveComp.zone
+                    // Flashback (CR 702.34a) and harmonize (CR 702.180a) are the two replacements
+                    // here worded "instead of putting it anywhere else any time it would leave the
+                    // stack" rather than naming the graveyard, so they outrank even the printed
+                    // clause: a flashbacked spell that shuffles itself in is exiled instead.
+                    pausedFlashbackExile -> Zone.EXILE
+                    pausedSelfShuffleIntoLibrary -> Zone.LIBRARY
+                    pausedSelfExile || pausedAdventureFaceExile || pausedReboundExile -> Zone.EXILE
                     pausedOmenFaceShuffle -> Zone.LIBRARY
                     else -> Zone.GRAVEYARD
                 }
@@ -2425,16 +2429,31 @@ class StackResolver(
         // on resolution instead of going to the graveyard, and arms a next-upkeep free recast.
         val reboundExile = spellComponent.castFromZone == Zone.HAND &&
             spellHasRebound(newState, spellId, cardDef)
+        // Not a plain priority order, because the underlying replacements aren't totally ordered:
+        // the rider loses to the printed self-shuffle clause, the self-shuffle clause loses to
+        // flashback, and flashback loses to the rider. What breaks the cycle is *what each
+        // replacement is worded to replace*, which is what the guards below encode:
+        //
+        //  - the rider and rebound/adventure/omen all replace "…instead of putting it into its
+        //    owner's **graveyard**", so a spell that shuffles itself into its owner's library
+        //    gives them nothing to replace;
+        //  - flashback and harmonize replace "…instead of putting it **anywhere else** any time it
+        //    would leave the stack", which covers the library move too, so they still apply.
+        //
+        // Countered and fizzled spells really are put into a graveyard, and those paths don't read
+        // the self-shuffle flag at all, so every clause here applies to them as usual.
         val intendedDestination = when {
-            // See the paused-resolve twin above: this one clause sits *above* the rider, because
-            // the riders replace "would be put into a graveyard" and a spell that shuffles itself
-            // into its owner's library never would be.
+            // The rider is the most specific instruction on this one spell, so it outranks the
+            // card-intrinsic exile reasons below rather than being OR'd into them — it is the only
+            // one that can send the card somewhere other than exile (Kylox's Voltstrider — "put it
+            // on the bottom of its owner's library instead"). The guard is the graveyard wording.
+            exileAfterResolveComp != null && !selfShuffleIntoLibrary -> exileAfterResolveComp.zone
+            // Flashback (CR 702.34a) / harmonize (CR 702.180a) — "anywhere else". Above the printed
+            // clause, below the rider, which leaves the pre-existing rider-vs-flashback precedence
+            // exactly as it was.
+            flashbackExile -> Zone.EXILE
             selfShuffleIntoLibrary -> Zone.LIBRARY
-            // The rider otherwise wins over the intrinsic exile reasons because it is the only one
-            // that can send the card somewhere other than exile (Kylox's Voltstrider — "put it on
-            // the bottom of its owner's library instead").
-            exileAfterResolveComp != null -> exileAfterResolveComp.zone
-            selfExile || flashbackExile || adventureFaceExile || reboundExile -> Zone.EXILE
+            selfExile || adventureFaceExile || reboundExile -> Zone.EXILE
             omenFaceShuffle -> Zone.LIBRARY
             else -> Zone.GRAVEYARD
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2249,9 +2249,20 @@ class StackResolver(
                     spellComponent.faceIndex != null
                 val pausedOmenFaceShuffle = pausedCardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
                     spellComponent.faceIndex != null
+                // "Shuffle <name> into its owner's library." printed on the card itself (the
+                // Mirrodin Besieged Zenith cycle). Same seam as pausedSelfExile — it replaces the
+                // CR 608.2n destination — but lands in the library shuffled rather than in exile.
+                val pausedSelfShuffleIntoLibrary = pausedResolvedScript?.selfShuffleIntoLibraryOnResolve == true
                 val pausedReboundExile = spellComponent.castFromZone == Zone.HAND &&
                     spellHasRebound(effectResult.state, spellId, pausedCardDef)
                 val pausedIntended = when {
+                    // Above the rider, unlike every other clause here: the cast-this-way riders are
+                    // written "if that spell *would be put into a graveyard*, [somewhere] instead"
+                    // (Kylox's Voltstrider), and a spell that shuffles itself in never would be — so
+                    // the rider has nothing to replace and the printed clause stands. The countered
+                    // and fizzled paths, which really do put the card into a graveyard, don't read
+                    // this flag at all, so the rider still wins there, as it should.
+                    pausedSelfShuffleIntoLibrary -> Zone.LIBRARY
                     // The cast-this-way rider is the most specific instruction on this one spell,
                     // so it outranks the card-intrinsic exile reasons below rather than being
                     // OR'd into them — it is the only one that can name a zone other than exile.
@@ -2314,8 +2325,13 @@ class StackResolver(
                     pausedState = applyExileCounters(pausedState, spellId, pausedExileAfterResolveComp.withCounters, pausedCounterEvents)
                 }
 
-                // Omen (Tarkir: Dragonstorm): shuffle the just-added card into its owner's library.
-                if (pausedOmenFaceShuffle && pausedDestZone == Zone.LIBRARY) {
+                // Omen (Tarkir: Dragonstorm), and the Zenith cycle's printed "Shuffle <name> into
+                // its owner's library.": shuffle the just-added card into its owner's library.
+                // Gated on the *final* destination for the same two reasons as the resolved twin —
+                // a RedirectZoneChange may have sent the card elsewhere, and
+                // AfterResolveDestination.BOTTOM_OF_LIBRARY also lands in Zone.LIBRARY but must
+                // not shuffle.
+                if ((pausedOmenFaceShuffle || pausedSelfShuffleIntoLibrary) && pausedDestZone == Zone.LIBRARY) {
                     pausedState = shuffleOwnerLibrary(pausedState, ownerId)
                     pausedCounterEvents.add(LibraryShuffledEvent(ownerId))
                 }
@@ -2401,14 +2417,22 @@ class StackResolver(
         // library instead of putting it in the graveyard. No cast-from-exile linkage.
         val omenFaceShuffle = cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
             spellComponent.faceIndex != null
+        // "Shuffle <name> into its owner's library." printed on the card itself (the Mirrodin
+        // Besieged Zenith cycle). Same seam as selfExile — it replaces the CR 608.2n destination —
+        // but lands in the library shuffled rather than in exile.
+        val selfShuffleIntoLibrary = resolvedScript?.selfShuffleIntoLibraryOnResolve == true
         // Rebound (CR 702.88): a spell cast from hand that has rebound (printed or granted) exiles
         // on resolution instead of going to the graveyard, and arms a next-upkeep free recast.
         val reboundExile = spellComponent.castFromZone == Zone.HAND &&
             spellHasRebound(newState, spellId, cardDef)
         val intendedDestination = when {
-            // See the paused-resolve twin above: the rider wins over the intrinsic exile reasons
-            // because it is the only one that can send the card somewhere other than exile
-            // (Kylox's Voltstrider — "put it on the bottom of its owner's library instead").
+            // See the paused-resolve twin above: this one clause sits *above* the rider, because
+            // the riders replace "would be put into a graveyard" and a spell that shuffles itself
+            // into its owner's library never would be.
+            selfShuffleIntoLibrary -> Zone.LIBRARY
+            // The rider otherwise wins over the intrinsic exile reasons because it is the only one
+            // that can send the card somewhere other than exile (Kylox's Voltstrider — "put it on
+            // the bottom of its owner's library instead").
             exileAfterResolveComp != null -> exileAfterResolveComp.zone
             selfExile || flashbackExile || adventureFaceExile || reboundExile -> Zone.EXILE
             omenFaceShuffle -> Zone.LIBRARY
@@ -2467,9 +2491,13 @@ class StackResolver(
             )
         }
 
-        // Omen (Tarkir: Dragonstorm): the card was just added to the bottom of its owner's
-        // library above — now shuffle that library and announce it.
-        if (omenFaceShuffle && destinationZone == Zone.LIBRARY) {
+        // Omen (Tarkir: Dragonstorm), and the Zenith cycle's printed "Shuffle <name> into its
+        // owner's library.": the card was just added to the bottom of its owner's library above —
+        // now shuffle that library and announce it. Gated on the *final* destination so a
+        // RedirectZoneChange that sent the card elsewhere doesn't shuffle for nothing, and so
+        // AfterResolveDestination.BOTTOM_OF_LIBRARY (which also lands in Zone.LIBRARY, but must
+        // not shuffle) is left alone.
+        if ((omenFaceShuffle || selfShuffleIntoLibrary) && destinationZone == Zone.LIBRARY) {
             newState = shuffleOwnerLibrary(newState, ownerId)
             events.add(LibraryShuffledEvent(ownerId))
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
@@ -1,0 +1,323 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.LibraryShuffledEvent
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AfterResolveDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * `spell { selfShuffleIntoLibrary() }` — the card-intrinsic "Shuffle <card name> into its owner's
+ * library." clause printed on the Mirrodin Besieged Zenith cycle.
+ *
+ * The sibling of `selfExile()`: both replace the destination of **CR 608.2n** ("as the final part of
+ * an instant or sorcery spell's resolution, the spell is put into its owner's graveyard"), read by
+ * `StackResolver` at the same seam. What makes it worth its own test file is that the seam is
+ * **duplicated**: `StackResolver` decides the destination once on the full-resolve path and again on
+ * the paused-resolve path, and each then places the card at its own site. A card whose effect never
+ * pauses exercises only the first pair — and Green Sun's Zenith, the cycle's headline card, pauses
+ * for its library search and so takes the *other* one. Wiring one and not the other fails silently:
+ * the card simply turns up in the graveyard.
+ *
+ * The negative cases matter as much as the positive ones. Unlike the cast-this-way rider
+ * ([com.wingedsheep.engine.state.components.identity.AfterResolveDestinationComponent], covered by
+ * [AfterResolveDestinationScenarioTest]), this clause is part of the spell's *effect*, so a spell
+ * that never resolves never performs it:
+ *
+ * - **Countered** (CR 701.5a) — the spell is put into its owner's graveyard, and no part of its
+ *   effect happens. Graveyard, not library.
+ * - **Fizzled** (CR 608.2b) — a spell whose every target is illegal doesn't resolve. Same answer.
+ *
+ * That is the exact opposite of the rider's answer to the same two questions, which is why both
+ * files exist.
+ */
+class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
+
+    /** Targetless and non-pausing: the full-resolve path, with nothing else going on. */
+    val plainZenith = card("Test Zenith Plain") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.GainLife(2)
+            selfShuffleIntoLibrary()
+        }
+    }
+
+    /** The control — same card, same effect, no clause. Proves the assertions are the flag's doing. */
+    val plainNoClause = card("Test Zenith No Clause") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(2) }
+    }
+
+    /**
+     * Green Sun's Zenith's shape: a library search pauses resolution for a card-selection decision,
+     * so the spell leaves the stack via the **paused-resolve** path rather than the full one.
+     */
+    val searchingZenith = card("Test Zenith Searching") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Creature,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+            )
+            selfShuffleIntoLibrary()
+        }
+    }
+
+    /** Targets, so its target can be removed in response and the spell can fizzle (CR 608.2b). */
+    val targetedZenith = card("Test Zenith Targeted") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            target("target creature", Targets.Creature)
+            effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+            selfShuffleIntoLibrary()
+        }
+    }
+
+    /**
+     * Kylox's Voltstrider's shape: casts a spell from a graveyard under the rider "if that spell
+     * would be put into a graveyard, put it on the bottom of its owner's library instead."
+     */
+    val bottomGranter = card("Test Bottom Granter For Zenith") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        filter = GameObjectFilter.InstantOrSorcery,
+                    ),
+                    storeAs = "pool",
+                ),
+                SelectFromCollectionEffect(
+                    from = "pool",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "pick",
+                ),
+                Effects.CastFromCollectionWithoutPayingCost(
+                    from = "pick",
+                    insteadOfGraveyard = AfterResolveDestination.BOTTOM_OF_LIBRARY,
+                ),
+            )
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(
+            listOf(plainZenith, plainNoClause, searchingZenith, targetedZenith, bottomGranter)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (guard++ < 30) {
+            when {
+                isPaused -> autoResolveDecision()
+                state.stack.isNotEmpty() -> bothPass()
+                else -> break
+            }
+        }
+    }
+
+    fun GameTestDriver.cast(
+        you: EntityId,
+        cardName: String,
+        targets: List<ChosenTarget> = emptyList(),
+    ): EntityId {
+        val cardId = putCardInHand(you, cardName)
+        giveMana(you, Color.BLUE, 4)
+        submit(
+            CastSpell(you, cardId, targets = targets, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        return cardId
+    }
+
+    test("a resolved spell is shuffled into its owner's library — the full-resolve path") {
+        val driver = newDriver()
+        val you = driver.player1
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+        val lifeBefore = driver.getLifeTotal(you)
+
+        val cardId = driver.cast(you, "Test Zenith Plain")
+        driver.settle()
+
+        withClue("the spell resolved — its effect happened") {
+            driver.getLifeTotal(you) shouldBe lifeBefore + 2
+        }
+        withClue("CR 608.2n's graveyard destination was replaced by the library") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore + 1
+            driver.getGraveyardCardNames(you).contains("Test Zenith Plain") shouldBe false
+            driver.getExile(you).contains(cardId) shouldBe false
+        }
+    }
+
+    test("it is shuffled in, not put on the bottom") {
+        val driver = newDriver()
+        val you = driver.player1
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+
+        driver.cast(you, "Test Zenith Plain")
+        driver.settle()
+
+        withClue("the library is randomized and the shuffle announced, so a later effect that " +
+            "looks at the top of the library can't be steered by casting this spell") {
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore + 1
+        }
+    }
+
+    test("a spell that pauses mid-resolution is still shuffled in — the paused-resolve path") {
+        val driver = newDriver()
+        val you = driver.player1
+        val creatureId = driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+
+        val cardId = driver.cast(you, "Test Zenith Searching")
+        // The search pauses for a card-selection decision; take the creature.
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(creatureId))
+        driver.settle()
+
+        withClue("the search resolved — the creature is on the battlefield") {
+            driver.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(creatureId) shouldBe true
+        }
+        withClue("the paused-resolve path honours the clause too (Green Sun's Zenith's own shape)") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe true
+            driver.getGraveyardCardNames(you).contains("Test Zenith Searching") shouldBe false
+        }
+        withClue("net library change: the searched creature left, the spell came back") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore
+        }
+        withClue("two separate shuffles, per the Green Sun's Zenith ruling: the search's own " +
+            "shuffle and then the spell's. Shuffling once would be enough to randomize the " +
+            "library, but effects that count shuffles (Psychogenic Probe) must see both") {
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore + 2
+        }
+    }
+
+    test("a countered spell goes to the graveyard — CR 701.5a, the effect never happened") {
+        val driver = newDriver()
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+        val counter = driver.putCardInHand(opponent, "Counterspell")
+        driver.giveMana(opponent, Color.BLUE, 2)
+
+        val cardId = driver.cast(you, "Test Zenith Plain")
+        driver.passPriority(you)
+        driver.submit(
+            CastSpell(
+                opponent, counter,
+                targets = listOf(ChosenTarget.Spell(cardId)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("it really was countered — no life gained") {
+            driver.getLifeTotal(you) shouldBe 20
+        }
+        withClue("the shuffle is part of the effect, so a countered spell never performs it — " +
+            "the opposite of the cast-this-way rider, which applies on the countered path too") {
+            driver.getGraveyardCardNames(you).contains("Test Zenith Plain") shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+        }
+    }
+
+    test("a fizzled spell goes to the graveyard — CR 608.2b") {
+        val driver = newDriver()
+        val you = driver.player1
+        val bear = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val cardId = driver.cast(
+            you, "Test Zenith Targeted",
+            targets = listOf(ChosenTarget.Permanent(bear)),
+        )
+        withClue("the spell waits on the stack with its target chosen") {
+            driver.state.stack.contains(cardId) shouldBe true
+        }
+
+        // Break the only target: every target is now illegal, so the spell is removed from the
+        // stack without resolving and none of its instructions are followed.
+        driver.moveToGraveyard(bear)
+        driver.settle()
+
+        withClue("a spell that doesn't resolve never reaches CR 608.2n's replaced destination") {
+            driver.getGraveyardCardNames(you).contains("Test Zenith Targeted") shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+        }
+    }
+
+    test("the printed clause beats a conditional cast-this-way rider") {
+        val driver = newDriver()
+        val you = driver.player1
+        val zenithId = driver.putCardInGraveyard(you, "Test Zenith Plain")
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+
+        val granterId = driver.putCardInHand(you, "Test Bottom Granter For Zenith")
+        driver.giveMana(you, Color.BLUE, 4)
+        driver.submit(
+            CastSpell(you, granterId, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(zenithId))
+        driver.settle()
+
+        withClue("the rider replaces 'would be put into a graveyard', and this spell never would " +
+            "be — so it is shuffled in, not laid on the bottom unshuffled") {
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore + 1
+            driver.getGraveyardCardNames(you).contains("Test Zenith Plain") shouldBe false
+        }
+    }
+
+    test("without the clause the same spell goes to the graveyard — the control") {
+        val driver = newDriver()
+        val you = driver.player1
+
+        val cardId = driver.cast(you, "Test Zenith No Clause")
+        driver.settle()
+
+        withClue("nothing replaced the destination, so CR 608.2n applies unchanged") {
+            driver.getGraveyardCardNames(you).contains("Test Zenith No Clause") shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
@@ -14,9 +14,13 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.effects.AfterResolveDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -55,6 +59,22 @@ import io.kotest.matchers.string.shouldContain
  *
  * That is the exact opposite of the rider's answer to the same two questions, which is why both
  * files exist.
+ *
+ * Two things about the seam are worth knowing before adding a card here:
+ *
+ * - **Flashback and harmonize still win.** They are the only replacements at this seam worded
+ *   "exile this card instead of putting it *anywhere else* any time it would leave the stack"
+ *   (CR 702.34a, CR 702.180a); every other clause — the cast-this-way rider, rebound, Adventure,
+ *   Omen — names the *graveyard*, which is why the printed clause beats those and not these.
+ *
+ * - **The paused path moves the card early.** `StackResolver` puts the spell in the library and
+ *   shuffles while the decision is still pending, so the remainder of that same resolution sees the
+ *   card already in the library. Harmless for Green Sun's Zenith — a search's candidate list is
+ *   built during effect execution, before the move, so the Zenith can never find itself — but it is
+ *   a sharper edge than the same early move is for `selfExile()`, because a library card can be
+ *   drawn or searched. A future pausing self-shuffling spell whose later steps draw cards would
+ *   need this revisited (Blue Sun's Zenith's own ruling — "you won't be able to draw the same Blue
+ *   Sun's Zenith that you cast" — depends on the ordering).
  */
 class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
 
@@ -103,6 +123,53 @@ class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
         }
     }
 
+    /** The clause plus flashback, the one replacement at this seam that still outranks it. */
+    val flashbackZenith = card("Test Zenith Flashback") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.GainLife(2)
+            selfShuffleIntoLibrary()
+        }
+        keywordAbility(KeywordAbility.flashback("{1}"))
+    }
+
+    /** The same, but pausing mid-resolution, so the paused-resolve path is checked too. */
+    val flashbackSearchingZenith = card("Test Zenith Flashback Searching") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Creature,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+            )
+            selfShuffleIntoLibrary()
+        }
+        keywordAbility(KeywordAbility.flashback("{1}"))
+    }
+
+    /**
+     * Progenitus' shape, pointed at the library: a card-intrinsic self-replacement that catches the
+     * spell on its way to the destination this clause chose. Proves the shuffle tail is gated on the
+     * *final* zone rather than on the flag.
+     */
+    val redirectedZenith = card("Test Zenith Redirected") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.GainLife(2)
+            selfShuffleIntoLibrary()
+        }
+        replacementEffect(
+            RedirectZoneChange(
+                newDestination = Zone.EXILE,
+                appliesTo = EventPattern.ZoneChangeEvent(to = Zone.LIBRARY),
+                selfOnly = true,
+            )
+        )
+    }
+
     /**
      * Kylox's Voltstrider's shape: casts a spell from a graveyard under the rider "if that spell
      * would be put into a graveyard, put it on the bottom of its owner's library instead."
@@ -136,7 +203,10 @@ class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all)
         driver.registerCards(
-            listOf(plainZenith, plainNoClause, searchingZenith, targetedZenith, bottomGranter)
+            listOf(
+                plainZenith, plainNoClause, searchingZenith, targetedZenith, bottomGranter,
+                flashbackZenith, flashbackSearchingZenith, redirectedZenith,
+            )
         )
         driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
@@ -310,6 +380,114 @@ class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
         }
     }
 
+    test("flashback outranks the printed clause — CR 702.34a's \"anywhere else\"") {
+        val driver = newDriver()
+        val you = driver.player1
+        val librarySizeBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+        val lifeBefore = driver.getLifeTotal(you)
+
+        val cardId = driver.putCardInGraveyard(you, "Test Zenith Flashback")
+        driver.giveMana(you, Color.BLUE, 4)
+        driver.submit(
+            CastSpell(
+                you, cardId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                useAlternativeCost = true,
+            )
+        ).error shouldBe null
+        driver.settle()
+
+        withClue("it resolved — the clause's own effect happened") {
+            driver.getLifeTotal(you) shouldBe lifeBefore + 2
+        }
+        withClue("flashback replaces 'anywhere else any time it would leave the stack', not just " +
+            "the graveyard, so it applies to the library move the printed clause asks for — " +
+            "unlike the rider, rebound, Adventure and Omen, which all name the graveyard") {
+            driver.getExile(you).contains(cardId) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe librarySizeBefore
+        }
+        withClue("and nothing was shuffled — the tail is gated on the final destination") {
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore
+        }
+    }
+
+    test("flashback outranks it on the paused-resolve path too") {
+        val driver = newDriver()
+        val you = driver.player1
+        val creatureId = driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        val cardId = driver.putCardInGraveyard(you, "Test Zenith Flashback Searching")
+        driver.giveMana(you, Color.BLUE, 4)
+        driver.submit(
+            CastSpell(
+                you, cardId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                useAlternativeCost = true,
+            )
+        ).error shouldBe null
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(creatureId))
+        driver.settle()
+
+        withClue("the search still resolved") {
+            driver.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(creatureId) shouldBe true
+        }
+        withClue("the duplicated seam has to agree with itself — wiring the precedence into only " +
+            "one of the two paths is the silent half-fix this file exists to catch") {
+            driver.getExile(you).contains(cardId) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+        }
+    }
+
+    test("a redirect away from the library suppresses the shuffle") {
+        val driver = newDriver()
+        val you = driver.player1
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+
+        val cardId = driver.cast(you, "Test Zenith Redirected")
+        driver.settle()
+
+        withClue("the self-replacement caught the card on its way to the library") {
+            driver.getExile(you).contains(cardId) shouldBe true
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(cardId) shouldBe false
+        }
+        withClue("so no library was shuffled — the tail is gated on the destination the card " +
+            "actually reached, not on the flag that asked for it") {
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                shufflesBefore
+        }
+    }
+
+    test("the printed clause beats the rider on the paused-resolve path too") {
+        val driver = newDriver()
+        val you = driver.player1
+        driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val zenithId = driver.putCardInGraveyard(you, "Test Zenith Searching")
+        val shufflesBefore = driver.events.count { it is LibraryShuffledEvent && it.playerId == you }
+
+        val granterId = driver.putCardInHand(you, "Test Bottom Granter For Zenith")
+        driver.giveMana(you, Color.BLUE, 8)
+        driver.submit(
+            CastSpell(you, granterId, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        driver.submitCardSelection(you, listOf(zenithId))
+        driver.settle()
+
+        withClue("the rider case was only ever checked on the full-resolve path; the paused one " +
+            "has its own copy of the precedence and must answer the same way") {
+            driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).contains(zenithId) shouldBe true
+            driver.getGraveyardCardNames(you).contains("Test Zenith Searching") shouldBe false
+            driver.events.count { it is LibraryShuffledEvent && it.playerId == you } shouldBe
+                (shufflesBefore + 2)
+        }
+    }
+
     test("a card can't print both destination clauses") {
         // Two spellings of one slot (the CR 608.2n destination). Without the guard this resolves
         // silently to whichever clause StackResolver checks first, which is not something a card
@@ -326,6 +504,15 @@ class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
             }
         }
         ex.message shouldContain "Test Zenith Contradictory"
+    }
+
+    test("nor can a CardScript built directly set both") {
+        // The DSL guard above never runs for a script assembled by hand — test fixtures and the
+        // Assay compiler both do that — so the type itself has to refuse the pair.
+        val ex = shouldThrow<IllegalArgumentException> {
+            CardScript(selfExileOnResolve = true, selfShuffleIntoLibraryOnResolve = true)
+        }
+        ex.message shouldContain "CR 608.2n destination"
     }
 
     test("without the clause the same spell goes to the graveyard — the control") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfShuffleIntoLibraryOnResolveScenarioTest.kt
@@ -25,9 +25,11 @@ import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 /**
  * `spell { selfShuffleIntoLibrary() }` — the card-intrinsic "Shuffle <card name> into its owner's
@@ -306,6 +308,24 @@ class SelfShuffleIntoLibraryOnResolveScenarioTest : FunSpec({
                 shufflesBefore + 1
             driver.getGraveyardCardNames(you).contains("Test Zenith Plain") shouldBe false
         }
+    }
+
+    test("a card can't print both destination clauses") {
+        // Two spellings of one slot (the CR 608.2n destination). Without the guard this resolves
+        // silently to whichever clause StackResolver checks first, which is not something a card
+        // author should have to know.
+        val ex = shouldThrow<IllegalArgumentException> {
+            card("Test Zenith Contradictory") {
+                manaCost = "{1}"
+                typeLine = "Sorcery"
+                spell {
+                    effect = Effects.GainLife(2)
+                    selfExile()
+                    selfShuffleIntoLibrary()
+                }
+            }
+        }
+        ex.message shouldContain "Test Zenith Contradictory"
     }
 
     test("without the clause the same spell goes to the graveyard — the control") {


### PR DESCRIPTION
# Add the Mirrodin Besieged Zenith cycle

All five Zeniths, canonical in MBS (their earliest real printing — the PMH-style promos that predate
the set by days are excluded), plus the one piece of card-script vocabulary the cycle needed.

| Card | | |
|---|---|---|
| Green Sun's Zenith | `{X}{G}` Sorcery | #81 |
| Blue Sun's Zenith | `{X}{U}{U}{U}` Instant | #20 |
| White Sun's Zenith | `{X}{W}{W}{W}` Instant | #19 |
| Black Sun's Zenith | `{X}{B}{B}` Sorcery | #39 |
| Red Sun's Zenith | `{X}{R}` Sorcery | #74 |

Green Sun's Zenith is the card that motivated this; the other four are the rest of its cycle and cost
almost nothing once the shared clause works.

## The new vocabulary, and why composition wasn't enough

All five print the same trailing clause — *"Shuffle &lt;card name&gt; into its owner's library."* —
and there was no way to say it.

The tempting composition is `Effects.ShuffleIntoLibrary(EffectTarget.Self)` in the spell effect. It
does not work. `StackResolver` moves the spell off the stack unconditionally after resolution, so the
card would be moved twice and end up in the graveyard anyway. Nor does the existing
`AfterResolveDestination` enum fit: it has `EXILE` and `BOTTOM_OF_LIBRARY` but deliberately not a
shuffle, and it is a *cast-this-way rider* that another effect stamps onto a spell it is casting, not
something a card declares about itself.

The right seam is the one next door. `CardScript.selfExileOnResolve` already models
*"Exile &lt;card name&gt;."* by replacing the destination of **CR 608.2n** — *"As the final part of an
instant or sorcery spell's resolution, the spell is put into its owner's graveyard."* This PR adds its
sibling, `selfShuffleIntoLibraryOnResolve`, reached from the DSL as
`spell { selfShuffleIntoLibrary() }`. That follows the shape `CardScript` already uses for
card-intrinsic destinations — one field per mechanic (`selfExileOnResolve`, `paradigm`,
`returnTransformedFromGraveyardOnResolve`), all feeding one `when` — rather than inventing a fourth
shape.

The two are two spellings of one slot, so setting both is rejected at card-construction time with the
offending card named — the winner would otherwise be decided silently by the order `StackResolver`
checks them in. No existing card trips that guard.

Two things about the wiring are worth a reviewer's attention.

**The destination seam is duplicated.** `StackResolver` decides where a spell goes once on the
full-resolve path and again on the paused-resolve path, and each then places the card at its own site
— four edits, not two. That is load-bearing rather than academic here: Green Sun's Zenith pauses for
its library-search decision and therefore takes the *paused* path, which the other four Zeniths never
reach. Wiring one and not the other fails silently, with the card simply turning up in the graveyard.
A mutation check confirmed the coverage: unwiring only the paused path fails exactly one test and
nothing else.

**The clause outranks the cast-this-way rider**, uniquely among the card-intrinsic destinations, so it
sits above it in both `when` blocks. Those riders read *"if that spell **would be put into a
graveyard**, [somewhere] instead"* — Kylox's Voltstrider, which is implemented in this corpus — and a
spell that shuffles itself into its owner's library never would be, so the rider has nothing to
replace. Without this the interaction is reachable and wrong: a Zenith in a graveyard (put there by
being countered) and then cast off Voltstrider would land on the bottom of the library unshuffled.
On the countered and fizzled paths, where the card really *is* put into a graveyard, the rider still
wins — and it wins for free, because those paths never read this flag.

That last point is also the rules answer the whole cycle turns on. Every Zenith carries the ruling
*"If this spell doesn't resolve, none of its effects occur. In particular, it will go to the graveyard
rather than to its owner's library."* The clause is part of the spell's **effect**, so a spell that is
countered (**CR 701.5a**) or fizzles (**CR 608.2b**) never performs it. That is the exact opposite of
how the cast-this-way rider answers the same two questions, which is why the two mechanisms get
separate test files.

Rule numbers above were checked against `MagicCompRules_20260808.txt` in this repo, not from memory.

## The cards

Four of the five are stock compositions:

- **Green Sun's Zenith** — `Patterns.Library.searchLibrary` pointed at the battlefield. `count = 1` is
  how many cards are found; the `{X}` paid lives in the *filter*, as `manaValueAtMostX()`.
- **Blue Sun's Zenith** — `Effects.DrawCards(DynamicAmount.XValue, …)` on a targeted **player**, not
  "you"; the card is as happy decking an opponent as refilling your own hand.
- **White Sun's Zenith** — the dynamic-count `Effects.CreateToken` overload. **2/2** Cats, not 1/1.
  MBS printed no Cat token of its own, so the art is the one Scryfall links from this printing via
  `all_parts`.
- **Black Sun's Zenith** — Darkness Descends' shape (`ForEachInGroup` over `GroupFilter.AllCreatures`,
  `EffectTarget.Self` rebound per creature) with the fixed count swapped for the dynamic one.
- **Red Sun's Zenith** — Carbonize's shape exactly: `AnyTarget()` plus `MarkExileOnDeathEffect`, the
  CR 614 death replacement lasting the turn. The mark is applied *before* the damage, as on Carbonize,
  so a creature killed by this very spell is exiled rather than only one that survives and dies later.

**Seven `Printing(...)` rows** come with them — Blue in C13/C15, White in C14/C17/CMR, Black in
C14/TLE. `just check-card-printing` fails on a missing reprint row in a scaffolded set exactly as it
fails on a misplaced canonical, and all five now report clean. Scryfall genuinely reports the TLE
printing's artist as `"Viacom"` (a licensed-art set); that was verified against the API rather than
assumed to be a data error.

## Dev scenarios

One `manual-scenarios/cards/…` JSON per card, for exercising them by hand in the client. Each board
is built so the card's own question is the interesting one — Blue's opponent has a 3-card library so
targeting *them* decks them, Black's board has deliberately staggered toughness so X = 2 kills the
caster's own Birds of Paradise, Red has two copies so both a 2/2 and a 6/4 can be checked for landing
in exile rather than the graveyard.

## Verification

- `just test-class SelfShuffleIntoLibraryOnResolveScenarioTest` — **8/8 pass.** Full-resolve path;
  paused-resolve path; shuffled-in rather than bottomed (asserted via `LibraryShuffledEvent`, since
  the resulting position is random); countered → graveyard; fizzled → graveyard; the rider-precedence
  case; the both-clauses-set guard; and a no-clause control.
- **Mutation check** — unwiring only the paused-resolve path failed exactly the paused test and left
  every other test in the file green, which is what proves that path is really covered.
- `just test-class GreenSunsZenithScenarioTest` — **3/3 pass.** Finds a creature within X and returns
  to the library; the X = 0 / Dryad Arbor line; and nothing-within-X, where the search finds nothing
  (CR 701.23b) and the spell still shuffles itself in.
- `just check-card-printing` — clean for all five.
- `just rebless-cards` — **263 insertions, 0 deletions, `MBS.json` only.** `CardSerialization` encodes
  with `encodeDefaults = false`, so the new field is omitted wherever it is false and does not churn
  the rest of the corpus; printings are not snapshotted, so the seven reprint rows produce no golden
  change.
- `just assay-differential --set MBS` — 0 divergences. **This says nothing about the five new cards**:
  only 4 of MBS's 12 hand-written cards are covered by the grammar, and all five Zeniths are among the
  8 declines (Assay has no rule for "Shuffle ~ into its owner's library"). It confirms the four
  pre-existing MBS cards were not disturbed. A decline is not a pass.
- `just test` — run twice. Every suite the diff can reach was green both times: all of `rules-engine`,
  the snapshot and round-trip tests across every set, and the 2008-2016 era where these cards live.

**What the gate does not cover, and one caveat on the full runs.** Neither full `just test` run came
back green overall, but no test has ever failed on an assertion — every red was a timeout or a killed
worker, in a *different* module each run, on a box showing load average 9.4 and a run stretching from
19 to 56 minutes. Run 1: `AbuJafarTest` (1993-1999), 120 s coroutine timeout. Run 2: `AIPlayerTest`
(`:ai`), 120 s timeout, plus `:mtg-sets:2003-2007:tests` failing with *"Test process encountered an
unexpected problem… exit value 13"* and **zero** recorded test failures — a killed worker JVM, not a
failing test. All three were re-run serially and pass: `AbuJafarTest` 3/3 in 25 s, `AIPlayerTest` 14/14
in 30 s, and the 2003-2007 era suite 670 test cases / 0 failures in 28 s.

There is also an argument from the diff itself. The change adds one `CardScript` field defaulting to
`false` and one `StackResolver` branch gated on it. No card outside these five sets that flag, so for
every other card in the corpus both `when` blocks evaluate exactly as before — including the
precedence reorder, which only fires when the flag is true.

Nothing here touches the web client, so no TypeScript was run and none is claimed.

## Deliberately not included

- **The mtgish emitter entry** (`add-feature` step 8b). It does not apply: the mtgish corpus has no IR
  tag for this clause — only `Shuffle`, `ShuffleGraveyardCardIntoLibrary`, and `ExileSpell`, which maps
  to `ExileTargetSpell`. This is a spell-envelope flag, and its sibling `selfExile()` likewise has no
  bridge entry; it is lowered by a set-specific recognizer. Registering a guessed tag would be a
  fabrication, so it is skipped rather than approximated.
- **An Assay grammar band.** Per `docs/oracle-assay.md` a rule ships as its own measured band with its
  own probe and PR, so this doesn't grow into one. Worth naming as newly reachable, though: Assay
  declines all five Zeniths today on the "Shuffle ~ into its owner's library" clause, and that is now
  expressible in the SDK.
