### PR TITLE
Read the whole table in Two-Headed Giant

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -491,9 +491,15 @@ sealed, or premade), then one N-player game".
     individually (CR 104.3b), and a team loses only once all its members have left (CR 104.2c).
     `maxPlayers` caps at 8.
 
-  The seat roster (`PlayerSeatInfo`) carries `teamIndex` for grouping and a game-level
-  `teamSharedLife` flag (`true` for 2HG, `false` for Team vs. Team) so the client renders either a
-  single shared-life team header or per-player life. Ignored outside a team mode.
+  Both facts reach the client twice. The seat roster (`PlayerSeatInfo`) carries `teamIndex` for
+  grouping and a game-level `teamSharedLife` flag (`true` for 2HG, `false` for Team vs. Team), and
+  **`ClientPlayer` carries the same two fields on every state update**. The roster alone is not
+  enough: it rides a one-shot game-start message, so a client that joins by *reconnecting*
+  (hotseat, scenario, a dropped connection resuming) never sees it and would render a team game as
+  a free-for-all. The client re-derives its seat → team map from the state on each update, which
+  covers every entry path into live play; spectate and replay still seed theirs from their own
+  rosters. Both `ClientPlayer` fields are additive with defaults (`null` / `false`), so they
+  serialize away entirely outside a team mode.
 - **Free mulligan.** A game that begins with more than two players (any FFA pod) uses the CR 800.6
   multiplayer mulligan: a player's *first* mulligan is free — it bottoms 0 cards and doesn't count
   toward the mulligan limit. This is engine-internal; the existing `MulliganDecision.cardsToPutOnBottom`

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ControlChangedRemovesFromCombatCheck.kt
@@ -16,22 +16,26 @@ import com.wingedsheep.sdk.model.EntityId
  * projected controller (which already reflects every Layer 2 control-changing effect, plus
  * Old Man of the Sea's post-Layer-7 power gate) to the player it should be fighting for:
  *
- * - Attackers must remain controlled by the active player (the only player who has
- *   declared attackers this turn). A projected controller that is no longer the active
- *   player → removed from combat.
- * - Blockers must remain controlled by a non-active player (the defender who declared
- *   them). A projected controller that has become the active player → removed from combat.
+ * - Attackers must remain controlled by the *active team* — every player who could have
+ *   declared an attacker this turn. A projected controller off that team → removed from combat.
+ * - Blockers must remain controlled by the defending team. A projected controller that has
+ *   joined the active team → removed from combat.
  *
- * The two-player approximation is sufficient for current scope; multi-player formats
- * can extend this once they're modelled. Removal uses [CombatRemovalHelper] so dependent
- * `BlockedComponent` / `BlockingComponent` references stay consistent.
+ * Asked through [GameState.isActiveTurnFor], which is the team-aware form of
+ * `controller == activePlayerId`: in Two-Headed Giant the attacking team declares one combined
+ * attack (CR 805.10a), so both teammates' creatures are legitimately attacking even though the
+ * engine names only one of them [GameState.activePlayerId] (CR 805.9). Comparing against that
+ * single id swept the non-active teammate's entire attack out of combat on the next SBA pass.
+ * Every format without shared team turns reduces to the plain equality, unchanged.
+ *
+ * Removal uses [CombatRemovalHelper] so dependent `BlockedComponent` / `BlockingComponent`
+ * references stay consistent.
  */
 class ControlChangedRemovesFromCombatCheck : StateBasedActionCheck {
     override val name = "506.4 Controller-Changed Combat Removal"
     override val order = SbaOrder.CONTROL_CHANGED_COMBAT
 
     override fun check(state: GameState): ExecutionResult {
-        val activePlayerId = state.activePlayerId
         val projected = state.projectedState
 
         val toRemove = mutableListOf<EntityId>()
@@ -43,8 +47,8 @@ class ControlChangedRemovesFromCombatCheck : StateBasedActionCheck {
 
             val controllerId = projected.getController(entityId) ?: continue
             val mismatched = when {
-                isAttacking -> controllerId != activePlayerId
-                isBlocking -> controllerId == activePlayerId
+                isAttacking -> !state.isActiveTurnFor(controllerId)
+                isBlocking -> state.isActiveTurnFor(controllerId)
                 else -> false
             }
             if (mismatched) toRemove.add(entityId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -824,7 +824,26 @@ data class ClientPlayer(
      * information like poison counters, so it is not masked. Defaulted so every non-energy game
      * serializes it away and the field costs nothing.
      */
-    val energyCounters: Int = 0
+    val energyCounters: Int = 0,
+
+    /**
+     * Team membership in a team variant (Two-Headed Giant — CR 810; Team vs. Team — CR 808):
+     * players sharing a [teamIndex] are teammates. `null` in every non-team game, where each
+     * player is their own team.
+     *
+     * Carried on the *state* rather than only on the seat roster because the roster is a
+     * one-shot game-start message: a client that joins by reconnecting (hotseat, scenario, a
+     * dropped connection resuming) never sees it, and without this would render a team game as
+     * a free-for-all — four separate life totals, no ally board, no team colors.
+     */
+    val teamIndex: Int? = null,
+
+    /**
+     * True when this game's format pools life per team (Two-Headed Giant, CR 810.4). A game-level
+     * fact, repeated per player so the client can read it off any seat. Team vs. Team is a team
+     * game with per-player life, so it sets [teamIndex] but leaves this false.
+     */
+    val teamSharedLife: Boolean = false
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2027,7 +2027,10 @@ class ClientStateTransformer(
             playerId = playerId,
             name = playerComponent?.name ?: "Unknown",
             life = displayedLife ?: 20,
-            poisonCounters = container?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0,
+            // CR 810.10a — a player's displayed poison is the team's pooled total in Two-Headed
+            // Giant, the same way [life] above is the team's shared total. The team orb and the
+            // 15-counter loss check (CR 810.8d) must read the same number.
+            poisonCounters = state.teamPoison(playerId),
             handSize = handSize,
             maxHandSize = maxHandSize,
             librarySize = librarySize,
@@ -2044,9 +2047,7 @@ class ClientStateTransformer(
             energyCounters = container?.get<CountersComponent>()?.getCount(CounterType.ENERGY) ?: 0,
             // Team variants (CR 810 / CR 808). Public information, and absent from every
             // non-team game, so both fields serialize away by default.
-            teamIndex = container
-                ?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()
-                ?.teamIndex,
+            teamIndex = container?.get<TeamComponent>()?.teamIndex,
             teamSharedLife = state.format.sharesTeamLife
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2041,7 +2041,13 @@ class ClientStateTransformer(
             // CR 702.179 — public information, and 0 for the overwhelming majority of games.
             speed = state.speed(playerId),
             // CR 107.14 — public information like poison counters, and 0 outside energy decks.
-            energyCounters = container?.get<CountersComponent>()?.getCount(CounterType.ENERGY) ?: 0
+            energyCounters = container?.get<CountersComponent>()?.getCount(CounterType.ENERGY) ?: 0,
+            // Team variants (CR 810 / CR 808). Public information, and absent from every
+            // non-team game, so both fields serialize away by default.
+            teamIndex = container
+                ?.get<com.wingedsheep.engine.state.components.identity.TeamComponent>()
+                ?.teamIndex,
+            teamSharedLife = state.format.sharesTeamLife
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.DeclareBlockers
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.GameInitializer
 import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.mechanics.StateBasedActionChecker
 import com.wingedsheep.engine.mechanics.combat.CombatDefenders
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
@@ -13,6 +14,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.BlockingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
@@ -149,5 +151,53 @@ class TwoHeadedGiantCombatTest : FunSpec({
 
         // p1 is on the attacking team, so it may not block (the active team never blocks).
         proc.process(state, DeclareBlockers(p[1], mapOf(blkP1 to listOf(atk)))).result.isSuccess.shouldBeFalse()
+    }
+    /*
+     * CR 506.4 removes a permanent from combat when its controller changes. The engine names one
+     * [GameState.activePlayerId] (CR 805.9), but in Two-Headed Giant the attacking *team* declares
+     * one combined attack (CR 805.10a), so the non-active teammate's attackers are legitimately
+     * attacking while controlled by somebody who is not that id. Comparing against it directly
+     * swept their whole attack out of combat on the next state-based-action pass — which any
+     * flash spell cast during combat forces.
+     */
+    test("the teammate's attackers survive a state-based-action pass (CR 805.10a / CR 506.4)") {
+        val (base, p) = init2hg()
+        val (s1, atkActive) = base.withBear(p[0], attacking = p[2])
+        val (s2, atkTeammate) = s1.withBear(p[1], attacking = p[3]) // the NON-active teammate's
+        val state = s2.copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT)
+
+        val after = StateBasedActionChecker(cardRegistry = registry()).checkAndApply(state).newState
+
+        after.getEntity(atkActive)!!.has<AttackingComponent>().shouldBeTrue()
+        after.getEntity(atkTeammate)!!.has<AttackingComponent>().shouldBeTrue()
+    }
+
+    test("both defenders' blockers survive a state-based-action pass (CR 805.10d / CR 506.4)") {
+        val (base, p) = init2hg()
+        val (s1, atk) = base.withBear(p[0], attacking = p[2])
+        val (s2, blkP2) = s1.withBear(p[2])
+        val (s3, blkP3) = s2.withBear(p[3])
+        val state = s3
+            .updateEntity(blkP2) { it.with(BlockingComponent(listOf(atk))) }
+            .updateEntity(blkP3) { it.with(BlockingComponent(listOf(atk))) }
+            .copy(step = Step.DECLARE_BLOCKERS, phase = Phase.COMBAT)
+
+        val after = StateBasedActionChecker(cardRegistry = registry()).checkAndApply(state).newState
+
+        after.getEntity(blkP2)!!.has<BlockingComponent>().shouldBeTrue()
+        after.getEntity(blkP3)!!.has<BlockingComponent>().shouldBeTrue()
+    }
+
+    test("an attacker stolen by the DEFENDING team is still removed from combat (CR 506.4)") {
+        val (base, p) = init2hg()
+        val (s1, atk) = base.withBear(p[0], attacking = p[2])
+        // Control moves across the table: p2 is on the defending team, so CR 506.4 still applies.
+        val state = s1
+            .updateEntity(atk) { it.with(ControllerComponent(p[2])) }
+            .copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT)
+
+        val after = StateBasedActionChecker(cardRegistry = registry()).checkAndApply(state).newState
+
+        after.getEntity(atk)!!.has<AttackingComponent>().shouldBeFalse()
     }
 })

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -2187,7 +2187,7 @@ function SelfBottomCell({
   spectatorMode: boolean
   hijackedSurfaceStyle?: React.CSSProperties
 }) {
-  const { cellRef, handHeight } = useCellHandMetrics()
+  const { cellRef, handBand } = useCellHandMetrics()
   return (
     <div
       ref={cellRef}
@@ -2216,7 +2216,7 @@ function SelfBottomCell({
       )}
       {/* Reservation band mirrors the other cells' name-plate + cell-hand bands so all bottom
           boards line up. */}
-      <div style={{ height: CELL_PLATE_BAND + handHeight, flexShrink: 0 }} aria-hidden />
+      <div style={{ height: CELL_PLATE_BAND + handBand, flexShrink: 0 }} aria-hidden />
       <div style={{ ...styles.playerRowWithZones, alignItems: 'flex-start', flex: 1 }}>
         <CommandZone player={player} />
         <div style={{ ...styles.playerMainArea, ...(hijackedSurfaceStyle ?? null) }}>

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useRef, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
-import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId, useViewerEliminated } from '@/store/selectors'
+import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId, useViewerEliminated, useIsSharedLifeTeamGame, useTeamLabelFor, useTeammateNames } from '@/store/selectors'
 import { useMultiplayerView, useCombatDefenderFocus } from '@/hooks/useMultiplayerView'
 import { OpponentRail, railReservedWidth } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
@@ -25,7 +25,7 @@ import { useResponsive } from '@/hooks/useResponsive'
 import { ManaSymbol } from '../ui/ManaSymbols'
 
 // Import extracted components
-import { Battlefield, CardRow, CommandZone, OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, StackDisplay, ZonePile, ResponsiveContext } from './board'
+import { Battlefield, CardRow, CommandZone, OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, CELL_PLATE_BAND, useCellHandMetrics, StackDisplay, ZonePile, ResponsiveContext } from './board'
 import { RenderProfiler } from '@/utils/renderProfiler'
 import { CardPreview } from './card'
 import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, SpeedGauge, DayNightBadge, ConcedeButton, FullscreenButton, SpectatorCountBadge } from './overlay'
@@ -190,7 +190,6 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   )
   const defenderFocusIds = useCombatDefenderFocus(isMulti && !spectatorMode)
   const viewedSeatColor = useIdentityColor(viewedOpponent?.playerId ?? null)
-  const isViewedOpponentAlly = useIsAlly(viewedOpponent?.playerId ?? null)
   const stripTouchX = useRef<number | null>(null)
 
   // Card counts per battlefield zone — used by useResponsive to decide when wrapping
@@ -391,14 +390,46 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const bottomHudPlayer = eliminatedBottomSeat ?? effectiveViewingPlayer
   const bottomHudSeatColor = useIdentityColor(bottomHudPlayer?.playerId ?? null)
 
-  // Team-split bottom half: the viewer's whole team, anchor seat first (leftmost), then teammates
-  // in turn order. When playing, the anchor is your interactive board; when spectating it's just
-  // the bottom-anchored seat. Teammate cells reuse the overview cell + per-board collapse.
+  // Two-Headed Giant (CR 810): teammates share one life total, so the center HUD stops being
+  // "you vs. the viewed opponent" and reads team-vs-team — each orb labelled with its team and
+  // carrying that team's single life. Every other place that would repeat the same number (the
+  // rail chips, the board name plates) drops it, so the total appears exactly once per team.
+  // An observer has no "your team" to be relative to, so they keep the per-player HUD.
+  const sharedLifeTeam = useIsSharedLifeTeamGame()
+  const teamCenterOrbs = sharedLifeTeam && !viewerIsObserver
+  // ...and the left-hand orb becomes the *enemy team's*, not the viewed board's. Your ally's
+  // board sits on the table beside yours, so the camera's nominal opponent is frequently a
+  // teammate — and two orbs both reading "Your Team 30" is precisely the duplicate this HUD
+  // exists to remove. The enemy team's first living seat in turn order stands for the team: it
+  // carries the shared total, the team hue, and (see `centerOrbOpponentId` below) the team's
+  // share of the player anchors.
+  const centerOrbOpponent = useMemo(() => {
+    if (!teamCenterOrbs || !gameState || viewerTeam == null) return effectiveOpponent
+    return (
+      gameState.players.find((p) => !p.hasLost && teamMap[p.playerId] !== viewerTeam) ??
+      effectiveOpponent
+    )
+  }, [teamCenterOrbs, gameState, viewerTeam, teamMap, effectiveOpponent])
+  // Exactly one element per player carries that player's anchors, and for whoever the left orb
+  // is showing, it's the orb — so their board plate and rail chip both stand down.
+  const centerOrbOpponentId = centerOrbOpponent?.playerId ?? null
+  const centerOrbSeatColor = useIdentityColor(centerOrbOpponentId)
+  const centerOrbIsAlly = useIsAlly(centerOrbOpponentId)
+  const opponentTeamLabel = useTeamLabelFor(centerOrbOpponentId)
+  const opponentTeamMembers = useTeammateNames(centerOrbOpponentId)
+  const bottomTeamLabel = useTeamLabelFor(bottomHudPlayer?.playerId ?? null)
+  const bottomTeamMembers = useTeammateNames(bottomHudPlayer?.playerId ?? null)
+
+  // Team-split bottom half: the viewer's whole team in turn order with the anchor seat *last* —
+  // i.e. bottom-right, directly under the right-hand life orb and the zone piles that are
+  // already right-aligned, so "your stuff" occupies one corner of the table instead of being
+  // split across it. When playing, the anchor is your interactive board; when spectating it's
+  // just the bottom-anchored seat. Teammate cells reuse the overview cell + per-board collapse.
   const bottomRowOrdered = useMemo(() => {
     if (!twoRowActive || !gameState) return []
     return gameState.players
       .filter((p) => bottomRowIds.includes(p.playerId))
-      .sort((a, b) => (a.playerId === anchorId ? -1 : b.playerId === anchorId ? 1 : 0))
+      .sort((a, b) => (a.playerId === anchorId ? 1 : b.playerId === anchorId ? -1 : 0))
   }, [twoRowActive, gameState, bottomRowIds, anchorId])
   // The bottom half becomes a multi-board strip only when it holds more than the anchor (team
   // games; 4+ player free-for-alls). A lone anchor keeps the classic single bottom board — but
@@ -432,7 +463,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // them over whenever the seat's own board is on screen: an expanded cell in the top strip, an
   // expanded cell in the bottom row, or the eliminated spectator's bottom board.
   const anchorVisibleBoardIds = useMemo<readonly EntityId[]>(() => {
-    const ids = [...expandedStripIds]
+    // A strip board's plate only exists in a shared-strip view; with the sliding camera the sole
+    // visible board has no plate at all, so its anchors live on the center orb — and only if the
+    // orb is actually pointed at it.
+    const ids = multiView ? [...expandedStripIds] : []
     if (eliminatedBottomSeat) ids.push(eliminatedBottomSeat.playerId)
     if (bottomStripActive) {
       for (const p of bottomRowOrdered) {
@@ -441,8 +475,17 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         }
       }
     }
+    if (centerOrbOpponentId && !ids.includes(centerOrbOpponentId)) ids.push(centerOrbOpponentId)
     return ids
-  }, [expandedStripIds, eliminatedBottomSeat, bottomStripActive, bottomRowOrdered, bottomCollapsedIds])
+  }, [
+    multiView,
+    expandedStripIds,
+    eliminatedBottomSeat,
+    bottomStripActive,
+    bottomRowOrdered,
+    bottomCollapsedIds,
+    centerOrbOpponentId,
+  ])
 
   // Compute mana selection progress using most-constrained-first matching
   const manaProgress = useMemo(() => {
@@ -910,7 +953,6 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 const renderStripBoard = (o: (typeof stripOpponents)[number], expandedCell: boolean) => {
                   // Two-Headed Giant: your teammate's board is an ally (face-up hand + marker).
                   const oIsAlly = viewerTeam != null && teamMap[o.playerId] === viewerTeam
-                  const isViewedCell = o.playerId === viewedOpponent?.playerId
                   return (
                     <OpponentBoardArea
                       key={o.playerId}
@@ -923,9 +965,11 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                       // and overflow off-screen (see offscreenStripBoards).
                       stripBasis={multiView && expandedCell ? expandedCellBasis : '100%'}
                       hideHand={multiView}
-                      // The viewed board's anchors stay on the center-HUD orb; every other
-                      // expanded board's plate takes over from its rail chip.
-                      plateCarriesAnchors={multiView && expandedCell && !isViewedCell}
+                      // The center-HUD orb's player keeps their anchors on that orb; every other
+                      // expanded board's plate takes over from its rail chip. Normally that's the
+                      // viewed board, but a Two-Headed Giant HUD points its orb at the enemy team
+                      // instead (see `centerOrbOpponent`).
+                      plateCarriesAnchors={multiView && expandedCell && o.playerId !== centerOrbOpponentId}
                       // With every board on screen the useful highlight is whose turn it is,
                       // not which cell the camera nominally tracks.
                       {...(multiView && expandedCell && o.playerId === gameState.activePlayerId
@@ -1022,27 +1066,30 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             targeting click target in the familiar spot (the chip carries the
             anchors for the other, off-screen opponents). */}
         <div style={{ ...styles.centerLifeSection, ...styles.centerLifeSectionLeft }}>
-          {effectiveOpponent && (
+          {centerOrbOpponent && (
             <>
               <LifeDisplay
-                life={effectiveOpponent.life}
-                playerId={effectiveOpponent.playerId}
-                playerName={effectiveOpponent.name}
+                life={centerOrbOpponent.life}
+                playerId={centerOrbOpponent.playerId}
+                playerName={centerOrbOpponent.name}
                 // An eliminated spectator has no opponents left to speak of — their orbs read
                 // spectator-shaped (no "OPPONENT" role tag, no targeting click), like the
                 // bottom-seat orb already does.
                 spectatorMode={viewerIsObserver}
-                poisonCounters={effectiveOpponent.poisonCounters}
-                energyCounters={effectiveOpponent.energyCounters ?? 0}
-                commanderDamage={effectiveOpponent.commanderDamage ?? []}
-                handSize={effectiveOpponent.handSize}
-                maxHandSize={effectiveOpponent.maxHandSize}
-                {...(isMulti ? { seatColor: viewedSeatColor.base } : {})}
-                {...(isViewedOpponentAlly ? { isAlly: true } : {})}
+                poisonCounters={centerOrbOpponent.poisonCounters}
+                energyCounters={centerOrbOpponent.energyCounters ?? 0}
+                commanderDamage={centerOrbOpponent.commanderDamage ?? []}
+                handSize={centerOrbOpponent.handSize}
+                maxHandSize={centerOrbOpponent.maxHandSize}
+                {...(isMulti ? { seatColor: centerOrbSeatColor.base } : {})}
+                {...(centerOrbIsAlly ? { isAlly: true } : {})}
+                {...(teamCenterOrbs
+                  ? { teamName: opponentTeamLabel, teamMembers: opponentTeamMembers }
+                  : {})}
               />
-              <SpeedGauge speed={effectiveOpponent.speed ?? 0} />
-              {!responsive.isMobile && <ActiveEffectsBadges effects={effectiveOpponent.activeEffects} />}
-              {!responsive.isMobile && effectiveOpponent.manaPool && <ManaPool manaPool={effectiveOpponent.manaPool} />}
+              <SpeedGauge speed={centerOrbOpponent.speed ?? 0} />
+              {!responsive.isMobile && <ActiveEffectsBadges effects={centerOrbOpponent.activeEffects} />}
+              {!responsive.isMobile && centerOrbOpponent.manaPool && <ManaPool manaPool={centerOrbOpponent.manaPool} />}
             </>
           )}
         </div>
@@ -1125,7 +1172,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             <>
               {/* When another seat is anchored here (eliminated spectator), the orb is
                   spectator-shaped: no "You" role tag, no player-click handling. */}
-              <LifeDisplay life={bottomHudPlayer.life} isPlayer playerId={bottomHudPlayer.playerId} playerName={bottomHudPlayer.name} spectatorMode={spectatorMode || eliminatedBottomSeat != null} poisonCounters={bottomHudPlayer.poisonCounters} energyCounters={bottomHudPlayer.energyCounters ?? 0} commanderDamage={bottomHudPlayer.commanderDamage ?? []} handSize={bottomHudPlayer.handSize} maxHandSize={bottomHudPlayer.maxHandSize} {...(isMulti ? { seatColor: bottomHudSeatColor.base } : {})} />
+              <LifeDisplay life={bottomHudPlayer.life} isPlayer playerId={bottomHudPlayer.playerId} playerName={bottomHudPlayer.name} spectatorMode={spectatorMode || eliminatedBottomSeat != null} poisonCounters={bottomHudPlayer.poisonCounters} energyCounters={bottomHudPlayer.energyCounters ?? 0} commanderDamage={bottomHudPlayer.commanderDamage ?? []} handSize={bottomHudPlayer.handSize} maxHandSize={bottomHudPlayer.maxHandSize} {...(isMulti ? { seatColor: bottomHudSeatColor.base } : {})} {...(teamCenterOrbs ? { teamName: bottomTeamLabel, teamMembers: bottomTeamMembers } : {})} />
               <SpeedGauge speed={bottomHudPlayer.speed ?? 0} />
               {!responsive.isMobile && <ActiveEffectsBadges effects={bottomHudPlayer.activeEffects} />}
               {!responsive.isMobile && bottomHudPlayer.manaPool && <ManaPool manaPool={bottomHudPlayer.manaPool} />}
@@ -1229,42 +1276,15 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             }
             if (isAnchorSelf) {
               return (
-                <div
+                <SelfBottomCell
                   key={p.playerId}
-                  style={{
-                    flex: `0 0 ${bottomCellBasis}`,
-                    minWidth: bottomCellBasis,
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
-                    position: 'relative',
-                  }}
-                >
-                  {/* Your own cell carries the same active-turn ring as every other board. */}
-                  {p.playerId === gameState.activePlayerId && (
-                    <div
-                      aria-hidden
-                      style={{
-                        position: 'absolute',
-                        inset: 2,
-                        pointerEvents: 'none',
-                        borderRadius: 10,
-                        boxShadow: `inset 0 0 0 2px ${selfSeatColor.base}55, inset 0 0 18px ${selfSeatColor.base}22`,
-                      }}
-                    />
-                  )}
-                  {/* Reservation band mirrors the other cells' name-plate band so all bottom
-                      boards line up. */}
-                  <div style={{ height: 34, flexShrink: 0 }} aria-hidden />
-                  <div style={{ ...styles.playerRowWithZones, alignItems: 'flex-start', flex: 1 }}>
-                    <CommandZone player={p} />
-                    <div style={{ ...styles.playerMainArea, ...(isHijacked ? hijackedSurfaceStyle : null) }}>
-                      <Battlefield isOpponent={false} spectatorMode={spectatorMode} />
-                    </div>
-                    <ZonePile player={p} />
-                  </div>
-                </div>
+                  player={p}
+                  basis={bottomCellBasis}
+                  isActiveTurn={p.playerId === gameState.activePlayerId}
+                  ringColor={selfSeatColor.base}
+                  spectatorMode={spectatorMode}
+                  {...(isHijacked ? { hijackedSurfaceStyle } : {})}
+                />
               )
             }
             return (
@@ -1277,7 +1297,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 stripBasis={bottomCellBasis}
                 hideHand
                 bottomHalf
-                plateCarriesAnchors={p.playerId !== bottomHudPlayer?.playerId}
+                plateCarriesAnchors={
+                  p.playerId !== bottomHudPlayer?.playerId && p.playerId !== centerOrbOpponentId
+                }
                 onToggleCollapse={() => toggleSeatCollapsed(p.playerId)}
                 // Same active-turn ring as the top row — the highlight has to mean the same
                 // thing on both halves of the table.
@@ -2138,5 +2160,70 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     <HelpDrawer />
     </ResponsiveContext.Provider>
     </RenderProfiler>
+  )
+}
+
+
+/**
+ * The viewing player's own board as a cell of the team-split bottom row. Its hand is the
+ * full-width interactive fan pinned to the bottom of the screen, not a cell hand — so instead
+ * of a hand it reserves the same band its neighbours use for their plate + cell fan, which is
+ * the only thing keeping all the bottom battlefields on one line. [useCellHandMetrics] measures
+ * this cell, so the reservation tracks the neighbours even as boards collapse and the cells
+ * resize.
+ */
+function SelfBottomCell({
+  player,
+  basis,
+  isActiveTurn,
+  ringColor,
+  spectatorMode,
+  hijackedSurfaceStyle,
+}: {
+  player: import('@/types').ClientPlayer
+  basis: string
+  isActiveTurn: boolean
+  ringColor: string
+  spectatorMode: boolean
+  hijackedSurfaceStyle?: React.CSSProperties
+}) {
+  const { cellRef, handHeight } = useCellHandMetrics()
+  return (
+    <div
+      ref={cellRef}
+      style={{
+        flex: `0 0 ${basis}`,
+        minWidth: basis,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      {/* Your own cell carries the same active-turn ring as every other board. */}
+      {isActiveTurn && (
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 2,
+            pointerEvents: 'none',
+            borderRadius: 10,
+            boxShadow: `inset 0 0 0 2px ${ringColor}55, inset 0 0 18px ${ringColor}22`,
+          }}
+        />
+      )}
+      {/* Reservation band mirrors the other cells' name-plate + cell-hand bands so all bottom
+          boards line up. */}
+      <div style={{ height: CELL_PLATE_BAND + handHeight, flexShrink: 0 }} aria-hidden />
+      <div style={{ ...styles.playerRowWithZones, alignItems: 'flex-start', flex: 1 }}>
+        <CommandZone player={player} />
+        <div style={{ ...styles.playerMainArea, ...(hijackedSurfaceStyle ?? null) }}>
+          <Battlefield isOpponent={false} spectatorMode={spectatorMode} />
+        </div>
+        <ZonePile player={player} />
+      </div>
+    </div>
   )
 }

--- a/web-client/src/components/game/board/HandZone.tsx
+++ b/web-client/src/components/game/board/HandZone.tsx
@@ -11,6 +11,14 @@ import { CARD_BACK_IMAGE_URL } from '@/utils/cardImages.ts'
  * Row of cards (hand or other horizontal zone).
  * Cards in hand are NOT grouped - each card is shown individually.
  */
+/**
+ * How far a [HandFan] lets its cards spill past the edge it hangs from, in px — applied twice
+ * (once as the box's negative margin, once as the cards' own negative edge offset), so a fan
+ * paints `2 × HAND_FAN_EDGE_MARGIN` beyond the box it is placed in. Exported because a fan
+ * rendered inside a fixed band has to reserve that overhang; see `useCellHandMetrics`.
+ */
+export const HAND_FAN_EDGE_MARGIN = 15
+
 export function CardRow({
   zoneId,
   faceDown = false,
@@ -226,7 +234,7 @@ export function HandFan({
   const totalWidth = cardSpacing * (cardCount - 1) + fittingWidth
 
   // Allow cards to extend slightly beyond the visible area to save vertical space
-  const edgeMargin = -15
+  const edgeMargin = -HAND_FAN_EDGE_MARGIN
 
   // For inverted fan, flip the arc and rotation direction
   const rotationMultiplier = inverted ? -1 : 1

--- a/web-client/src/components/game/board/HandZone.tsx
+++ b/web-client/src/components/game/board/HandZone.tsx
@@ -18,6 +18,9 @@ export function CardRow({
   small = false,
   inverted = false,
   ghostCards = [],
+  fitWidth,
+  maxCardWidth,
+  fan = false,
 }: {
   zoneId: ZoneId
   faceDown?: boolean
@@ -25,6 +28,25 @@ export function CardRow({
   small?: boolean
   inverted?: boolean
   ghostCards?: readonly ClientCard[]
+  /**
+   * Fit the fan into this width instead of the viewport, and don't shift it toward the game
+   * log — a hand rendered *inside* a multiplayer strip cell is centered on its own cell, not
+   * on the screen. Undefined for the full-width hands (yours at the bottom, the viewed
+   * opponent's at the top), which keep the viewport-relative sizing.
+   */
+  fitWidth?: number
+  /**
+   * Cap the card width here instead of at the responsive small/normal width. A strip cell's
+   * hand has to give most of its cell back to the board, so it renders deliberately smaller
+   * than a fan that fits the width would.
+   */
+  maxCardWidth?: number
+  /**
+   * Render as a fan even when the built-in rules wouldn't. Those rules key off face-down-ness
+   * and interactivity, which between them miss a face-up hand you may read but not play from —
+   * a Two-Headed Giant ally's (CR 810.5). It's still a hand and should look like one.
+   */
+  fan?: boolean
 }) {
   const cards = useZoneCards(zoneId)
   const zone = useZone(zoneId)
@@ -53,16 +75,18 @@ export function CardRow({
     ? (isOwnHand ? 110 : 8)
     : responsive.pileWidth + 20
   const availableWidth =
-    responsive.viewportWidth - (responsive.containerPadding * 2) - leftReserve - rightReserve
+    fitWidth ??
+    (responsive.viewportWidth - (responsive.containerPadding * 2) - leftReserve - rightReserve)
   // Centering the fan with this much right margin places it exactly between
   // the reserves (left edge ≥ leftReserve, right edge clear of the buttons).
-  const fanShift = rightReserve - leftReserve
+  // A cell-scoped fan is already centered on its cell, so it never shifts.
+  const fanShift = fitWidth != null ? 0 : rightReserve - leftReserve
 
   // Calculate card width that fits all cards (revealed + unrevealed + ghost)
   const totalCardCount = (faceDown ? zoneSize : cards.length) + ghostCards.length
   const cardCount = showPlaceholders ? zoneSize : totalCardCount
-  const baseWidth = small ? responsive.smallCardWidth : responsive.cardWidth
-  const minWidth = small ? 30 : 45
+  const baseWidth = maxCardWidth ?? (small ? responsive.smallCardWidth : responsive.cardWidth)
+  const minWidth = Math.min(small ? 30 : 45, baseWidth)
   const fittingWidth = calculateFittingCardWidth(
     cardCount,
     availableWidth,
@@ -82,7 +106,7 @@ export function CardRow({
 
   // For opponent's hand: show revealed cards face-up, plus placeholders for unrevealed cards
   const hasRevealedCards = faceDown && cards.length > 0
-  const shouldShowFan = isPlayerHand || isOpponentHand || isSpectatorBottomHand
+  const shouldShowFan = fan || isPlayerHand || isOpponentHand || isSpectatorBottomHand
 
   if (shouldShowFan && (cards.length > 0 || showPlaceholders || unrevealedCount > 0 || ghostCards.length > 0)) {
     return (

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -1,15 +1,66 @@
-import { useMemo } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
+import type { RefObject } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import type { ClientPlayer } from '@/types'
 import { hand } from '@/types'
-import { useRevealedLibraryTopCard, useIdentityColor } from '@/store/selectors'
+import { useRevealedLibraryTopCard, useIdentityColor, useIsSharedLifeTeamGame } from '@/store/selectors'
+import { useResponsiveContext } from './shared'
 import { Battlefield } from './Battlefield'
 import { CardRow } from './HandZone'
 import { CommandZone } from './CommandZone'
 import { ZonePile } from './ZonePiles'
 import { styles } from './styles'
 import { isLoneTargetRequirement } from '@/utils/targeting.ts'
+
+/** Height of a shared-strip cell's name-plate band (the pill plus its top margin). */
+export const CELL_PLATE_BAND = 34
+
+/**
+ * How far an inverted [HandFan] paints above the top of the box it is placed in — its own
+ * negative `marginTop` plus the cards' negative `top` edge margin. Pushing an inverted cell hand
+ * down by this much is what keeps it clear of the name plate above it.
+ */
+const INVERTED_FAN_LIFT = 30
+
+/**
+ * Sizing for the hand a board renders *inside* a shared-strip cell (table overview, team-split
+ * bottom row, combat defender-focus split). The full-width fan is viewport-relative and would
+ * run straight over the neighbouring cells, so the cell measures itself and the fan is capped
+ * from that — deliberately smaller than a fan that merely fits, because with every board on
+ * screen at once the battlefields are what the width is for.
+ *
+ * [handHeight] is an upper bound (`calculateFittingCardWidth` only ever shrinks the cap), which
+ * is what makes it safe to reserve as a fixed band above the board. Exported so the viewer's own
+ * bottom-row cell — which has no cell hand, its fan being the full-width one at the screen
+ * bottom — can reserve the identical band and stay aligned with its neighbours.
+ */
+export function useCellHandMetrics(): {
+  cellRef: RefObject<HTMLDivElement | null>
+  cellWidth: number
+  cardWidth: number
+  handHeight: number
+} {
+  const responsive = useResponsiveContext()
+  const cellRef = useRef<HTMLDivElement | null>(null)
+  const [cellWidth, setCellWidth] = useState(0)
+  useLayoutEffect(() => {
+    const node = cellRef.current
+    if (!node) return
+    setCellWidth(node.getBoundingClientRect().width)
+    const obs = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) setCellWidth(entry.contentRect.width)
+    })
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [])
+  const cardWidth = Math.max(
+    22,
+    Math.min(Math.round(responsive.smallCardWidth * 0.72), Math.round(cellWidth / 9) || 999),
+  )
+  return { cellRef, cellWidth, cardWidth, handHeight: Math.round(cardWidth * 1.4) + 12 }
+}
 
 /**
  * One opponent's half of the board: hand fan (top), command zone | battlefield |
@@ -104,6 +155,11 @@ export function OpponentBoardArea({
     () => (revealedTopCard ? [revealedTopCard] : []),
     [revealedTopCard]
   )
+  const { cellRef, cellWidth, cardWidth: cellHandCardWidth, handHeight: cellHandHeight } =
+    useCellHandMetrics()
+  // A bottom-half cell's board is oriented like a player's own, so its hand hangs the same way
+  // as yours (face toward the bottom edge) rather than inverted like an opponent's.
+  const cellHandInverted = !bottomHalf
 
   /* Opponent hand — fixed at top of screen in grid layout; absolute inside the
      strip cell in strip layout (a strip cell starts at the viewport top, so the
@@ -184,6 +240,7 @@ export function OpponentBoardArea({
 
   return (
     <div
+      ref={cellRef}
       data-opponent-board={opponent.playerId}
       data-ally={isAlly || undefined}
       style={{
@@ -199,7 +256,7 @@ export function OpponentBoardArea({
     >
       {/* Two-Headed Giant ally marker — a team-colored corner badge so a teammate's board (with
           its face-up hand) is never mistaken for an opponent's. */}
-      {isAlly && (
+      {isAlly && !hideHand && (
         <div
           aria-hidden
           style={{
@@ -228,16 +285,57 @@ export function OpponentBoardArea({
         </div>
       )}
       {/* A hijack-controlled hand must stay visible even in shared-strip views —
-          this client is playing from it. */}
+          this client is playing from it, so it keeps the full-size interactive fan. */}
       {(!hideHand || isHijacking) && handBlock}
-      {/* Shared-strip view: the board's "face" — name + life at the top of the cell.
-          Sits below the hand when a hijack forces the fan visible. */}
+      {/* Shared-strip view: the board's "face" — name (+ life outside a shared-life team
+          game) at the top of the cell. Sits below the hand when a hijack forces the fan
+          visible. */}
       {hideHand && (
         <BoardNamePlate
           player={opponent}
           carriesAnchors={plateCarriesAnchors}
           top={(isHijacking ? handReservation : 0) + 6}
+          isAlly={isAlly}
+          {...(allyColor ? { allyColor } : {})}
         />
+      )}
+      {/* Shared-strip view: this seat's hand, scaled down to the cell and sitting under the
+          name plate. Knowing how many cards each player is holding — and, for a Two-Headed
+          Giant ally whose hand is open to you (CR 810.5b), *which* cards — is board state you
+          shouldn't have to slide the camera onto a board to read. */}
+      {hideHand && !isHijacking && (
+        <div
+          data-zone="opponent-hand"
+          style={{
+            position: 'absolute',
+            // An inverted fan lifts itself 30px above its box (HandFan's negative marginTop plus
+            // the cards' own edge margin) — without matching that offset the top row's cards
+            // would be drawn straight through the name plate.
+            top: CELL_PLATE_BAND + (cellHandInverted ? INVERTED_FAN_LIFT : 0),
+            left: 0,
+            right: 0,
+            height: cellHandHeight,
+            display: 'flex',
+            // Anchor the fan at the edge it hangs from, so the arc grows into the band rather
+            // than out of it: down from the top for an opponent-side hand, up from the bottom
+            // for a bottom-row one.
+            alignItems: cellHandInverted ? 'flex-start' : 'flex-end',
+            justifyContent: 'center',
+            zIndex: 50,
+            pointerEvents: isAlly ? 'auto' : 'none',
+          }}
+        >
+          <CardRow
+            zoneId={hand(opponent.playerId)}
+            faceDown={!isAlly}
+            small
+            inverted={cellHandInverted}
+            fan
+            fitWidth={Math.max(60, cellWidth - 16)}
+            maxCardWidth={cellHandCardWidth}
+            ghostCards={[]}
+          />
+        </div>
       )}
       {/* Fold-away control (table overview): collapse this cell to a tab so the
           other boards grow. Top-right corner, clear of the centered name plate. */}
@@ -288,7 +386,11 @@ export function OpponentBoardArea({
           vertical space back. */}
       <div
         style={{
-          height: hideHand ? (isHijacking ? handReservation : 0) + 34 : handReservation,
+          height: hideHand
+            ? (isHijacking
+                ? handReservation
+                : cellHandHeight + (cellHandInverted ? INVERTED_FAN_LIFT : 0)) + CELL_PLATE_BAND
+            : handReservation,
           flexShrink: 0,
         }}
         aria-hidden
@@ -405,13 +507,26 @@ function BoardNamePlate({
   player,
   carriesAnchors,
   top,
+  isAlly = false,
+  allyColor,
 }: {
   player: ClientPlayer
   carriesAnchors: boolean
   top: number
+  /**
+   * Two-Headed Giant: mark this board as your teammate's. The floating corner badge stands down
+   * wherever a plate renders — two labels naming the same player is one too many — so the plate
+   * carries the marker instead.
+   */
+  isAlly?: boolean
+  allyColor?: string
 }) {
   const seat = useIdentityColor(player.playerId)
   const playerId = player.playerId
+  // Two-Headed Giant (CR 810): the team's single shared life lives on the center-HUD team orb,
+  // so repeating it on every teammate's plate would print the same number up to four times.
+  // The plate keeps the name (which is the thing a plate is for) and drops the life.
+  const sharedLifeTeam = useIsSharedLifeTeamGame()
 
   const combatState = useGameStore((state) => state.combatState)
   const assignDefender = useGameStore((state) => state.assignDefenderToSelectedAttackers)
@@ -551,18 +666,39 @@ function BoardNamePlate({
       >
         {player.name}
       </span>
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 3,
-          fontVariantNumeric: 'tabular-nums',
-          color: lifeDanger ? '#ff5555' : '#ffffff',
-        }}
-      >
-        <span aria-hidden style={{ color: '#ff6b6b', fontSize: 11 }}>❤</span>
-        {player.life}
-      </span>
+      {isAlly && (
+        <span
+          aria-hidden
+          title="Your teammate"
+          style={{
+            fontSize: 9,
+            fontWeight: 800,
+            letterSpacing: '0.1em',
+            color: allyColor ?? seat.bright,
+            border: `1px solid ${allyColor ?? seat.base}`,
+            padding: '0 4px',
+            borderRadius: 3,
+            lineHeight: '13px',
+            flexShrink: 0,
+          }}
+        >
+          ALLY
+        </span>
+      )}
+      {!sharedLifeTeam && (
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 3,
+            fontVariantNumeric: 'tabular-nums',
+            color: lifeDanger ? '#ff5555' : '#ffffff',
+          }}
+        >
+          <span aria-hidden style={{ color: '#ff6b6b', fontSize: 11 }}>❤</span>
+          {player.life}
+        </span>
+      )}
     </div>
   )
 }

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -7,7 +7,7 @@ import { hand } from '@/types'
 import { useRevealedLibraryTopCard, useIdentityColor, useIsSharedLifeTeamGame } from '@/store/selectors'
 import { useResponsiveContext } from './shared'
 import { Battlefield } from './Battlefield'
-import { CardRow } from './HandZone'
+import { CardRow, HAND_FAN_EDGE_MARGIN } from './HandZone'
 import { CommandZone } from './CommandZone'
 import { ZonePile } from './ZonePiles'
 import { styles } from './styles'
@@ -17,11 +17,14 @@ import { isLoneTargetRequirement } from '@/utils/targeting.ts'
 export const CELL_PLATE_BAND = 34
 
 /**
- * How far an inverted [HandFan] paints above the top of the box it is placed in — its own
- * negative `marginTop` plus the cards' negative `top` edge margin. Pushing an inverted cell hand
- * down by this much is what keeps it clear of the name plate above it.
+ * How far a [HandFan] paints past the edge it hangs from — its own negative margin plus the
+ * cards' negative edge offset. Symmetric: an inverted fan spills this far *above* its box, a
+ * normal one this far *below*. Either way the band a cell hand sits in has to reserve it, or the
+ * fan draws through the name plate above (inverted) or the battlefield below (normal) — and
+ * because an ally's cell hand is click-through-able, an unreserved overhang also swallows clicks
+ * meant for the permanents underneath it.
  */
-const INVERTED_FAN_LIFT = 30
+const FAN_EDGE_OVERHANG = HAND_FAN_EDGE_MARGIN * 2
 
 /**
  * Sizing for the hand a board renders *inside* a shared-strip cell (table overview, team-split
@@ -30,16 +33,18 @@ const INVERTED_FAN_LIFT = 30
  * from that — deliberately smaller than a fan that merely fits, because with every board on
  * screen at once the battlefields are what the width is for.
  *
- * [handHeight] is an upper bound (`calculateFittingCardWidth` only ever shrinks the cap), which
- * is what makes it safe to reserve as a fixed band above the board. Exported so the viewer's own
- * bottom-row cell — which has no cell hand, its fan being the full-width one at the screen
- * bottom — can reserve the identical band and stay aligned with its neighbours.
+ * [handHeight] is the fan's own box and an upper bound on it (`calculateFittingCardWidth` only
+ * ever shrinks the cap). [handBand] is what a cell must actually reserve: that box plus the
+ * [FAN_EDGE_OVERHANG] the fan spills past whichever edge it hangs from. Exported so the viewer's
+ * own bottom-row cell — which has no cell hand, its fan being the full-width one at the screen
+ * bottom — reserves the identical band and stays aligned with its neighbours.
  */
 export function useCellHandMetrics(): {
   cellRef: RefObject<HTMLDivElement | null>
   cellWidth: number
   cardWidth: number
   handHeight: number
+  handBand: number
 } {
   const responsive = useResponsiveContext()
   const cellRef = useRef<HTMLDivElement | null>(null)
@@ -59,7 +64,8 @@ export function useCellHandMetrics(): {
     22,
     Math.min(Math.round(responsive.smallCardWidth * 0.72), Math.round(cellWidth / 9) || 999),
   )
-  return { cellRef, cellWidth, cardWidth, handHeight: Math.round(cardWidth * 1.4) + 12 }
+  const handHeight = Math.round(cardWidth * 1.4) + 12
+  return { cellRef, cellWidth, cardWidth, handHeight, handBand: handHeight + FAN_EDGE_OVERHANG }
 }
 
 /**
@@ -137,7 +143,7 @@ export function OpponentBoardArea({
   hijackedSurfaceStyle?: React.CSSProperties
   /**
    * Two-Headed Giant (CR 810): this board belongs to your teammate. You may see their hand
-   * (CR 810.5b), so it renders face-up, and the cell gets an "ALLY" marker so it never reads as
+   * (CR 810.5), so it renders face-up, and the cell gets an "ALLY" marker so it never reads as
    * an enemy board. You still can't act with their cards — only its controller plays from it.
    */
   isAlly?: boolean
@@ -155,8 +161,13 @@ export function OpponentBoardArea({
     () => (revealedTopCard ? [revealedTopCard] : []),
     [revealedTopCard]
   )
-  const { cellRef, cellWidth, cardWidth: cellHandCardWidth, handHeight: cellHandHeight } =
-    useCellHandMetrics()
+  const {
+    cellRef,
+    cellWidth,
+    cardWidth: cellHandCardWidth,
+    handHeight: cellHandHeight,
+    handBand: cellHandBand,
+  } = useCellHandMetrics()
   // A bottom-half cell's board is oriented like a player's own, so its hand hangs the same way
   // as yours (face toward the bottom edge) rather than inverted like an opponent's.
   const cellHandInverted = !bottomHalf
@@ -301,17 +312,17 @@ export function OpponentBoardArea({
       )}
       {/* Shared-strip view: this seat's hand, scaled down to the cell and sitting under the
           name plate. Knowing how many cards each player is holding — and, for a Two-Headed
-          Giant ally whose hand is open to you (CR 810.5b), *which* cards — is board state you
+          Giant ally whose hand is open to you (CR 810.5), *which* cards — is board state you
           shouldn't have to slide the camera onto a board to read. */}
       {hideHand && !isHijacking && (
         <div
           data-zone="opponent-hand"
           style={{
             position: 'absolute',
-            // An inverted fan lifts itself 30px above its box (HandFan's negative marginTop plus
-            // the cards' own edge margin) — without matching that offset the top row's cards
-            // would be drawn straight through the name plate.
-            top: CELL_PLATE_BAND + (cellHandInverted ? INVERTED_FAN_LIFT : 0),
+            // Only the inverted fan spills *upward*; pushing it down by the overhang is what
+            // keeps its top row from drawing straight through the name plate. A normal fan
+            // spills downward instead — that half is reserved in the band below.
+            top: CELL_PLATE_BAND + (cellHandInverted ? FAN_EDGE_OVERHANG : 0),
             left: 0,
             right: 0,
             height: cellHandHeight,
@@ -389,7 +400,7 @@ export function OpponentBoardArea({
           height: hideHand
             ? (isHijacking
                 ? handReservation
-                : cellHandHeight + (cellHandInverted ? INVERTED_FAN_LIFT : 0)) + CELL_PLATE_BAND
+                : cellHandBand) + CELL_PLATE_BAND
             : handReservation,
           flexShrink: 0,
         }}

--- a/web-client/src/components/game/board/index.ts
+++ b/web-client/src/components/game/board/index.ts
@@ -1,5 +1,5 @@
 export { Battlefield } from './Battlefield'
-export { OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH } from './OpponentBoardArea'
+export { OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, CELL_PLATE_BAND, useCellHandMetrics } from './OpponentBoardArea'
 export { CardRow, HandFan } from './HandZone'
 export { CommandZone } from './CommandZone'
 export { StackDisplay } from './StackZone'

--- a/web-client/src/components/game/overlay/LifeDisplay.tsx
+++ b/web-client/src/components/game/overlay/LifeDisplay.tsx
@@ -22,6 +22,8 @@ export function LifeDisplay({
   commanderDamage,
   seatColor,
   isAlly = false,
+  teamName,
+  teamMembers,
   handSize,
   maxHandSize,
 }: {
@@ -51,6 +53,15 @@ export function LifeDisplay({
    * their board is viewed). The role tag reads "Ally" so it never reads as an opponent.
    */
   isAlly?: boolean
+  /**
+   * Two-Headed Giant (CR 810): print the *team's* name here instead of the player's. Both
+   * teammates share one life total, so the center HUD reads team-vs-team — one orb per team,
+   * one life total per team — and the individual seats keep their identity on the rail chips
+   * and board name plates. Undefined outside a shared-life team game.
+   */
+  teamName?: string
+  /** Team members behind [teamName], for the orb's tooltip ("Bob & Carol"). */
+  teamMembers?: string
 }) {
   const responsive = useResponsiveContext()
   const targetingState = useGameStore((state) => state.targetingState)
@@ -196,11 +207,20 @@ export function LifeDisplay({
             ? '0 0 16px rgba(255, 68, 68, 0.7), 0 0 32px rgba(255, 68, 68, 0.4)'
             : 'none'
 
-  const nameText = playerName ? playerName.toUpperCase() : (isPlayer ? 'YOU' : 'OPPONENT')
+  // A team orb stands for the whole team, so it may only carry team-scoped facts. Life and
+  // poison are pooled in Two-Headed Giant (CR 810.4, CR 810.10) and stay; the hand-limit badge
+  // is one player's (CR 402.2) and would read as the team's, so it stands down — the seat's own
+  // rail chip still carries it.
+  const effectiveMaxHandSize = teamName ? undefined : maxHandSize
+
+  const nameText = teamName
+    ? teamName.toUpperCase()
+    : playerName ? playerName.toUpperCase() : (isPlayer ? 'YOU' : 'OPPONENT')
   // Only show the "YOU" / "OPPONENT" role tag when a custom name is rendered
   // (otherwise the name itself already carries the same information) and when
-  // not spectating (there's no "you" in spectator mode).
-  const showRoleTag = !spectatorMode && !!playerName
+  // not spectating (there's no "you" in spectator mode). A team name already says
+  // "yours" or "theirs", so it replaces the tag rather than doubling it.
+  const showRoleTag = !spectatorMode && !!playerName && !teamName
   // Seat-tinted in multiplayer (SEAT_COLORS are 6-digit hex, so appending an alpha byte gives the
   // translucent variants the tag uses). A supplied seatColor wins for both roles; otherwise fall
   // back to the fixed 2-player blue (player) / orange (opponent).
@@ -239,7 +259,7 @@ export function LifeDisplay({
           textOverflow: 'ellipsis',
           textShadow: '0 1px 2px rgba(0, 0, 0, 0.6)',
         }}
-        title={playerName}
+        title={teamName ? `${teamName}${teamMembers ? ` — ${teamMembers}` : ''}` : playerName}
       >
         {nameText}
       </span>
@@ -450,7 +470,7 @@ export function LifeDisplay({
           ⚡ {energyCounters}
         </div>
       )}
-      <MaxHandSizeBadge handSize={handSize} maxHandSize={maxHandSize} />
+      <MaxHandSizeBadge handSize={handSize} maxHandSize={effectiveMaxHandSize} />
       <CommanderDamageBadges entries={commanderDamage ?? []} />
     </div>
   )

--- a/web-client/src/components/replay/ReplayPage.tsx
+++ b/web-client/src/components/replay/ReplayPage.tsx
@@ -49,8 +49,9 @@ export function ReplayPage() {
         setMetadata(data.metadata)
         setSnapshots(reconstructSnapshots(data.initialSnapshot, data.deltas))
         // Stamp the seat → team map from the replay roster so a team-game replay lights up the
-        // team-grouped rail, ally treatment, and team-split layout (team membership only rides
-        // in the roster, never the per-frame board state).
+        // team-grouped rail, ally treatment, and team-split layout (replay frames are fed
+        // straight into the store, bypassing the state-update handler that re-derives this in
+        // live play).
         const roster = data.initialSnapshot.players
         if (roster?.some((p) => p.teamIndex != null)) {
           const teams: Record<string, number> = {}

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -379,6 +379,43 @@ export function useIdentityColor(playerId: EntityId | null): SeatColor {
 }
 
 /**
+ * The name to print for a team: "Your Team" / "Opponents" from the viewer's seat, and the
+ * neutral "Team N" when there is no viewer team to be relative to (spectator, replay). Same
+ * vocabulary the rail's two team sections already use, so the center HUD and the rail agree.
+ */
+export function teamLabel(teamIndex: number | null, viewerTeam: number | null): string {
+  if (teamIndex == null) return ''
+  if (viewerTeam == null) return `Team ${teamIndex + 1}`
+  return teamIndex === viewerTeam ? 'Your Team' : 'Opponents'
+}
+
+/** Hook form of [teamLabel] for a player's team. */
+export function useTeamLabelFor(playerId: EntityId | null): string {
+  const teamMap = useGameStore(selectTeamMap)
+  const viewerTeam = useViewerTeamIndex()
+  const t = playerId != null ? teamMap[playerId] ?? null : null
+  return teamLabel(t, viewerTeam)
+}
+
+/**
+ * The living members of `playerId`'s team, in turn order — the tooltip behind a team-labelled
+ * orb ("Opponents" → "Bob & Carol") and the source of the team's single shared life total.
+ */
+export function useTeammateNames(playerId: EntityId | null): string {
+  const gameState = useGameStore(selectGameState)
+  const teamMap = useGameStore(selectTeamMap)
+  return useMemo(() => {
+    if (!gameState || playerId == null) return ''
+    const t = teamMap[playerId]
+    if (t == null) return gameState.players.find((p) => p.playerId === playerId)?.name ?? ''
+    return gameState.players
+      .filter((p) => teamMap[p.playerId] === t && !p.hasLost)
+      .map((p) => p.name)
+      .join(' & ')
+  }, [gameState, teamMap, playerId])
+}
+
+/**
  * True when `playerId` is the viewing player's teammate (same team, not self) in a team game —
  * i.e. an ally whose board/hand you may see and whom you can't attack.
  */

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -18,6 +18,7 @@ import {
   visibleStackDepth,
   groupCards,
 } from './cardGrouping'
+import { teamLabel } from './teamLabel'
 
 /**
  * Select the game state (works for both normal play and spectating).
@@ -378,16 +379,7 @@ export function useIdentityColor(playerId: EntityId | null): SeatColor {
   return useMemo(() => identitySeatColor(teamMap, playerId, seatIndex), [teamMap, playerId, seatIndex])
 }
 
-/**
- * The name to print for a team: "Your Team" / "Opponents" from the viewer's seat, and the
- * neutral "Team N" when there is no viewer team to be relative to (spectator, replay). Same
- * vocabulary the rail's two team sections already use, so the center HUD and the rail agree.
- */
-export function teamLabel(teamIndex: number | null, viewerTeam: number | null): string {
-  if (teamIndex == null) return ''
-  if (viewerTeam == null) return `Team ${teamIndex + 1}`
-  return teamIndex === viewerTeam ? 'Your Team' : 'Opponents'
-}
+export { teamLabel } from './teamLabel'
 
 /** Hook form of [teamLabel] for a player's team. */
 export function useTeamLabelFor(playerId: EntityId | null): string {

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -185,11 +185,14 @@ interface StateUpdateEnvelope {
  * Takes the resolved (full) ClientGameState and the envelope fields.
  */
 /**
- * Stamp the seat → team map from the state's own team fields, unless it already matches. Skipped
- * entirely for the overwhelmingly common non-team game (no seat carries a `teamIndex`), so the
- * comparison never runs there.
+ * Stamp the seat → team map from the state's own team fields, unless it already matches. In the
+ * overwhelmingly common non-team game no seat carries a `teamIndex`, so this settles into
+ * comparing two empty maps and returning without ever writing to the store.
+ *
+ * Exported for its own tests: this is the whole of the reconnect fix, and the bug it replaced
+ * (team state riding only on the one-shot game-start roster) is an easy one to reintroduce.
  */
-function syncSeatTeams(state: ClientGameState, get: GetState): void {
+export function syncSeatTeams(state: ClientGameState, get: GetState): void {
   const next: Record<EntityId, number> = {}
   for (const p of state.players) {
     if (p.teamIndex != null) next[p.playerId] = p.teamIndex

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -184,6 +184,30 @@ interface StateUpdateEnvelope {
  * Process a state update — shared between full StateUpdate and StateDeltaUpdate.
  * Takes the resolved (full) ClientGameState and the envelope fields.
  */
+/**
+ * Stamp the seat → team map from the state's own team fields, unless it already matches. Skipped
+ * entirely for the overwhelmingly common non-team game (no seat carries a `teamIndex`), so the
+ * comparison never runs there.
+ */
+function syncSeatTeams(state: ClientGameState, get: GetState): void {
+  const next: Record<EntityId, number> = {}
+  for (const p of state.players) {
+    if (p.teamIndex != null) next[p.playerId] = p.teamIndex
+  }
+  const sharedLife = state.players.some((p) => p.teamSharedLife === true)
+  const store = get()
+  const current = store.teamByPlayerId
+  const keys = Object.keys(next)
+  if (
+    keys.length === Object.keys(current).length &&
+    keys.every((k) => current[k as EntityId] === next[k as EntityId]) &&
+    store.teamSharedLife === sharedLife
+  ) {
+    return
+  }
+  store.setSeatTeams(next, sharedLife)
+}
+
 function processStateUpdate(
   resolvedState: ClientGameState,
   msg: StateUpdateEnvelope,
@@ -191,6 +215,13 @@ function processStateUpdate(
   get: GetState
 ): void {
   const { playerId, addBeholdPulse, reconcileBeholdPulses } = get()
+
+  // Two-Headed Giant (CR 810) / Team vs. Team (CR 808): re-derive the seat → team map from the
+  // state itself. The game-start roster also carries it, but that message is a one-shot — a
+  // client that joined by *reconnecting* (hotseat, a scenario, a dropped connection resuming)
+  // never receives it and would render a team game as a free-for-all. Doing it here covers every
+  // entry path with one write, and it's a no-op (reference-stable) once the map already matches.
+  syncSeatTeams(resolvedState, get)
 
   // Animations spawned by this update are collected here and committed with the state itself,
   // in one store write. Each separate write re-runs every subscriber's selector across the

--- a/web-client/src/store/slices/handlers/syncSeatTeams.test.ts
+++ b/web-client/src/store/slices/handlers/syncSeatTeams.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { syncSeatTeams } from './gameplayHandlers'
+import type { ClientGameState, ClientPlayer } from '@/types'
+import { entityId } from '@/types'
+import type { GetState } from './types'
+
+/**
+ * The seat → team map used to be stamped only from the `gameStarted` roster, a one-shot message a
+ * reconnecting client never receives — so every hotseat, scenario and resumed connection rendered
+ * a team game as a free-for-all. `syncSeatTeams` re-derives it from the state itself, which every
+ * update carries. These tests pin that, and pin that a non-team game never touches the store.
+ */
+
+function player(id: string, over: Partial<ClientPlayer> = {}): ClientPlayer {
+  return { playerId: entityId(id), name: id, ...over } as unknown as ClientPlayer
+}
+
+function state(...players: ClientPlayer[]): ClientGameState {
+  return { players } as unknown as ClientGameState
+}
+
+/** A stand-in store: whatever the map currently is, plus a spy for the write. */
+function store(teamByPlayerId: Record<string, number> = {}, teamSharedLife = false) {
+  const setSeatTeams = vi.fn()
+  const get = (() => ({ teamByPlayerId, teamSharedLife, setSeatTeams })) as unknown as GetState
+  return { get, setSeatTeams }
+}
+
+describe('syncSeatTeams', () => {
+  it('stamps the map from the state alone — the reconnect path, with no roster ever seen', () => {
+    const { get, setSeatTeams } = store()
+    syncSeatTeams(
+      state(
+        player('a', { teamIndex: 0, teamSharedLife: true }),
+        player('b', { teamIndex: 0, teamSharedLife: true }),
+        player('c', { teamIndex: 1, teamSharedLife: true }),
+        player('d', { teamIndex: 1, teamSharedLife: true }),
+      ),
+      get,
+    )
+    expect(setSeatTeams).toHaveBeenCalledWith({ a: 0, b: 0, c: 1, d: 1 }, true)
+  })
+
+  it('is a no-op once the map already matches, so it never re-renders the board', () => {
+    const { get, setSeatTeams } = store({ a: 0, b: 1 }, true)
+    syncSeatTeams(
+      state(
+        player('a', { teamIndex: 0, teamSharedLife: true }),
+        player('b', { teamIndex: 1, teamSharedLife: true }),
+      ),
+      get,
+    )
+    expect(setSeatTeams).not.toHaveBeenCalled()
+  })
+
+  it('never writes in a non-team game', () => {
+    const { get, setSeatTeams } = store()
+    syncSeatTeams(state(player('a'), player('b')), get)
+    expect(setSeatTeams).not.toHaveBeenCalled()
+  })
+
+  it('sets teamIndex but not shared life for Team vs. Team (CR 808.5)', () => {
+    const { get, setSeatTeams } = store()
+    syncSeatTeams(
+      state(player('a', { teamIndex: 0 }), player('b', { teamIndex: 1 })),
+      get,
+    )
+    expect(setSeatTeams).toHaveBeenCalledWith({ a: 0, b: 1 }, false)
+  })
+
+  it('rewrites when a seat changes team, not just when the seat count does', () => {
+    const { get, setSeatTeams } = store({ a: 0, b: 0 }, true)
+    syncSeatTeams(
+      state(
+        player('a', { teamIndex: 0, teamSharedLife: true }),
+        player('b', { teamIndex: 1, teamSharedLife: true }),
+      ),
+      get,
+    )
+    expect(setSeatTeams).toHaveBeenCalledWith({ a: 0, b: 1 }, true)
+  })
+})

--- a/web-client/src/store/teamLabel.test.ts
+++ b/web-client/src/store/teamLabel.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { teamLabel } from './teamLabel'
+
+/**
+ * The center HUD's two orbs are labelled by team in a shared-life game, and they borrow the
+ * opponent rail's own vocabulary so the two never disagree about what to call a team.
+ */
+describe('teamLabel', () => {
+  it('names the viewer’s own team and the other one relative to them', () => {
+    expect(teamLabel(1, 1)).toBe('Your Team')
+    expect(teamLabel(0, 1)).toBe('Opponents')
+  })
+
+  it('falls back to a neutral number when the viewer has no team (spectator, replay)', () => {
+    // 1-based for display: team index 0 is "Team 1".
+    expect(teamLabel(0, null)).toBe('Team 1')
+    expect(teamLabel(1, null)).toBe('Team 2')
+  })
+
+  it('is empty for a player with no team, so a non-team orb keeps its player name', () => {
+    expect(teamLabel(null, 0)).toBe('')
+    expect(teamLabel(null, null)).toBe('')
+  })
+})

--- a/web-client/src/store/teamLabel.ts
+++ b/web-client/src/store/teamLabel.ts
@@ -1,0 +1,13 @@
+/**
+ * The name to print for a team: "Your Team" / "Opponents" from the viewer's seat, and the
+ * neutral "Team N" when there is no viewer team to be relative to (spectator, replay). Same
+ * vocabulary the rail's two team sections already use, so the center HUD and the rail agree.
+ *
+ * Its own module rather than a member of `selectors.ts`: it reads no store, and keeping it clear
+ * of the store's import graph is what lets it be tested without a DOM.
+ */
+export function teamLabel(teamIndex: number | null, viewerTeam: number | null): string {
+  if (teamIndex == null) return ''
+  if (viewerTeam == null) return `Team ${teamIndex + 1}`
+  return teamIndex === viewerTeam ? 'Your Team' : 'Opponents'
+}

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -664,6 +664,15 @@ export interface ClientPlayer {
    * badge is rendered.
    */
   readonly energyCounters?: number
+  /**
+   * Team membership in a team variant (Two-Headed Giant — CR 810; Team vs. Team — CR 808):
+   * players sharing a `teamIndex` are teammates. Absent in every non-team game. Carried on the
+   * state (not just the game-start seat roster) so a client that joins by reconnecting — hotseat,
+   * a scenario, a dropped connection resuming — still knows it's in a team game.
+   */
+  readonly teamIndex?: number | null
+  /** True when the format pools life per team (Two-Headed Giant, CR 810.4). */
+  readonly teamSharedLife?: boolean
 }
 
 /**


### PR DESCRIPTION
The 2HG board asked you to work out the game from four scattered copies of two numbers. This pass makes the table read as two teams.

## The load-bearing find: none of it was reachable

The seat → team map was stamped only in `onGameStarted`, from the `gameStarted` roster's `PlayerSeatInfo.teamIndex`. A client that joins by **reconnecting** — every hotseat, every scenario, every dropped connection resuming — gets `reconnected` + `stateUpdate` and never that roster, so `teamByPlayerId` stayed empty and a team game rendered as a free-for-all: four separate life totals, no ally board, no team colours.

`teamIndex` and `teamSharedLife` are now fields on `ClientPlayer`, so the fact rides the state every update carries, and `processStateUpdate` re-derives the map (a reference-stable no-op once it matches). One write covers play, spectate, replay and reconnect. A one-shot message was the wrong home for something the UI needs for the whole game.

Both fields are additive with defaults, so every non-team game serializes them away.

## On top of that

**The center HUD reads team-vs-team.** The left orb is the *enemy team's*, not the viewed board's — your ally's board sits on the table beside yours, so the camera's nominal opponent is frequently a teammate, and two orbs both reading "Your Team 30" is exactly the duplicate this is meant to remove. Labels borrow the rail's own vocabulary ("Your Team" / "Opponents"; "Team N" for a viewer with no team of their own), with the members in the tooltip. Board name plates drop their life, so the shared total appears once per team rather than up to four times.

**Hands render inside each shared-strip cell**, in every multiplayer view and not just 2HG: how many cards each player is holding — and, for an ally whose hand is open to you (CR 810.5), which ones — is board state you shouldn't have to slide the camera onto a board to read. `useCellHandMetrics` measures the cell, because `stripBasis` is a percentage (and a `calc(...)` once boards are collapsed) and can't be sized from. An inverted `HandFan` paints ~30px above the box it's placed in, which is what `INVERTED_FAN_LIFT` exists to clear — without it the top row draws straight through the name plate.

**Your own board moved to the bottom right** of the two-row table, under the right-hand life orb and the zone piles that were already right-aligned, so your stuff occupies one corner instead of being split across the table. `SelfBottomCell` came out of `GameBoard` so it can reserve the *same* plate-plus-hand band its neighbours use; without that the bottom battlefields don't stay on one line.

## Anchors

Exactly one element per player carries that player's anchors, so pointing the orb at someone other than the viewed board means `centerOrbOpponentId` — not "the viewed cell" — decides which plate stands down, and `anchorVisibleBoardIds` has to include it. The sliding camera renders no plate at all, so that branch now contributes nothing and the rail chip keeps the anchors.

## Two smaller things surfaced on the way

- A face-up, non-interactive hand (an ally's) matched none of `CardRow`'s three built-in fan shapes and fell back to a flat row, so fanning is now requestable via a `fan` prop.
- The hand-limit badge is one player's (CR 402.2) and would have read as the team's, so a team orb drops it. Life and poison are genuinely pooled (CR 810.4, CR 810.10) and stay.

## What this deliberately does *not* change

Choosing which defending player each creature attacks. CR 805.10b: *"For each attacking creature, the attacking team announces which defending player, planeswalker, or battle that creature is attacking."* Only blocking is team-wide (805.10d), so the per-creature choice is real and rules-relevant even with a shared life total. The existing "Attack which player?" prompt already resolves it in one click and already excludes your teammate.

## Verification

Driven against a 2HG hotseat (`POST /api/scenarios`, `mode: "SELF"`, four seats, `teams: [[0,1],[2,3]]`), a 4-player free-for-all, and a 2-player game — the last unchanged, as the multiplayer gate requires.

- `just client-typecheck` — clean
- 658 client tests across 45 files — pass
- `:rules-engine:test` and `:game-server:test` — pass

Not covered: real 4-client multiplayer and mobile. Dev can only stand up a hotseat, so the live interactive-play layout still wants eyes on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
