### PR TITLE
Multiplayer UX pass: pin semantics, key badges, turn context, elimination notice

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -308,20 +308,35 @@ are gated on `players.length > 2`).
   name, life (also the floating ±delta anchor via `data-life-display`), hand count, poison,
   commander-damage warning, active-turn ring, priority dot, deciding spinner
   (`opponentDecisionStatus.playerId`), attention pulses, and a tombstone once a player has
-  left the game. The *viewed* opponent additionally keeps a full-size life orb in the
-  center HUD (seat-tinted to match their chip) — the familiar, biggest click target for
-  targeting and defender assignment. Anchors (`data-player-id` / `data-life-id` /
+  left the game, and (desktop) a `kbd` badge with the digit that focuses the board — the
+  same living-opponent index `useMultiplayerView` maps keys 1–9 to, so a tombstone takes
+  no key and the team rail's regrouping never renumbers. With the sliding camera the
+  *viewed* opponent additionally keeps a full-size life orb in the center HUD (seat-tinted
+  to match their chip) — the familiar, biggest click target for targeting and defender
+  assignment. On the two-row table overview that orb is dropped (`centerOrbStandsIn`):
+  every board's plate already prints the name and life, and the orb was the same number
+  sixty pixels above the plate. Anchors (`data-player-id` / `data-life-id` /
   `data-life-display`) are carried by exactly one element per player: the orb for the
-  viewed opponent, the cell's name plate for every other board visible in a shared-strip
-  view (the plate is also a defender-assignment / player-target click target), and the
-  rail chip only while the board is off-screen — never more than one, so arrows, damage
-  floats, and player-target clicks resolve unambiguously.
+  viewed opponent while it stands in, the cell's name plate for every other board visible
+  in a shared-strip view (the plate is also a defender-assignment / player-target click
+  target), and the rail chip only while the board is off-screen — never more than one, so
+  arrows, damage floats, and player-target clicks resolve unambiguously.
 - **Board switching**: rail-chip click (pins; re-click unpins), keyboard `1`/`2`/`3`,
   horizontal swipe. Follow-the-action (`useMultiplayerView` + the `boardView` slice:
   `viewedOpponentId`, `viewPinned`, `followAction`) slides automatically on coarse
   boundaries — an opponent's turn starting, the attacker's board when you're attacked, the
   priority seat in hotseat — and is refused inside `followViewTo` while any input is
-  pending (the camera never moves under an in-progress selection).
+  pending (the camera never moves under an in-progress selection). A pin *suspends* the
+  follow setting rather than flipping it: `followAction` is the persisted preference,
+  `isFollowingAction(state)` (= `followAction && !viewPinned`) is what the camera does and
+  what the rail's Follow button shows, and Esc / re-clicking the chip / clicking Follow all
+  release the pin. Pinning used to write `followAction: false`, which left Esc a no-op and
+  the camera permanently manual after one chip click.
+- **Turn context in a pod**: the step strip names the active seat ("Tomasz's Turn") and,
+  outside a shared-turn team game, how far off your turn is ("You're next" / "You in 2",
+  counted over living seats). Another seat's elimination shows a transient top-centre
+  `EliminationNotice` (derived from `hasLost` flipping in the roster, so it fires however
+  the seat died) and keeps its seat colour in the log.
 - **Table overview** (`boardView.overviewMode`, rail toggle or key `0`; desktop/tablet
   only — phones keep the focused camera). **Every 3+ player game opens on it** — the
   one-board camera hides most of a pod — and `GameBoard` re-defaults once per game

--- a/web-client/src/components/combat/CombatArrows.tsx
+++ b/web-client/src/components/combat/CombatArrows.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
-import { selectGameState, selectViewingPlayerId, useViewedOpponent } from '@/store/selectors.ts'
-import { seatColor } from '@/styles/seatColors'
+import { selectGameState, selectViewingPlayerId, useViewedOpponent, selectTeamMap, identitySeatColor } from '@/store/selectors.ts'
 import type { EntityId } from '@/types'
 import { Step, ZoneType } from '@/types'
 
@@ -259,6 +258,7 @@ export function CombatArrows() {
   const currentStep = gameState?.currentStep
   const cards = gameState?.cards
   const players = gameState?.players
+  const teamMap = useGameStore(selectTeamMap)
   const viewingPlayerId = useGameStore(selectViewingPlayerId)
   const viewedOpponent = useViewedOpponent()
   const viewedOpponentId = viewedOpponent?.playerId ?? null
@@ -330,10 +330,11 @@ export function CombatArrows() {
 
       // Seat-identity color for a defending player ("whose seat is this hitting").
       // Attacks against the viewing player stay combat red, as do all 2-player arrows.
+      // Identity colour (the team hue in 2HG), so an arrow matches the chip and plate it points at.
       const seatColorOf = (defenderId: EntityId): string => {
         if (!isMulti || !players || defenderId === viewingPlayerId) return '#ff4444'
         const idx = players.findIndex((p) => p.playerId === defenderId)
-        return idx >= 0 ? seatColor(idx).base : '#ff4444'
+        return idx >= 0 ? identitySeatColor(teamMap, defenderId, idx).base : '#ff4444'
       }
 
       // Card anchor that survives the multiplayer board strip: a card on a
@@ -611,7 +612,7 @@ export function CombatArrows() {
     updateArrows()
     const interval = setInterval(updateArrows, 100)
     return () => clearInterval(interval)
-  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, cards, isSpectating, isSelectingDamageOrder, players, isMulti, viewedOpponentId, viewingPlayerId])
+  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, cards, isSpectating, isSelectingDamageOrder, players, teamMap, isMulti, viewedOpponentId, viewingPlayerId])
 
   // Don't render during full-screen overlay decisions
   if (hasOverlayDecision) {

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useRef, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
-import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId, useViewerEliminated, useIsSharedLifeTeamGame, useTeamLabelFor, useTeammateNames, useTeamHasPriority, useIsMyTeamTurn } from '@/store/selectors'
+import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId, useViewerEliminated, useIsSharedLifeTeamGame, useTeamLabelFor, useTeammateNames, useTeamHasPriority, useIsMyTeamTurn, useIsSharedTurnTeamGame, turnQueueHintFor } from '@/store/selectors'
 import { useMultiplayerView, useCombatDefenderFocus } from '@/hooks/useMultiplayerView'
 import { OpponentRail, railReservedWidth } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
@@ -138,6 +138,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const teamHoldsPriority = useTeamHasPriority(playerId ?? null)
   // ...and is it the viewer's *team's* turn (CR 805.4)? Also false outside a shared-turns format.
   const teamActiveTurn = useIsMyTeamTurn()
+  const sharedTurnTeamGame = useIsSharedTurnTeamGame()
   // The teammate currently on the baton. Read off the priority holder rather than "the ally",
   // because the ally seat is suppressed while this client is the one driving it (hotseat) — and
   // that is exactly a case where naming who is acting matters most.
@@ -767,18 +768,12 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // controls (combat declaration, sorcery-speed plays) light up for the driving client.
       (youAreHijacking != null && gameState.activePlayerId === youAreHijacking))
   // Multiplayer: how far off your next turn is, in living seats — "You're next" / "You in 2". The
