### PR TITLE
Add 60 Assay-ready cards to Theros

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ReadTheBonesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ReadTheBonesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Read the Bones reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val ReadTheBonesReprint = Printing(
+    oracleId = "5bf4d8d9-a2b2-4dba-ac05-9d4470a89db2",
+    name = "Read the Bones",
+    setCode = "C14",
+    collectorNumber = "158",
+    scryfallId = "76affba3-ec52-4b98-8991-f542d92ecdaa",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76affba3-ec52-4b98-8991-f542d92ecdaa.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/DuelDecksHeroesVsMonstersSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/DuelDecksHeroesVsMonstersSet.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ddl
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Duel Decks: Heroes vs. Monsters (2013)
+ *
+ * Scaffolded so that Satyr Hedonist — printed here on 2013-09-06, three weeks before Theros —
+ * can hold its canonical [CardDefinition] in its earliest real printing, with a [Printing] row
+ * in THS. The rest of the product is still unauthored.
+ *
+ * [sealedSupported] stays false: a duel deck is two fixed 60-card decks, not a draftable product.
+ *
+ * Set Code: DDL
+ * Release Date: 2013-09-06
+ */
+object DuelDecksHeroesVsMonstersSet : MtgSet {
+
+    override val code = "DDL"
+    override val displayName = "Duel Decks: Heroes vs. Monsters"
+    override val releaseDate = "2013-09-06"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ddl.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/MagmaJetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/MagmaJetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magma Jet reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val MagmaJetReprint = Printing(
+    oracleId = "2f292253-64d3-4cf2-881f-a3eea4fda388",
+    name = "Magma Jet",
+    setCode = "DDL",
+    collectorNumber = "22",
+    scryfallId = "b4f4726e-036c-40c1-ba03-d1bb0275c4c6",
+    artist = null,
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4f4726e-036c-40c1-ba03-d1bb0275c4c6.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/SatyrHedonist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/SatyrHedonist.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Satyr Hedonist
+ * {1}{G}
+ * Creature — Satyr
+ * 2 / 1
+ *
+ * {R}, Sacrifice this creature: Add {R}{R}{R}.
+ *
+ * Duel Decks: Heroes vs. Monsters is this card's earliest printing, so the canonical definition
+ * lives here rather than in Theros. `manaAbility = true` is the whole timing declaration — the
+ * builder derives `TimingRule.ManaAbility` from it, so writing the timing out again would be a
+ * second authoring choice for one fact.
+ */
+val SatyrHedonist = card("Satyr Hedonist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Satyr"
+    power = 2
+    toughness = 1
+    oracleText = "{R}, Sacrifice this creature: Add {R}{R}{R}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.SacrificeSelf)
+        manaAbility = true
+        effect = Effects.AddMana(Color.RED, 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Chase Stone"
+        flavorText = "\"Any festival you can walk away from wasn't worth attending in the first place.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c6a5405-2bc8-4439-a09a-2c4844ba3a35.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/ReadTheBonesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/ReadTheBonesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Read the Bones reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val ReadTheBonesReprint = Printing(
+    oracleId = "5bf4d8d9-a2b2-4dba-ac05-9d4470a89db2",
+    name = "Read the Bones",
+    setCode = "DDP",
+    collectorNumber = "56",
+    scryfallId = "0975e578-cd4e-43fa-800c-c38e6cd1248a",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/0975e578-cd4e-43fa-800c-c38e6cd1248a.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/Griptide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/Griptide.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Griptide
+ * {3}{U}
+ * Instant
+ *
+ * Put target creature on top of its owner's library.
+ *
+ * A plain move to the top of the library — "its owner's" is not a knob, since a card always leaves
+ * the battlefield for its owner's zone (CR 400.3). Totally Lost (GTC) is the same shape.
+ */
+val Griptide = card("Griptide") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Put target creature on top of its owner's library."
+
+    spell {
+        val victim = target("target", Targets.Creature)
+        effect = Effects.Move(victim, Zone.LIBRARY, ZonePlacement.Top)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Igor Kieryluk"
+        flavorText = "\"Beware the seagrafs just off the shore. These waters are filled with hungry geists looking for an easy meal.\"\n—Captain Eberhart"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DivineVerdictReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DivineVerdictReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Verdict reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineVerdictReprint = Printing(
+    oracleId = "3070f997-24f2-471d-af96-a2f3b588198e",
+    name = "Divine Verdict",
+    setCode = "M13",
+    collectorNumber = "12",
+    scryfallId = "cc52c269-d44f-449c-af59-4c425aa10bbf",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/cc52c269-d44f-449c-af59-4c425aa10bbf.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DivineVerdictReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DivineVerdictReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Verdict reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineVerdictReprint = Printing(
+    oracleId = "3070f997-24f2-471d-af96-a2f3b588198e",
+    name = "Divine Verdict",
+    setCode = "ORI",
+    collectorNumber = "274",
+    scryfallId = "562f1a7b-149d-42ba-aaea-345ccae7227c",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/562f1a7b-149d-42ba-aaea-345ccae7227c.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardiansOfMeletisReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardiansOfMeletisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guardians of Meletis reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val GuardiansOfMeletisReprint = Printing(
+    oracleId = "7604aac7-82ae-4f5b-888d-a008754f716a",
+    name = "Guardians of Meletis",
+    setCode = "ORI",
+    collectorNumber = "228",
+    scryfallId = "2ff39de2-d071-4568-baac-25b505a2da56",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2ff39de2-d071-4568-baac-25b505a2da56.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReadTheBonesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReadTheBonesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Read the Bones reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val ReadTheBonesReprint = Printing(
+    oracleId = "5bf4d8d9-a2b2-4dba-ac05-9d4470a89db2",
+    name = "Read the Bones",
+    setCode = "ORI",
+    collectorNumber = "114",
+    scryfallId = "0cc51b90-7f1e-4e20-bc36-e3a198bc71bf",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0cc51b90-7f1e-4e20-bc36-e3a198bc71bf.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TitanSStrengthReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TitanSStrengthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titan's Strength reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val TitanSStrengthReprint = Printing(
+    oracleId = "b0206b34-68b4-4b1f-ae79-6e2d0432ad4b",
+    name = "Titan's Strength",
+    setCode = "ORI",
+    collectorNumber = "166",
+    scryfallId = "0e48f309-8e56-4741-a9ff-e899dafb333a",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e48f309-8e56-4741-a9ff-e899dafb333a.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SavageSurge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SavageSurge.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Savage Surge
+ * {1}{G}
+ * Instant
+ *
+ * Target creature gets +2/+2 until end of turn. Untap that creature.
+ */
+val SavageSurge = card("Savage Surge") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. Untap that creature."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.Untap(t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Svetlin Velinov"
+        flavorText = "Gruul warriors never need to be stirred to battle. They need only to be shown where the battle is."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AgentOfHorizons.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AgentOfHorizons.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Agent of Horizons
+ * {2}{G}
+ * Creature — Human Rogue
+ * 3 / 2
+ *
+ * {2}{U}: This creature can't be blocked this turn.
+ */
+val AgentOfHorizons = card("Agent of Horizons") {
+    manaCost = "{2}{G}"
+    colorIdentity = "UG"
+    typeLine = "Creature — Human Rogue"
+    power = 3
+    toughness = 2
+    oracleText = "{2}{U}: This creature can't be blocked this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Clint Cearley"
+        flavorText = "The light in the woods just before dawn reveals a glimmering network of branches, roots, and spiderwebs. The acolytes of Kruphix walk this lattice unseen."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AnvilwroughtRaptor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AnvilwroughtRaptor.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anvilwrought Raptor
+ * {4}
+ * Artifact Creature — Bird
+ * 2 / 1
+ *
+ * Flying
+ * First strike (This creature deals combat damage before creatures without first strike.)
+ */
+val AnvilwroughtRaptor = card("Anvilwrought Raptor") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Bird"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)"
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "James Zapata"
+        flavorText = "\"I know its lightness, for I have seen it fly. I know its weight, for I have seen it strike.\"\n—Brigone, soldier of Meletis"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ArtisansSorrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ArtisansSorrow.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Artisan's Sorrow
+ * {3}{G}
+ * Instant
+ *
+ * Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val ArtisansSorrow = card("Artisan's Sorrow") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
+            Effects.Scry(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Jung Park"
+        flavorText = "Some seers read bones or entrails. Others just like to break things."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AshenRider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AshenRider.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ashen Rider
+ * {4}{W}{W}{B}{B}
+ * Creature — Archon
+ * 5 / 5
+ *
+ * Flying
+ * When this creature enters or dies, exile target permanent.
+ *
+ * "Enters **or** dies" is two separate triggered abilities sharing one printed sentence
+ * (CR 603.1) — each declares its own target, so the dies half targets afresh rather than
+ * reusing the entry half's choice.
+ */
+val AshenRider = card("Ashen Rider") {
+    manaCost = "{4}{W}{W}{B}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Archon"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\nWhen this creature enters or dies, exile target permanent."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Permanent)
+        effect = Effects.Exile(t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target", Targets.Permanent)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "187"
+        artist = "Chris Rahn"
+        flavorText = "One offering to appease her on her arrival. Another to celebrate her departure."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AsphodelWanderer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/AsphodelWanderer.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Asphodel Wanderer
+ * {B}
+ * Creature — Skeleton Soldier
+ * 1 / 1
+ *
+ * {2}{B}: Regenerate this creature.
+ *
+ * There is no `Effects.Regenerate` facade — [RegenerateEffect] on [EffectTarget.Self] is the shipped
+ * spelling (Cudgel Troll, Cinderbones, Kin-Tree Warden).
+ */
+val AsphodelWanderer = card("Asphodel Wanderer") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{B}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Scott Chou"
+        flavorText = "He killed out of hate, so now only hate sustains him. He sought immortality, so the gods gave it to him."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BattlewiseValor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BattlewiseValor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battlewise Valor
+ * {1}{W}
+ * Instant
+ *
+ * Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val BattlewiseValor = card("Battlewise Valor") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2),
+            Effects.Scry(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Zack Stella"
+        flavorText = "It's never good to walk into an ambush, but with the right spell you might walk out again."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BenthicGiant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BenthicGiant.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Benthic Giant
+ * {5}{U}
+ * Creature — Giant
+ * 4 / 5
+ *
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ */
+val BenthicGiant = card("Benthic Giant") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 5
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Jaime Jones"
+        flavorText = "\"Some fates you can see coming for you, plain as day, and there's nothing you can do about them.\"\n—Callaphe the mariner"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ChosenByHeliod.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ChosenByHeliod.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Chosen by Heliod
+ * {1}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +0/+2.
+ */
+val ChosenByHeliod = card("Chosen by Heliod") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +0/+2."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(0, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Zack Stella"
+        flavorText = "\"Training and studies aid a soldier in meager amounts. The gods do the rest.\"\n—Brigone, soldier of Meletis"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CoordinatedAssault.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CoordinatedAssault.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Coordinated Assault
+ * {R}
+ * Instant
+ *
+ * Up to two target creatures each get +1/+0 and gain first strike until end of turn. (They deal combat damage before creatures without first strike.)
+ *
+ * "Up to two target creatures **each**" is one requirement with `count = 2, optional = true`, and the
+ * pump body runs once per chosen target via [IterationSpace.Targets] — so one, two, or zero targets
+ * all resolve correctly and a target that became illegal is simply skipped.
+ */
+val CoordinatedAssault = card("Coordinated Assault") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Up to two target creatures each get +1/+0 and gain first strike until end of turn. (They deal combat damage before creatures without first strike.)"
+
+    spell {
+        target = TargetCreature(count = 2, optional = true)
+        effect = ForEachEffect(
+            space = IterationSpace.Targets,
+            body = Effects.Composite(
+                Effects.ModifyStats(1, 0),
+                Effects.GrantKeyword(Keyword.FIRST_STRIKE),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "116"
+        artist = "John Severin Brassell"
+        flavorText = "It's hard to shout \"Shields up!\" with a javelin in your chest."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CracklingTriton.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CracklingTriton.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Crackling Triton
+ * {2}{U}
+ * Creature — Merfolk Wizard
+ * 2 / 3
+ *
+ * {2}{R}, Sacrifice this creature: It deals 2 damage to any target.
+ *
+ * "It" is the sacrificed creature itself, which is the effect's default damage source — no explicit
+ * `damageSource` belongs here.
+ */
+val CracklingTriton = card("Crackling Triton") {
+    manaCost = "{2}{U}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "{2}{R}, Sacrifice this creature: It deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{R}"),
+            Costs.SacrificeSelf
+        )
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Greg Staples"
+        flavorText = "He calls upon both the currents in the sea and the current in the clouds."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CutthroatManeuver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/CutthroatManeuver.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cutthroat Maneuver
+ * {3}{B}
+ * Instant
+ *
+ * Up to two target creatures each get +1/+1 and gain lifelink until end of turn.
+ *
+ * "Up to two target creatures **each** get ..." is a plural requirement, so the pump and the
+ * keyword grant run once per chosen target ([ForEachTargetEffect] over `ContextTarget(0)`)
+ * rather than once against the requirement as a whole.
+ */
+val CutthroatManeuver = card("Cutthroat Maneuver") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Up to two target creatures each get +1/+1 and gain lifelink until end of turn."
+
+    spell {
+        target("target", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.ModifyStats(1, 1, EffectTarget.ContextTarget(0)),
+                Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.ContextTarget(0)),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Brad Rigney"
+        flavorText = "\"Our ambition drives us forward. Together we will claim what is ours, no matter who holds it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DarkBetrayal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DarkBetrayal.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Betrayal
+ * {B}
+ * Instant
+ *
+ * Destroy target black creature.
+ *
+ * The "black" is a targeting predicate, so it rides [Targets.CreatureWithColor] rather than a
+ * separate condition.
+ */
+val DarkBetrayal = card("Dark Betrayal") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target black creature."
+
+    spell {
+        val t = target("target", Targets.CreatureWithColor(Color.BLACK))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Nils Hamm"
+        flavorText = "\"You're just like me: ruthless, cunning, and ambitious. Obviously you're a threat.\"\n—Basarios the Blade"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DauntlessOnslaught.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DauntlessOnslaught.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dauntless Onslaught
+ * {2}{W}
+ * Instant
+ *
+ * Up to two target creatures each get +2/+2 until end of turn.
+ *
+ * "Up to two target creatures **each** get +2/+2" is a plural requirement, so the pump runs
+ * once per chosen target ([ForEachTargetEffect] over `ContextTarget(0)`) rather than once
+ * against the requirement as a whole.
+ */
+val DauntlessOnslaught = card("Dauntless Onslaught") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Up to two target creatures each get +2/+2 until end of turn."
+
+    spell {
+        target("target", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            listOf(Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Peter Mohrbacher"
+        flavorText = "\"The people of Akros must learn from our leonin adversaries. If we match their staunch ferocity with our superior faith, we cannot fail.\"\n—Cymede, queen of Akros"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DecoratedGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DecoratedGriffin.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Decorated Griffin
+ * {4}{W}
+ * Creature — Griffin
+ * 2 / 3
+ *
+ * Flying
+ * {1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.
+ *
+ * The shield's recipient is the controller — [PreventDamageEffect]'s default `target` — so "dealt
+ * to you" is the absence of a target, not a target of its own. `Effects` publishes fourteen
+ * prevention facades and none of them freezes *this* point of the product (a bounded amount **and**
+ * [PreventionScope.CombatOnly]), so the type is constructed directly, as Al-abara's Carpet does for
+ * the same reason. Keeping the amount non-null is load-bearing: an amount-less combat-only shield
+ * on the default target is what `PreventDamageExecutor` reads as the global Fog.
+ */
+val DecoratedGriffin = card("Decorated Griffin") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = PreventDamageEffect(
+            amount = DynamicAmount.Fixed(1),
+            scope = PreventionScope.CombatOnly
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Phill Simmer"
+        flavorText = "The awards and medals of polis-dwellers mean nothing to griffins, but they repay acts of generosity."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Dissolve.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Dissolve.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dissolve
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The scry is not conditional on the counter resolving — it is a second sentence in the same effect,
+ * so a countered-or-not-still-legal target does not gate it.
+ */
+val Dissolve = card("Dissolve") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.Scry(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Wesley Burt"
+        flavorText = "\"You thought only the gods could stop you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DivineVerdictReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/DivineVerdictReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Verdict reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineVerdictReprint = Printing(
+    oracleId = "3070f997-24f2-471d-af96-a2f3b588198e",
+    name = "Divine Verdict",
+    setCode = "THS",
+    collectorNumber = "8",
+    scryfallId = "79f46ac0-9e2f-4f9f-beee-0a7914475ac1",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/79f46ac0-9e2f-4f9f-beee-0a7914475ac1.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/EpharasWarden.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/EpharasWarden.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ephara's Warden
+ * {3}{W}
+ * Creature — Human Cleric
+ * 1 / 2
+ *
+ * {T}: Tap target creature with power 3 or less.
+ */
+val EpharasWarden = card("Ephara's Warden") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Tap target creature with power 3 or less."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Zack Stella"
+        flavorText = "\"When you threaten the sanctity of the polis, you insult Ephara herself. If she doesn't smite you, I will.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FadeIntoAntiquity.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FadeIntoAntiquity.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fade into Antiquity
+ * {2}{G}
+ * Sorcery
+ *
+ * Exile target artifact or enchantment.
+ */
+val FadeIntoAntiquity = card("Fade into Antiquity") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Exile target artifact or enchantment."
+
+    spell {
+        val permanent = target("artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Noah Bradley"
+        flavorText = "\"Are the gods angry at our discontent with what they give us, or jealous that we made a thing they cannot?\"\n—Kleon the Iron-Booted"
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FlamecastWheel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FlamecastWheel.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flamecast Wheel
+ * {1}
+ * Artifact
+ *
+ * {5}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.
+ *
+ * The wheel itself is the damage source ("It deals"), which is what [Effects.DealDamage] uses
+ * when no explicit `damageSource` is given.
+ */
+val FlamecastWheel = card("Flamecast Wheel") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{5}, {T}, Sacrifice this artifact: It deals 3 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{5}"),
+            Costs.Tap,
+            Costs.SacrificeSelf,
+        )
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Jasper Sandner"
+        flavorText = "Beware the gifts of an ill-tempered forge god."
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FleetfeatherSandals.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FleetfeatherSandals.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Fleetfeather Sandals
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature has flying and haste.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val FleetfeatherSandals = card("Fleetfeather Sandals") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Steve Prescott"
+        flavorText = "\"The gods gave us no wings to fly, but they gave us an even greater gift: imagination.\"\n—Daxos of Meletis"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GlareOfHeresy.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GlareOfHeresy.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Glare of Heresy
+ * {1}{W}
+ * Sorcery
+ *
+ * Exile target white permanent.
+ *
+ * "White permanent" is the permanent filter plus a colour predicate, so it reads *projected* colour
+ * — a permanent turned white by a continuous effect is a legal target, and a white one turned
+ * colourless is not.
+ */
+val GlareOfHeresy = card("Glare of Heresy") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target white permanent."
+
+    spell {
+        val permanent = target(
+            "white permanent",
+            TargetPermanent(filter = TargetFilter.Permanent.withColor(Color.WHITE))
+        )
+        effect = Effects.Exile(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Raymond Swanland"
+        flavorText = "No foe is more hated than the former friend."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GriptideReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GriptideReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griptide reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val GriptideReprint = Printing(
+    oracleId = "5a6bbc45-6cb8-40ff-9f7c-7b2c5713dd78",
+    name = "Griptide",
+    setCode = "THS",
+    collectorNumber = "50",
+    scryfallId = "9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9fe8228b-ff9c-4a2a-a0e3-12f6d388a3c2.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GuardiansOfMeletis.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/GuardiansOfMeletis.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guardians of Meletis
+ * {3}
+ * Artifact Creature — Golem
+ * 0 / 6
+ *
+ * Defender (This creature can't attack.)
+ */
+val GuardiansOfMeletis = card("Guardians of Meletis") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 0
+    toughness = 6
+    oracleText = "Defender (This creature can't attack.)"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Magali Villeneuve"
+        flavorText = "The histories speak of two feuding rulers whose deaths were celebrated and whose monuments symbolized the end of their wars. In truth they were peaceful lovers, their story lost to the ages."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/InsatiableHarpy.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/InsatiableHarpy.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Insatiable Harpy
+ * {2}{B}{B}
+ * Creature — Harpy
+ * 2 / 2
+ *
+ * Flying, lifelink
+ */
+val InsatiableHarpy = card("Insatiable Harpy") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Harpy"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, lifelink"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "92"
+        artist = "Matt Stewart"
+        flavorText = "Gold coin, battered helmet, broken wrist bone—all have the same value in the eyes of a harpy."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LagonnaBandElder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LagonnaBandElder.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Lagonna-Band Elder
+ * {2}{W}
+ * Creature — Centaur Advisor
+ * 3 / 2
+ *
+ * When this creature enters, if you control an enchantment, you gain 3 life.
+ */
+val LagonnaBandElder = card("Lagonna-Band Elder") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Centaur Advisor"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, if you control an enchantment, you gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Enchantment)
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Min Yum"
+        flavorText = "\"The best lessons are not the ones I teach. They are the ones the pupils realize for themselves.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LashOfTheWhip.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LashOfTheWhip.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lash of the Whip
+ * {4}{B}
+ * Instant
+ *
+ * Target creature gets -4/-4 until end of turn.
+ */
+val LashOfTheWhip = card("Lash of the Whip") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-4 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-4, -4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"No matter who their fickle hearts worship, all mortals belong to one god in the end.\"\n—Iadorna, death priest of Erebos"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LostInALabyrinth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LostInALabyrinth.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lost in a Labyrinth
+ * {U}
+ * Instant
+ *
+ * Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val LostInALabyrinth = card("Lost in a Labyrinth") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(-3, 0, t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Winona Nelson"
+        flavorText = "Even those who leave the labyrinth never escape it, forever dreaming of their time trapped within."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MagmaJetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MagmaJetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magma Jet reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val MagmaJetReprint = Printing(
+    oracleId = "2f292253-64d3-4cf2-881f-a3eea4fda388",
+    name = "Magma Jet",
+    setCode = "THS",
+    collectorNumber = "128",
+    scryfallId = "8b0686b0-27a2-46bc-bc04-717f368d9a78",
+    artist = "Maciej Kuciara",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b0686b0-27a2-46bc-bc04-717f368d9a78.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MessengersSpeed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MessengersSpeed.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Messenger's Speed
+ * {R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has trample and haste.
+ */
+val MessengersSpeed = card("Messenger's Speed") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature has trample and haste."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Clint Cearley"
+        flavorText = "\"He outran arrows. He outran even the archers' insults.\"\n—Bayma, storyteller of Lagonna Band"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MistcutterHydra.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MistcutterHydra.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mistcutter Hydra
+ * {X}{G}
+ * Creature — Hydra
+ * 0 / 0
+ *
+ * This spell can't be countered.
+ * Haste, protection from blue
+ * This creature enters with X +1/+1 counters on it.
+ *
+ * The printed P/T is 0/0; the body comes entirely from the entry counters, which is a replacement
+ * effect ([EntersWithDynamicCounters]) rather than a triggered ability. "This spell can't be
+ * countered" is a characteristic of the *spell*, so it rides the card-level `cantBeCountered` flag.
+ */
+val MistcutterHydra = card("Mistcutter Hydra") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Hydra"
+    power = 0
+    toughness = 0
+    oracleText = "This spell can't be countered.\nHaste, protection from blue\nThis creature enters with X +1/+1 counters on it."
+
+    cantBeCountered = true
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLUE)))
+
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "162"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/OpalineUnicorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/OpalineUnicorn.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Opaline Unicorn
+ * {3}
+ * Artifact Creature — Unicorn
+ * 1 / 2
+ *
+ * {T}: Add one mana of any color.
+ */
+val OpalineUnicorn = card("Opaline Unicorn") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Unicorn"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Christine Choi"
+        flavorText = "Purphoros once loved Nylea, the god of the hunt. His passion inspired his most astounding works of art."
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PharikasCure.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PharikasCure.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pharika's Cure
+ * {B}{B}
+ * Instant
+ *
+ * Pharika's Cure deals 2 damage to target creature and you gain 2 life.
+ *
+ * One sentence, two effects: the life gain is not conditional on the damage, so it is a plain
+ * composite rather than a gated rider.
+ */
+val PharikasCure = card("Pharika's Cure") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Pharika's Cure deals 2 damage to target creature and you gain 2 life."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.DealDamage(2, creature),
+            Effects.GainLife(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Igor Kieryluk"
+        flavorText = "\"The venom cleanses the sickness from your body, but it will not be pleasant, and you may not survive. Pharika's blessings are fickle.\"\n—Solon, acolyte of Pharika"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PharikasMender.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PharikasMender.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pharika's Mender
+ * {3}{B}{G}
+ * Creature — Gorgon
+ * 4 / 3
+ *
+ * When this creature enters, you may return target creature or enchantment card from your graveyard to your hand.
+ *
+ * - The graveyard is carried by the *target filter's* `zone`, not by a `fromZone` guard on the move:
+ *   a targeted return re-checks its target's legality at resolution (CR 608.2b), so the guard would
+ *   be redundant. [Effects.ReturnToHand]'s KDoc spells out the same split.
+ * - The printed "you may" is the builder's `optional = true`, which lowers to a `Gate.MayDecide`
+ *   around the return.
+ */
+val PharikasMender = card("Pharika's Mender") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Gorgon"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, you may return target creature or enchantment card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val recovered = target(
+            "creature or enchantment card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.CreatureOrEnchantment.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        optional = true
+        effect = Effects.ReturnToHand(recovered)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Peter Mohrbacher"
+        flavorText = "\"The direst venom becomes a panacea under Pharika's guidance. I bring it to the worthy, clinging at the edge of the abyss.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PriestOfIroas.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PriestOfIroas.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Priest of Iroas
+ * {R}
+ * Creature — Human Cleric
+ * 1 / 1
+ *
+ * {3}{W}, Sacrifice this creature: Destroy target enchantment.
+ */
+val PriestOfIroas = card("Priest of Iroas") {
+    manaCost = "{R}"
+    colorIdentity = "WR"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{3}{W}, Sacrifice this creature: Destroy target enchantment."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.Enchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Clint Cearley"
+        flavorText = "\"Even my last breath will be a blow struck for Iroas.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ProwlersHelm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ProwlersHelm.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Prowler's Helm
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature can't be blocked except by Walls.
+ * Equip {2}
+ *
+ * The evasion is about the *equipped creature*, never the Equipment itself, so the static is scoped
+ * with [GroupFilter.attachedCreature] — `CantBeBlockedExceptBy` defaults to `GroupFilter.source()`,
+ * which would land the restriction on a permanent that never blocks or is blocked. Invisibility
+ * (LEA) is the same shape on an Aura.
+ */
+val ProwlersHelm = card("Prowler's Helm") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature can't be blocked except by Walls.\nEquip {2}"
+
+    staticAbility {
+        ability = CantBeBlockedExceptBy(
+            blockerFilter = GameObjectFilter.Permanent.withSubtype(Subtype.WALL),
+            filter = GroupFilter.attachedCreature()
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Igor Kieryluk"
+        flavorText = "\"The youths prattle on about heroic deeds, but avoiding the noose is a feat more daring than their entire careers.\"\n—Basarios the Blade"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/RayOfDissolution.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/RayOfDissolution.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ray of Dissolution
+ * {2}{W}
+ * Instant
+ *
+ * Destroy target enchantment. You gain 3 life.
+ */
+val RayOfDissolution = card("Ray of Dissolution") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target enchantment. You gain 3 life."
+
+    spell {
+        val t = target("target", Targets.Enchantment)
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "Terese Nielsen"
+        flavorText = "The works of one god last only as long as the patience of another."
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ReadTheBones.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ReadTheBones.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Read the Bones
+ * {2}{B}
+ * Sorcery
+ *
+ * Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val ReadTheBones = card("Read the Bones") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Scry(2),
+            Effects.DrawCards(2),
+            Effects.LoseLife(2, EffectTarget.Controller)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Lars Grant-West"
+        flavorText = "The dead know lessons the living haven't learned."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SatyrHedonistReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SatyrHedonistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Satyr Hedonist reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val SatyrHedonistReprint = Printing(
+    oracleId = "a75bf714-ed3e-4403-a009-3a81f430bc64",
+    name = "Satyr Hedonist",
+    setCode = "THS",
+    collectorNumber = "174",
+    scryfallId = "88c67e15-833c-406a-b75f-8de97fbacf5a",
+    artist = "Chase Stone",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88c67e15-833c-406a-b75f-8de97fbacf5a.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SatyrRambler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SatyrRambler.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Satyr Rambler
+ * {1}{R}
+ * Creature — Satyr
+ * 2 / 1
+ *
+ * Trample
+ */
+val SatyrRambler = card("Satyr Rambler") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Satyr"
+    power = 2
+    toughness = 1
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "John Stanko"
+        flavorText = "A satyr is bound by nothing—not home, not family, not loyalty."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SavageSurgeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SavageSurgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savage Surge reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val SavageSurgeReprint = Printing(
+    oracleId = "0acbc9a6-0de0-4096-b35c-1a586a1312ea",
+    name = "Savage Surge",
+    setCode = "THS",
+    collectorNumber = "176",
+    scryfallId = "5916d5e7-0825-4d72-82e4-1e4c86d1fafe",
+    artist = "Jasper Sandner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/5916d5e7-0825-4d72-82e4-1e4c86d1fafe.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Scourgemark.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Scourgemark.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Scourgemark
+ * {1}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +1/+0.
+ */
+val Scourgemark = card("Scourgemark") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +1/+0."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Franz Vohwinkel"
+        flavorText = "To members of the cult of Erebos, gold-infused tattoos symbolize the inevitable grasp of the god of death."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SedgeScorpion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SedgeScorpion.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sedge Scorpion
+ * {G}
+ * Creature — Scorpion
+ * 1 / 1
+ *
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ */
+val SedgeScorpion = card("Sedge Scorpion") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Scorpion"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "John Stanko"
+        flavorText = "Thakolides the Mighty\nSlayer of minotaurs\nVanquisher of giants\nKilled by a scorpion\n—Inscription on an Akroan grave"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SentryOfTheUnderworld.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SentryOfTheUnderworld.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sentry of the Underworld
+ * {3}{W}{B}
+ * Creature — Griffin Skeleton
+ * 3 / 3
+ *
+ * Flying, vigilance
+ * {W}{B}, Pay 3 life: Regenerate this creature.
+ *
+ * "Regenerate this creature" is [RegenerateEffect] on [EffectTarget.Self]; there is no
+ * `Effects.Regenerate` facade — the effect class is the shipped spelling (Cudgel Troll).
+ */
+val SentryOfTheUnderworld = card("Sentry of the Underworld") {
+    manaCost = "{3}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Griffin Skeleton"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, vigilance\n{W}{B}, Pay 3 life: Regenerate this creature."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}{B}"), Costs.PayLife(3))
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{W}{B}, Pay 3 life: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Dave Kendall"
+        flavorText = "When Athreos gathers the newly dead to be ferried across the Five Rivers That Ring the World, he sends skeletal griffins to fetch those who stray."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SetessanGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SetessanGriffin.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Setessan Griffin
+ * {4}{W}
+ * Creature — Griffin
+ * 3 / 2
+ *
+ * Flying
+ * {2}{G}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn.
+ */
+val SetessanGriffin = card("Setessan Griffin") {
+    manaCost = "{4}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Griffin"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n{2}{G}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}{G}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Greg Staples"
+        flavorText = "Most griffins must be caught and broken into the service of the polis. Not so in Setessa, where they volunteer."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ShreddingWinds.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ShreddingWinds.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shredding Winds
+ * {2}{G}
+ * Instant
+ *
+ * Shredding Winds deals 7 damage to target creature with flying.
+ */
+val ShreddingWinds = card("Shredding Winds") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Shredding Winds deals 7 damage to target creature with flying."
+
+    spell {
+        val t = target("target", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.DealDamage(7, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Christopher Moeller"
+        flavorText = "\"Enemies of the wood! Your presence here is a slap in Nylea's face. Do not be surprised if she slaps back.\"\n—Telphe, druid of Nylea"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SparkJolt.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SparkJolt.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spark Jolt
+ * {R}
+ * Instant
+ *
+ * Spark Jolt deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val SparkJolt = card("Spark Jolt") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Spark Jolt deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(1, t),
+            Effects.Scry(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Mike Bierek"
+        flavorText = "Acolytes of Purphoros hammer the world until they see the sparks of change."
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SylvanCaryatid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SylvanCaryatid.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sylvan Caryatid
+ * {1}{G}
+ * Creature — Plant
+ * 0 / 3
+ *
+ * Defender, hexproof
+ * {T}: Add one mana of any color.
+ */
+val SylvanCaryatid = card("Sylvan Caryatid") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    power = 0
+    toughness = 3
+    oracleText = "Defender, hexproof\n{T}: Add one mana of any color."
+
+    keywords(Keyword.DEFENDER, Keyword.HEXPROOF)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "180"
+        artist = "Chase Stone"
+        flavorText = "Those who enter the copse never leave. They find peace there and take root, becoming part of the ever-growing grove."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TherosBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TherosBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Theros Basic Lands
+ *
+ * Theros contains 4 art variants of each basic land type.
+ * Cards 230-249 (Plains 230-233, Island 234-237, Swamp 238-241, Mountain 242-245, Forest 246-249)
+ */
+
+// =============================================================================
+// Plains (Cards 230-233)
+// =============================================================================
+
+val TherosPlains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/18013a78-d156-42bf-89b7-72e7070872c0.jpg"
+}
+
+val TherosPlains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e891d622-9369-4eeb-b7e2-183c60ec54d2.jpg"
+}
+
+val TherosPlains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fa4b03f-60f1-441f-8066-8bc13d5637d1.jpg"
+}
+
+val TherosPlains233 = basicLand("Plains") {
+    collectorNumber = "233"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f37db921-ab2a-46db-82c1-1f1abf7a3cf7.jpg"
+}
+
+// =============================================================================
+// Island (Cards 234-237)
+// =============================================================================
+
+val TherosIsland234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d851b88b-6ce6-4889-83c2-e191307bcee6.jpg"
+}
+
+val TherosIsland235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac928336-f534-4682-a952-c536a1b14e1e.jpg"
+}
+
+val TherosIsland236 = basicLand("Island") {
+    collectorNumber = "236"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9c266e3-d403-434a-b645-dcb9cf441680.jpg"
+}
+
+val TherosIsland237 = basicLand("Island") {
+    collectorNumber = "237"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/51852e9d-9183-4f9a-a724-cb60cf677e38.jpg"
+}
+
+// =============================================================================
+// Swamp (Cards 238-241)
+// =============================================================================
+
+val TherosSwamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b153bb8-f9d9-44dc-ae19-d0eb2ea26ba1.jpg"
+}
+
+val TherosSwamp239 = basicLand("Swamp") {
+    collectorNumber = "239"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bfc9f472-c410-4595-b08d-87c115b9148d.jpg"
+}
+
+val TherosSwamp240 = basicLand("Swamp") {
+    collectorNumber = "240"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e49a9a01-46fb-4e9d-8e7d-5f2c267ab1f9.jpg"
+}
+
+val TherosSwamp241 = basicLand("Swamp") {
+    collectorNumber = "241"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81047292-e537-47b5-acfa-ed839707109c.jpg"
+}
+
+// =============================================================================
+// Mountain (Cards 242-245)
+// =============================================================================
+
+val TherosMountain242 = basicLand("Mountain") {
+    collectorNumber = "242"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e78801a7-af8c-4f1d-b29e-7a36676b6818.jpg"
+}
+
+val TherosMountain243 = basicLand("Mountain") {
+    collectorNumber = "243"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc0a5a9c-e59a-4e33-b584-d6daa7f81547.jpg"
+}
+
+val TherosMountain244 = basicLand("Mountain") {
+    collectorNumber = "244"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a7245d4-7a29-4423-8b44-5e9694e1d9a1.jpg"
+}
+
+val TherosMountain245 = basicLand("Mountain") {
+    collectorNumber = "245"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/29557b92-fded-4aa8-8db7-99168c8e70d8.jpg"
+}
+
+// =============================================================================
+// Forest (Cards 246-249)
+// =============================================================================
+
+val TherosForest246 = basicLand("Forest") {
+    collectorNumber = "246"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddfd1469-94b9-4964-ada6-4fb43b0b9282.jpg"
+}
+
+val TherosForest247 = basicLand("Forest") {
+    collectorNumber = "247"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b3a37f57-5d3e-488e-a909-f53bd4c2576b.jpg"
+}
+
+val TherosForest248 = basicLand("Forest") {
+    collectorNumber = "248"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f13b34d7-e2a6-4cbc-9d5f-b6fe05a1c701.jpg"
+}
+
+val TherosForest249 = basicLand("Forest") {
+    collectorNumber = "249"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a80d346-84e3-4eaf-9635-09da472475d8.jpg"
+}
+
+/**
+ * All Theros basic land variants.
+ */
+val TherosBasicLands = listOf(
+    TherosPlains230, TherosPlains231, TherosPlains232, TherosPlains233,
+    TherosIsland234, TherosIsland235, TherosIsland236, TherosIsland237,
+    TherosSwamp238, TherosSwamp239, TherosSwamp240, TherosSwamp241,
+    TherosMountain242, TherosMountain243, TherosMountain244, TherosMountain245,
+    TherosForest246, TherosForest247, TherosForest248, TherosForest249
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TitansStrength.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TitansStrength.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titan's Strength
+ * {R}
+ * Instant
+ *
+ * Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val TitansStrength = card("Titan's Strength") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 1, t),
+            Effects.Scry(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TravelerSAmuletReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TravelerSAmuletReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Traveler's Amulet reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val TravelerSAmuletReprint = Printing(
+    oracleId = "48b561dd-f23d-409a-87c8-e49902b2477b",
+    name = "Traveler's Amulet",
+    setCode = "THS",
+    collectorNumber = "221",
+    scryfallId = "245a683f-280e-405c-aa2a-dfabb78dc34e",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/245a683f-280e-405c-aa2a-dfabb78dc34e.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TwoHeadedCerberus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TwoHeadedCerberus.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Two-Headed Cerberus
+ * {1}{R}{R}
+ * Creature — Dog
+ * 1 / 2
+ *
+ * Double strike (This creature deals both first-strike and regular combat damage.)
+ */
+val TwoHeadedCerberus = card("Two-Headed Cerberus") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog"
+    power = 1
+    toughness = 2
+    oracleText = "Double strike (This creature deals both first-strike and regular combat damage.)"
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Karl Kopinski"
+        flavorText = "The left head keeps the right head starved as motivation to track new prey."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TymaretTheMurderKing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TymaretTheMurderKing.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tymaret, the Murder King
+ * {B}{R}
+ * Legendary Creature — Zombie Warrior
+ * 2 / 2
+ *
+ * {1}{R}, Sacrifice another creature: Tymaret deals 2 damage to target player or planeswalker.
+ * {1}{B}, Sacrifice a creature: Return this card from your graveyard to your hand.
+ */
+val TymaretTheMurderKing = card("Tymaret, the Murder King") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Zombie Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{R}, Sacrifice another creature: Tymaret deals 2 damage to target player or planeswalker.\n{1}{B}, Sacrifice a creature: Return this card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.SacrificeAnother(GameObjectFilter.Creature))
+        val t = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.GRAVEYARD)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "207"
+        artist = "Volkan Baǵa"
+        flavorText = "His memories remained in the Underworld, but his cruelty crossed the Rivers with him."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VanquishTheFoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VanquishTheFoul.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Vanquish the Foul
+ * {5}{W}
+ * Sorcery
+ *
+ * Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val VanquishTheFoul = card("Vanquish the Foul") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(4)))
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Eric Deschamps"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Vaporkin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Vaporkin.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Vaporkin
+ * {1}{U}
+ * Creature — Elemental
+ * 2 / 1
+ *
+ * Flying
+ * This creature can block only creatures with flying.
+ *
+ * The blocking restriction is a printed static on the creature itself, so
+ * [CanOnlyBlockCreaturesWith]'s `filter` default (`GroupFilter.source()`) is the right one — only an
+ * Equipment or Aura would have to pass `GroupFilter.attachedCreature()` instead. Welkin Tern shape.
+ */
+val Vaporkin = card("Vaporkin") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nThis creature can block only creatures with flying."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Seb McKinnon"
+        flavorText = "\"Mists are carefree. They drift where they will, unencumbered by rocks and river beds.\"\n—Thrasios, triton hero"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VoyagingSatyr.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VoyagingSatyr.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voyaging Satyr
+ * {1}{G}
+ * Creature — Satyr Druid
+ * 1 / 2
+ *
+ * {T}: Untap target land.
+ */
+val VoyagingSatyr = card("Voyaging Satyr") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Satyr Druid"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Untap target land."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val land = target("target", Targets.Land)
+        effect = Effects.Untap(land)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Tyler Jacobson"
+        flavorText = "\"None can own the land's bounty. The gods made this world for all to share its riches. And I'm not just saying that because you caught me stealing your fruit.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VulpineGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VulpineGoliath.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vulpine Goliath
+ * {4}{G}{G}
+ * Creature — Fox
+ * 6 / 5
+ *
+ * Trample
+ */
+val VulpineGoliath = card("Vulpine Goliath") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fox"
+    power = 6
+    toughness = 5
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Adam Paquette"
+        flavorText = "\"With a diet of hydras, giants, and massive serpents, anything would get that big.\"\n—Corisande, Setessan hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ReadTheBonesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ReadTheBonesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Read the Bones reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val ReadTheBonesReprint = Printing(
+    oracleId = "5bf4d8d9-a2b2-4dba-ac05-9d4470a89db2",
+    name = "Read the Bones",
+    setCode = "C17",
+    collectorNumber = "122",
+    scryfallId = "ece1852d-8b7f-4fe6-b9fe-0584a94087ab",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ece1852d-8b7f-4fe6-b9fe-0584a94087ab.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/TravelerSAmuletReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/TravelerSAmuletReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Traveler's Amulet reprint in HOU. Canonical CardDefinition lives in its earliest set.
+ */
+val TravelerSAmuletReprint = Printing(
+    oracleId = "48b561dd-f23d-409a-87c8-e49902b2477b",
+    name = "Traveler's Amulet",
+    setCode = "HOU",
+    collectorNumber = "167",
+    scryfallId = "195464f1-f01c-4211-950d-963c5bad786f",
+    artist = "Marco Nelor",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/195464f1-f01c-4211-950d-963c5bad786f.jpg",
+    releaseDate = "2017-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DauntlessOnslaughtReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DauntlessOnslaughtReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dauntless Onslaught reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DauntlessOnslaughtReprint = Printing(
+    oracleId = "ce29f71a-6662-4be4-9915-5a4be87288e0",
+    name = "Dauntless Onslaught",
+    setCode = "JMP",
+    collectorNumber = "99",
+    scryfallId = "aae001aa-10a0-482a-86fe-bf6ca7fc0866",
+    artist = "Peter Mohrbacher",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aae001aa-10a0-482a-86fe-bf6ca7fc0866.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AnvilwroughtRaptorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AnvilwroughtRaptorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anvilwrought Raptor reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val AnvilwroughtRaptorReprint = Printing(
+    oracleId = "d87ebd8c-ad2c-45c9-8c97-f046aeda861c",
+    name = "Anvilwrought Raptor",
+    setCode = "M20",
+    collectorNumber = "221",
+    scryfallId = "aa6d7bbe-0418-4a58-a97b-13b50eb0b642",
+    artist = "James Zapata",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa6d7bbe-0418-4a58-a97b-13b50eb0b642.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SedgeScorpionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SedgeScorpionReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sedge Scorpion reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val SedgeScorpionReprint = Printing(
+    oracleId = "fbadf7a3-0d54-40fe-a763-f641dd448e56",
+    name = "Sedge Scorpion",
+    setCode = "M20",
+    collectorNumber = "192",
+    scryfallId = "9864f811-db2e-4d6d-ad59-a491a790bdd4",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/9864f811-db2e-4d6d-ad59-a491a790bdd4.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/FadeIntoAntiquityReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/FadeIntoAntiquityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fade into Antiquity reprint in NEO. Canonical CardDefinition lives in its earliest set.
+ */
+val FadeIntoAntiquityReprint = Printing(
+    oracleId = "3bd3156f-dbc7-48f7-9e50-1f2b8b227f97",
+    name = "Fade into Antiquity",
+    setCode = "NEO",
+    collectorNumber = "182",
+    scryfallId = "55174ab7-9f2e-42e5-a61b-57458cfd33f3",
+    artist = "Muhammad Firdaus",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55174ab7-9f2e-42e5-a61b-57458cfd33f3.jpg",
+    releaseDate = "2022-02-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/DivineVerdictReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/DivineVerdictReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Verdict reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineVerdictReprint = Printing(
+    oracleId = "3070f997-24f2-471d-af96-a2f3b588198e",
+    name = "Divine Verdict",
+    setCode = "RIX",
+    collectorNumber = "5",
+    scryfallId = "ed07b708-7232-4b87-b5d9-edaa20a69293",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed07b708-7232-4b87-b5d9-edaa20a69293.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/TravelerSAmuletReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/TravelerSAmuletReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Traveler's Amulet reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val TravelerSAmuletReprint = Printing(
+    oracleId = "48b561dd-f23d-409a-87c8-e49902b2477b",
+    name = "Traveler's Amulet",
+    setCode = "RIX",
+    collectorNumber = "184",
+    scryfallId = "393e2aa2-110e-4824-a9c9-5a76cb2bec23",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/393e2aa2-110e-4824-a9c9-5a76cb2bec23.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TravelerSAmuletReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TravelerSAmuletReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Traveler's Amulet reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TravelerSAmuletReprint = Printing(
+    oracleId = "48b561dd-f23d-409a-87c8-e49902b2477b",
+    name = "Traveler's Amulet",
+    setCode = "THB",
+    collectorNumber = "240",
+    scryfallId = "590926db-279c-494a-b92d-680b8abf9699",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/590926db-279c-494a-b92d-680b8abf9699.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DDL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DDL.json
@@ -1,0 +1,51 @@
+// Satyr Hedonist
+{
+    "name": "Satyr Hedonist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Satyr",
+    "oracleText": "{R}, Sacrifice this creature: Add {R}{R}{R}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Chase Stone",
+        "flavorText": "\"Any festival you can walk away from wasn't worth attending in the first place.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c6a5405-2bc8-4439-a09a-2c4844ba3a35.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -759,6 +759,43 @@
     ]
 }
 
+// Griptide
+{
+    "name": "Griptide",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Put target creature on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"Beware the seagrafs just off the shore. These waters are filled with hungry geists looking for an easy meal.\"\n—Captain Eberhart",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27f92b74-86bb-4bb3-8f78-640984698f28.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Havengul Runebinder
 {
     "name": "Havengul Runebinder",

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -885,6 +885,63 @@
     "colorIdentityOverride": []
 }
 
+// Savage Surge
+{
+    "name": "Savage Surge",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. Untap that creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Gruul warriors never need to be stirred to battle. They need only to be shown where the battle is.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fa74aae-e857-410c-8836-953c8623d0b0.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Selesnya Charm
 {
     "name": "Selesnya Charm",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -1,3 +1,304 @@
+// Agent of Horizons
+{
+    "name": "Agent of Horizons",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "{2}{U}: This creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Clint Cearley",
+        "flavorText": "The light in the woods just before dawn reveals a glimmering network of branches, roots, and spiderwebs. The acolytes of Kruphix walk this lattice unseen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc08576f-1d48-4db4-9bb9-e039f75c98b8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
+// Anvilwrought Raptor
+{
+    "name": "Anvilwrought Raptor",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nFirst strike (This creature deals combat damage before creatures without first strike.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "James Zapata",
+        "flavorText": "\"I know its lightness, for I have seen it fly. I know its weight, for I have seen it strike.\"\n—Brigone, soldier of Meletis",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76330494-ce39-444e-b5da-8905bcccb8ad.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Artisan's Sorrow
+{
+    "name": "Artisan's Sorrow",
+    "manaCost": "{3}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment. Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Scry",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Jung Park",
+        "flavorText": "Some seers read bones or entrails. Others just like to break things.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4f38f7e-2369-48c9-9121-4b13c29ea869.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ashen Rider
+{
+    "name": "Ashen Rider",
+    "manaCost": "{4}{W}{W}{B}{B}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nWhen this creature enters or dies, exile target permanent.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "flavorText": "One offering to appease her on her arrival. Another to celebrate her departure.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/602e43b1-1b1c-4eb1-be0a-61b673646c6f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Asphodel Wanderer
+{
+    "name": "Asphodel Wanderer",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Skeleton Soldier",
+    "oracleText": "{2}{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Scott Chou",
+        "flavorText": "He killed out of hate, so now only hate sustains him. He sought immortality, so the gods gave it to him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/675112db-c477-43f4-b755-54162445fb49.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Battlewise Valor
+{
+    "name": "Battlewise Valor",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Zack Stella",
+        "flavorText": "It's never good to walk into an ambush, but with the right spell you might walk out again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d967a4c-2323-4361-a907-5ca9140d8793.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Benthic Giant
+{
+    "name": "Benthic Giant",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Jaime Jones",
+        "flavorText": "\"Some fates you can see coming for you, plain as day, and there's nothing you can do about them.\"\n—Callaphe the mariner",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/295f9eb0-5a75-4f86-aca9-3f76b0213c41.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Borderland Minotaur
 {
     "name": "Borderland Minotaur",
@@ -113,6 +414,493 @@
     "colorIdentityOverride": []
 }
 
+// Chosen by Heliod
+{
+    "name": "Chosen by Heliod",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +0/+2.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Zack Stella",
+        "flavorText": "\"Training and studies aid a soldier in meager amounts. The gods do the rest.\"\n—Brigone, soldier of Meletis",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8ead499-920c-465a-a23d-f08710d7e9bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Coordinated Assault
+{
+    "name": "Coordinated Assault",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Up to two target creatures each get +1/+0 and gain first strike until end of turn. (They deal combat damage before creatures without first strike.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "FIRST_STRIKE",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "UNCOMMON",
+        "artist": "John Severin Brassell",
+        "flavorText": "It's hard to shout \"Shields up!\" with a javelin in your chest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c29f484-5f4b-4d29-846f-192425ab7fe3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crackling Triton
+{
+    "name": "Crackling Triton",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{2}{R}, Sacrifice this creature: It deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Greg Staples",
+        "flavorText": "He calls upon both the currents in the sea and the current in the clouds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d6bb19c-3610-4609-b23c-21d4d80e4582.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Cutthroat Maneuver
+{
+    "name": "Cutthroat Maneuver",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Up to two target creatures each get +1/+1 and gain lifelink until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "LIFELINK",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "UNCOMMON",
+        "artist": "Brad Rigney",
+        "flavorText": "\"Our ambition drives us forward. Together we will claim what is ours, no matter who holds it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62497880-64dc-4911-8513-f95b73086136.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dark Betrayal
+{
+    "name": "Dark Betrayal",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target black creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature black"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"You're just like me: ruthless, cunning, and ambitious. Obviously you're a threat.\"\n—Basarios the Blade",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56adf4ea-1b1c-4737-8574-1848ca47d4f3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dauntless Onslaught
+{
+    "name": "Dauntless Onslaught",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Up to two target creatures each get +2/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Peter Mohrbacher",
+        "flavorText": "\"The people of Akros must learn from our leonin adversaries. If we match their staunch ferocity with our superior faith, we cannot fail.\"\n—Cymede, queen of Akros",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e652229d-81fe-4261-bebc-9e405bb2d991.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Decorated Griffin
+{
+    "name": "Decorated Griffin",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\n{1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "scope": "CombatOnly"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Phill Simmer",
+        "flavorText": "The awards and medals of polis-dwellers mean nothing to griffins, but they repay acts of generosity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7bc2f3a0-444d-4cad-970f-6c4a63b02cce.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dissolve
+{
+    "name": "Dissolve",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Wesley Burt",
+        "flavorText": "\"You thought only the gods could stop you?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/992e8119-f933-4e54-bb04-e1cc78f7e87b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ephara's Warden
+{
+    "name": "Ephara's Warden",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Tap target creature with power 3 or less.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=3"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Zack Stella",
+        "flavorText": "\"When you threaten the sanctity of the polis, you insult Ephara herself. If she doesn't smite you, I will.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71f7f788-2795-46a7-82ae-270f1e9415ca.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Fade into Antiquity
+{
+    "name": "Fade into Antiquity",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "artifact or enchantment"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "artifact or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Noah Bradley",
+        "flavorText": "\"Are the gods angry at our discontent with what they give us, or jealous that we made a thing they cannot?\"\n—Kleon the Iron-Booted",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e43e46a6-f7de-482a-a386-73932d1d9002.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Felhide Minotaur
 {
     "name": "Felhide Minotaur",
@@ -166,6 +954,180 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Flamecast Wheel
+{
+    "name": "Flamecast Wheel",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{5}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Jasper Sandner",
+        "flavorText": "Beware the gifts of an ill-tempered forge god.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cfa31c9-5a11-4366-9063-056a659f3d0d.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Fleetfeather Sandals
+{
+    "name": "Fleetfeather Sandals",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Steve Prescott",
+        "flavorText": "\"The gods gave us no wings to fly, but they gave us an even greater gift: imagination.\"\n—Daxos of Meletis",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/2222f499-09f9-45a6-8255-9de79df76f1c.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Glare of Heresy
+{
+    "name": "Glare of Heresy",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target white permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "white permanent"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent white"
+                },
+                "id": "white permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Swanland",
+        "flavorText": "No foe is more hated than the former friend.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ed3d16f-f0c6-4080-8913-758208b08234.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Guardians of Meletis
+{
+    "name": "Guardians of Meletis",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Defender (This creature can't attack.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "217",
+        "artist": "Magali Villeneuve",
+        "flavorText": "The histories speak of two feuding rulers whose deaths were celebrated and whose monuments symbolized the end of their wars. In truth they were peaceful lovers, their story lost to the ages.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85284586-7a9d-4344-aebd-f0e072c1f266.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Hero's Downfall
@@ -239,6 +1201,120 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Insatiable Harpy
+{
+    "name": "Insatiable Harpy",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Harpy",
+    "oracleText": "Flying, lifelink",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "flavorText": "Gold coin, battered helmet, broken wrist bone—all have the same value in the eyes of a harpy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1439ed8d-ae11-4159-9420-5d98c6cc93b3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lagonna-Band Elder
+{
+    "name": "Lagonna-Band Elder",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Centaur Advisor",
+    "oracleText": "When this creature enters, if you control an enchantment, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Min Yum",
+        "flavorText": "\"The best lessons are not the ones I teach. They are the ones the pupils realize for themselves.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68b9df54-e78e-4a86-a8b1-b735ec08a812.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lash of the Whip
+{
+    "name": "Lash of the Whip",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"No matter who their fickle hearts worship, all mortals belong to one god in the end.\"\n—Iadorna, death priest of Erebos",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba32cf1f-375c-4cc5-9963-c4f9510e3b39.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -327,6 +1403,93 @@
     ]
 }
 
+// Lost in a Labyrinth
+{
+    "name": "Lost in a Labyrinth",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -3/-0 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Winona Nelson",
+        "flavorText": "Even those who leave the labyrinth never escape it, forever dreaming of their time trapped within.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09aa7744-680f-4c2a-8fa0-9cb0c176ae8f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Messenger's Speed
+{
+    "name": "Messenger's Speed",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has trample and haste.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Clint Cearley",
+        "flavorText": "\"He outran arrows. He outran even the archers' insults.\"\n—Bayma, storyteller of Lagonna Band",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93d7f033-217f-4fb3-a57b-e32291257ec8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Minotaur Skullcleaver
 {
     "name": "Minotaur Skullcleaver",
@@ -375,6 +1538,48 @@
     ]
 }
 
+// Mistcutter Hydra
+{
+    "name": "Mistcutter Hydra",
+    "manaCost": "{X}{G}",
+    "typeLine": "Creature — Hydra",
+    "oracleText": "This spell can't be countered.\nHaste, protection from blue\nThis creature enters with X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLUE"
+            }
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Omenspeaker
 {
     "name": "Omenspeaker",
@@ -408,6 +1613,141 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Opaline Unicorn
+{
+    "name": "Opaline Unicorn",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Unicorn",
+    "oracleText": "{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Christine Choi",
+        "flavorText": "Purphoros once loved Nylea, the god of the hunt. His passion inspired his most astounding works of art.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfba304c-9cb8-4d5c-b70d-b7f61a365977.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Pharika's Cure
+{
+    "name": "Pharika's Cure",
+    "manaCost": "{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Pharika's Cure deals 2 damage to target creature and you gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"The venom cleanses the sickness from your body, but it will not be pleasant, and you may not survive. Pharika's blessings are fickle.\"\n—Solon, acolyte of Pharika",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0efc963-5848-44eb-a654-c08b5bd4501d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Pharika's Mender
+{
+    "name": "Pharika's Mender",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Creature — Gorgon",
+    "oracleText": "When this creature enters, you may return target creature or enchantment card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature or enchantment card in your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|enchantment own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "creature or enchantment card in your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Peter Mohrbacher",
+        "flavorText": "\"The direst venom becomes a panacea under Pharika's guidance. I bring it to the worthy, clinging at the edge of the abyss.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3dcd1ce-717c-431a-9895-f7701d276743.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -481,6 +1821,472 @@
     ]
 }
 
+// Priest of Iroas
+{
+    "name": "Priest of Iroas",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{3}{W}, Sacrifice this creature: Destroy target enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Clint Cearley",
+        "flavorText": "\"Even my last breath will be a blow struck for Iroas.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/013ec9f5-8bf3-4067-a942-d535d011af82.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
+// Prowler's Helm
+{
+    "name": "Prowler's Helm",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature can't be blocked except by Walls.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedExceptBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsPermanent",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Wall"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"The youths prattle on about heroic deeds, but avoiding the noose is a feat more daring than their entire careers.\"\n—Basarios the Blade",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c100a22c-bf34-42b7-9339-4733698c0935.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Ray of Dissolution
+{
+    "name": "Ray of Dissolution",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target enchantment. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "Terese Nielsen",
+        "flavorText": "The works of one god last only as long as the patience of another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b55c31d1-6b05-4ea1-a444-51ad57ebcfa0.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Read the Bones
+{
+    "name": "Read the Bones",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Scry 2, then draw two cards. You lose 2 life. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Lars Grant-West",
+        "flavorText": "The dead know lessons the living haven't learned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbbdbf1a-2d15-4291-aa19-614f854d8cb3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Satyr Rambler
+{
+    "name": "Satyr Rambler",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Satyr",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "John Stanko",
+        "flavorText": "A satyr is bound by nothing—not home, not family, not loyalty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fabccddd-c0ea-45a5-bebc-d8f858242a2a.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Scourgemark
+{
+    "name": "Scourgemark",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +1/+0.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "To members of the cult of Erebos, gold-infused tattoos symbolize the inevitable grasp of the god of death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed36a150-a686-4fa6-8364-8be262ad7d98.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sedge Scorpion
+{
+    "name": "Sedge Scorpion",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Scorpion",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "John Stanko",
+        "flavorText": "Thakolides the Mighty\nSlayer of minotaurs\nVanquisher of giants\nKilled by a scorpion\n—Inscription on an Akroan grave",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66733fcb-fddc-4c15-bc51-c2cd42ac5a70.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sentry of the Underworld
+{
+    "name": "Sentry of the Underworld",
+    "manaCost": "{3}{W}{B}",
+    "typeLine": "Creature — Griffin Skeleton",
+    "oracleText": "Flying, vigilance\n{W}{B}, Pay 3 life: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{W}{B}, Pay 3 life: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "When Athreos gathers the newly dead to be ferried across the Five Rivers That Ring the World, he sends skeletal griffins to fetch those who stray.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/018a9c98-1cb4-4c53-a765-c15808c4ab44.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Setessan Griffin
+{
+    "name": "Setessan Griffin",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\n{2}{G}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Greg Staples",
+        "flavorText": "Most griffins must be caught and broken into the service of the polis. Not so in Setessa, where they volunteer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35d2ae77-b16c-4a01-84ce-5c78be5a54d8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Shredding Winds
+{
+    "name": "Shredding Winds",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Shredding Winds deals 7 damage to target creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 7
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Enemies of the wood! Your presence here is a slap in Nylea's face. Do not be surprised if she slaps back.\"\n—Telphe, druid of Nylea",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33f36143-85b6-412c-8c79-053728b45c25.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Silent Artisan
 {
     "name": "Silent Artisan",
@@ -498,6 +2304,88 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Spark Jolt
+{
+    "name": "Spark Jolt",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Spark Jolt deals 1 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Mike Bierek",
+        "flavorText": "Acolytes of Purphoros hammer the world until they see the sparks of change.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6ee479c2-a115-450b-bc2e-b03d23b82f2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sylvan Caryatid
+{
+    "name": "Sylvan Caryatid",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "Defender, hexproof\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER",
+        "HEXPROOF"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "RARE",
+        "artist": "Chase Stone",
+        "flavorText": "Those who enter the copse never leave. They find peace there and take root, becoming part of the ever-growing grove.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d40b65c1-b24d-492d-81b9-d8474ebdc08c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -791,6 +2679,57 @@
     ]
 }
 
+// Titan's Strength
+{
+    "name": "Titan's Strength",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+1 until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Karl Kopinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3db6ee53-c5e6-4344-9f35-084cd8cc9cd3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Traveling Philosopher
 {
     "name": "Traveling Philosopher",
@@ -828,6 +2767,126 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Two-Headed Cerberus
+{
+    "name": "Two-Headed Cerberus",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Double strike (This creature deals both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Karl Kopinski",
+        "flavorText": "The left head keeps the right head starved as motivation to track new prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8d2f75c-ef2a-4d30-86d1-c47307fc47ac.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tymaret, the Murder King
+{
+    "name": "Tymaret, the Murder King",
+    "manaCost": "{B}{R}",
+    "typeLine": "Legendary Creature — Zombie Warrior",
+    "oracleText": "{1}{R}, Sacrifice another creature: Tymaret deals 2 damage to target player or planeswalker.\n{1}{B}, Sacrifice a creature: Return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "flavorText": "His memories remained in the Underworld, but his cruelty crossed the Rivers with him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c4ce848-a57d-4e88-8093-9fb1408523bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -882,6 +2941,92 @@
     "colorIdentityOverride": []
 }
 
+// Vanquish the Foul
+{
+    "name": "Vanquish the Foul",
+    "manaCost": "{5}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature with power 4 or greater. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow>=4"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fdcec06-e33c-4737-b81e-b156d6e3fd77.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Vaporkin
+{
+    "name": "Vaporkin",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Mists are carefree. They drift where they will, unencumbered by rocks and river beds.\"\n—Thrasios, triton hero",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09b661a5-359b-4f21-b1b6-aa0988810b4d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Voyage's End
 {
     "name": "Voyage's End",
@@ -923,6 +3068,76 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Voyaging Satyr
+{
+    "name": "Voyaging Satyr",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Satyr Druid",
+    "oracleText": "{T}: Untap target land.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Tyler Jacobson",
+        "flavorText": "\"None can own the land's bounty. The gods made this world for all to share its riches. And I'm not just saying that because you caught me stealing your fruit.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/155ae6c0-5085-45f1-ba9f-508d501fee2c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vulpine Goliath
+{
+    "name": "Vulpine Goliath",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Fox",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Adam Paquette",
+        "flavorText": "\"With a diet of hydras, giants, and massive serpents, anything would get that big.\"\n—Corisande, Setessan hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdacb147-35ce-4751-961e-576b5f958048.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Every card Argentum Assay reads whole that Theros had not authored. `just assay-ready THS` went **60 → 0**, re-run on this branch rather than inferred.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 49 | canonical authored in THS — its earliest real printing |
| `elsewhere` | 2 | Griptide → **DKA**, Savage Surge → **RTR**, plus a `Printing` row back in THS |
| `row-only` | 3 | Divine Verdict, Magma Jet, Traveler's Amulet — row only |
| `basic` | 5 | `TherosBasicLands.kt`, 20 art variants (collector 230–249) |
| `unscaffolded` | 1 | Satyr Hedonist → **DDL**, scaffolded in this PR |

Plus the reprint tail: **23 `Printing(...)` rows across 13 sets** (THS 6, ORI 4, M20 2, RIX 2, C14/C17/DDL/DDP/HOU/JMP/M13/NEO/THB 1 each), generated scoped to these canonicals with `--cards-from` — not a corpus-wide run.

**DDL** (Duel Decks: Heroes vs. Monsters, 2013-09-06) is scaffolded the way DDF was: `incomplete = true`, `sealedSupported = false`, enough for Satyr Hedonist to hold its canonical in its earliest real printing three weeks before Theros.

No card left the batch. No new SDK vocabulary — every one composes existing primitives.

## Verification

| Gate | Result |
|---|---|
| `just build` | green (includes `:mtg-sets:test` — FacadeBoundaryTest, snapshots) |
| `just rebless-cards` | DKA +1, RTR +1, DDL +1 (new golden), THS +49 — **0 existing cards changed**, verified by a structural per-card diff, not by eyeballing the line diff |
| differential | **5515 / 5466 / 49 → 5567 / 5518 / 49** — compared +52, confirmed +52, **divergent unchanged**. Every card in the batch landed in `confirmed`. |
| `check-card-printing` | 0 drift across all 52 authored canonicals |
| `just assay-ready THS` | 60 → **0** |

Differential baseline was taken with the same freshly-built binary used afterwards, so the A/B is clean.

## Capability pre-flight

All 14 constructs the batch needs were traced to a live `rules-engine` consumer — **nothing display-only**. Three naming traps came out of it and went into the authoring brief:

1. **There is no `Effects.Regenerate` facade.** `RegenerateEffect(EffectTarget.Self)` is written directly (Asphodel Wanderer, Sentry of the Underworld), as `CudgelTroll.kt` already documents.
2. **`CANT_BE_BLOCKED` is `AbilityFlag`, not `Keyword`** — and on an Aura or Equipment the flag is a **silent no-op**. Agent of Horizons is the creature case (`Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)`); the Equipment case needs the static.
3. **`CantBeBlockedExceptBy` / `CanOnlyBlockCreaturesWith` default to `filter = GroupFilter.source()`**, which is wrong on an Equipment. **Prowler's Helm** is exactly that case and is written with `GroupFilter.attachedCreature()` — the tell is `"scope": {"type": "AttachedTo"}` in the compile JSON. This is the family Assay's combat-restriction band already caught four shipped cards in.

## Findings the sweep surfaced

- **The brief generator derived `colorIdentity` from the mana cost**, which is wrong for any card with a coloured symbol in an ability cost. Two authoring agents independently flagged it against Scryfall; **5 cards** were affected and are fixed: Agent of Horizons `UG`, Crackling Triton `UR`, Priest of Iroas `WR`, Setessan Griffin `WG`, Satyr Hedonist `RG`. The corpus convention is Scryfall's true `color_identity` in WUBRG order (588 corpus cards have an identity exceeding their cost; `WB` outnumbers `BW` 124:26), so two further cards were normalized from `BW` to `WB`. Worth fixing in whatever renders these briefs next time.
- **`Decorated Griffin` has no facade for its shape.** `PreventDamageShield {amount: Fixed 1, scope: CombatOnly}` sits between `Effects.PreventNextDamage(n, target)` (AllDamage) and `Effects.PreventAllCombatDamageTo(target)` (amount-less), so `PreventDamageEffect` is constructed directly — `leg/cards/AlabarasCarpet.kt` already does the same for the same reason. Not on `FacadeBoundaryTest`'s forbidden list, but it is a real gap in the prevention facade surface.
- **`Scourgemark`'s aura target cannot be named.** Assay's compile JSON stamps `"id": "target"` on the aura requirement; the corpus convention `auraTarget = Targets.Creature` leaves `id` null and there is no DSL seam to name an aura target. Followed the corpus convention (identical to `FeralInvocation` and ~30 other shipped Auras); the differential normalizes the slot name, so it does not show up as a divergence — but the seam is missing.
- **`ForEachEffect` has no `Effects.ForEach` facade** — Coordinated Assault and Cutthroat Maneuver construct it directly, as `dsk/cards/OmnivorousFlytrap.kt` does.
- **`compile`'s `setCode` is the Oracle-bulk printing, not the canonical placement**, on 12 of the 52 (2X2, BBD, CLU, CN2, DDM, DSC, IMA, JMP, M20, NEO, ORI, TDC). Metadata was taken from each set's own Scryfall payload throughout, as the stderr note instructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)