### PR TITLE
Add 57 Assay-ready cards to Amonkhet

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/BruteStrength.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/BruteStrength.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brute Strength
+ * {1}{R}
+ * Instant
+ * Target creature gets +3/+1 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ */
+val BruteStrength = card("Brute Strength") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+1 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 1, creature),
+            Effects.GrantKeyword(Keyword.TRAMPLE, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Wayne Reynolds"
+        flavorText = "It's not the size of the rock. It's how badly you want to lift it."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg?1783937908"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/AmonkhetSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/AmonkhetSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.akh
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -18,11 +17,14 @@ object AmonkhetSet : MtgSet {
     override val displayName = "Amonkhet"
     override val releaseDate = "2017-04-28"
     override val block = "Amonkhet"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AmonkhetBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AmonkhetBasicLands.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Amonkhet Basic Lands
+ *
+ * Collector numbers 250-269.
+ */
+
+val AkhPlains250 = basicLand("Plains") {
+    collectorNumber = "250"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg?1783936441"
+}
+
+val AkhIsland251 = basicLand("Island") {
+    collectorNumber = "251"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg?1783936441"
+}
+
+val AkhSwamp252 = basicLand("Swamp") {
+    collectorNumber = "252"
+    artist = "Clint Cearley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg?1783936441"
+}
+
+val AkhMountain253 = basicLand("Mountain") {
+    collectorNumber = "253"
+    artist = "Florian de Gesincourt"
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg?1783936441"
+}
+
+val AkhForest254 = basicLand("Forest") {
+    collectorNumber = "254"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg?1783936441"
+}
+
+val AkhPlains255 = basicLand("Plains") {
+    collectorNumber = "255"
+    artist = "Volkan Baǵa"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg?1783936441"
+}
+
+val AkhPlains256 = basicLand("Plains") {
+    collectorNumber = "256"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba708fff-a428-4783-b405-4c7e6ea72fd3.jpg?1783936441"
+}
+
+val AkhPlains257 = basicLand("Plains") {
+    collectorNumber = "257"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e4734a7c-67d0-4124-b76e-d53634557c7d.jpg?1783936441"
+}
+
+val AkhIsland258 = basicLand("Island") {
+    collectorNumber = "258"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg?1783936440"
+}
+
+val AkhIsland259 = basicLand("Island") {
+    collectorNumber = "259"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/2177da89-184b-4ecd-ae08-a074ac4862e1.jpg?1783936440"
+}
+
+val AkhIsland260 = basicLand("Island") {
+    collectorNumber = "260"
+    artist = "Mark Poole"
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d61c6c6c-319f-4636-8482-26b6909f7b8e.jpg?1783936440"
+}
+
+val AkhSwamp261 = basicLand("Swamp") {
+    collectorNumber = "261"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg?1783936440"
+}
+
+val AkhSwamp262 = basicLand("Swamp") {
+    collectorNumber = "262"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6566108-ccc7-4fac-b935-1eb212889543.jpg?1783936439"
+}
+
+val AkhSwamp263 = basicLand("Swamp") {
+    collectorNumber = "263"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6be28351-642c-4ed1-9041-e99ecb79cba8.jpg?1783936439"
+}
+
+val AkhMountain264 = basicLand("Mountain") {
+    collectorNumber = "264"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg?1783936439"
+}
+
+val AkhMountain265 = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2eced8a4-67ce-403c-a567-82ace69d1cf1.jpg?1783936439"
+}
+
+val AkhMountain266 = basicLand("Mountain") {
+    collectorNumber = "266"
+    artist = "Chris Rahn"
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9eb742de-57fa-49f5-977e-bee1b8186e9a.jpg?1783936438"
+}
+
+val AkhForest267 = basicLand("Forest") {
+    collectorNumber = "267"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg?1783936438"
+}
+
+val AkhForest268 = basicLand("Forest") {
+    collectorNumber = "268"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/14c94463-31e8-4a2e-b879-d096a27cc60e.jpg?1783936438"
+}
+
+val AkhForest269 = basicLand("Forest") {
+    collectorNumber = "269"
+    artist = "Matt Stewart"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a3b0668-0a4c-489f-aa2b-4faa8ef3e429.jpg?1783936437"
+}
+

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AnglerDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AnglerDrake.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Angler Drake
+ * {4}{U}{U}
+ * Creature — Drake
+ * 4/4
+ * Flying
+ * When this creature enters, you may return target creature to its owner's hand.
+ *
+ * The target is mandatory at announcement — the trigger carries a `targetRequirement`, so a
+ * creature is chosen when the ability goes on the stack — and the printed "you may" is only the
+ * resolution-time yes/no (`optional = true` lowers to a `Gate.MayDecide`).
+ */
+val AnglerDrake = card("Angler Drake") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying\n" +
+            "When this creature enters, you may return target creature to its owner's hand."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val victim = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.ReturnToHand(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Svetlin Velinov"
+        flavorText = "From the time they are hatchlings, river drakes are taught to pull the largest prey from the Luxa."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg?1783936527"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BalefulAmmit.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BalefulAmmit.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baleful Ammit
+ * {2}{B}
+ * Creature — Crocodile Demon
+ * 4/3
+ * Lifelink
+ * When this creature enters, put a -1/-1 counter on target creature you control.
+ */
+val BalefulAmmit = card("Baleful Ammit") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Crocodile Demon"
+    oracleText = "Lifelink\n" +
+            "When this creature enters, put a -1/-1 counter on target creature you control."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "79"
+        artist = "Seb McKinnon"
+        flavorText = "\"Not all in our crop deserve the afterlife. We must leave the unworthy behind, Samut.\"\n—Djeru, initiate of Tah crop"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg?1783936511"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BloodlustInciter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BloodlustInciter.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodlust Inciter
+ * {R}
+ * Creature — Human Warrior
+ * 1/1
+ * {T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)
+ */
+val BloodlustInciter = card("Bloodlust Inciter") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    oracleText = "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)"
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.HASTE, creature)
+        description = "{T}: Target creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Anthony Palumbo"
+        flavorText = "\"To victory! To glory! To eternity!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg?1783936494"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BontusMonument.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BontusMonument.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bontu's Monument
+ * {3}
+ * Legendary Artifact
+ * Black creature spells you cast cost {1} less to cast.
+ * Whenever you cast a creature spell, each opponent loses 1 life and you gain 1 life.
+ *
+ * The two lines read different sets of spells on purpose: only *black* creature spells are cheaper,
+ * but the drain trigger fires on any creature spell you cast.
+ */
+val BontusMonument = card("Bontu's Monument") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Black creature spells you cast cost {1} less to cast.\n" +
+        "Whenever you cast a creature spell, each opponent loses 1 life and you gain 1 life."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature.withColor(Color.BLACK)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Jonas De Ro"
+        flavorText = "\"The worthy shall strive for greatness. Supremacy in life leads to supremacy in the afterlife.\"\n—Monument inscription"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg?1783936454"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BruteStrengthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BruteStrengthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brute Strength reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val BruteStrengthReprint = Printing(
+    oracleId = "b7a16caa-96e0-40c5-8fcb-81e06d26f92a",
+    name = "Brute Strength",
+    setCode = "AKH",
+    collectorNumber = "122",
+    scryfallId = "1a7bd68d-02eb-44ec-955f-08b328e1b6d3",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a7bd68d-02eb-44ec-955f-08b328e1b6d3.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CanyonSlough.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CanyonSlough.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Canyon Slough
+ *
+ * Land — Swamp Mountain
+ * ({T}: Add {B} or {R}.)
+ * This land enters tapped.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val CanyonSlough = card("Canyon Slough") {
+    colorIdentity = "BR"
+    typeLine = "Land — Swamp Mountain"
+    oracleText = "({T}: Add {B} or {R}.)\n" +
+        "This land enters tapped.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "239"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg?1783936446"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfAmbition.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfAmbition.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Cartouche of Ambition
+ * {2}{B}
+ * Enchantment — Aura Cartouche
+ * Enchant creature you control
+ * When this Aura enters, you may put a -1/-1 counter on target creature.
+ * Enchanted creature gets +1/+1 and has lifelink.
+ *
+ * The printed "you may" is the resolution-time yes/no: `optional = true` lowers to the
+ * `Gate.MayDecide` gate around the counter, so the target is still chosen on announcement.
+ */
+val CartoucheOfAmbition = card("Cartouche of Ambition") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura Cartouche"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, you may put a -1/-1 counter on target creature.\n" +
+        "Enchanted creature gets +1/+1 and has lifelink."
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        optional = true
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg?1783936514"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfKnowledge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfKnowledge.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Cartouche of Knowledge
+ * {1}{U}
+ * Enchantment — Aura Cartouche
+ * Enchant creature you control
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +1/+1 and has flying.
+ */
+val CartoucheOfKnowledge = card("Cartouche of Knowledge") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura Cartouche"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature gets +1/+1 and has flying."
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Kieran Yanner"
+        flavorText = "Cartouches chronicle the initiates' achievements in the trials."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg?1783936525"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfSolidarity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfSolidarity.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Cartouche of Solidarity
+ * {W}
+ * Enchantment — Aura Cartouche
+ * Enchant creature you control
+ * When this Aura enters, create a 1/1 white Warrior creature token with vigilance.
+ * Enchanted creature gets +1/+1 and has first strike. (It deals combat damage before creatures without first strike.)
+ */
+val CartoucheOfSolidarity = card("Cartouche of Solidarity") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura Cartouche"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, create a 1/1 white Warrior creature token with vigilance.\n" +
+        "Enchanted creature gets +1/+1 and has first strike. (It deals combat damage before creatures without first strike.)"
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Warrior"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg?1783936543"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfZeal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CartoucheOfZeal.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Cartouche of Zeal
+ * {R}
+ * Enchantment — Aura Cartouche
+ * Enchant creature you control
+ * When this Aura enters, target creature can't block this turn.
+ * Enchanted creature gets +1/+1 and has haste. (It can attack and {T} no matter when it came under your control.)
+ */
+val CartoucheOfZeal = card("Cartouche of Zeal") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura Cartouche"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, target creature can't block this turn.\n" +
+        "Enchanted creature gets +1/+1 and has haste. (It can attack and {T} no matter when it came under your control.)"
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.CantBlock(t)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Kieran Yanner"
+        flavorText = "The fifth cartouche is the final affirmation of glory, granted only to the worthy dead."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg?1783936492"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CascadingCataracts.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CascadingCataracts.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cascading Cataracts
+ *
+ * Land
+ * Indestructible
+ * {T}: Add {C}.
+ * {5}, {T}: Add five mana in any combination of colors.
+ */
+val CascadingCataracts = card("Cascading Cataracts") {
+    typeLine = "Land"
+    oracleText = "Indestructible\n" +
+        "{T}: Add {C}.\n" +
+        "{5}, {T}: Add five mana in any combination of colors."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        effect = Effects.AddManaInAnyCombination(5)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Noah Bradley"
+        flavorText = "\"The power that flows here cannot be denied. But where is the source?\"\n—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg?1783936447"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ChannelerInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ChannelerInitiate.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Channeler Initiate
+ * {1}{G}
+ * Creature — Human Druid
+ * 3/4
+ * When this creature enters, put three -1/-1 counters on target creature you control.
+ * {T}, Remove a -1/-1 counter from this creature: Add one mana of any color.
+ *
+ * The three counters are an ordinary *targeted* enters trigger, not an enters-with-counters
+ * replacement — the printed line lets them land on any creature you control, and Channeler
+ * Initiate itself is only the usual choice. Removing one to pay the mana ability grows the
+ * body back, so the counters are the ability's fuel rather than a fixed drawback.
+ */
+val ChannelerInitiate = card("Channeler Initiate") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    oracleText = "When this creature enters, put three -1/-1 counters on target creature you control.\n" +
+            "{T}, Remove a -1/-1 counter from this creature: Add one mana of any color."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 3, creature)
+        description = "When this creature enters, put three -1/-1 counters on target creature you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.MINUS_ONE_MINUS_ONE))
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        description = "{T}, Remove a -1/-1 counter from this creature: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "160"
+        artist = "Yongjae Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg?1783936478"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CompanionOfTheTrials.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CompanionOfTheTrials.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Companion of the Trials
+ * {2}{W}
+ * Creature — Bird Soldier
+ * 2/2
+ * Flying
+ * {1}{W}: Untap target creature. Activate only if you control a Gideon planeswalker.
+ */
+val CompanionOfTheTrials = card("Companion of the Trials") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    oracleText = "Flying\n" +
+            "{1}{W}: Untap target creature. Activate only if you control a Gideon planeswalker."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Untap(creature)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Exists(
+                    Player.You,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Planeswalker.withSubtype("Gideon")
+                )
+            )
+        )
+        description = "{1}{W}: Untap target creature. Activate only if you control a Gideon planeswalker."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "271"
+        artist = "Aaron Miller"
+        flavorText = "\"The fiercest loyalties are earned in battle.\"\n—Gideon Jura"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg?1783936437"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CradleOfTheAccursed.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CradleOfTheAccursed.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Cradle of the Accursed
+ *
+ * Land — Desert
+ * {T}: Add {C}.
+ * {3}, {T}, Sacrifice this land: Create a 2/2 black Zombie creature token. Activate only as a sorcery.
+ *
+ * "Activate only as a sorcery" is [TimingRule.SorcerySpeed]. The token-making ability is not a mana
+ * ability even though the first one is.
+ */
+val CradleOfTheAccursed = card("Cradle of the Accursed") {
+    typeLine = "Land — Desert"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}, {T}, Sacrifice this land: Create a 2/2 black Zombie creature token. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Noah Bradley"
+        flavorText = "Many such monuments dot the wasteland known as Ifnir."
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg?1783936446"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CrocodileOfTheCrossing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CrocodileOfTheCrossing.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crocodile of the Crossing
+ * {3}{G}
+ * Creature — Crocodile
+ * 5/4
+ * Haste
+ * When this creature enters, put a -1/-1 counter on target creature you control.
+ */
+val CrocodileOfTheCrossing = card("Crocodile of the Crossing") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Crocodile"
+    oracleText = "Haste\n" +
+            "When this creature enters, put a -1/-1 counter on target creature you control."
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature)
+        description = "When this creature enters, put a -1/-1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Kev Walker"
+        flavorText = "\"Everything in the trial has teeth. You will overcome them, or you will feed them.\"\n—Rhonas, god of strength"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg?1783936477"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CursedMinotaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CursedMinotaur.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cursed Minotaur
+ * {2}{B}
+ * Creature — Zombie Minotaur
+ * 3/2
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val CursedMinotaur = card("Cursed Minotaur") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Minotaur"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "David Palumbo"
+        flavorText = "\"Look! That is why we must never waver. That is what awaits us if we fail.\"\n—Djeru, initiate of Tah crop"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg?1783936509"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DesertCerodon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DesertCerodon.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Desert Cerodon
+ * {5}{R}
+ * Creature — Beast
+ * 6/4
+ * Cycling {R} ({R}, Discard this card: Draw a card.)
+ */
+val DesertCerodon = card("Desert Cerodon") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    oracleText = "Cycling {R} ({R}, Discard this card: Draw a card.)"
+    power = 6
+    toughness = 4
+
+    keywordAbility(KeywordAbility.cycling("{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Igor Kieryluk"
+        flavorText = "The endless expanse of desert surrounding Naktamun sometimes yields threats that the gods themselves must answer."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg?1783936491"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DissentersDeliverance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DissentersDeliverance.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Dissenter's Deliverance
+ * {1}{G}
+ * Instant
+ * Destroy target artifact.
+ * Cycling {G} ({G}, Discard this card: Draw a card.)
+ */
+val DissentersDeliverance = card("Dissenter's Deliverance") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact.\n" +
+            "Cycling {G} ({G}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.Artifact)
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"When all doubts have melted away, the worthy will meet the Hour of Eternity and earn a place at the God-Pharaoh's side.\"\n—*The Accounting of Hours*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg?1783936477"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DjerusResolve.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DjerusResolve.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+
+/**
+ * Djeru's Resolve
+ * {W}
+ * Instant
+ * Untap target creature. Prevent all damage that would be dealt to it this turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "it" is the same creature both halves act on, so there is one named target and both effects bind
+ * to it. No `Effects.*` facade spells the plain "prevent all damage that would be dealt to target
+ * this turn" shield — every parameter is [PreventDamageEffect]'s own default except the recipient.
+ */
+val DjerusResolve = card("Djeru's Resolve") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Untap target creature. Prevent all damage that would be dealt to it this turn.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Untap(creature),
+            PreventDamageEffect(target = creature)
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Kieran Yanner"
+        flavorText = "\"When I wish to be strong, I train. When I wish to be wise, I study. When I wish to rest, I start again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg?1783936540"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FanBearer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FanBearer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fan Bearer
+ * {W}
+ * Creature — Zombie
+ * 1/2
+ * {2}, {T}: Tap target creature.
+ */
+val FanBearer = card("Fan Bearer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Zombie"
+    oracleText = "{2}, {T}: Tap target creature."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Tap(creature)
+        description = "{2}, {T}: Tap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Anthony Palumbo"
+        flavorText = "Rest sometimes requires the right prompting."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg?1783936543"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FesteringMummy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FesteringMummy.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Festering Mummy
+ * {B}
+ * Creature — Zombie
+ * 1/1
+ * When this creature dies, you may put a -1/-1 counter on target creature.
+ *
+ * The printed "you may" is the builder's `optional = true`, which lowers into the same
+ * `Gate.MayDecide` consent gate a hand-written `MayEffect` would build — the target is still
+ * chosen as the ability goes on the stack (CR 603.3d), the yes/no is asked at resolution.
+ */
+val FesteringMummy = card("Festering Mummy") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText = "When this creature dies, you may put a -1/-1 counter on target creature."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        optional = true
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Christopher Burdett"
+        flavorText = "As its parched flesh withers away, its malignant hunger grows."
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg?1783936508"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FetidPools.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FetidPools.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Fetid Pools
+ *
+ * Land — Island Swamp
+ * ({T}: Add {U} or {B}.)
+ * This land enters tapped.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val FetidPools = card("Fetid Pools") {
+    colorIdentity = "BU"
+    typeLine = "Land — Island Swamp"
+    oracleText = "({T}: Add {U} or {B}.)\n" +
+        "This land enters tapped.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "243"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg?1783936446"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FinalReward.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FinalReward.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Final Reward
+ * {4}{B}
+ * Instant
+ * Exile target creature.
+ */
+val FinalReward = card("Final Reward") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "92"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "Those who earn a glorious death are given the highest honor. They are carried on funeral barges through the gate to the afterlife."
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg?1783936505"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Floodwaters.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Floodwaters.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Floodwaters
+ * {4}{U}{U}
+ * Sorcery
+ * Return up to two target creatures to their owners' hands.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Up to two target creatures" is one requirement with `count = 2, optional = true`; the body runs
+ * once per chosen target via [ForEachTargetEffect], so [EffectTarget.ContextTarget] index 0 is the
+ * creature of the current iteration rather than the first-chosen one.
+ */
+val Floodwaters = card("Floodwaters") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return up to two target creatures to their owners' hands.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        target("target", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Jung Park"
+        flavorText = "\"It usually appears placid, but don't be fooled. The Luxa River is a snake, and it can swallow you whole.\"\n—Neponem, vizier of Kefnet"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg?1783936522"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ForsakeTheWorldly.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ForsakeTheWorldly.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Forsake the Worldly
+ * {2}{W}
+ * Instant
+ * Exile target artifact or enchantment.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val ForsakeTheWorldly = card("Forsake the Worldly") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target artifact or enchantment.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Steve Argyle"
+        flavorText = "\"Why cling to these trappings? They are but tools and affectations. True wealth can be possessed only in the afterlife.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg?1783936539"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GracefulCat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GracefulCat.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Graceful Cat
+ * {2}{W}
+ * Creature — Cat
+ * 2/2
+ * Whenever this creature attacks, it gets +1/+1 until end of turn.
+ */
+val GracefulCat = card("Graceful Cat") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    oracleText = "Whenever this creature attacks, it gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "273"
+        artist = "John Stanko"
+        flavorText = "Though they are held in high regard as symbols of the god Oketra, cats often lack her sense of solidarity."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg?1783936438"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GraspingDunes.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/GraspingDunes.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Grasping Dunes
+ *
+ * Land — Desert
+ * {T}: Add {C}.
+ * {1}, {T}, Sacrifice this land: Put a -1/-1 counter on target creature. Activate only as a sorcery.
+ *
+ * "Activate only as a sorcery" is [TimingRule.SorcerySpeed]. The second ability targets, so it is
+ * not a mana ability even though the first one is.
+ */
+val GraspingDunes = card("Grasping Dunes") {
+    typeLine = "Land — Desert"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}, Sacrifice this land: Put a -1/-1 counter on target creature. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg?1783936446"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HapatraVizierOfPoisons.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HapatraVizierOfPoisons.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Hapatra, Vizier of Poisons
+ * {B}{G}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ * Whenever Hapatra deals combat damage to a player, you may put a -1/-1 counter on target creature.
+ * Whenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch.
+ *
+ * The second trigger is the per-recipient shape of [Triggers.countersPlacedOn] — the current Oracle
+ * text says "on **a** creature", so an effect that hits three creatures fires it three times, and
+ * `batch` stays at its default `false`. `firstTimeEachTurn` is passed explicitly because the facade
+ * defaults it to `!batch`, which is the Stalwart Successor rider this card does not print. The
+ * recipient filter carries no `youControl()` — any creature qualifies; it is `placedBy` that scopes
+ * the trigger to counters *you* put (CR 122.6a).
+ */
+val HapatraVizierOfPoisons = card("Hapatra, Vizier of Poisons") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Human Cleric"
+    oracleText = "Whenever Hapatra deals combat damage to a player, you may put a -1/-1 counter on target creature.\n" +
+            "Whenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        optional = true
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Creature,
+            counterType = Counters.MINUS_ONE_MINUS_ONE,
+            firstTimeEachTurn = false,
+            placedBy = Player.You,
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Snake"),
+            keywords = setOf(Keyword.DEATHTOUCH),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "199"
+        artist = "Tyler Jacobson"
+        flavorText = "Her subtle smile is suffused with venom."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg?1783936464"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HazeOfPollen.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HazeOfPollen.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Haze of Pollen
+ * {1}{G}
+ * Instant
+ * Prevent all combat damage that would be dealt this turn.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val HazeOfPollen = card("Haze of Pollen") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn.\n" +
+            "Cycling {3} ({3}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Mark Zug"
+        flavorText = "Few can overcome an assault of such aggressive serenity."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg?1783936475"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HonedKhopesh.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HonedKhopesh.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Honed Khopesh
+ * {1}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+1.
+ * Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val HonedKhopesh = card("Honed Khopesh") {
+    manaCost = "{1}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "230"
+        artist = "Aaron Miller"
+        flavorText = "Blades and bravery go hand in hand."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg?1783936452"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ImpeccableTimingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ImpeccableTimingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impeccable Timing reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val ImpeccableTimingReprint = Printing(
+    oracleId = "102bbedf-9f84-433a-bd01-e1a4c05fbedb",
+    name = "Impeccable Timing",
+    setCode = "AKH",
+    collectorNumber = "18",
+    scryfallId = "a98cee1e-64d8-4662-a911-009b031dc888",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a98cee1e-64d8-4662-a911-009b031dc888.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/IrrigatedFarmland.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/IrrigatedFarmland.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Irrigated Farmland
+ *
+ * Land — Plains Island
+ * ({T}: Add {W} or {U}.)
+ * This land enters tapped.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val IrrigatedFarmland = card("Irrigated Farmland") {
+    colorIdentity = "UW"
+    typeLine = "Land — Plains Island"
+    oracleText = "({T}: Add {W} or {U}.)\n" +
+        "This land enters tapped.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg?1783936447"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/KhenraCharioteer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/KhenraCharioteer.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Khenra Charioteer
+ * {1}{R}{G}
+ * Creature — Jackal Warrior
+ * 3/3
+ * Trample
+ * Other creatures you control have trample.
+ */
+val KhenraCharioteer = card("Khenra Charioteer") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Jackal Warrior"
+    oracleText = "Trample\n" +
+            "Other creatures you control have trample."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.TRAMPLE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Chris Rallis"
+        flavorText = "\"We do not swerve.\"\n—Tah-crop charioteer motto"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg?1783936463"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ManticoreOfTheGauntlet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ManticoreOfTheGauntlet.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Manticore of the Gauntlet
+ * {4}{R}
+ * Creature — Manticore
+ * 5/4
+ * When this creature enters, put a -1/-1 counter on target creature you control. This creature deals 3 damage to target opponent or planeswalker.
+ *
+ * One trigger, two targets: the counter's own creature and the damage's opponent-or-planeswalker,
+ * both chosen as the ability goes on the stack.
+ */
+val ManticoreOfTheGauntlet = card("Manticore of the Gauntlet") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Manticore"
+    oracleText = "When this creature enters, put a -1/-1 counter on target creature you control. This creature deals 3 damage to target opponent or planeswalker."
+    power = 5
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.CreatureYouControl)
+        val damaged = target("target 1", Targets.OpponentOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature),
+            Effects.DealDamage(3, damaged),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "James Paick"
+        flavorText = "In the training ground known as the Gauntlet, initiates are pushed to practice more destructive techniques."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg?1783936485"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MercilessJavelineer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MercilessJavelineer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Merciless Javelineer
+ * {2}{B}{R}
+ * Creature — Minotaur Warrior
+ * 4/2
+ * {2}, Discard a card: Put a -1/-1 counter on target creature. That creature can't block this turn.
+ *
+ * "That creature" is the same bound target as the counter, so both halves of the composite point
+ * at the one target requirement rather than declaring a second one.
+ */
+val MercilessJavelineer = card("Merciless Javelineer") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Minotaur Warrior"
+    oracleText = "{2}, Discard a card: Put a -1/-1 counter on target creature. That creature can't block this turn."
+    power = 4
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t),
+            Effects.CantBlock(t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Nils Hamm"
+        flavorText = "\"My mind is the calm in the midst of the storm, and my javelin the lightning.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg?1783936462"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/NagaOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/NagaOracle.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Naga Oracle
+ * {3}{U}
+ * Creature — Snake Cleric
+ * 2/4
+ * When this creature enters, surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+ *
+ * Printed in Amonkhet as "scry 3"; the current Oracle text is the errata'd surveil.
+ */
+val NagaOracle = card("Naga Oracle") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Snake Cleric"
+    oracleText = "When this creature enters, surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Surveil(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"All questions will be answered during the Hour of Revelation.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg?1783936518"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/NimbleBladeKhenra.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/NimbleBladeKhenra.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nimble-Blade Khenra
+ * {1}{R}
+ * Creature — Jackal Warrior
+ * 1/3
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ */
+val NimbleBladeKhenra = card("Nimble-Blade Khenra") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Jackal Warrior"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+    power = 1
+    toughness = 3
+
+    prowess()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"In the Hour of Glory, the gods and the untested will prove their worth before the God-Pharaoh.\"\n—*The Accounting of Hours*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg?1783936484"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/OketrasMonument.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/OketrasMonument.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Oketra's Monument
+ * {3}
+ * Legendary Artifact
+ * White creature spells you cast cost {1} less to cast.
+ * Whenever you cast a creature spell, create a 1/1 white Warrior creature token with vigilance.
+ *
+ * The two lines read different sets of spells on purpose: only *white* creature spells are cheaper,
+ * but the token trigger fires on any creature spell you cast.
+ */
+val OketrasMonument = card("Oketra's Monument") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "White creature spells you cast cost {1} less to cast.\n" +
+        "Whenever you cast a creature spell, create a 1/1 white Warrior creature token with vigilance."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature.withColor(Color.WHITE)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Warrior"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Christine Choi"
+        flavorText = "\"The worthy shall respect the worthy. In the afterlife, all will stand united.\"\n—Monument inscription"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg?1783936451"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/OrneryKudu.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/OrneryKudu.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ornery Kudu
+ * {2}{G}
+ * Creature — Antelope
+ * 3/4
+ * When this creature enters, put a -1/-1 counter on target creature you control.
+ */
+val OrneryKudu = card("Ornery Kudu") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Antelope"
+    oracleText = "When this creature enters, put a -1/-1 counter on target creature you control."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature)
+        description = "When this creature enters, put a -1/-1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Deruchenko Alexander"
+        flavorText = "Debate rages among the viziers whether comparing the kudu's horns to the God-Pharaoh's is blasphemy or reverence."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg?1783936471"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PaintedBluffs.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PaintedBluffs.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Painted Bluffs
+ *
+ * Land — Desert
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ */
+val PaintedBluffs = card("Painted Bluffs") {
+    typeLine = "Land — Desert"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Mark Poole"
+        flavorText = "Centuries of scouring sands have carved and polished the rocky terrain of the Shefet."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg?1783936445"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PathmakerInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PathmakerInitiate.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pathmaker Initiate
+ * {1}{R}
+ * Creature — Human Wizard
+ * 2/1
+ * {T}: Target creature with power 2 or less can't be blocked this turn.
+ */
+val PathmakerInitiate = card("Pathmaker Initiate") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "{T}: Target creature with power 2 or less can't be blocked this turn."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature with power 2 or less", Targets.CreatureWithPowerAtMost(2))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+        description = "{T}: Target creature with power 2 or less can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Josu Hernaiz"
+        flavorText = "\"The expected way through the trial is far too tedious.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg?1783936484"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PursueGlory.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PursueGlory.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pursue Glory
+ * {3}{R}
+ * Instant
+ * Attacking creatures get +2/+0 until end of turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Attacking creatures" is every attacker on the battlefield, not just yours, so the [GroupFilter]
+ * carries no controller predicate and the body points at [EffectTarget.Self] — the iterated
+ * creature, not the spell's source.
+ */
+val PursueGlory = card("Pursue Glory") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +2/+0 until end of turn.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.attacking()),
+            Effects.ModifyStats(2, 0, EffectTarget.Self)
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Johann Bodin"
+        flavorText = "\"Combat is a form of worship, the clash of steel a solemn prayer.\"\n—Pytamun, initiate of Nef crop"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg?1783936483"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/RhonassMonument.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/RhonassMonument.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Rhonas's Monument
+ * {3}
+ * Legendary Artifact
+ * Green creature spells you cast cost {1} less to cast.
+ * Whenever you cast a creature spell, target creature you control gets +2/+2 and gains trample until end of turn.
+ *
+ * The two lines read different sets of spells on purpose: only *green* creature spells are cheaper,
+ * but the pump trigger fires on any creature spell you cast.
+ */
+val RhonassMonument = card("Rhonas's Monument") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Green creature spells you cast cost {1} less to cast.\n" +
+        "Whenever you cast a creature spell, target creature you control gets +2/+2 and gains trample until end of turn."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature.withColor(Color.GREEN)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Cliff Childs"
+        flavorText = "\"The worthy shall hone a strong body to endure the boundless energies of the afterlife.\"\n—Monument inscription"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg?1783936447"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ScatteredGroves.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ScatteredGroves.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Scattered Groves
+ *
+ * Land — Forest Plains
+ * ({T}: Add {G} or {W}.)
+ * This land enters tapped.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val ScatteredGroves = card("Scattered Groves") {
+    colorIdentity = "GW"
+    typeLine = "Land — Forest Plains"
+    oracleText = "({T}: Add {G} or {W}.)\n" +
+        "This land enters tapped.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Christine Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg?1783936445"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SeraphOfTheSuns.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SeraphOfTheSuns.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seraph of the Suns
+ * {5}{W}{W}
+ * Creature — Angel
+ * 4/4
+ * Flying
+ * Indestructible (Damage and effects that say "destroy" don't destroy this creature. If its
+ * toughness is 0 or less, it still dies.)
+ */
+val SeraphOfTheSuns = card("Seraph of the Suns") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying\n" +
+            "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it still dies.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.INDESTRUCTIBLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Winona Nelson"
+        flavorText = "\"Angels? My feelings remain unchanged.\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg?1783941503"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ShimmerscaleDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ShimmerscaleDrake.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Shimmerscale Drake
+ * {4}{U}
+ * Creature — Drake
+ * 3/4
+ * Flying
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val ShimmerscaleDrake = card("Shimmerscale Drake") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Tony Foti"
+        flavorText = "They are drawn by the brilliant blue glint of the mineral lazotep from the mines below."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg?1783936516"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SlitherBlade.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SlitherBlade.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slither Blade
+ * {U}
+ * Creature — Snake Rogue
+ * 1/2
+ * This creature can't be blocked.
+ */
+val SlitherBlade = card("Slither Blade") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Snake Rogue"
+    oracleText = "This creature can't be blocked."
+    power = 1
+    toughness = 2
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Zezhou Chen"
+        flavorText = "Some naga initiates move as silently the suns' reflections on the water."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg?1783936514"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SparringMummy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SparringMummy.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sparring Mummy
+ * {3}{W}
+ * Creature — Zombie
+ * 3/3
+ * When this creature enters, untap target creature.
+ */
+val SparringMummy = card("Sparring Mummy") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Zombie"
+    oracleText = "When this creature enters, untap target creature."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Untap(creature)
+        description = "When this creature enters, untap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Ryan Pancoast"
+        flavorText = "Aspiring to earn their place in the afterlife, acolytes train every day against those who fell short of that glory."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg?1783936532"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StingingShot.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StingingShot.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Stinging Shot
+ * {G}
+ * Instant
+ * Put three -1/-1 counters on target creature with flying.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val StingingShot = card("Stinging Shot") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Put three -1/-1 counters on target creature with flying.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val flier = target("target", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 3, flier)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Scott Murphy"
+        flavorText = "Initiates must train to resist the natural toxins they use as weapons."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg?1783936466"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StirTheSands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StirTheSands.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Stir the Sands
+ * {4}{B}{B}
+ * Sorcery
+ * Create three 2/2 black Zombie creature tokens.
+ * Cycling {3}{B} ({3}{B}, Discard this card: Draw a card.)
+ * When you cycle this card, create a 2/2 black Zombie creature token.
+ *
+ * Three parts: the `spell { }` body, [KeywordAbility.cycling], and a [Triggers.YouCycleThis]
+ * triggered ability that fires from the graveyard once the cycling ability has resolved.
+ */
+val StirTheSands = card("Stir the Sands") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Create three 2/2 black Zombie creature tokens.\n" +
+            "Cycling {3}{B} ({3}{B}, Discard this card: Draw a card.)\n" +
+            "When you cycle this card, create a 2/2 black Zombie creature token."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            count = 3,
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{3}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+        description = "When you cycle this card, create a 2/2 black Zombie creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "David Gaillet"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg?1783936499"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SunscorchedDesert.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SunscorchedDesert.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunscorched Desert
+ *
+ * Land — Desert
+ * When this land enters, it deals 1 damage to target player or planeswalker.
+ * {T}: Add {C}.
+ */
+val SunscorchedDesert = card("Sunscorched Desert") {
+    typeLine = "Land — Desert"
+    oracleText = "When this land enters, it deals 1 damage to target player or planeswalker.\n" +
+        "{T}: Add {C}."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Min Yum"
+        flavorText = "The only relief in sight is a mirage."
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg?1783936445"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SupplyCaravan.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SupplyCaravan.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Supply Caravan
+ * {4}{W}
+ * Creature — Camel
+ * 3/5
+ * When this creature enters, if you control a tapped creature, create a 1/1 white Warrior creature token with vigilance.
+ *
+ * The "if you control a tapped creature" clause is printed straight after the trigger event, so it
+ * is an intervening-if (CR 603.4) — checked both when the trigger would go on the stack and again
+ * on resolution.
+ */
+val SupplyCaravan = card("Supply Caravan") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Camel"
+    oracleText = "When this creature enters, if you control a tapped creature, create a 1/1 white Warrior creature token with vigilance."
+    power = 3
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControl(GameObjectFilter.Creature.tapped())
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Warrior"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Nils Hamm"
+        flavorText = "\"We each have a weight to carry on the road to the afterlife.\"\n—Oketra, god of solidarity"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg?1783936532"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SwelteringSuns.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SwelteringSuns.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sweltering Suns
+ * {1}{R}{R}
+ * Sorcery
+ * Sweltering Suns deals 3 damage to each creature.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ *
+ * "Each creature" is [Effects.ForEachInGroup] over an unrestricted creature [GroupFilter], with the
+ * body pointed at [EffectTarget.Self] — the iterated permanent, not the spell's source.
+ */
+val SwelteringSuns = card("Sweltering Suns") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Sweltering Suns deals 3 damage to each creature.\n" +
+            "Cycling {3} ({3}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature),
+            Effects.DealDamage(3, EffectTarget.Self)
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "149"
+        artist = "Raymond Swanland"
+        flavorText = "The Hekma may repel storms and monsters, but nothing holds back the heat of the suns."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg?1783936482"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ViolentImpact.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ViolentImpact.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Violent Impact
+ * {3}{R}
+ * Sorcery
+ * Destroy target artifact or land.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val ViolentImpact = card("Violent Impact") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or land.\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrLand)
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Jason Rainville"
+        flavorText = "Initiates in the heat of combat must be able to adapt to changing conditions."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg?1783936481"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WastelandScorpion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WastelandScorpion.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Wasteland Scorpion
+ * {2}{B}
+ * Creature — Scorpion
+ * 2/2
+ * Deathtouch
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val WastelandScorpion = card("Wasteland Scorpion") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Scorpion"
+    oracleText = "Deathtouch\n" +
+            "Cycling {2} ({2}, Discard this card: Draw a card.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Yeong-Hao Han"
+        flavorText = "All but the gods fear the scorpion's sting."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg?1783936495"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WaywardServant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WaywardServant.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wayward Servant
+ * {W}{B}
+ * Creature — Zombie
+ * 2/2
+ * Whenever another Zombie you control enters, each opponent loses 1 life and you gain 1 life.
+ *
+ * The printed noun is bare "Zombie", which means any Zombie *permanent* you control — not just
+ * creatures — so the trigger filter is [GameObjectFilter.Permanent]. "Another" is
+ * [TriggerBinding.OTHER].
+ */
+val WaywardServant = card("Wayward Servant") {
+    manaCost = "{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Zombie"
+    oracleText = "Whenever another Zombie you control enters, each opponent loses 1 life and you gain 1 life."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Anthony Palumbo"
+        flavorText = "If one of the anointed fails to serve with perfect obedience, the desert is always ready to receive it."
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg?1783936460"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WeaverOfCurrents.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WeaverOfCurrents.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weaver of Currents
+ * {1}{G}{U}
+ * Creature — Snake Druid
+ * 2/2
+ * {T}: Add {C}{C}.
+ */
+val WeaverOfCurrents = card("Weaver of Currents") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Snake Druid"
+    oracleText = "{T}: Add {C}{C}."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Winona Nelson"
+        flavorText = "\"Your waters sustain the living and carry the dead. Mighty Luxa, let your power flow through me!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg?1783936459"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WingedShepherd.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WingedShepherd.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Winged Shepherd
+ * {5}{W}
+ * Creature — Angel
+ * 3/3
+ * Flying, vigilance
+ * Cycling {W} ({W}, Discard this card: Draw a card.)
+ */
+val WingedShepherd = card("Winged Shepherd") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying, vigilance\n" +
+            "Cycling {W} ({W}, Discard this card: Draw a card.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.cycling("{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Chris Rahn"
+        flavorText = "\"When the Hour of Promise arrives, the God-Pharaoh will tear down the Hekma, for its protection will be needed no longer.\"\n—*The Accounting of Hours*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg?1783936530"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/CanyonSloughReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/CanyonSloughReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Slough reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val CanyonSloughReprint = Printing(
+    oracleId = "2031b17c-0536-446f-a9aa-b46fe79b7ea7",
+    name = "Canyon Slough",
+    setCode = "MSC",
+    collectorNumber = "228",
+    scryfallId = "587cc3ba-75c2-46a0-bd44-6f953fe1eb01",
+    artist = "Arthur Yuan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/587cc3ba-75c2-46a0-bd44-6f953fe1eb01.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/FetidPoolsReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/FetidPoolsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fetid Pools reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val FetidPoolsReprint = Printing(
+    oracleId = "32b03b48-06da-4a74-a7ac-e5ae39a4f428",
+    name = "Fetid Pools",
+    setCode = "MSC",
+    collectorNumber = "243",
+    scryfallId = "5fa4556f-2fdc-42e6-98cb-291cee2ca3ac",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fa4556f-2fdc-42e6-98cb-291cee2ca3ac.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/IrrigatedFarmlandReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/IrrigatedFarmlandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Irrigated Farmland reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val IrrigatedFarmlandReprint = Printing(
+    oracleId = "406eabe2-df62-49e2-bb39-c0227509d875",
+    name = "Irrigated Farmland",
+    setCode = "MSC",
+    collectorNumber = "251",
+    scryfallId = "996b4484-a701-409a-822c-aa19be89a2c6",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/996b4484-a701-409a-822c-aa19be89a2c6.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ScatteredGrovesReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ScatteredGrovesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scattered Groves reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val ScatteredGrovesReprint = Printing(
+    oracleId = "3c87ea85-ca29-45a7-b5b2-758c62898b0a",
+    name = "Scattered Groves",
+    setCode = "MSC",
+    collectorNumber = "262",
+    scryfallId = "6bd38442-854d-43b1-a80c-9d841c3a304d",
+    artist = "Josu Hernaiz",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6bd38442-854d-43b1-a80c-9d841c3a304d.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -1,3 +1,110 @@
+// Angler Drake
+{
+    "name": "Angler Drake",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, you may return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "From the time they are hatchlings, river drakes are taught to pull the largest prey from the Luxa.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d14c753e-c5bf-4c34-b408-ac367b6ca6ab.jpg?1783936527"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Baleful Ammit
+{
+    "name": "Baleful Ammit",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Crocodile Demon",
+    "oracleText": "Lifelink\nWhen this creature enters, put a -1/-1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "UNCOMMON",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Not all in our crop deserve the afterlife. We must leave the unworthy behind, Samut.\"\n—Djeru, initiate of Tah crop",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb662d58-ae50-423d-b1c5-abd45baca12b.jpg?1783936511"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blighted Bat
 {
     "name": "Blighted Bat",
@@ -39,6 +146,53 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Bloodlust Inciter
+{
+    "name": "Bloodlust Inciter",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target creature gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Anthony Palumbo",
+        "flavorText": "\"To victory! To glory! To eternity!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1cd0757-1b06-4e1b-a236-31271bd0d9a3.jpg?1783936494"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -111,6 +265,474 @@
     ]
 }
 
+// Bontu's Monument
+{
+    "name": "Bontu's Monument",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Black creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, each opponent loses 1 life and you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature black"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Jonas De Ro",
+        "flavorText": "\"The worthy shall strive for greatness. Supremacy in life leads to supremacy in the afterlife.\"\n—Monument inscription",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9b00377-9acc-47c4-ae2f-b396d7050a15.jpg?1783936454"
+    }
+}
+
+// Canyon Slough
+{
+    "name": "Canyon Slough",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Mountain",
+    "oracleText": "({T}: Add {B} or {R}.)\nThis land enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "RARE",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cb273d9-466d-416d-b27d-d1bc8a249076.jpg?1783936446"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Cartouche of Ambition
+{
+    "name": "Cartouche of Ambition",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Aura Cartouche",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, you may put a -1/-1 counter on target creature.\nEnchanted creature gets +1/+1 and has lifelink.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "-1/-1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e68b96b1-b75e-4ee1-a6d7-6545a34fef9b.jpg?1783936514"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cartouche of Knowledge
+{
+    "name": "Cartouche of Knowledge",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura Cartouche",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, draw a card.\nEnchanted creature gets +1/+1 and has flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Kieran Yanner",
+        "flavorText": "Cartouches chronicle the initiates' achievements in the trials.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d806458e-81cd-4413-bba0-14d957bece79.jpg?1783936525"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cartouche of Solidarity
+{
+    "name": "Cartouche of Solidarity",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment — Aura Cartouche",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, create a 1/1 white Warrior creature token with vigilance.\nEnchanted creature gets +1/+1 and has first strike. (It deals combat damage before creatures without first strike.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Warrior"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90eaf94e-85a7-4958-aa58-8e2fe44db58d.jpg?1783936543"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Cartouche of Zeal
+{
+    "name": "Cartouche of Zeal",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura Cartouche",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, target creature can't block this turn.\nEnchanted creature gets +1/+1 and has haste. (It can attack and {T} no matter when it came under your control.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Kieran Yanner",
+        "flavorText": "The fifth cartouche is the final affirmation of glory, granted only to the worthy dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d09b2d9-b944-480b-93f9-76fc9bc319ce.jpg?1783936492"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cascading Cataracts
+{
+    "name": "Cascading Cataracts",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Indestructible\n{T}: Add {C}.\n{5}, {T}: Add five mana in any combination of colors.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Noah Bradley",
+        "flavorText": "\"The power that flows here cannot be denied. But where is the source?\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/778739db-4431-4e58-91de-d2619aeef3ce.jpg?1783936447"
+    }
+}
+
+// Channeler Initiate
+{
+    "name": "Channeler Initiate",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "When this creature enters, put three -1/-1 counters on target creature you control.\n{T}, Remove a -1/-1 counter from this creature: Add one mana of any color.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 3,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "When this creature enters, put three -1/-1 counters on target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "-1/-1",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a -1/-1 counter from this creature: Add one mana of any color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "RARE",
+        "artist": "Yongjae Choi",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/bef38c5a-07fc-477f-a1c0-70cc3ad64f96.jpg?1783936478"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Colossapede
 {
     "name": "Colossapede",
@@ -125,6 +747,188 @@
         "artist": "Jason Kang",
         "flavorText": "\"If it is bigger, you must be faster. If it is stronger, you must be sharper. Anything less, and you will never seize a place in our God-Pharaoh's perfect afterlife.\"\n—Rhonas, god of strength",
         "imageUri": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg?1783936478"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Companion of the Trials
+{
+    "name": "Companion of the Trials",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying\n{1}{W}: Untap target creature. Activate only if you control a Gideon planeswalker.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "planeswalker Gideon"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{1}{W}: Untap target creature. Activate only if you control a Gideon planeswalker."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "UNCOMMON",
+        "artist": "Aaron Miller",
+        "flavorText": "\"The fiercest loyalties are earned in battle.\"\n—Gideon Jura",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/637ac220-058f-4212-ba8b-a389bb0528bd.jpg?1783936437"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Cradle of the Accursed
+{
+    "name": "Cradle of the Accursed",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}, Sacrifice this land: Create a 2/2 black Zombie creature token. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "artist": "Noah Bradley",
+        "flavorText": "Many such monuments dot the wasteland known as Ifnir.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41713e82-c3d3-4c2f-b075-f684cbd68ce8.jpg?1783936446"
+    }
+}
+
+// Crocodile of the Crossing
+{
+    "name": "Crocodile of the Crossing",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Crocodile",
+    "oracleText": "Haste\nWhen this creature enters, put a -1/-1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "When this creature enters, put a -1/-1 counter on target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"Everything in the trial has teeth. You will overcome them, or you will feed them.\"\n—Rhonas, god of strength",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f64ca9c-99c4-45d4-bd21-3ede61702250.jpg?1783936477"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -165,6 +969,154 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Cursed Minotaur
+{
+    "name": "Cursed Minotaur",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Minotaur",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "David Palumbo",
+        "flavorText": "\"Look! That is why we must never waver. That is what awaits us if we fail.\"\n—Djeru, initiate of Tah crop",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3990d2f-39d9-49f9-936f-1d40adcf295c.jpg?1783936509"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Desert Cerodon
+{
+    "name": "Desert Cerodon",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Cycling {R} ({R}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{R}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Igor Kieryluk",
+        "flavorText": "The endless expanse of desert surrounding Naktamun sometimes yields threats that the gods themselves must answer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/2047c2e5-8b3b-4c6b-91cf-3484f21e52f0.jpg?1783936491"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Dissenter's Deliverance
+{
+    "name": "Dissenter's Deliverance",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact.\nCycling {G} ({G}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"When all doubts have melted away, the worthy will meet the Hour of Eternity and earn a place at the God-Pharaoh's side.\"\n—*The Accounting of Hours*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/543eb854-bac7-468f-b3b0-d9987cfac318.jpg?1783936477"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Djeru's Resolve
+{
+    "name": "Djeru's Resolve",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Untap target creature. Prevent all damage that would be dealt to it this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"When I wish to be strong, I train. When I wish to be wise, I study. When I wish to rest, I start again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad60ebb9-4acc-41a8-90d9-04d55e414ed1.jpg?1783936540"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -306,6 +1258,272 @@
     ]
 }
 
+// Fan Bearer
+{
+    "name": "Fan Bearer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{2}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}: Tap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Anthony Palumbo",
+        "flavorText": "Rest sometimes requires the right prompting.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6cec477-f86f-4ccf-aa57-b6b7ade46eed.jpg?1783936543"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Festering Mummy
+{
+    "name": "Festering Mummy",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, you may put a -1/-1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "-1/-1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Christopher Burdett",
+        "flavorText": "As its parched flesh withers away, its malignant hunger grows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/906c4c95-5815-44c8-8d3c-b0fda9db55a1.jpg?1783936508"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Fetid Pools
+{
+    "name": "Fetid Pools",
+    "manaCost": "",
+    "typeLine": "Land — Island Swamp",
+    "oracleText": "({T}: Add {U} or {B}.)\nThis land enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae703d94-6f1f-463b-ab25-1b3f462e7e78.jpg?1783936446"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Final Reward
+{
+    "name": "Final Reward",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "Those who earn a glorious death are given the highest honor. They are carried on funeral barges through the gate to the afterlife.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f202f6b-710f-4376-a49c-e5f135b26eaf.jpg?1783936505"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Floodwaters
+{
+    "name": "Floodwaters",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to two target creatures to their owners' hands.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Jung Park",
+        "flavorText": "\"It usually appears placid, but don't be fooled. The Luxa River is a snake, and it can swallow you whole.\"\n—Neponem, vizier of Kefnet",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a211df0-fe9e-4d2c-9e0e-c7be50e6b906.jpg?1783936522"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Forsake the Worldly
+{
+    "name": "Forsake the Worldly",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target artifact or enchantment.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Why cling to these trappings? They are but tools and affectations. True wealth can be possessed only in the afterlife.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cca4e95e-f14e-4cfa-918a-cfb15f912293.jpg?1783936539"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Galestrike
 {
     "name": "Galestrike",
@@ -355,6 +1573,114 @@
     ]
 }
 
+// Graceful Cat
+{
+    "name": "Graceful Cat",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever this creature attacks, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "273",
+        "artist": "John Stanko",
+        "flavorText": "Though they are held in high regard as symbols of the god Oketra, cats often lack her sense of solidarity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b42ba8bf-9fc1-4d57-9c80-42491d18d929.jpg?1783936438"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Grasping Dunes
+{
+    "name": "Grasping Dunes",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}, Sacrifice this land: Put a -1/-1 counter on target creature. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8fcc939-6a31-4fb3-abe7-7663b85868dd.jpg?1783936446"
+    }
+}
+
 // Greater Sandwurm
 {
     "name": "Greater Sandwurm",
@@ -398,6 +1724,114 @@
     ]
 }
 
+// Hapatra, Vizier of Poisons
+{
+    "name": "Hapatra, Vizier of Poisons",
+    "manaCost": "{B}{G}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "Whenever Hapatra deals combat damage to a player, you may put a -1/-1 counter on target creature.\nWhenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "-1/-1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "-1/-1",
+                    "filter": "creature",
+                    "placedBy": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Snake"
+                    ],
+                    "keywords": [
+                        "DEATHTOUCH"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "RARE",
+        "artist": "Tyler Jacobson",
+        "flavorText": "Her subtle smile is suffused with venom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56fbbcc9-db23-4902-b0f7-cea78a2a36af.jpg?1783936464"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Haze of Pollen
+{
+    "name": "Haze of Pollen",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Mark Zug",
+        "flavorText": "Few can overcome an assault of such aggressive serenity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b636925d-1c32-4fdc-b814-e6111393d04e.jpg?1783936475"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hieroglyphic Illumination
 {
     "name": "Hieroglyphic Illumination",
@@ -428,6 +1862,60 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Honed Khopesh
+{
+    "name": "Honed Khopesh",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "230",
+        "artist": "Aaron Miller",
+        "flavorText": "Blades and bravery go hand in hand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7d80b98-baa2-48ea-9611-96e64d7cb950.jpg?1783936452"
+    }
 }
 
 // Hyena Pack
@@ -496,6 +1984,73 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Irrigated Farmland
+{
+    "name": "Irrigated Farmland",
+    "manaCost": "",
+    "typeLine": "Land — Plains Island",
+    "oracleText": "({T}: Add {W} or {U}.)\nThis land enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d87fcc0-cef5-4410-adf1-91c5f50c1d01.jpg?1783936447"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Khenra Charioteer
+{
+    "name": "Khenra Charioteer",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Jackal Warrior",
+    "oracleText": "Trample\nOther creatures you control have trample.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rallis",
+        "flavorText": "\"We do not swerve.\"\n—Tah-crop charioteer motto",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ab1454e-3c69-4450-bd4c-934af2ff2bcb.jpg?1783936463"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }
 
@@ -622,6 +2177,152 @@
     ]
 }
 
+// Manticore of the Gauntlet
+{
+    "name": "Manticore of the Gauntlet",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Manticore",
+    "oracleText": "When this creature enters, put a -1/-1 counter on target creature you control. This creature deals 3 damage to target opponent or planeswalker.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "-1/-1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target 1"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetOpponentOrPlaneswalker",
+                        "id": "target 1"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "James Paick",
+        "flavorText": "In the training ground known as the Gauntlet, initiates are pushed to practice more destructive techniques.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82b6ece3-1574-4634-b940-829e54c4f78d.jpg?1783936485"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Merciless Javelineer
+{
+    "name": "Merciless Javelineer",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "oracleText": "{2}, Discard a card: Put a -1/-1 counter on target creature. That creature can't block this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "-1/-1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"My mind is the calm in the midst of the storm, and my javelin the lightning.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee0e8c57-3046-414d-be00-39bfb2537026.jpg?1783936462"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Minotaur Sureshot
 {
     "name": "Minotaur Sureshot",
@@ -673,6 +2374,298 @@
     ]
 }
 
+// Naga Oracle
+{
+    "name": "Naga Oracle",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Snake Cleric",
+    "oracleText": "When this creature enters, surveil 3. (Look at the top three cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 3
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"All questions will be answered during the Hour of Revelation.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/9060b7b5-3ef1-443e-8f8a-450cc42c43a6.jpg?1783936518"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Nimble-Blade Khenra
+{
+    "name": "Nimble-Blade Khenra",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Jackal Warrior",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"In the Hour of Glory, the gods and the untested will prove their worth before the God-Pharaoh.\"\n—*The Accounting of Hours*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e36a17b-89d6-4de9-867b-9762afedb4f1.jpg?1783936484"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Oketra's Monument
+{
+    "name": "Oketra's Monument",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "White creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, create a 1/1 white Warrior creature token with vigilance.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Warrior"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature white"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Christine Choi",
+        "flavorText": "\"The worthy shall respect the worthy. In the afterlife, all will stand united.\"\n—Monument inscription",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/104503a6-bca5-48d7-88b1-424f98985d75.jpg?1783936451"
+    }
+}
+
+// Ornery Kudu
+{
+    "name": "Ornery Kudu",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Antelope",
+    "oracleText": "When this creature enters, put a -1/-1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "When this creature enters, put a -1/-1 counter on target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Debate rages among the viziers whether comparing the kudu's horns to the God-Pharaoh's is blasphemy or reverence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8ba1d3a1-8c1b-4b77-b149-13d5ad9f125a.jpg?1783936471"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Painted Bluffs
+{
+    "name": "Painted Bluffs",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Mark Poole",
+        "flavorText": "Centuries of scouring sands have carved and polished the rocky terrain of the Shefet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b373131-2a1d-4710-8a11-c1b366a174d4.jpg?1783936445"
+    }
+}
+
+// Pathmaker Initiate
+{
+    "name": "Pathmaker Initiate",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{T}: Target creature with power 2 or less can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with power 2 or less"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=2"
+                        },
+                        "id": "target creature with power 2 or less"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target creature with power 2 or less can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"The expected way through the trial is far too tedious.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4ccc6b34-aaa7-4ec1-9f37-b03f9b5919f2.jpg?1783936484"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pouncing Cheetah
 {
     "name": "Pouncing Cheetah",
@@ -694,6 +2687,52 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Pursue Glory
+{
+    "name": "Pursue Glory",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +2/+0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Johann Bodin",
+        "flavorText": "\"Combat is a form of worship, the clash of steel a solemn prayer.\"\n—Pytamun, initiate of Nef crop",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5668ae2-fa74-47c9-877e-5326cac67659.jpg?1783936483"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -767,6 +2806,85 @@
     ]
 }
 
+// Rhonas's Monument
+{
+    "name": "Rhonas's Monument",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Green creature spells you cast cost {1} less to cast.\nWhenever you cast a creature spell, target creature you control gets +2/+2 and gains trample until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature green"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "\"The worthy shall hone a strong body to endure the boundless energies of the afterlife.\"\n—Monument inscription",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53d2260a-e001-4d03-a108-759591e4d233.jpg?1783936447"
+    }
+}
+
 // Scaled Behemoth
 {
     "name": "Scaled Behemoth",
@@ -789,6 +2907,61 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Scattered Groves
+{
+    "name": "Scattered Groves",
+    "manaCost": "",
+    "typeLine": "Land — Forest Plains",
+    "oracleText": "({T}: Add {G} or {W}.)\nThis land enters tapped.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Christine Choi",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccb541aa-3bf6-41f3-89e5-9c6c56ea210a.jpg?1783936445"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Seraph of the Suns
+{
+    "name": "Seraph of the Suns",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it still dies.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "INDESTRUCTIBLE"
+    ],
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"Angels? My feelings remain unchanged.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85dc4ed8-4674-44a1-8a06-ecce72c85e60.jpg?1783941503"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -818,6 +2991,60 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Shimmerscale Drake
+{
+    "name": "Shimmerscale Drake",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Tony Foti",
+        "flavorText": "They are drawn by the brilliant blue glint of the mineral lazotep from the mines below.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edb13075-0ea0-480a-84c0-8eec3119db45.jpg?1783936516"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Slither Blade
+{
+    "name": "Slither Blade",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Snake Rogue",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Zezhou Chen",
+        "flavorText": "Some naga initiates move as silently the suns' reflections on the water.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63cf067e-4d76-4676-85fa-ebfb0755440a.jpg?1783936514"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -900,6 +3127,307 @@
     ]
 }
 
+// Sparring Mummy
+{
+    "name": "Sparring Mummy",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature enters, untap target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature enters, untap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Ryan Pancoast",
+        "flavorText": "Aspiring to earn their place in the afterlife, acolytes train every day against those who fell short of that glory.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4ec1587-0405-4b4d-96b5-1ac2c5a7c9dc.jpg?1783936532"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Stinging Shot
+{
+    "name": "Stinging Shot",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Put three -1/-1 counters on target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "AddCounters",
+            "counterType": "-1/-1",
+            "count": 3,
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Scott Murphy",
+        "flavorText": "Initiates must train to resist the natural toxins they use as weapons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/547c4c26-1118-41fa-aec8-1b43a7792e59.jpg?1783936466"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Stir the Sands
+{
+    "name": "Stir the Sands",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create three 2/2 black Zombie creature tokens.\nCycling {3}{B} ({3}{B}, Discard this card: Draw a card.)\nWhen you cycle this card, create a 2/2 black Zombie creature token.",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 2,
+            "toughness": 2,
+            "colors": [
+                "BLACK"
+            ],
+            "creatureTypes": [
+                "Zombie"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        },
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+                },
+                "descriptionOverride": "When you cycle this card, create a 2/2 black Zombie creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "David Gaillet",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cb84193-9648-46e5-a34d-c12cc3f1d7f2.jpg?1783936499"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sunscorched Desert
+{
+    "name": "Sunscorched Desert",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "When this land enters, it deals 1 damage to target player or planeswalker.\n{T}: Add {C}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayerOrPlaneswalker",
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Min Yum",
+        "flavorText": "The only relief in sight is a mirage.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/405434c7-9206-45b7-af0f-d59aae294d39.jpg?1783936445"
+    }
+}
+
+// Supply Caravan
+{
+    "name": "Supply Caravan",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Camel",
+    "oracleText": "When this creature enters, if you control a tapped creature, create a 1/1 white Warrior creature token with vigilance.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Warrior"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature tapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Nils Hamm",
+        "flavorText": "\"We each have a weight to carry on the road to the afterlife.\"\n—Oketra, god of solidarity",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d247bd88-9593-462c-8f9e-28e29c064c10.jpg?1783936532"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sweltering Suns
+{
+    "name": "Sweltering Suns",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sweltering Suns deals 3 damage to each creature.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "The Hekma may repel storms and monsters, but nothing holds back the heat of the suns.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg?1783936482"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tattered Mummy
 {
     "name": "Tattered Mummy",
@@ -964,6 +3492,49 @@
     ]
 }
 
+// Violent Impact
+{
+    "name": "Violent Impact",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Jason Rainville",
+        "flavorText": "Initiates in the heat of combat must be able to adapt to changing conditions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/49b8673a-ce93-4881-b712-8db82446d83c.jpg?1783936481"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vizier of the Menagerie
 {
     "name": "Vizier of the Menagerie",
@@ -1021,5 +3592,165 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wasteland Scorpion
+{
+    "name": "Wasteland Scorpion",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Scorpion",
+    "oracleText": "Deathtouch\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "All but the gods fear the scorpion's sting.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bab1782-498c-40fc-bf2e-5c991d0c3501.jpg?1783936495"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wayward Servant
+{
+    "name": "Wayward Servant",
+    "manaCost": "{W}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Whenever another Zombie you control enters, each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Zombie ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony Palumbo",
+        "flavorText": "If one of the anointed fails to serve with perfect obedience, the desert is always ready to receive it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9e00112-8c6c-4551-ad68-389e315fe148.jpg?1783936460"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Weaver of Currents
+{
+    "name": "Weaver of Currents",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Creature — Snake Druid",
+    "oracleText": "{T}: Add {C}{C}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"Your waters sustain the living and carry the dead. Mighty Luxa, let your power flow through me!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/dac35181-baae-4c50-b397-a10b234833e5.jpg?1783936459"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Winged Shepherd
+{
+    "name": "Winged Shepherd",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying, vigilance\nCycling {W} ({W}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{W}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Chris Rahn",
+        "flavorText": "\"When the Hour of Promise arrives, the God-Pharaoh will tear down the Hekma, for its protection will be needed no longer.\"\n—*The Accounting of Hours*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04301470-82d9-43c7-aaf1-a41e185cb109.jpg?1783936530"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -144,6 +144,62 @@
     ]
 }
 
+// Brute Strength
+{
+    "name": "Brute Strength",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+1 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Wayne Reynolds",
+        "flavorText": "It's not the size of the rock. It's how badly you want to lift it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec60192a-19b3-447c-b732-bbcb2d275df6.jpg?1783937908"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Canopy Gorger
 {
     "name": "Canopy Gorger",


### PR DESCRIPTION
Sweeps Amonkhet's Assay-ready tail to zero — the cards Argentum Assay reads whole
that the set hadn't authored yet.

## The four-way split (63 badged)

| Bucket | Count | What was done |
|---|---:|---|
| `original` | 56 | canonical `card(...)` authored in AKH |
| `elsewhere` | 1 | Brute Strength — canonical authored in **OGW** (its earliest real printing), `Printing` row here |
| `row-only` | 1 | Impeccable Timing — canonical already in KLD, `Printing` row here |
| `basic` | 5 | `AmonkhetBasicLands.kt` (20 `basicLand(...)` vals, arts 250–269) + the `basicLands` override |
| `unscaffolded` | 0 | — |

**Reprint tail: 4 more rows in MSC** (Canyon Slough, Fetid Pools, Irrigated Farmland,
Scattered Groves). Those only became visible to `check-card-printing` once the cycling
duals' canonicals existed, so they belong in this PR. `generate-reprints.py` was scoped
with `--since main` so the run emitted exactly the 5 rows this batch owes, not the
corpus's backlog; the Impeccable Timing row was generated separately with `--card`
because its canonical predates the branch.

Amonkhet's `basicLandsFallback = PortalSet` is dropped now that the set has its own basics.

## Gates

| Gate | Result |
|---|---|
| `just build` | green |
| `just rebless-cards` | only `snapshots/cards/AKH.json` + `OGW.json` moved |
| differential (before) | 5353 compared / 5304 confirmed / **49 divergent** |
| differential (after) | 5409 compared / 5360 confirmed / **49 divergent** |
| `check-card-printing` × 57 | 0 findings |
| `just assay-ready AKH` (before) | 63 Assay-ready |
| `just assay-ready AKH` (after) | **0 Assay-ready** (165 missing, all `LINE_DECLINED` 150 / `MULTI_FACE` 15) |

Delta: **+56 compared, +56 confirmed, zero new divergences.** Both baselines were taken
with the freshly-built binary in this checkout.

Every card was authored to `assay compile`'s JSON rather than to the oracle text, which
is why the differential is a formality rather than a bug hunt.

### The one card that left the compared set

**Nimble-Blade Khenra** — 57 authored, 56 compared. `prowess()` spells the rule out as
keyword + triggered ability, so `Differential.carriesUnreadAbilities` sees an extra
triggered ability against Assay's script-less `keywordAbilities: [Simple PROWESS]` and
buckets it as "script slot not modelled yet". This is the correct outcome and the same
one riot got in the RNA sweep (#2038): shipping bare `keywords(Keyword.PROWESS)` would
confirm the differential and ship an inert card.

## Capability pre-flight

Every construct the batch touches was traced to its `rules-engine` consumer before
authoring — cycling (activated-from-hand via `CyclingEnumerator`/`CycleCardHandler`,
plus the `CardCycledEvent` trigger), surveil, `Land — Desert`, `ModifySpellCost` +
`ReduceGeneric`, `CreateToken`, `Gate.MayDecide`, `PreventDamageShield`,
`AttachEquipment`, `CantBlockTargetCreatures`, the three mana-adding effects,
`-1/-1` counters + `CountersPlacedEvent`, `ActivationOnlyIfCondition` and
`EntersTapped`. **All live** — no display-only keyword in the batch, so no card
needed rules spelled out of primitives.

## Oracle errata worth knowing

Two cards' current Oracle text differs from the AKH printing; both are authored to the
current text (which is what Assay and the field-verification tests compare against):

- **Naga Oracle** — printed `scry 3`, errata'd to **`surveil 3`**.
- **Hapatra, Vizier of Poisons** — printed "one or more -1/-1 counters on one or more
  creatures an opponent controls", errata'd to "on **a** creature". That is the
  per-recipient template, not the batch one, so the trigger is `batch = false` — matching
  both the compile JSON and `Triggers.kt`'s `countersPlacedRule`, which never passes
  `batch`.

## Findings surfaced, not fixed

Three things the sweep turned up that are outside its scope:

1. **`Triggers.countersPlacedOn`'s `firstTimeEachTurn = !batch` default is a trap.**
   With `batch = false` it silently adds a once-per-turn rider the card doesn't print.
   Every corpus caller except Stalwart Successor overrides it back to `false`, and
   Assay's own grammar carries a KDoc explaining why it must pass the value explicitly.
   A default every real caller has to undo is arguably the wrong default.

2. **`Targets.UpToCreatures(n)` leaves `minCount = count`.** `TargetCreature`'s
   `minCount: Int = count` means "up to two target creatures" compiles with
   `minCount = 2` despite `optional = true`. It serializes identically to Assay (the
   default makes it omitted) and `ktk/Waterwhirl` has the same shape, so it is
   consistent corpus-wide — but if `minCount` is what the engine enforces, every
   "up to N targets" card may be over-constrained. Not touched here.

3. **`uds/cards/TrumpetBlast.kt`** — Pursue Glory's exact script twin, and the corpus's
   only prior art for the attacking-creatures pump family, still carries its
   `// === GENERATED by mtgish-tooling` banner (i.e. unreviewed).

Also noted: **Companion of the Trials** is collector number 271, past AKH's 269-card
main set — it's the Planeswalker-deck exclusive, so it will look odd in a set-completion
count. Metadata is copied verbatim from Scryfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