-  // rail lists the table in turn order, but counting chips is the player's job today. Team games
-  // take one shared turn per team (CR 805.4), where a per-seat count would mislead, so none there.
-  const turnQueueHint = (() => {
-    if (!isMulti || isTeamGame || spectatorMode || isMyTurn || !viewingPlayer || viewingPlayer.hasLost) return undefined
-    const living = gameState.players.filter((p) => !p.hasLost)
-    const from = living.findIndex((p) => p.playerId === gameState.activePlayerId)
-    const to = living.findIndex((p) => p.playerId === viewingPlayer.playerId)
-    if (from < 0 || to < 0) return undefined
-    const distance = (to - from + living.length) % living.length
-    if (distance === 0) return undefined
-    return distance === 1 ? "You're next" : `You in ${distance}`
-  })()
+  // rail lists the table in turn order, but counting chips is the player's job today. Two-Headed
+  // Giant takes one shared turn per team (CR 805.4), where a per-seat count would mislead, so none
+  // there; Team vs. Team takes individual turns (CR 808.4) and keeps it.
+  const turnQueueHint = !isMulti || sharedTurnTeamGame || spectatorMode || isMyTurn
+    ? undefined
+    : turnQueueHintFor(gameState.players, gameState.activePlayerId, viewingPlayer?.playerId)
   const isInCombatMode = spectatorMode ? false : (combatState !== null)
   const isInDistributeMode = !spectatorMode && distributeState !== null
   const distributeTotalAllocated = distributeState

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -28,7 +28,7 @@ import { ManaSymbol } from '../ui/ManaSymbols'
 import { Battlefield, CardRow, CommandZone, OpponentBoardArea, BoardNamePlate, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, CELL_PLATE_BAND, useCellHandMetrics, StackDisplay, ZonePile, ResponsiveContext } from './board'
 import { RenderProfiler } from '@/utils/renderProfiler'
 import { CardPreview } from './card'
-import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, SpeedGauge, DayNightBadge, ConcedeButton, FullscreenButton, SpectatorCountBadge, TeamLifeBanner } from './overlay'
+import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, SpeedGauge, DayNightBadge, ConcedeButton, FullscreenButton, SpectatorCountBadge, TeamLifeBanner, EliminationNotice } from './overlay'
 import { HelpDrawer, HelpDrawerButton } from '../help/HelpDrawer'
 import { styles } from './board/styles'
 
@@ -452,6 +452,12 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // the step strip. Every plate then carries its own player's anchors again — there is no orb
   // standing in for a seat any more.
   const teamBannersActive = teamBannerSeats != null
+  // The center-left orb stands in for one opponent only while that opponent has no plate of their
+  // own — the sliding camera. On the two-row table every board's plate already carries its name,
+  // life and anchors, so the orb would print the same number sixty pixels above the plate: the
+  // duplicate the team banners exist to remove, just in a free-for-all. Every plate then carries
+  // its own player's anchors, exactly as with the banners up.
+  const centerOrbStandsIn = !teamBannersActive && !twoRowActive
   // The one ally seat whose hand you may read (CR 810.5). Null outside a shared-life team game,
   // while spectating, and for the (unsupported today) team of one.
   const allySeat = useMemo(() => {
@@ -543,14 +549,15 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         }
       }
     }
-    // Outside a team-banner game the center orb stands in for one opponent, so it carries their
-    // anchors wherever their own board doesn't. With the banners up nothing stands in for a seat.
-    if (!teamBannersActive && centerOrbOpponentId && !ids.includes(centerOrbOpponentId)) {
+    // With the sliding camera the center orb stands in for one opponent, so it carries their
+    // anchors wherever their own board doesn't. With the banners up, or on the two-row table,
+    // nothing stands in for a seat — every visible plate is its own player's anchor.
+    if (centerOrbStandsIn && centerOrbOpponentId && !ids.includes(centerOrbOpponentId)) {
       ids.push(centerOrbOpponentId)
     }
     return ids
   }, [
-    teamBannersActive,
+    centerOrbStandsIn,
     multiView,
     expandedStripIds,
     eliminatedBottomSeat,
@@ -759,6 +766,19 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // During a hijack of the opponent's turn, treat it as "my turn" so the active-player
       // controls (combat declaration, sorcery-speed plays) light up for the driving client.
       (youAreHijacking != null && gameState.activePlayerId === youAreHijacking))
+  // Multiplayer: how far off your next turn is, in living seats — "You're next" / "You in 2". The
+  // rail lists the table in turn order, but counting chips is the player's job today. Team games
+  // take one shared turn per team (CR 805.4), where a per-seat count would mislead, so none there.
+  const turnQueueHint = (() => {
+    if (!isMulti || isTeamGame || spectatorMode || isMyTurn || !viewingPlayer || viewingPlayer.hasLost) return undefined
+    const living = gameState.players.filter((p) => !p.hasLost)
+    const from = living.findIndex((p) => p.playerId === gameState.activePlayerId)
+    const to = living.findIndex((p) => p.playerId === viewingPlayer.playerId)
+    if (from < 0 || to < 0) return undefined
+    const distance = (to - from + living.length) % living.length
+    if (distance === 0) return undefined
+    return distance === 1 ? "You're next" : `You in ${distance}`
+  })()
   const isInCombatMode = spectatorMode ? false : (combatState !== null)
   const isInDistributeMode = !spectatorMode && distributeState !== null
   const distributeTotalAllocated = distributeState
@@ -1092,7 +1112,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                       // viewed board, but a Two-Headed Giant HUD points its orb at the enemy team
                       // instead (see `centerOrbOpponent`).
                       plateCarriesAnchors={
-                        multiView && expandedCell && (teamBannersActive || o.playerId !== centerOrbOpponentId)
+                        multiView && expandedCell && (!centerOrbStandsIn || o.playerId !== centerOrbOpponentId)
                       }
                       // With every board on screen the useful highlight is whose turn it is,
                       // not which cell the camera nominally tracks.
@@ -1196,7 +1216,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                   table ([TeamLifeBanner]), so the center band keeps only the step strip and the
                   per-player badges. Printing the same number here as well is the duplicate the
                   banners exist to remove. */}
-              {!teamBannersActive && <LifeDisplay
+              {centerOrbStandsIn && <LifeDisplay
                 life={centerOrbOpponent.life}
                 playerId={centerOrbOpponent.playerId}
                 playerName={centerOrbOpponent.name}
@@ -1308,10 +1328,13 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           isActivePlayer={isMyTurn}
           hasPriority={hasPriority}
           priorityMode={priorityMode}
-          activePlayerName={spectatorMode
+          // Name the active seat in a pod: "Opponent's Turn" says nothing at a four-seat table.
+          // While responding the strip keeps saying so — the name is on the rail's turn ring.
+          activePlayerName={spectatorMode || (isMulti && !isMyTurn && priorityMode !== 'responding')
             ? gameState.players.find(p => p.playerId === gameState.activePlayerId)?.name
             : undefined
           }
+          turnQueueHint={turnQueueHint}
           activeSide={
             spectatorMode
               ? (gameState.activePlayerId === effectiveViewingPlayer?.playerId ? 'bottom' : 'top')
@@ -1472,7 +1495,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 liftHand={teamBannersActive}
                 plateCarriesAnchors={
                   p.playerId !== bottomHudPlayer?.playerId &&
-                  (teamBannersActive || p.playerId !== centerOrbOpponentId)
+                  (!centerOrbStandsIn || p.playerId !== centerOrbOpponentId)
                 }
                 onToggleCollapse={() => toggleSeatCollapsed(p.playerId)}
                 // Same active-turn ring as the top row — the highlight has to mean the same
@@ -1740,6 +1763,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           </div>
         )
       })()}
+
+      {isMulti && <EliminationNotice topOffset={effectiveTopOffset} />}
 
       {/* Attack-restriction explainer — "attack left/right" (CR 803.1) and similar
           restrictions are invisible on the board itself, so say exactly who can be

--- a/web-client/src/components/game/GameLog.tsx
+++ b/web-client/src/components/game/GameLog.tsx
@@ -1,5 +1,6 @@
 import { useGameStore, type LogEntry } from '@/store/gameStore.ts'
-import { seatColor } from '@/styles/seatColors'
+import { identitySeatColor, selectTeamMap } from '@/store/selectors.ts'
+import type { EntityId } from '@/types'
 import React, { useState, useRef, useEffect } from 'react'
 
 /**
@@ -11,11 +12,14 @@ export function GameLog() {
   // Multiplayer: log entries take the actor's seat color ("who did that?" is the
   // dominant question in a pod). 2-player keeps the classic cyan/orange split.
   const players = useGameStore((state) => state.gameState?.players)
+  const teamMap = useGameStore(selectTeamMap)
   const isMulti = (players?.length ?? 0) > 2
-  const seatColorFor = (entryPlayerId: string | null): string | null => {
+  // Identity colour, not raw seat colour: in a Two-Headed Giant game the rail, orbs and plates
+  // paint team hues, and the log has to agree with them or "who did that" reads wrong.
+  const seatColorFor = (entryPlayerId: EntityId | null): string | null => {
     if (!isMulti || !players || !entryPlayerId || entryPlayerId === playerId) return null
     const idx = players.findIndex((p) => p.playerId === entryPlayerId)
-    return idx >= 0 ? seatColor(idx).base : null
+    return idx >= 0 ? identitySeatColor(teamMap, entryPlayerId, idx).base : null
   }
   const [expanded, setExpanded] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -72,8 +76,10 @@ function LogEntryRow({ entry, isPlayer, seatColor }: { entry: LogEntry; isPlayer
     )
   }
 
+  // A system line *about* a seat ("Bob has been eliminated") keeps that seat's colour in a pod —
+  // it is the one log line where "who" matters most, and it was the only one that couldn't have it.
   const color = entry.type === 'system'
-    ? '#999'
+    ? seatColor ?? '#999'
     : entry.playerId === null
       ? '#888'
       : isPlayer

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -889,6 +889,9 @@ function RailChip({
         title={chipTitle(opponent) + (isAttackRestricted ? "\nCan't be attacked this combat" : '')}
         onClick={handleChipClick}
         onKeyDown={(e) => {
+          // Only the chip itself: the crosshair and distribute buttons inside it are focusable
+          // and handle their own Enter, which must not also change the view.
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             handleChipClick()

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
 import { useGameStore } from '@/store/gameStore'
+import { isFollowingAction } from '@/store/slices/ui/boardViewSlice'
 import {
   selectGameState,
   selectTeamMap,
@@ -85,7 +86,8 @@ export function OpponentRail({
   const viewedOpponent = useViewedOpponent()
   const self = useViewingPlayer()
   const viewPinned = useGameStore((state) => state.viewPinned)
-  const followAction = useGameStore((state) => state.followAction)
+  // The *effective* camera behaviour: the persisted setting minus a manual pin.
+  const followAction = useGameStore(isFollowingAction)
   const toggleFollowAction = useGameStore((state) => state.toggleFollowAction)
   const overviewMode = useGameStore((state) => state.overviewMode)
   const toggleOverviewMode = useGameStore((state) => state.toggleOverviewMode)
@@ -94,6 +96,14 @@ export function OpponentRail({
   // team sections — your team (you + ally) and the opposing team — colored by team with one
   // shared-life header each. Spectators (no "you") keep the flat per-seat rail.
   const isTeamGame = useIsTeamGame()
+  // The digit that focuses each living opponent's board — the same `opponents.filter(!hasLost)`
+  // order `useMultiplayerView` indexes for keys 1-9, so the badge on a chip is always the key
+  // that selects it (a tombstone takes no key, and a team rail's regrouping doesn't renumber).
+  const keyIndexById = useMemo(() => {
+    const map = new Map<EntityId, number>()
+    opponents.filter((o) => !o.hasLost).forEach((o, i) => map.set(o.playerId, i + 1))
+    return map
+  }, [opponents])
   const teamMap = useGameStore(selectTeamMap)
   const viewerTeam = useViewerTeamIndex()
   const teamMode = isTeamGame && viewerTeam != null && !spectatorMode
@@ -175,6 +185,7 @@ export function OpponentRail({
                 viewPinned={viewPinned}
                 spectatorMode={spectatorMode}
                 isAlly
+                keyIndex={keyIndexById.get(opponent.playerId) ?? null}
               />
             ))}
           </TeamRailSection>
@@ -188,6 +199,7 @@ export function OpponentRail({
                 isBoardVisible={visibleBoardIds.includes(opponent.playerId)}
                 viewPinned={viewPinned}
                 spectatorMode={spectatorMode}
+                keyIndex={keyIndexById.get(opponent.playerId) ?? null}
               />
             ))}
           </TeamRailSection>
@@ -209,6 +221,7 @@ export function OpponentRail({
               isBoardVisible={visibleBoardIds.includes(opponent.playerId)}
               viewPinned={viewPinned}
               spectatorMode={spectatorMode}
+              keyIndex={keyIndexById.get(opponent.playerId) ?? null}
             />
           ))}
         </>
@@ -651,6 +664,7 @@ function RailChip({
   viewPinned,
   spectatorMode,
   isAlly = false,
+  keyIndex = null,
 }: {
   opponent: ClientPlayer
   isViewed: boolean
@@ -660,6 +674,8 @@ function RailChip({
   spectatorMode: boolean
   /** Two-Headed Giant: this seat is the viewing player's teammate (ally treatment, no own life). */
   isAlly?: boolean
+  /** The 1-9 key that focuses this board (null for a tombstone). Shown as a badge on desktop. */
+  keyIndex?: number | null
 }) {
   const responsive = useResponsiveContext()
   const gameState = useGameStore(selectGameState)
@@ -869,8 +885,15 @@ function RailChip({
             }
           : {})}
         role="button"
+        tabIndex={tomb && !spectatorMode ? -1 : 0}
         title={chipTitle(opponent) + (isAttackRestricted ? "\nCan't be attacked this combat" : '')}
         onClick={handleChipClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleChipClick()
+          }
+        }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         style={{
@@ -893,18 +916,21 @@ function RailChip({
           opacity: tomb ? 0.6 : isAttackRestricted ? 0.5 : 1,
           transition: 'border-color 150ms, background 150ms, opacity 200ms',
           ...(ringShadow ? { boxShadow: ringShadow } : {}),
-          // Active turn wins the animation slot (clearest signal); otherwise the
-          // "board has targets" halo. Both drive box-shadow, so only one can run.
-          ...(isActiveTurn && !tomb
+          // Both animations drive box-shadow, so only one can run. While a selection is in
+          // progress the "board has targets" halo wins: it is the answer to the question the
+          // player is asking right now ("where are my targets?"), and the active player's board
+          // is the most common place for them — which is exactly when the turn ring used to
+          // drown it out. The ▶ marker still says whose turn it is.
+          ...(boardHasTargets && !isViewed
             ? {
-                animation: 'railTurnRing 1.4s ease-in-out infinite',
-                ['--turn-color' as string]: seat.bright,
-                ['--turn-glow' as string]: seat.soft,
+                animation: 'railHalo 1.2s ease-in-out infinite',
+                ['--halo-color' as string]: 'rgba(0, 187, 255, 0.7)',
               }
-            : boardHasTargets && !isViewed
+            : isActiveTurn && !tomb
               ? {
-                  animation: 'railHalo 1.2s ease-in-out infinite',
-                  ['--halo-color' as string]: 'rgba(0, 187, 255, 0.7)',
+                  animation: 'railTurnRing 1.4s ease-in-out infinite',
+                  ['--turn-color' as string]: seat.bright,
+                  ['--turn-glow' as string]: seat.soft,
                 }
               : {}),
         }}
@@ -1179,6 +1205,35 @@ function RailChip({
               +
             </button>
           </span>
+        )}
+        {/* Key badge — the digit that focuses this board (keys 1-9). The one place the shortcut
+            is visible without opening help; stands down while the chip is busy being a target
+            or a distribute row. Desktop only: phones have no keyboard and a compact chip. */}
+        {!compact && !tomb && keyIndex != null && keyIndex <= 9 && !isPlayerTargetable && !isDistributeTarget && (
+          <kbd
+            aria-hidden
+            title={`Press ${keyIndex} to focus this board`}
+            style={{
+              flexShrink: 0,
+              minWidth: 13,
+              height: 13,
+              padding: '0 3px',
+              boxSizing: 'border-box',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 3,
+              border: `1px solid ${isViewed ? seat.base : 'rgba(255, 255, 255, 0.18)'}`,
+              background: 'rgba(0, 0, 0, 0.35)',
+              color: isViewed ? seat.bright : '#8a90a0',
+              fontFamily: 'inherit',
+              fontSize: 9,
+              fontWeight: 800,
+              lineHeight: 1,
+            }}
+          >
+            {keyIndex}
+          </kbd>
         )}
       </div>
 

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -1,8 +1,7 @@
 import type React from 'react'
 import { useState } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
-import { useStackCards, selectGameState } from '@/store/selectors.ts'
-import { seatColor } from '@/styles/seatColors'
+import { useStackCards, selectGameState, selectTeamMap, identitySeatColor } from '@/store/selectors.ts'
 import type { EntityId } from '@/types'
 import type { ClientAbilityIdentity, ClientCard } from '@/types/gameState'
 import { getCardImageUrl, faceDownImageUrl } from '@/utils/cardImages.ts'
@@ -55,12 +54,14 @@ export function StackDisplay() {
   // tagged with the caster's name, so "whose spell is that" reads at a glance. 2-player games
   // have only one possible caster per side, so this stays off.
   const players = useGameStore((state) => selectGameState(state)?.players)
+  const teamMap = useGameStore(selectTeamMap)
   const isMulti = (players?.length ?? 0) > 2
   const seatMetaFor = (controllerId: EntityId) => {
     if (!isMulti || !players) return null
     const idx = players.findIndex((p) => p.playerId === controllerId)
     if (idx < 0) return null
-    return { name: players[idx]?.name ?? 'Player', seat: seatColor(idx) }
+    // Identity colour (team hue in 2HG) so the stack agrees with the rail and the plates.
+    return { name: players[idx]?.name ?? 'Player', seat: identitySeatColor(teamMap, controllerId, idx) }
   }
   const seatBorderFor = (controllerId: EntityId): React.CSSProperties => {
     const meta = seatMetaFor(controllerId)

--- a/web-client/src/components/game/overlay/EliminationNotice.tsx
+++ b/web-client/src/components/game/overlay/EliminationNotice.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react'
+import { useGameStore } from '@/store/gameStore'
+import { identitySeatColor, selectGameState, selectTeamMap, selectViewingPlayerId } from '@/store/selectors'
+import type { EntityId } from '@/types'
+
+/** How long an elimination notice stays up. Long enough to read, short enough to never queue. */
+const NOTICE_MS = 5000
+
+interface Notice {
+  key: number
+  name: string
+  color: string
+}
+
+/**
+ * "💀 Bob has been eliminated" — a transient top-centre notice when another seat leaves a
+ * multiplayer game (CR 800.4a). Until now the only signal was a rail chip quietly turning into
+ * a tombstone and a grey log line; in a four-seat pod that is easy to miss, and "who is still in
+ * this" is the question the whole table is asking at that moment.
+ *
+ * Derived from the roster (`hasLost` flipping true), not from the elimination message, so it
+ * fires however the seat died — concede, damage, poison, decking — and for spectators too. The
+ * seats already out when this mounts (a reconnect, a spectator joining late) are not announced.
+ * Your own elimination is the defeat overlay's business, not a toast.
+ */
+export function EliminationNotice({ topOffset = 0 }: { topOffset?: number }) {
+  const gameState = useGameStore(selectGameState)
+  const viewingPlayerId = useGameStore(selectViewingPlayerId)
+  const teamMap = useGameStore(selectTeamMap)
+  const players = gameState?.players
+  const isMulti = (players?.length ?? 0) > 2
+
+  const seenLost = useRef<Set<EntityId> | null>(null)
+  const [notice, setNotice] = useState<Notice | null>(null)
+
+  useEffect(() => {
+    if (!players) return
+    if (seenLost.current === null) {
+      seenLost.current = new Set(players.filter((p) => p.hasLost).map((p) => p.playerId))
+      return
+    }
+    const seen = seenLost.current
+    players.forEach((p, idx) => {
+      if (!p.hasLost || seen.has(p.playerId)) return
+      seen.add(p.playerId)
+      if (!isMulti || p.playerId === viewingPlayerId) return
+      setNotice({ key: Date.now(), name: p.name, color: identitySeatColor(teamMap, p.playerId, idx).bright })
+    })
+  }, [players, isMulti, viewingPlayerId, teamMap])
+
+  useEffect(() => {
+    if (!notice) return
+    const timer = setTimeout(() => setNotice((n) => (n?.key === notice.key ? null : n)), NOTICE_MS)
+    return () => clearTimeout(timer)
+  }, [notice])
+
+  if (!notice) return null
+  return (
+    <div
+      key={notice.key}
+      role="status"
+      aria-live="polite"
+      onClick={() => setNotice(null)}
+      style={{
+        position: 'fixed',
+        top: topOffset + 52,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 120,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 14px',
+        borderRadius: 999,
+        border: `1px solid ${notice.color}`,
+        background: 'rgba(12, 12, 18, 0.92)',
+        boxShadow: `0 0 14px ${notice.color}55`,
+        color: '#e8ecf5',
+        fontSize: 12,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+        animation: 'eliminationNoticeIn 220ms ease-out',
+      }}
+    >
+      <span aria-hidden>💀</span>
+      <span style={{ color: notice.color, fontWeight: 800 }}>{notice.name}</span>
+      <span>has been eliminated</span>
+      <style>{`
+        @keyframes eliminationNoticeIn {
+          from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
+          to { opacity: 1; transform: translateX(-50%) translateY(0); }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/web-client/src/components/game/overlay/EliminationNotice.tsx
+++ b/web-client/src/components/game/overlay/EliminationNotice.tsx
@@ -21,7 +21,9 @@ interface Notice {
  * Derived from the roster (`hasLost` flipping true), not from the elimination message, so it
  * fires however the seat died — concede, damage, poison, decking — and for spectators too. The
  * seats already out when this mounts (a reconnect, a spectator joining late) are not announced.
- * Your own elimination is the defeat overlay's business, not a toast.
+ * Your own elimination is the defeat overlay's business, not a toast, and so is the elimination
+ * that ends the game — fewer than two teams left standing (CR 104.2a / 104.2c) — which in
+ * Two-Headed Giant is always both members of the losing team at once (CR 810.8a).
  */
 export function EliminationNotice({ topOffset = 0 }: { topOffset?: number }) {
   const gameState = useGameStore(selectGameState)
@@ -40,10 +42,12 @@ export function EliminationNotice({ topOffset = 0 }: { topOffset?: number }) {
       return
     }
     const seen = seenLost.current
+    const livingTeams = new Set(players.filter((p) => !p.hasLost).map((p) => teamMap[p.playerId] ?? p.playerId))
+    const gameOver = livingTeams.size < 2
     players.forEach((p, idx) => {
       if (!p.hasLost || seen.has(p.playerId)) return
       seen.add(p.playerId)
-      if (!isMulti || p.playerId === viewingPlayerId) return
+      if (!isMulti || gameOver || p.playerId === viewingPlayerId) return
       setNotice({ key: Date.now(), name: p.name, color: identitySeatColor(teamMap, p.playerId, idx).bright })
     })
   }, [players, isMulti, viewingPlayerId, teamMap])

--- a/web-client/src/components/game/overlay/GameControls.tsx
+++ b/web-client/src/components/game/overlay/GameControls.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
+import { useIsSharedLifeTeamGame } from '@/store/selectors'
 import { useResponsiveContext } from '../board/shared'
 
 /**
@@ -8,8 +9,14 @@ import { useResponsiveContext } from '../board/shared'
 export function ConcedeButton() {
   const concede = useGameStore((state) => state.concede)
   // In a pod, conceding eliminates *you* while the game goes on (CR 800.4a) — say so, since
-  // "Concede" reads as "end the game" everywhere else.
+  // "Concede" reads as "end the game" everywhere else. Two-Headed Giant is the exception: a team
+  // wins and loses together, so one concession takes the whole team out (CR 810.8b).
   const isPod = useGameStore((state) => (state.gameState?.players.length ?? 0) > 2)
+  const teamConcedes = useIsSharedLifeTeamGame()
+  const confirmLabel = teamConcedes ? 'Concede for the team' : isPod ? 'Concede & leave' : 'Confirm'
+  // Rides inside the button so the confirm row keeps its width — beside the buttons it ran into
+  // the top-right board's name plate, below them into that cell's collapse button.
+  const podNote = teamConcedes ? 'your team is out' : isPod ? 'the others play on' : null
   const [confirming, setConfirming] = useState(false)
   const responsive = useResponsiveContext()
 
@@ -24,12 +31,7 @@ export function ConcedeButton() {
 
   if (confirming) {
     return (
-      <div style={{ ...base, alignItems: 'center' }}>
-        {isPod && !responsive.isMobile && (
-          <span style={{ fontSize: 11, color: '#c9a0a0', whiteSpace: 'nowrap', marginRight: 4 }}>
-            You're out; the others play on.
-          </span>
-        )}
+      <div style={base}>
         <button
           onClick={() => { concede(); setConfirming(false) }}
           style={{
@@ -41,9 +43,16 @@ export function ConcedeButton() {
             borderRadius: 6,
             cursor: 'pointer',
             fontWeight: 600,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            lineHeight: 1.15,
           }}
         >
-          {isPod ? 'Concede & leave' : 'Confirm'}
+          <span>{confirmLabel}</span>
+          {podNote && !responsive.isMobile && (
+            <span style={{ fontSize: 9, fontWeight: 500, opacity: 0.85 }}>{podNote}</span>
+          )}
         </button>
         <button
           onClick={() => setConfirming(false)}

--- a/web-client/src/components/game/overlay/GameControls.tsx
+++ b/web-client/src/components/game/overlay/GameControls.tsx
@@ -7,6 +7,9 @@ import { useResponsiveContext } from '../board/shared'
  */
 export function ConcedeButton() {
   const concede = useGameStore((state) => state.concede)
+  // In a pod, conceding eliminates *you* while the game goes on (CR 800.4a) — say so, since
+  // "Concede" reads as "end the game" everywhere else.
+  const isPod = useGameStore((state) => (state.gameState?.players.length ?? 0) > 2)
   const [confirming, setConfirming] = useState(false)
   const responsive = useResponsiveContext()
 
@@ -21,7 +24,12 @@ export function ConcedeButton() {
 
   if (confirming) {
     return (
-      <div style={base}>
+      <div style={{ ...base, alignItems: 'center' }}>
+        {isPod && !responsive.isMobile && (
+          <span style={{ fontSize: 11, color: '#c9a0a0', whiteSpace: 'nowrap', marginRight: 4 }}>
+            You're out; the others play on.
+          </span>
+        )}
         <button
           onClick={() => { concede(); setConfirming(false) }}
           style={{
@@ -35,7 +43,7 @@ export function ConcedeButton() {
             fontWeight: 600,
           }}
         >
-          Confirm
+          {isPod ? 'Concede & leave' : 'Confirm'}
         </button>
         <button
           onClick={() => setConfirming(false)}

--- a/web-client/src/components/game/overlay/index.ts
+++ b/web-client/src/components/game/overlay/index.ts
@@ -4,4 +4,5 @@ export { LifeDisplay, ActiveEffectsBadges, CommanderDamageBadges } from './LifeD
 export { SpeedGauge } from './SpeedGauge'
 export { TeamLifeBanner } from './TeamLifeBanner'
 export { DayNightBadge } from './DayNightBadge'
+export { EliminationNotice } from './EliminationNotice'
 export { ConcedeButton, StandaloneConcedeButton, FullscreenButton, SpectatorCountBadge } from './GameControls'

--- a/web-client/src/components/ui/StepStrip.tsx
+++ b/web-client/src/components/ui/StepStrip.tsx
@@ -11,6 +11,11 @@ interface StepStripProps {
   hasPriority: boolean
   priorityMode: PriorityMode
   activePlayerName?: string | undefined
+  /**
+   * Multiplayer: where the viewer sits in the turn order relative to the active player —
+   * "You're next" / "You in 2". Rendered after the status text; absent on your own turn.
+   */
+  turnQueueHint?: string | undefined
   /** Which side the active player sits on relative to the board: 'top' = opponent, 'bottom' = viewing player. */
   activeSide: 'top' | 'bottom'
   stopOverrides: { myTurnStops: Step[]; opponentTurnStops: Step[] }
@@ -98,6 +103,7 @@ export function StepStrip({
   hasPriority,
   priorityMode,
   activePlayerName,
+  turnQueueHint,
   activeSide,
   stopOverrides,
   onToggleStop,
@@ -213,6 +219,18 @@ export function StepStrip({
         }}>
           {statusText}
         </span>
+        {turnQueueHint && (
+          <span style={{
+            color: '#7d8494',
+            fontSize: isMobile ? 8 : 9,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            whiteSpace: 'nowrap',
+          }}>
+            · {turnQueueHint}
+          </span>
+        )}
         <span style={{
           color: '#555',
           fontSize: isMobile ? 7 : 9,

--- a/web-client/src/help/shortcuts.ts
+++ b/web-client/src/help/shortcuts.ts
@@ -35,6 +35,12 @@ export const SHORTCUTS: readonly Shortcut[] = [
     where: 'Everywhere',
   },
   {
+    id: 'strip-swipe',
+    keys: 'Swipe ← / →',
+    label: 'Slide to the previous or next opponent’s board',
+    where: 'Multiplayer games, on the opponent board (focused camera)',
+  },
+  {
     id: 'deck-browser',
     keys: 'D',
     label: 'Open or close the deck browser',

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -688,10 +688,10 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     summary:
       'Overview shows every opponent board side by side; turn it off to focus one board at a time. Follow slides the view to whoever is acting; turn it off for a manual camera.',
     body: [
-      { kind: 'p', text: 'Number keys 1–9 jump to an opponent’s board and 0 toggles the overview. Clicking an opponent chip pins that board until you press Esc.' },
+      { kind: 'p', text: 'Number keys 1–9 jump to an opponent’s board — each chip in the rail shows its key — and 0 toggles the overview. Clicking a chip pins that board (📌) and pauses Follow until you press Esc, click the chip again, or click Follow. With the focused camera you can also swipe left and right across the opponent’s board.' },
       { kind: 'p', text: 'Overview is desktop and landscape-tablet only — three boards side by side are unusable on a portrait phone.' },
     ],
-    shortcuts: ['opponent-boards', 'overview', 'escape'],
+    shortcuts: ['opponent-boards', 'overview', 'escape', 'strip-swipe'],
     related: ['table-free-for-all'],
   },
   {

--- a/web-client/src/hooks/useMultiplayerView.ts
+++ b/web-client/src/hooks/useMultiplayerView.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { selectGameState, selectViewingPlayerId, useViewedOpponent } from '@/store/selectors'
-import { hasPendingInputSelection } from '@/store/slices/ui/boardViewSlice'
+import { hasPendingInputSelection, isFollowingAction } from '@/store/slices/ui/boardViewSlice'
 import { MOBILE_BREAKPOINT } from '@/hooks/useResponsive'
 import type { ClientPlayer, EntityId } from '@/types'
 
@@ -156,7 +156,7 @@ export function useCombatDefenderFocus(enabled: boolean): readonly EntityId[] {
       // Entering (not updating) the split view respects the camera guards.
       if (prev.length === 0) {
         const store = useGameStore.getState()
-        if (!store.followAction || store.viewPinned || hasPendingInputSelection(store)) return prev
+        if (!isFollowingAction(store) || hasPendingInputSelection(store)) return prev
       }
       return prev.length === next.length && prev.every((id, i) => id === next[i]) ? prev : next
     })

--- a/web-client/src/hooks/useMultiplayerView.ts
+++ b/web-client/src/hooks/useMultiplayerView.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { selectGameState, selectViewingPlayerId, useViewedOpponent } from '@/store/selectors'
 import { hasPendingInputSelection } from '@/store/slices/ui/boardViewSlice'
+import { MOBILE_BREAKPOINT } from '@/hooks/useResponsive'
 import type { ClientPlayer, EntityId } from '@/types'
 
 /**
@@ -70,6 +71,10 @@ export function useMultiplayerView(enabled: boolean, opponents: readonly ClientP
         if (picked) store.viewOpponent(picked.playerId)
       } else if (e.key === '0') {
         if (store.selectedCardId) return
+        // The overview is desktop / landscape-tablet only (the rail hides its button on phones);
+        // toggling it from the keyboard used to leave the store in a mode the layout only half
+        // honoured.
+        if (window.innerWidth < MOBILE_BREAKPOINT) return
         store.toggleOverviewMode()
       } else if (e.key === 'Escape') {
         // Esc means "cancel" inside selection modes; only unpin when idle.

--- a/web-client/src/hooks/useResponsive.ts
+++ b/web-client/src/hooks/useResponsive.ts
@@ -116,6 +116,9 @@ export function calculateFittingCardWidth(
 /**
  * Hook to track viewport dimensions.
  */
+/** Below this viewport width the layout is the phone layout (`isMobile`). */
+export const MOBILE_BREAKPOINT = 640
+
 export function useViewportSize(): ViewportSize {
   const [size, setSize] = useState<ViewportSize>({
     width: typeof window !== 'undefined' ? window.innerWidth : 1200,
@@ -155,7 +158,7 @@ export function useResponsive(
     // =========================================================================
     // Breakpoint Detection
     // =========================================================================
-    const isMobile = width < 640
+    const isMobile = width < MOBILE_BREAKPOINT
     const isTablet = width >= 640 && width < 1024
     const isCompact = width < 1024 || height < 700
     // Short-viewport desktops (e.g. MBP 14" at 1512×982). Still "desktop" by

--- a/web-client/src/hooks/useResponsive.ts
+++ b/web-client/src/hooks/useResponsive.ts
@@ -159,7 +159,7 @@ export function useResponsive(
     // Breakpoint Detection
     // =========================================================================
     const isMobile = width < MOBILE_BREAKPOINT
-    const isTablet = width >= 640 && width < 1024
+    const isTablet = width >= MOBILE_BREAKPOINT && width < 1024
     const isCompact = width < 1024 || height < 700
     // Short-viewport desktops (e.g. MBP 14" at 1512×982). Still "desktop" by
     // width, but the hand's fixed grid-row reservation at the desktop 150px

--- a/web-client/src/store/selectors.test.ts
+++ b/web-client/src/store/selectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { LegalActionInfo } from '../types'
+import type { ClientPlayer, LegalActionInfo } from '../types'
 
 // selectors.ts transitively imports gameStore.ts, whose gameplay slice reads
 // localStorage.getItem(...) at module-init time to seed autoTapEnabled — a browser global
@@ -12,7 +12,7 @@ vi.stubGlobal('localStorage', {
   removeItem: () => {},
 })
 
-const { cardIdForAction, isHighlightable } = await import('./selectors')
+const { cardIdForAction, isHighlightable, turnQueueHintFor } = await import('./selectors')
 const { entityId } = await import('../types')
 
 // --- Fixture builders -------------------------------------------------------
@@ -124,5 +124,33 @@ describe('isHighlightable', () => {
       { type: 'ActivateAbility', playerId: PLAYER, sourceId: SOURCE, abilityId: 'tap', targets: [] },
       { isManaAbility: true, manaCostString: '{U}' },
     ))).toBe(true)
+  })
+})
+
+describe('turnQueueHintFor', () => {
+  const seat = (id: string, hasLost = false) => ({ playerId: entityId(id), hasLost }) as unknown as ClientPlayer
+  const table = [seat('a'), seat('b'), seat('c'), seat('d')]
+
+  it('counts living seats from the active player to the viewer', () => {
+    expect(turnQueueHintFor(table, entityId('a'), entityId('b'))).toBe("You're next")
+    expect(turnQueueHintFor(table, entityId('a'), entityId('c'))).toBe('You in 2')
+    expect(turnQueueHintFor(table, entityId('a'), entityId('d'))).toBe('You in 3')
+  })
+
+  it('wraps around the end of the turn order', () => {
+    expect(turnQueueHintFor(table, entityId('d'), entityId('a'))).toBe("You're next")
+    expect(turnQueueHintFor(table, entityId('c'), entityId('b'))).toBe('You in 3')
+  })
+
+  it('skips eliminated seats', () => {
+    const withTomb = [seat('a'), seat('b', true), seat('c'), seat('d')]
+    expect(turnQueueHintFor(withTomb, entityId('a'), entityId('c'))).toBe("You're next")
+  })
+
+  it('says nothing on your own turn, for an eliminated viewer, or for an unknown seat', () => {
+    expect(turnQueueHintFor(table, entityId('a'), entityId('a'))).toBeUndefined()
+    expect(turnQueueHintFor([seat('a'), seat('b', true), seat('c')], entityId('a'), entityId('b'))).toBeUndefined()
+    expect(turnQueueHintFor(table, entityId('a'), entityId('zz'))).toBeUndefined()
+    expect(turnQueueHintFor(table, null, entityId('b'))).toBeUndefined()
   })
 })

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -369,6 +369,27 @@ export function useIsSharedLifeTeamGame(): boolean {
 }
 
 /**
+ * Multiplayer: how far off the viewer's next turn is, counted in living seats around the turn
+ * order (`players` is the server's turn order) — "You're next" / "You in 2". Undefined on the
+ * viewer's own turn and when either seat is unknown or out. Callers skip it for shared-turn team
+ * games (CR 805.4), where a per-seat count would mislead.
+ */
+export function turnQueueHintFor(
+  players: readonly ClientPlayer[],
+  activePlayerId: EntityId | null | undefined,
+  viewerId: EntityId | null | undefined,
+): string | undefined {
+  if (!activePlayerId || !viewerId) return undefined
+  const living = players.filter((p) => !p.hasLost)
+  const from = living.findIndex((p) => p.playerId === activePlayerId)
+  const to = living.findIndex((p) => p.playerId === viewerId)
+  if (from < 0 || to < 0) return undefined
+  const distance = (to - from + living.length) % living.length
+  if (distance === 0) return undefined
+  return distance === 1 ? "You're next" : `You in ${distance}`
+}
+
+/**
  * True only for a team game whose teams take one shared turn and hold priority together
  * (Two-Headed Giant — CR 805 / 810.2). This is the flag that decides whether a teammate may act in
  * your priority window; Team vs. Team is a team game that takes individual turns (CR 808.4), so it

--- a/web-client/src/store/slices/ui/boardViewSlice.test.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// gameStore.ts reads localStorage at module-init time (autoTapEnabled, the follow-action
+// preference); the plain Node vitest environment has no Storage API. Stub the minimum and
+// pull the real store in afterwards, so the slice under test is the one the app runs.
+vi.stubGlobal('localStorage', {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+})
+vi.stubGlobal('window', { addEventListener: () => {}, removeEventListener: () => {} })
+
+const { useGameStore } = await import('../../gameStore')
+const { isFollowingAction } = await import('./boardViewSlice')
+const { entityId } = await import('../../../types')
+
+const ME = entityId('me')
+const A = entityId('a')
+const B = entityId('b')
+
+function seatTable() {
+  const gameState = {
+    players: [{ playerId: ME }, { playerId: A }, { playerId: B }],
+  } as unknown as NonNullable<ReturnType<typeof useGameStore.getState>['gameState']>
+  useGameStore.setState({ gameState, playerId: ME, spectatingState: null })
+  useGameStore.getState().resetBoardView()
+  useGameStore.setState({ followAction: true })
+}
+
+describe('boardView pin / follow-the-action', () => {
+  it('a pin suspends follow without flipping the persisted setting', () => {
+    seatTable()
+    useGameStore.getState().viewOpponent(A)
+    const s = useGameStore.getState()
+    expect(s.viewedOpponentId).toBe(A)
+    expect(s.viewPinned).toBe(true)
+    expect(s.followAction).toBe(true)
+    expect(isFollowingAction(s)).toBe(false)
+  })
+
+  it('unpinning (Esc / re-click) hands the camera straight back to the follow rules', () => {
+    seatTable()
+    useGameStore.getState().viewOpponent(A)
+    useGameStore.getState().unpinView()
+    expect(isFollowingAction(useGameStore.getState())).toBe(true)
+    // …and follow moves the view again.
+    useGameStore.getState().followViewTo(B)
+    expect(useGameStore.getState().viewedOpponentId).toBe(B)
+  })
+
+  it('a pinned camera refuses follow writes', () => {
+    seatTable()
+    useGameStore.getState().viewOpponent(A)
+    useGameStore.getState().followViewTo(B)
+    expect(useGameStore.getState().viewedOpponentId).toBe(A)
+  })
+
+  it('clicking Follow while pinned releases the pin instead of turning the setting off', () => {
+    seatTable()
+    useGameStore.getState().viewOpponent(A)
+    useGameStore.getState().toggleFollowAction()
+    const s = useGameStore.getState()
+    expect(s.viewPinned).toBe(false)
+    expect(s.followAction).toBe(true)
+    expect(isFollowingAction(s)).toBe(true)
+  })
+
+  it('clicking Follow when unpinned toggles the setting', () => {
+    seatTable()
+    useGameStore.getState().toggleFollowAction()
+    expect(useGameStore.getState().followAction).toBe(false)
+    expect(isFollowingAction(useGameStore.getState())).toBe(false)
+    useGameStore.getState().toggleFollowAction()
+    expect(useGameStore.getState().followAction).toBe(true)
+  })
+})

--- a/web-client/src/store/slices/ui/boardViewSlice.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.ts
@@ -31,6 +31,14 @@ export function hasPendingInputSelection(state: GameStore): boolean {
 }
 
 /**
+ * Follow-the-action as the camera actually behaves right now: the persisted setting, minus a
+ * manual pin holding the view still. This is what the rail's Follow button shows.
+ */
+export function isFollowingAction(state: Pick<GameStore, 'followAction' | 'viewPinned'>): boolean {
+  return state.followAction && !state.viewPinned
+}
+
+/**
  * True when the local player's own seat is out of a multiplayer game the others are still
  * playing (CR 800.4a). That's the spectator layout: a survivor takes over the bottom half of
  * the table and all action UI hides.
@@ -69,7 +77,9 @@ export interface BoardViewSliceState {
   viewedOpponentId: EntityId | null
   /**
    * True when the player manually selected a board — suspends follow-the-action
-   * until unpinned (re-click the viewed chip / Esc).
+   * until unpinned (re-click the viewed chip / Esc / the Follow button). A pin never
+   * touches [followAction]: it is a *suspension* of the setting, not a change to it, so
+   * unpinning brings the camera straight back.
    */
   viewPinned: boolean
   /** Follow-the-action camera setting (persisted). Default on. */
@@ -201,21 +211,22 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     // bottom — it never also occupies the viewed strip slot.
     if (isViewerEliminated(get()) && playerId === get().eliminatedBottomSeatId) return
     const pin = opts?.pin ?? true
-    // Pinning a board and follow-the-action are mutually exclusive: pinning turns follow off
-    // (the camera is locked), so the Follow toggle reflects that rather than lying "on".
+    // A pin suspends follow-the-action (the camera is locked) without flipping the persisted
+    // setting — so Esc / re-clicking the chip hands the camera back to the follow rules, as the
+    // help text promises. The Follow button shows the *effective* state (`isFollowingAction`)
+    // rather than lying "on" while a pin holds the camera still.
     // Picking a single board also exits the table overview — it *is* the focus gesture.
-    set({
-      viewedOpponentId: playerId,
-      viewPinned: pin,
-      overviewMode: false,
-      ...(pin ? { followAction: false } : {}),
-    })
+    set({ viewedOpponentId: playerId, viewPinned: pin, overviewMode: false })
   },
 
   unpinView: () => set({ viewPinned: false }),
 
   toggleFollowAction: () => {
-    const next = !get().followAction
+    const { followAction, viewPinned } = get()
+    // With follow on but suspended by a pin, the button reads "Off" — clicking it means "follow
+    // again", i.e. release the pin, not "turn the setting off" (which would be a second click
+    // that looks like a no-op).
+    const next = viewPinned && followAction ? true : !followAction
     try {
       localStorage.setItem(FOLLOW_ACTION_KEY, String(next))
     } catch {


### PR DESCRIPTION
## What

A screenshot walk of a four-seat hotseat (FFA + Two-Headed Giant) plus a code survey of the multiplayer client. This PR ships the fixes that change what a player at a pod actually sees; the rest of the survey is in the session notes below.

- **Pin no longer breaks follow-the-action.** Clicking a rail chip wrote `followAction: false`, so Esc (which only cleared `viewPinned`) was a no-op and the camera stayed manual for the rest of the game — contradicting the slice doc and the help topic. A pin now *suspends* the setting; `isFollowingAction()` is what the camera does and what the Follow button shows. Clicking Follow while pinned releases the pin. Unit-tested.
- **Rail chips show their key** — a `kbd` badge with the digit that focuses that board, using the same living-opponent index the 1–9 handler uses (tombstones take no key; the 2HG team regrouping doesn't renumber). Chips are keyboard-focusable.
- **Targets halo wins over the turn ring** — the active player's board is where targets usually are, which was exactly when the halo was hidden.
- **Turn context in the step strip**: "Tomasz's Turn · You in 2" instead of "Opponent's Turn". Skipped in shared-turn team games (CR 805.4).
- **Elimination notice** — transient top-centre "💀 Aisha has been eliminated", derived from `hasLost` flipping in the roster so it fires however the seat died; the log line keeps the seat colour.
- **Team hues everywhere in 2HG** — GameLog, StackZone and CombatArrows bypassed `identitySeatColor` and painted six seat hues where the rail/plates painted two.
- **No duplicate orb on the table overview** — the centre-left orb printed the same name+life sixty pixels above that player's plate (the same duplicate the 2HG banners removed). Plates carry their own anchors there; targeting now outlines every plate consistently (before, the orb's player was the one plate that didn't light up).
- `0` is a no-op on phones (the overview was half-applied there); Concede in a pod says you're out and the others play on; help lists swipe and describes pin/Esc correctly.

## Screenshots

1440×900 hotseat (`mode: SELF`) scenarios; images hosted on the `screenshots/pr-2050` branch (not for merging).

**Table overview, four-seat FFA.** Rail chips carry their `1`/`2`/`3` key badge, Tomasz's chip wears the turn ring, the strip reads *Responding · You in 2*. No centre-left orb: every plate is its own player's anchor.

![01-ffa-overview.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/01-ffa-overview.png)

**Focused camera after pressing `1`.** Bram's board is pinned (📌); Follow shows *Off* while the pin holds — the persisted setting is untouched, Esc / re-click / Follow all hand the camera back.

![02-ffa-focused-pinned.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/02-ffa-focused-pinned.png)

**Targeting with the focused camera.** The rail chips turn into ⊕ player targets (key badges stand down); the halo on a board with targets now beats the turn ring.

![03-ffa-targeting-focused.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/03-ffa-targeting-focused.png)

**Targeting on the overview.** Every plate outlines as a target — before, the orb's player was the one plate that didn't light up.

![04-ffa-targeting-overview.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/04-ffa-targeting-overview.png)

**Concede in a pod.** *Concede & leave — the others play on.*

![05-ffa-concede-confirm.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/05-ffa-concede-confirm.png)

**Elimination notice.** *💀 Bram has been eliminated* in Bram's seat colour; his chip is a tombstone and the key badges renumber (Tomasz `1`, Dana `2`). Fired via the live store — a hotseat client re-seats onto the priority holder in the same update, so this is another seat's view.

![06-ffa-elimination-notice.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/06-ffa-elimination-notice.png)

**Two-Headed Giant.** Team hues on the rail, plates and banners; the strip says *Your Turn* with no queue hint (one shared turn per team, CR 805.4).

![07-2hg-overview.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/07-2hg-overview.png)

**2HG stack and arrow.** Aisha's Lightning Bolt on the stack carries the team hue, as does the arrow to Tomasz — GameLog, StackZone and CombatArrows all go through `identitySeatColor` now.

![09-2hg-stack.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/09-2hg-stack.png)

**Concede in 2HG.** *Concede for the team — your team is out* (CR 810.8b), instead of the pod copy.

![08-2hg-concede-confirm.png](https://raw.githubusercontent.com/wingedsheep/argentum-engine/screenshots/pr-2050/08-2hg-concede-confirm.png)

## Review fixes (second pass)

- **2HG concede copy was wrong** — a concession takes the whole team out (CR 810.8b, and the engine's `TeamLossPropagationCheck` does exactly that); the confirm now says so. The pod note rides inside the button so the row never collides with the top-right plate.
- **Rail chip `onKeyDown` bubbled from the crosshair / distribute buttons inside it** — Enter on a focused target badge also changed the view. Guarded to the chip itself.
- **Turn-queue hint was hidden in Team vs. Team** — gated on `isTeamGame`, but TvT takes individual turns (CR 808.4). Now gated on `teamSharedTurns`; the count lives in `turnQueueHintFor` with tests (wrap-around, tombstones, own turn).
- **No elimination notice for the elimination that ends the game** — in 2HG both members flip at once under the game-over overlay.
- `useCombatDefenderFocus` reads `isFollowingAction`; `isTablet` uses `MOBILE_BREAKPOINT`.

## Verification

- Playwright walk over a 4-seat `mode: SELF` scenario on a worktree server: targeting in both camera modes (rail ⊕ + plates), pin/Esc/Follow, elimination via the live store, a declared attack through the "Attack which player?" popup with arrows to a plate (overview) and to a bundled rail chip (focused); the 2HG variant for the team rail.
- `tsc` clean; web-client unit suite 676/676 (+5 for the pin/follow semantics, +4 for `turnQueueHintFor`).
- No engine/server changes.

## Not in this PR (surfaced by the survey)

- Rail chips aren't blocker drop targets (attack flow has them, block flow doesn't).
- Planeswalker attack flyout is hover-only; no touch path.
- 2HG: both heads attack on one turn but `combat.attackingPlayerId` is single-valued, so a defender's camera can land on one head's board.
- Commander-damage badges name the commander, never the seat.
- `SEAT_COLORS` has 6 hues; Team vs. Team allows 8 seats.
- Lobby never previews seat colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvmwWWYd6M5DN6543xgEH4
