### PR TITLE
Add 65 Assay-ready cards to Magic Origins

### DIFF
--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/apc/cards/SylvanMessenger.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/apc/cards/SylvanMessenger.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.apc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sylvan Messenger
+ * {3}{G}
+ * Creature — Elf
+ * 2/2
+ * Trample
+ * When this creature enters, reveal the top four cards of your library. Put all Elf cards revealed
+ * this way into your hand and the rest on the bottom of your library in any order.
+ */
+val SylvanMessenger = card("Sylvan Messenger") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf"
+    power = 2
+    toughness = 2
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen this creature enters, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.revealTopPutAllMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.ELF),
+            restOrder = CardOrder.ControllerChooses,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg?1783945339"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/StratusWalk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/StratusWalk.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Stratus Walk
+ * {1}{U}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature has flying.
+ * Enchanted creature can block only creatures with flying.
+ */
+val StratusWalk = card("Stratus Walk") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\nEnchanted creature can block only creatures with flying."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        // `CanOnlyBlockCreaturesWith` defaults its `filter` to `GroupFilter.source()`, which would
+        // restrict the *Aura*; the printed line is about the enchanted creature.
+        ability = CanOnlyBlockCreaturesWith(
+            blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+            filter = GroupFilter.attachedCreature(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg?1783939565"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/WeightOfTheUnderworld.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/WeightOfTheUnderworld.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Weight of the Underworld
+ * {3}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets -3/-2.
+ */
+val WeightOfTheUnderworld = card("Weight of the Underworld") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets -3/-2."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = -3, toughnessBonus = -2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Wesley Burt"
+        flavorText = "Proud Alkmenos, who would not bow to Erebos in death, is now bowed by his own hubris for all eternity."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg?1783939550"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "C15",
+    collectorNumber = "80",
+    scryfallId = "500005f0-77b5-4922-9563-8383f929aad7",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/500005f0-77b5-4922-9563-8383f929aad7.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "DDL",
+    collectorNumber = "9",
+    scryfallId = "9a7d0013-f631-4f88-b6b6-69813908e118",
+    artist = null,
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a7d0013-f631-4f88-b6b6-69813908e118.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkaabGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkaabGoliath.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skaab Goliath
+ * {5}{U}
+ * Creature — Zombie Giant
+ * 6/9
+ * As an additional cost to cast this spell, exile two creature cards from your graveyard.
+ * Trample
+ */
+val SkaabGoliath = card("Skaab Goliath") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Giant"
+    power = 6
+    toughness = 9
+    oracleText = "As an additional cost to cast this spell, exile two creature cards from your graveyard.\nTrample"
+
+    keywords(Keyword.TRAMPLE)
+
+    additionalCost(Costs.additional.ExileCards(count = 2, filter = GameObjectFilter.Creature))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Volkan Baǵa"
+        flavorText = "\"Three heads, six arms, and some armor grafts are better than . . . the normal numbers of those things.\"\n—Stitcher Geralf"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg?1783940966"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/EagleOfTheWatch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/EagleOfTheWatch.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eagle of the Watch
+ * {2}{W}
+ * Creature — Bird
+ * 2/1
+ * Flying, vigilance
+ */
+val EagleOfTheWatch = card("Eagle of the Watch") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 1
+    oracleText = "Flying, vigilance"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Scott Murphy"
+        flavorText = "\"Even from miles away, I could see our eagles circling. That's when I gave the command to pick up the pace. I knew we were needed at home.\"\n—Kanlos, Akroan captain"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg?1783939461"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/GoldForgedSentinel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/GoldForgedSentinel.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gold-Forged Sentinel
+ * {6}
+ * Artifact Creature — Chimera
+ * 4/4
+ * Flying
+ */
+val GoldForgedSentinel = card("Gold-Forged Sentinel") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Chimera"
+    power = 4
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "James Zapata"
+        flavorText = "Blessed by the gods. Coveted by mortals. Beholden to neither."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg?1783939399"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "M12",
+    collectorNumber = "9",
+    scryfallId = "b702dc6d-4c05-4313-b303-c321847ad6a9",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Watercourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Watercourser.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Watercourser
+ * {2}{U}
+ * Creature — Elemental
+ * 2/3
+ * {U}: This creature gets +1/-1 until end of turn.
+ */
+val Watercourser = card("Watercourser") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 3
+    oracleText = "{U}: This creature gets +1/-1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Mathias Kollros"
+        flavorText = "\"Beware an eddy where there should be none or a stretch that flows too fast or too slow.\"\n—Old Fishbones, Martyne river guide"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg?1783940499"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/YevasForcemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/YevasForcemage.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yeva's Forcemage
+ * {2}{G}
+ * Creature — Elf Shaman
+ * 2/2
+ * When this creature enters, target creature gets +2/+2 until end of turn.
+ */
+val YevasForcemage = card("Yeva's Forcemage") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, target creature gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Eric Deschamps"
+        flavorText = "\"Nature can't be stopped. It rips and tears at Ravnica's tallest buildings to claim its place in the sun.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg?1783940464"
+
+        ruling("2012-07-01", "Yeva's Forcemage's ability is mandatory, although you can choose Yeva's Forcemage as the target.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "M14",
+    collectorNumber = "6",
+    scryfallId = "0a3dc4ab-1c45-4495-91b6-27d62087380c",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChargingGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChargingGriffin.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Charging Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2/2
+ * Flying
+ * Whenever this creature attacks, it gets +1/+1 until end of turn.
+ */
+val ChargingGriffin = card("Charging Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 2
+    toughness = 2
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever this creature attacks, it gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Erica Yang"
+        flavorText = "Four claws, two wings, one beak, no fear."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg?1783939945"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AbbotOfKeralKeep.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AbbotOfKeralKeep.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abbot of Keral Keep
+ * {1}{R}
+ * Creature — Human Monk
+ * 2/1
+ * Prowess
+ * When this creature enters, exile the top card of your library. Until end of turn, you may play
+ * that card.
+ */
+val AbbotOfKeralKeep = card("Abbot of Keral Keep") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 1
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, exile the top card of your library. Until end of turn, you may play that card."
+
+    keywords(Keyword.PROWESS)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Exile.impulse(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Deruchenko Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg?1783938334"
+
+        ruling("2015-06-22", "The card exiled by Abbot of Keral Keep's ability is exiled face up.")
+        ruling("2015-06-22", "You may play that card that turn even if Abbot of Keral Keep is no longer on the battlefield or under your control.")
+        ruling("2015-06-22", "Playing the card exiled with Abbot of Keral Keep's ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty.")
+        ruling("2015-06-22", "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Abbot of Keral Keep's ability only if you haven't played a land yet that turn.")
+        ruling("2015-06-22", "If you don't play the card, it will remain exiled.")
+        ruling("2015-06-22", "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger.")
+        ruling("2015-06-22", "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+        ruling("2015-06-22", "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AerialVolley.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AerialVolley.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Aerial Volley
+ * {G}
+ * Instant
+ * Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures
+ * with flying.
+ */
+val AerialVolley = card("Aerial Volley") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying."
+
+    spell {
+        target = TargetObject(
+            filter = TargetFilter.Creature.withKeyword(Keyword.FLYING),
+            count = 3,
+            minCount = 1
+        )
+        effect = DividedDamageEffect(
+            totalDamage = 3,
+            minTargets = 1,
+            maxTargets = 3
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Lake Hurwitz"
+        flavorText = "Drakes can swerve to avoid a single arrow, but they can't dodge the whole sky."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg?1783938325"
+
+        ruling("2015-06-22", "You choose how many targets Aerial Volley has and how the damage is divided as you cast the spell. Each target must receive at least 1 damage.")
+        ruling("2015-06-22", "If some (but not all) of the targets become illegal before Aerial Volley tries to resolve, the original division of damage still applies, but no damage is dealt to illegal targets. If all targets become illegal, Aerial Volley won't resolve.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanJailer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanJailer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akroan Jailer
+ * {W}
+ * Creature — Human Soldier
+ * 1/1
+ * {2}{W}, {T}: Tap target creature.
+ */
+val AkroanJailer = card("Akroan Jailer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "He ensures escape attempts are just that—attempts."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg?1783938366"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanSergeant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanSergeant.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Akroan Sergeant
+ * {2}{R}
+ * Creature — Human Soldier
+ * 2/2
+ * First strike
+ * Renown 1
+ */
+val AkroanSergeant = card("Akroan Sergeant") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "First strike (This creature deals combat damage before creatures without first strike.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.FIRST_STRIKE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Zack Stella"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg?1783938333"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AlchemistsVial.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AlchemistsVial.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Vial
+ * {2}
+ * Artifact
+ * When this artifact enters, draw a card.
+ * {1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn.
+ */
+val AlchemistsVial = card("Alchemist's Vial") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, draw a card.\n{1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.CantAttackOrBlock(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Lindsey Look"
+        flavorText = "A weapon best suited for those with good aim and steady hands."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg?1783938312"
+
+        ruling("2015-06-22", "Activating the last ability of Alchemist's Vial targeting a creature that's already attacking or blocking won't cause that creature to stop attacking or blocking. It will prevent that creature from attacking or blocking in any additional combat phases the turn may have (although this is unusual).")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AmprynTactician.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AmprynTactician.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ampryn Tactician
+ * {2}{W}{W}
+ * Creature — Human Soldier
+ * 3/3
+ * When this creature enters, creatures you control get +1/+1 until end of turn.
+ */
+val AmprynTactician = card("Ampryn Tactician") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, creatures you control get +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Cynthia Sheppard"
+        flavorText = "\"It's all a game. You shouldn't get too attached to the pieces.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg?1783938365"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnointerOfChampions.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnointerOfChampions.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anointer of Champions
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * {T}: Target attacking creature gets +1/+1 until end of turn.
+ */
+val AnointerOfChampions = card("Anointer of Champions") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target attacking creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.ModifyStats(1, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Arise. You have been anointed by the light. Go forth and fight without fear, for you shall be victorious.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg?1783938365"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "ORI",
+    collectorNumber = "5",
+    scryfallId = "598ebb91-57d6-4800-8931-4d0016e9fec1",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AvenBattlePriest.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AvenBattlePriest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aven Battle Priest
+ * {5}{W}
+ * Creature — Bird Cleric
+ * 3/3
+ * Flying
+ * When this creature enters, you gain 3 life.
+ */
+val AvenBattlePriest = card("Aven Battle Priest") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen this creature enters, you gain 3 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "John Severin Brassell"
+        flavorText = "When the shadow of the aven falls across the battlefield, hope rises in the hearts of the soldiers."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg?1783938364"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BellowsLizardReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BellowsLizardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bellows Lizard reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val BellowsLizardReprint = Printing(
+    oracleId = "667dae0b-5006-4e38-be80-eae79c2a2a95",
+    name = "Bellows Lizard",
+    setCode = "ORI",
+    collectorNumber = "132",
+    scryfallId = "285d2e99-13f1-4ce8-9a54-139de193c1b3",
+    artist = "Jack Wang",
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlazingHellhound.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlazingHellhound.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Blazing Hellhound
+ * {2}{B}{R}
+ * Creature — Elemental Dog
+ * 4/3
+ * {1}, Sacrifice another creature: This creature deals 1 damage to any target.
+ */
+val BlazingHellhound = card("Blazing Hellhound") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Elemental Dog"
+    power = 4
+    toughness = 3
+    oracleText = "{1}, Sacrifice another creature: This creature deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Eric Velhagen"
+        flavorText = "It tears the flesh from your bones and then swallows the ash with its fiery maw."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg?1783938315"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BloodCursedKnight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BloodCursedKnight.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blood-Cursed Knight
+ * {1}{W}{B}
+ * Creature — Vampire Knight
+ * 3/2
+ * As long as you control an enchantment, this creature gets +1/+1 and has lifelink.
+ */
+val BloodCursedKnight = card("Blood-Cursed Knight") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Vampire Knight"
+    power = 3
+    toughness = 2
+    oracleText = "As long as you control an enchantment, this creature gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Enchantment),
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.LIFELINK.name, GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Enchantment),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Winona Nelson"
+        flavorText = "\"The bloodlust shall not control me, for my oath is my greatest compulsion.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg?1783938315"
+
+        ruling("2015-06-22", "If you cast an Aura spell targeting a creature controlled by an opponent, you still control that Aura. It will count for Blood-Cursed Knight's ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ChargingGriffinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ChargingGriffinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charging Griffin reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val ChargingGriffinReprint = Printing(
+    oracleId = "1c99a5cc-d974-4a4b-a03b-a78bfe738ed7",
+    name = "Charging Griffin",
+    setCode = "ORI",
+    collectorNumber = "9",
+    scryfallId = "d86bd259-bc2f-402c-9e7a-030f9a3781e2",
+    artist = "Erica Yang",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CitadelCastellan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CitadelCastellan.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Citadel Castellan
+ * {1}{G}{W}
+ * Creature — Human Knight
+ * 2/3
+ * Vigilance
+ * Renown 2
+ */
+val CitadelCastellan = card("Citadel Castellan") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.renown(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "\"I am the first line of defense. You will not encounter the second.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg?1783938314"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ConclaveNaturalists.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ConclaveNaturalists.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Conclave Naturalists
+ * {4}{G}
+ * Creature — Dryad
+ * 4/4
+ * When this creature enters, you may destroy target artifact or enchantment.
+ */
+val ConclaveNaturalists = card("Conclave Naturalists") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, you may destroy target artifact or enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = MayEffect(Effects.Destroy(t))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Howard Lyon"
+        flavorText = "\"Your swords and wards have no power here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg?1783938324"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EagleOfTheWatchReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EagleOfTheWatchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eagle of the Watch reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val EagleOfTheWatchReprint = Printing(
+    oracleId = "954836f8-c225-450a-bb51-f2adb6923ef5",
+    name = "Eagle of the Watch",
+    setCode = "ORI",
+    collectorNumber = "275",
+    scryfallId = "8af7956d-f811-49d3-bef7-07f294dcea3c",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ElementalBond.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ElementalBond.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Elemental Bond
+ * {2}{G}
+ * Enchantment
+ * Whenever a creature you control with power 3 or greater enters, draw a card.
+ */
+val ElementalBond = card("Elemental Bond") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control with power 3 or greater enters, draw a card."
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().powerAtLeast(3),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "David Gaillet"
+        flavorText = "\"I want to help Zendikar. Show me the way.\"\n—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg?1783938323"
+
+        ruling("2025-10-02", "The creature must have power 3 or greater as it enters, or Elemental Bond's ability won't trigger. Static abilities that raise (or lower) a creature's power are taken into account. However, you can't have a creature with power 2 or less enter and try to raise its power with a spell, an activated ability, or a triggered ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EnlightenedAscetic.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EnlightenedAscetic.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Enlightened Ascetic
+ * {1}{W}
+ * Creature — Cat Monk
+ * 1/1
+ * When this creature enters, you may destroy target enchantment.
+ */
+val EnlightenedAscetic = card("Enlightened Ascetic") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Monk"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, you may destroy target enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target enchantment", Targets.Enchantment)
+        effect = MayEffect(Effects.Destroy(t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "James Zapata"
+        flavorText = "\"I do not reject the gods. I reject their authority, their pettiness, and their arrogance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg?1783938363"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FirefiendElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FirefiendElemental.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Firefiend Elemental
+ * {3}{R}
+ * Creature — Elemental
+ * 3/2
+ * Haste
+ * Renown 1
+ */
+val FirefiendElemental = card("Firefiend Elemental") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 2
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Torstein Nordstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg?1783938330"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GhirapurAetherGrid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GhirapurAetherGrid.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ghirapur Aether Grid
+ * {2}{R}
+ * Enchantment
+ * Tap two untapped artifacts you control: This enchantment deals 1 damage to any target.
+ */
+val GhirapurAetherGrid = card("Ghirapur Aether Grid") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Tap two untapped artifacts you control: This enchantment deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 2, filter = GameObjectFilter.Artifact)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Cynthia Sheppard"
+        flavorText = "The city of Ghirapur is a living thing, and living things defend themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg?1783938330"
+
+        ruling("2015-06-22", "You may tap any two untapped artifacts you control, including artifact creatures that haven't been under your control continuously since the beginning of your most recent turn.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GoldForgedSentinelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GoldForgedSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gold-Forged Sentinel reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val GoldForgedSentinelReprint = Printing(
+    oracleId = "c338fb29-2dd2-4f76-ba3d-fa6770adcce8",
+    name = "Gold-Forged Sentinel",
+    setCode = "ORI",
+    collectorNumber = "226",
+    scryfallId = "c9fdf08b-b812-4ad9-a4ca-3a9b7000b749",
+    artist = "James Zapata",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardianAutomaton.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardianAutomaton.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guardian Automaton
+ * {4}
+ * Artifact Creature — Construct
+ * 3/3
+ * When this creature dies, you gain 3 life.
+ */
+val GuardianAutomaton = card("Guardian Automaton") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature dies, you gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Vincent Proce"
+        flavorText = "The wealthy in the city of Ghirapur outfit their lives with grand machines, entrusting even their children to filigree and gears."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg?1783938311"
+
+        ruling("2015-06-22", "If Guardian Automaton dies at the same time as your life total is reduced to 0 or less, you'll lose the game before the triggered ability resolves.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeavyInfantry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeavyInfantry.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heavy Infantry
+ * {4}{W}
+ * Creature — Human Soldier
+ * 3/4
+ * When this creature enters, tap target creature an opponent controls.
+ */
+val HeavyInfantry = card("Heavy Infantry") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, tap target creature an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "David Gaillet"
+        flavorText = "Doors, walls, skulls . . . it matters not. All barriers will be broken."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg?1783938361"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeraldOfThePantheon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeraldOfThePantheon.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Herald of the Pantheon
+ * {1}{G}
+ * Creature — Centaur Shaman
+ * 2/2
+ * Enchantment spells you cast cost {1} less to cast.
+ * Whenever you cast an enchantment spell, you gain 1 life.
+ */
+val HeraldOfThePantheon = card("Herald of the Pantheon") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Enchantment),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "180"
+        artist = "Jason A. Engle"
+        flavorText = "The distinction of bearing the gods' banner is nothing compared to the glory of being closer to Nyx."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg?1783938322"
+
+        ruling("2015-06-22", "Herald of the Pantheon's first ability can't reduce the colored mana requirement of an enchantment spell.")
+        ruling("2015-06-22", "If there are additional costs to cast an enchantment spell, apply those before applying cost reductions.")
+        ruling("2015-06-22", "Herald of the Pantheon can reduce alternative costs such as bestow costs.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/IroassChampion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/IroassChampion.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iroas's Champion
+ * {1}{R}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Double strike
+ */
+val IroassChampion = card("Iroas's Champion") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Double strike (This creature deals both first-strike and regular combat damage.)"
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Marco Nelor"
+        flavorText = "Accustomed to battling before an audience in the arena, Iroas's champions know how to put on a good show."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg?1783938314"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JhessianThief.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JhessianThief.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhessian Thief
+ * {2}{U}
+ * Creature — Human Rogue
+ * 1/3
+ * Prowess
+ * Whenever this creature deals combat damage to a player, draw a card.
+ */
+val JhessianThief = card("Jhessian Thief") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, draw a card."
+
+    keywords(Keyword.PROWESS)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Miles Johnston"
+        flavorText = "\"Where's the fun in an escape if it's not at least a little daring?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg?1783938350"
+
+        ruling("2015-06-22", "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger.")
+        ruling("2015-06-22", "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+        ruling("2015-06-22", "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightOfThePilgrimsRoad.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightOfThePilgrimsRoad.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Knight of the Pilgrim's Road
+ * {2}{W}
+ * Creature — Human Knight
+ * 3/2
+ * Renown 1
+ */
+val KnightOfThePilgrimsRoad = card("Knight of the Pilgrim's Road") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 2
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "David Gaillet"
+        flavorText = "\"To be a knight, Gideon, is to be the shield for the meek against the cruel.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg?1783938360"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KytheonsIrregulars.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KytheonsIrregulars.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Kytheon's Irregulars
+ * {2}{W}{W}
+ * Creature — Human Soldier
+ * 4/3
+ * Renown 1
+ * {W}{W}: Tap target creature.
+ */
+val KytheonsIrregulars = card("Kytheon's Irregulars") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 4
+    toughness = 3
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{W}{W}: Tap target creature."
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{W}")
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Mark Winters"
+        flavorText = "Kytheon and his irregulars worked outside the law to bring justice to the streets of Akros."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg?1783938360"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LightningJavelin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LightningJavelin.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Javelin
+ * {3}{R}
+ * Sorcery
+ * Lightning Javelin deals 3 damage to any target. Scry 1.
+ */
+val LightningJavelin = card("Lightning Javelin") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(3, t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Seb McKinnon"
+        flavorText = "The harpies descended without mercy upon Akros, only to find their attack put them within range of the javelineers."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg?1783938329"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagicOriginsBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagicOriginsBasicLands.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Magic Origins Basic Lands
+ *
+ * Magic Origins contains 4 art variants of each basic land type.
+ * Cards 253-272 (Plains 253-256, Island 257-260, Swamp 261-264, Mountain 265-268, Forest 269-272)
+ */
+
+// =============================================================================
+// Plains
+// =============================================================================
+
+val MagicOriginsPlains253 = basicLand("Plains") {
+    collectorNumber = "253"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg?1783938305"
+}
+
+val MagicOriginsPlains254 = basicLand("Plains") {
+    collectorNumber = "254"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/763c1eaa-fe29-4b24-8e41-96b94e5a75a4.jpg?1783938304"
+}
+
+val MagicOriginsPlains255 = basicLand("Plains") {
+    collectorNumber = "255"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e683531-4a59-4461-b589-5ebcbc51a600.jpg?1783938304"
+}
+
+val MagicOriginsPlains256 = basicLand("Plains") {
+    collectorNumber = "256"
+    artist = "Raoul Vitale"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed4f7329-9c72-4369-8b66-2a89423e957d.jpg?1783938303"
+}
+
+// =============================================================================
+// Island
+// =============================================================================
+
+val MagicOriginsIsland257 = basicLand("Island") {
+    collectorNumber = "257"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg?1783938303"
+}
+
+val MagicOriginsIsland258 = basicLand("Island") {
+    collectorNumber = "258"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13d88f06-276b-41d4-a4c3-d904f93ea403.jpg?1783938303"
+}
+
+val MagicOriginsIsland259 = basicLand("Island") {
+    collectorNumber = "259"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/7880b12e-948b-4f3a-bb0b-604e3dd66f78.jpg?1783938303"
+}
+
+val MagicOriginsIsland260 = basicLand("Island") {
+    collectorNumber = "260"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03f845b1-3b8a-4387-aae3-fd497acf193c.jpg?1783938302"
+}
+
+// =============================================================================
+// Swamp
+// =============================================================================
+
+val MagicOriginsSwamp261 = basicLand("Swamp") {
+    collectorNumber = "261"
+    artist = "Larry Elmore"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg?1783938302"
+}
+
+val MagicOriginsSwamp262 = basicLand("Swamp") {
+    collectorNumber = "262"
+    artist = "Dan Frazier"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b56d4e89-93aa-4b1e-84f6-8addef529a3f.jpg?1783938302"
+}
+
+val MagicOriginsSwamp263 = basicLand("Swamp") {
+    collectorNumber = "263"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a63b7238-ebdc-4dd8-b799-1ca33c14163b.jpg?1783938302"
+}
+
+val MagicOriginsSwamp264 = basicLand("Swamp") {
+    collectorNumber = "264"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c617c618-8320-4f76-80a6-83581470dc13.jpg?1783938301"
+}
+
+// =============================================================================
+// Mountain
+// =============================================================================
+
+val MagicOriginsMountain265 = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg?1783938302"
+}
+
+val MagicOriginsMountain266 = basicLand("Mountain") {
+    collectorNumber = "266"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6a0ca9e-c72b-4c99-8e6b-b6dbebf894e9.jpg?1783938302"
+}
+
+val MagicOriginsMountain267 = basicLand("Mountain") {
+    collectorNumber = "267"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1f7fe3c3-9cf7-4b73-b2bd-301667a2cd4d.jpg?1783938301"
+}
+
+val MagicOriginsMountain268 = basicLand("Mountain") {
+    collectorNumber = "268"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f1ddd6e0-dbdc-4ce0-bc26-f94c951f90ad.jpg?1783938301"
+}
+
+// =============================================================================
+// Forest
+// =============================================================================
+
+val MagicOriginsForest269 = basicLand("Forest") {
+    collectorNumber = "269"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg?1783938301"
+}
+
+val MagicOriginsForest270 = basicLand("Forest") {
+    collectorNumber = "270"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04dcdbcd-2c5e-4733-a4c4-c5a345e9206a.jpg?1783938300"
+}
+
+val MagicOriginsForest271 = basicLand("Forest") {
+    collectorNumber = "271"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2b101184-71b2-4400-a5dc-4113df5a4f12.jpg?1783938300"
+}
+
+val MagicOriginsForest272 = basicLand("Forest") {
+    collectorNumber = "272"
+    artist = "Vincent Proce"
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9be1afc-eb3d-46ba-a645-ab2f33264f36.jpg?1783938299"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagmaticInsight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagmaticInsight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Magmatic Insight
+ * {R}
+ * Sorcery
+ * As an additional cost to cast this spell, discard a land card.
+ * Draw two cards.
+ */
+val MagmaticInsight = card("Magmatic Insight") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, discard a land card.\nDraw two cards."
+
+    additionalCost(Costs.additional.DiscardCards(filter = GameObjectFilter.Land))
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Ryan Barger"
+        flavorText = "Chief among the tenets of Purphoros is that one must destroy in order to create."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg?1783938328"
+
+        ruling("2015-06-22", "You must discard exactly one land card to cast Magmatic Insight. You can't cast it without discarding a land card, and you can't discard additional cards.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MantleOfWebs.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MantleOfWebs.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Mantle of Webs
+ * {1}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+3 and has reach.
+ */
+val MantleOfWebs = card("Mantle of Webs") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = 1, toughnessBonus = 3)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Mathias Kollros"
+        flavorText = "\"Why does everything the Golgari touch end up sticky?\"\n—Arrester Lavinia, Tenth Precinct"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg?1783938320"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "ORI",
+    collectorNumber = "233",
+    scryfallId = "23a8969f-d7a6-479a-9277-1270ee533c4a",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MoltenVortex.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MoltenVortex.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Molten Vortex
+ * {R}
+ * Enchantment
+ * {R}, Discard a land card: This enchantment deals 2 damage to any target.
+ */
+val MoltenVortex = card("Molten Vortex") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{R}, Discard a land card: This enchantment deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Discard(GameObjectFilter.Land))
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "156"
+        artist = "Philip Straub"
+        flavorText = "If you can't take the heat . . . well, that's going to be a problem."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg?1783938327"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/NivixBarrier.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/NivixBarrier.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nivix Barrier
+ * {3}{U}
+ * Creature — Illusion Wall
+ * 0/4
+ * Flash
+ * Defender
+ * When this creature enters, target attacking creature gets -4/-0 until end of turn.
+ */
+val NivixBarrier = card("Nivix Barrier") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nDefender (This creature can't attack.)\nWhen this creature enters, target attacking creature gets -4/-0 until end of turn."
+
+    keywords(Keyword.FLASH, Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.ModifyStats(-4, 0, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg?1783938350"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/OutlandColossus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/OutlandColossus.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Outland Colossus
+ * {3}{G}{G}
+ * Creature — Giant
+ * 6/6
+ * Renown 6
+ * This creature can't be blocked by more than one creature.
+ */
+val OutlandColossus = card("Outland Colossus") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Giant"
+    power = 6
+    toughness = 6
+    oracleText = "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)\nThis creature can't be blocked by more than one creature."
+
+    keywordAbility(KeywordAbility.renown(6))
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg?1783938318"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PharikasDisciple.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PharikasDisciple.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Pharika's Disciple
+ * {3}{G}
+ * Creature — Centaur Warrior
+ * 2/3
+ * Deathtouch
+ * Renown 1
+ */
+val PharikasDisciple = card("Pharika's Disciple") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg?1783938319"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RhoxMaulers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RhoxMaulers.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rhox Maulers
+ * {4}{G}
+ * Creature — Rhino Soldier
+ * 4/4
+ * Trample
+ * Renown 2
+ */
+val RhoxMaulers = card("Rhox Maulers") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)"
+
+    keywords(Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.renown(2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg?1783938318"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RingwardenOwl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RingwardenOwl.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ringwarden Owl
+ * {3}{U}{U}
+ * Creature — Bird
+ * 3/3
+ * Flying
+ * Prowess
+ */
+val RingwardenOwl = card("Ringwarden Owl") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 3
+    toughness = 3
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.FLYING, Keyword.PROWESS)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Titus Lunter"
+        flavorText = "The owls learn of mana from the mages who know it best."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg?1783938348"
+
+        ruling("2015-06-22", "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+        ruling("2015-06-22", "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger.")
+        ruling("2015-06-22", "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SeparatistVoidmage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SeparatistVoidmage.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Separatist Voidmage
+ * {3}{U}
+ * Creature — Human Wizard
+ * 2/2
+ * When this creature enters, you may return target creature to its owner's hand.
+ */
+val SeparatistVoidmage = card("Separatist Voidmage") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you may return target creature to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.Creature)
+        effect = MayEffect(Effects.ReturnToHand(t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Jason Rainville"
+        flavorText = "\"As long as each side thinks it can win, the balance holds, and the mage-rings stand.\"\n—Alhammarret"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg?1783938348"
+
+        ruling("2015-06-22", "Separatist Voidmage's ability can target itself.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "ORI",
+    collectorNumber = "31",
+    scryfallId = "386f050c-0233-490f-94ab-92a7b5dc65cf",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkaabGoliathReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkaabGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skaab Goliath reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SkaabGoliathReprint = Printing(
+    oracleId = "498707db-258f-423a-9ff6-9e294fce84d6",
+    name = "Skaab Goliath",
+    setCode = "ORI",
+    collectorNumber = "74",
+    scryfallId = "3682b3d3-cb3d-4c2c-a419-f08e3a370cd1",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkysnareSpider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkysnareSpider.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skysnare Spider
+ * {4}{G}{G}
+ * Creature — Spider
+ * 6/6
+ * Vigilance
+ * Reach
+ */
+val SkysnareSpider = card("Skysnare Spider") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 6
+    toughness = 6
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Filip Burburan"
+        flavorText = "The only thing more ill-tempered than a griffin in a web is the spider that must subdue it."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg?1783938318"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SomberwaldAlpha.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SomberwaldAlpha.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Somberwald Alpha
+ * {3}{G}
+ * Creature — Wolf
+ * 3/2
+ * Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.
+ * {1}{G}: Target creature you control gains trample until end of turn.
+ */
+val SomberwaldAlpha = card("Somberwald Alpha") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.\n{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.TriggeringEntity)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg?1783938317"
+
+        ruling("2015-06-22", "Somberwald Alpha's first ability will give each creature you control that becomes blocked +1/+1 until end of turn. It doesn't matter how many of your opponent's creatures are blocking each of your creatures.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SoulbladeDjinn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SoulbladeDjinn.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Soulblade Djinn
+ * {3}{U}{U}
+ * Creature — Djinn
+ * 4/3
+ * Flying
+ * Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.
+ */
+val SoulbladeDjinn = card("Soulblade Djinn") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Viktor Titov"
+        flavorText = "He grants endless wishes, as long as you always wish for a blade."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg?1783938347"
+
+        ruling("2015-06-22", "Any spell you cast that doesn't have the type creature will cause Soulblade Djinn's ability to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause the ability to trigger. Playing a land also won't cause it to trigger.")
+        ruling("2015-06-22", "Soulblade Djinn's ability goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StalwartAven.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StalwartAven.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Stalwart Aven
+ * {2}{W}
+ * Creature — Bird Soldier
+ * 1/3
+ * Flying
+ * Renown 1
+ */
+val StalwartAven = card("Stalwart Aven") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Scott Murphy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg?1783938357"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StratusWalkReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StratusWalkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stratus Walk reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val StratusWalkReprint = Printing(
+    oracleId = "eda37caa-d676-460a-804b-3ba9d8a8d044",
+    name = "Stratus Walk",
+    setCode = "ORI",
+    collectorNumber = "77",
+    scryfallId = "947bb8f3-51f5-4fbe-9098-7e48f9fe1452",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SylvanMessengerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SylvanMessengerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Messenger reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanMessengerReprint = Printing(
+    oracleId = "ba310102-8272-4d64-a00b-9e7346cb5f46",
+    name = "Sylvan Messenger",
+    setCode = "ORI",
+    collectorNumber = "199",
+    scryfallId = "95e0550c-d3ad-4bd4-a259-d597991079b1",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ThunderclapWyvern.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ThunderclapWyvern.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thunderclap Wyvern
+ * {2}{W}{U}
+ * Creature — Drake
+ * 2/3
+ * Flash
+ * Flying
+ * Other creatures you control with flying get +1/+1.
+ */
+val ThunderclapWyvern = card("Thunderclap Wyvern") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Drake"
+    power = 2
+    toughness = 3
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nOther creatures you control with flying get +1/+1."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Jason Felix"
+        flavorText = "Thunder doesn't always mean rain. Sometimes it means ruin."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg?1783938312"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TopanFreeblade.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TopanFreeblade.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Topan Freeblade
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance
+ * Renown 1
+ */
+val TopanFreeblade = card("Topan Freeblade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Johannes Voss"
+        flavorText = "\"My scars are my sigils. I will wear them with pride long after you're gone.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg?1783938358"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/UndercityTroll.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/UndercityTroll.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Undercity Troll
+ * {1}{G}
+ * Creature — Troll
+ * 2/2
+ * Renown 1
+ * {2}{G}: Regenerate this creature.
+ */
+val UndercityTroll = card("Undercity Troll") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll"
+    power = 2
+    toughness = 2
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{2}{G}: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg?1783938316"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VeteransSidearm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VeteransSidearm.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Veteran's Sidearm
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+1.
+ * Equip {1}
+ */
+val VeteransSidearm = card("Veteran's Sidearm") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter.attachedCreature()
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Aaron Miller"
+        flavorText = "\"I've broken three swords, eighteen lances, and countless shields, but this little blade has survived every battle, just like I have.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg?1783938307"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VineSnare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VineSnare.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.effects.PreventionDirection
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+import com.wingedsheep.sdk.scripting.effects.PreventionSourceFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Vine Snare
+ * {2}{G}
+ * Instant
+ * Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.
+ */
+val VineSnare = card("Vine Snare") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less."
+
+    spell {
+        effect = PreventDamageEffect(
+            scope = PreventionScope.CombatOnly,
+            direction = PreventionDirection.FromTarget,
+            sourceFilter = PreventionSourceFilter.FromGroup(
+                GroupFilter(GameObjectFilter.Creature.powerAtMost(4))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Igor Kieryluk"
+        flavorText = "Nissa found that the vines of the marsh could ensnare just as well as forest vines could—maybe even better."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg?1783938317"
+
+        ruling("2015-06-22", "Check the power of each creature as it would deal combat damage to determine if that damage is prevented. It doesn't matter what any creature's power is as Vine Snare resolves.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VolcanicRambler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VolcanicRambler.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Rambler
+ * {5}{R}
+ * Creature — Elemental
+ * 6/4
+ * {2}{R}: This creature deals 1 damage to target player or planeswalker.
+ */
+val VolcanicRambler = card("Volcanic Rambler") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 6
+    toughness = 4
+    oracleText = "{2}{R}: This creature deals 1 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        val t = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Vincent Proce"
+        flavorText = "It moves through lava with the force of an erupting volcano."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg?1783938326"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VrynWingmare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VrynWingmare.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Vryn Wingmare
+ * {2}{W}
+ * Creature — Pegasus
+ * 2/1
+ * Flying
+ * Noncreature spells cost {1} more to cast.
+ */
+val VrynWingmare = card("Vryn Wingmare") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Pegasus"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nNoncreature spells cost {1} more to cast."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Noncreature),
+            modification = CostModification.IncreaseGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Seb McKinnon"
+        flavorText = "It's the favored mount of military commanders as well as anyone with a flair for the dramatic."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg?1783938356"
+
+        ruling("2020-06-23", "The ability affects each spell that's not a creature spell, including your own. Creature spells with another type, such as artifact creature spells, aren't affected.")
+        ruling("2020-06-23", "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases (such as that of Vryn Wingmare), then apply any cost reductions. The mana value of the spell remains unchanged, no matter what the total cost to cast it was.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarHorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarHorn.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * War Horn
+ * {3}
+ * Artifact
+ * Attacking creatures you control get +1/+0.
+ */
+val WarHorn = card("War Horn") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Attacking creatures you control get +1/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.attacking().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "243"
+        artist = "Lars Grant-West"
+        flavorText = "The reverberations course through the warriors' veins, beat with their hearts, and pound with their footfalls as they charge into battle."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg?1783938307"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarOracle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarOracle.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * War Oracle
+ * {2}{W}{W}
+ * Creature — Human Cleric
+ * 3/3
+ * Lifelink
+ * Renown 1
+ */
+val WarOracle = card("War Oracle") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+
+    keywords(Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Steve Prescott"
+        flavorText = "\"When you are felled by my mace, you shall know it was divine fate.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg?1783938356"
+
+        ruling("2015-06-22", "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player.")
+        ruling("2015-06-22", "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger.")
+        ruling("2015-06-22", "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WatercourserReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WatercourserReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Watercourser reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val WatercourserReprint = Printing(
+    oracleId = "65dd4ae3-432c-4d57-ac14-4d827262ea0b",
+    name = "Watercourser",
+    setCode = "ORI",
+    collectorNumber = "82",
+    scryfallId = "60b12e87-ccd6-4c84-80b2-9ac7d099be89",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WeightOfTheUnderworldReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WeightOfTheUnderworldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weight of the Underworld reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val WeightOfTheUnderworldReprint = Printing(
+    oracleId = "b960d17b-3679-4dc5-9a5d-c8e7fd81fa9a",
+    name = "Weight of the Underworld",
+    setCode = "ORI",
+    collectorNumber = "126",
+    scryfallId = "e2f31943-e26c-4bd2-bdbd-d980836f99b9",
+    artist = "Wesley Burt",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YevaSForcemageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YevaSForcemageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yeva's Forcemage reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val YevaSForcemageReprint = Printing(
+    oracleId = "785e451d-87b6-4772-97e5-d2744818e0fd",
+    name = "Yeva's Forcemage",
+    setCode = "ORI",
+    collectorNumber = "208",
+    scryfallId = "50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarIncarnate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarIncarnate.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zendikar Incarnate
+ * {2}{R}{G}
+ * Creature — Elemental
+ * ★/4
+ * Zendikar Incarnate's power is equal to the number of lands you control.
+ */
+val ZendikarIncarnate = card("Zendikar Incarnate") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Elemental"
+    toughness = 4
+    oracleText = "Zendikar Incarnate's power is equal to the number of lands you control."
+
+    dynamicPower(
+        DynamicAmount.AggregateBattlefield(
+            player = Player.You,
+            filter = GameObjectFilter.Land
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Lucas Graciano"
+        flavorText = "\"Her people angered Zendikar, and they faced the land's wrath. That is why Nissa is the last of the animists.\"\n—Numa, Joraga chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg?1783938312"
+
+        ruling("2015-06-22", "The ability defining Zendikar Incarnate's power works in all zones, not just the battlefield. Zendikar Incarnate's power changes as the number of lands you control does.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "PC2",
+    collectorNumber = "2",
+    scryfallId = "441012c4-b9f8-40dc-b0be-907d03573360",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/441012c4-b9f8-40dc-b0be-907d03573360.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "PC2",
+    collectorNumber = "11",
+    scryfallId = "1dff2430-506e-4ffa-86fc-aa655e2ba306",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1dff2430-506e-4ffa-86fc-aa655e2ba306.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/BellowsLizard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/BellowsLizard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bellows Lizard
+ * {R}
+ * Creature — Lizard
+ * 1/1
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ */
+val BellowsLizard = card("Bellows Lizard") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{R}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Jack Wang"
+        flavorText = "As the price of wood and coal rose, smiths found creative ways to keep their forges burning."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg?1783940357"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SoulbladeDjinnReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SoulbladeDjinnReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soulblade Djinn reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val SoulbladeDjinnReprint = Printing(
+    oracleId = "a598e6ce-21ee-49c1-989e-ee864208262f",
+    name = "Soulblade Djinn",
+    setCode = "ANB",
+    collectorNumber = "34",
+    scryfallId = "3c7631df-2e6c-4472-8dd6-8b07fcc545fb",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ElementalBondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ElementalBondReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elemental Bond reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val ElementalBondReprint = Printing(
+    oracleId = "d9a7e5a6-3e41-4fc6-987a-18fe1b9d67dd",
+    name = "Elemental Bond",
+    setCode = "C17",
+    collectorNumber = "148",
+    scryfallId = "7170ad9e-f43d-46e2-a9dd-97be31099c02",
+    artist = "David Gaillet",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/7170ad9e-f43d-46e2-a9dd-97be31099c02.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SkaabGoliathReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SkaabGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skaab Goliath reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val SkaabGoliathReprint = Printing(
+    oracleId = "498707db-258f-423a-9ff6-9e294fce84d6",
+    name = "Skaab Goliath",
+    setCode = "CMR",
+    collectorNumber = "97",
+    scryfallId = "d151fe63-3b3a-4cd4-9a2d-d80e7434e63c",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlchemistSVialReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlchemistSVialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Vial reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val AlchemistSVialReprint = Printing(
+    oracleId = "f574bd9f-4246-42cb-bf4e-d2888daa44c9",
+    name = "Alchemist's Vial",
+    setCode = "J22",
+    collectorNumber = "753",
+    scryfallId = "8d22523a-bb2d-489d-994e-65455def4fc5",
+    artist = "Lindsey Look",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SylvanMessengerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SylvanMessengerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Messenger reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanMessengerReprint = Printing(
+    oracleId = "ba310102-8272-4d64-a00b-9e7346cb5f46",
+    name = "Sylvan Messenger",
+    setCode = "KHC",
+    collectorNumber = "75",
+    scryfallId = "085f1b89-857b-4e2b-b796-0b95e53322bd",
+    artist = "PINDURSKI",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/085f1b89-857b-4e2b-b796-0b95e53322bd.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ThunderclapWyvernReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ThunderclapWyvernReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunderclap Wyvern reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val ThunderclapWyvernReprint = Printing(
+    oracleId = "15276d3b-a117-44bf-87c3-c17e032e4a26",
+    name = "Thunderclap Wyvern",
+    setCode = "KHC",
+    collectorNumber = "94",
+    scryfallId = "7fc3c21f-99d5-48dc-b36e-8db597da44bf",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fc3c21f-99d5-48dc-b36e-8db597da44bf.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "M21",
+    collectorNumber = "233",
+    scryfallId = "ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/VrynWingmareReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/VrynWingmareReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vryn Wingmare reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val VrynWingmareReprint = Printing(
+    oracleId = "c7c241f2-d3cc-4032-a9da-149de73c2539",
+    name = "Vryn Wingmare",
+    setCode = "M21",
+    collectorNumber = "43",
+    scryfallId = "17b59819-4746-4c67-b6e5-4157d498a065",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ElementalBondReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ElementalBondReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elemental Bond reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val ElementalBondReprint = Printing(
+    oracleId = "d9a7e5a6-3e41-4fc6-987a-18fe1b9d67dd",
+    name = "Elemental Bond",
+    setCode = "TLE",
+    collectorNumber = "40",
+    scryfallId = "da25ea1d-2fa6-42ca-bd06-a2edeb300eb5",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/da25ea1d-2fa6-42ca-bd06-a2edeb300eb5.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "TLE",
+    collectorNumber = "54",
+    scryfallId = "3dd36ba1-4f96-415a-90ec-1d9e5e355eb9",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3dd36ba1-4f96-415a-90ec-1d9e5e355eb9.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/APC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/APC.json
@@ -2511,6 +2511,89 @@
     ]
 }
 
+// Sylvan Messenger
+{
+    "name": "Sylvan Messenger",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen this creature enters, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "looked"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "permanent Elf"
+                            },
+                            "storeMatching": "kept",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Heather Hudson",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg?1783945339"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Temporal Spring
 {
     "name": "Temporal Spring",

--- a/mtg-sets/src/test/resources/snapshots/cards/BNG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BNG.json
@@ -38,6 +38,68 @@
     ]
 }
 
+// Stratus Walk
+{
+    "name": "Stratus Walk",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\nEnchanted creature can block only creatures with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Aaron Miller",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg?1783939565"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Swordwise Centaur
 {
     "name": "Swordwise Centaur",
@@ -229,5 +291,37 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Weight of the Underworld
+{
+    "name": "Weight of the Underworld",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets -3/-2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -3,
+                "toughnessBonus": -2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Wesley Burt",
+        "flavorText": "Proud Alkmenos, who would not bow to Erebos in death, is now bowed by his own hubris for all eternity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg?1783939550"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -5362,6 +5362,44 @@
     ]
 }
 
+// Skaab Goliath
+{
+    "name": "Skaab Goliath",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Zombie Giant",
+    "oracleText": "As an additional cost to cast this spell, exile two creature cards from your graveyard.\nTrample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 9
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "filter": "creature",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"Three heads, six arms, and some armor grafts are better than . . . the normal numbers of those things.\"\n—Stitcher Geralf",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg?1783940966"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Skirsdag Cultist
 {
     "name": "Skirsdag Cultist",

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -111,6 +111,31 @@
     ]
 }
 
+// Eagle of the Watch
+{
+    "name": "Eagle of the Watch",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Even from miles away, I could see our eagles circling. That's when I gave the command to pick up the pace. I knew we were needed at home.\"\n—Kanlos, Akroan captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg?1783939461"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Flurry of Horns
 {
     "name": "Flurry of Horns",
@@ -146,6 +171,29 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Gold-Forged Sentinel
+{
+    "name": "Gold-Forged Sentinel",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Chimera",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "James Zapata",
+        "flavorText": "Blessed by the gods. Coveted by mortals. Beholden to neither.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg?1783939399"
+    },
+    "colorIdentityOverride": []
 }
 
 // Heroes' Bane

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -811,3 +811,110 @@
         "GREEN"
     ]
 }
+
+// Watercourser
+{
+    "name": "Watercourser",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{U}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Beware an eddy where there should be none or a stretch that flows too fast or too slow.\"\n—Old Fishbones, Martyne river guide",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg?1783940499"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Yeva's Forcemage
+{
+    "name": "Yeva's Forcemage",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "When this creature enters, target creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"Nature can't be stopped. It rips and tears at Ravnica's tallest buildings to claim its place in the sun.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg?1783940464",
+        "rulings": [
+            {
+                "date": "2012-07-01",
+                "text": "Yeva's Forcemage's ability is mandatory, although you can choose Yeva's Forcemage as the target."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -81,6 +81,50 @@
     ]
 }
 
+// Charging Griffin
+{
+    "name": "Charging Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever this creature attacks, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Erica Yang",
+        "flavorText": "Four claws, two wings, one beak, no fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg?1783939945"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elvish Mystic
 {
     "name": "Elvish Mystic",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -1,3 +1,384 @@
+// Abbot of Keral Keep
+{
+    "name": "Abbot of Keral Keep",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, exile the top card of your library. Until end of turn, you may play that card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Deruchenko Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg?1783938334",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "The card exiled by Abbot of Keral Keep's ability is exiled face up."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "You may play that card that turn even if Abbot of Keral Keep is no longer on the battlefield or under your control."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Playing the card exiled with Abbot of Keral Keep's ability follows the normal rules for playing that card. You must pay its costs, and you must follow all applicable timing rules. For example, if the card is a creature card, you can cast that card by paying its mana cost only during your main phase while the stack is empty."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Unless an effect allows you to play additional lands that turn, you can play a land card exiled with Abbot of Keral Keep's ability only if you haven't played a land yet that turn."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If you don't play the card, it will remain exiled."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Aerial Volley
+{
+    "name": "Aerial Volley",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "DividedDamage",
+            "totalDamage": 3
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Lake Hurwitz",
+        "flavorText": "Drakes can swerve to avoid a single arrow, but they can't dodge the whole sky.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg?1783938325",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "You choose how many targets Aerial Volley has and how the damage is divided as you cast the spell. Each target must receive at least 1 damage."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If some (but not all) of the targets become illegal before Aerial Volley tries to resolve, the original division of damage still applies, but no damage is dealt to illegal targets. If all targets become illegal, Aerial Volley won't resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Akroan Jailer
+{
+    "name": "Akroan Jailer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{2}{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "He ensures escape attempts are just that—attempts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg?1783938366"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Akroan Sergeant
+{
+    "name": "Akroan Sergeant",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike (This creature deals combat damage before creatures without first strike.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Zack Stella",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg?1783938333",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Alchemist's Vial
+{
+    "name": "Alchemist's Vial",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, draw a card.\n{1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CantAttack",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Lindsey Look",
+        "flavorText": "A weapon best suited for those with good aim and steady hands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg?1783938312",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Activating the last ability of Alchemist's Vial targeting a creature that's already attacking or blocking won't cause that creature to stop attacking or blocking. It will prevent that creature from attacking or blocking in any additional combat phases the turn may have (although this is unusual)."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
+// Ampryn Tactician
+{
+    "name": "Ampryn Tactician",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "\"It's all a game. You shouldn't get too attached to the pieces.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg?1783938365"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Anchor to the Aether
 {
     "name": "Anchor to the Aether",
@@ -41,6 +422,60 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Anointer of Champions
+{
+    "name": "Anointer of Champions",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Target attacking creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target attacking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Arise. You have been anointed by the light. Go forth and fight without fear, for you shall be victorious.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg?1783938365"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -96,6 +531,115 @@
     ]
 }
 
+// Aven Battle Priest
+{
+    "name": "Aven Battle Priest",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Bird Cleric",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen this creature enters, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "John Severin Brassell",
+        "flavorText": "When the shadow of the aven falls across the battlefield, hope rises in the hearts of the soldiers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg?1783938364"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blazing Hellhound
+{
+    "name": "Blazing Hellhound",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "{1}, Sacrifice another creature: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Velhagen",
+        "flavorText": "It tears the flesh from your bones and then swallows the ash with its fiery maw.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg?1783938315"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Blessed Spirits
 {
     "name": "Blessed Spirits",
@@ -145,6 +689,74 @@
         ]
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blood-Cursed Knight
+{
+    "name": "Blood-Cursed Knight",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "As long as you control an enchantment, this creature gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "enchantment"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"The bloodlust shall not control me, for my oath is my greatest compulsion.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg?1783938315",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "If you cast an Aura spell targeting a creature controlled by an opponent, you still control that Aura. It will count for Blood-Cursed Knight's ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "WHITE"
     ]
 }
@@ -262,6 +874,107 @@
         "flavorText": "The foundries of Kaladesh run like clockwork under the supervision of their formidable overseers.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg?1783938311"
     }
+}
+
+// Citadel Castellan
+{
+    "name": "Citadel Castellan",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "\"I am the first line of defense. You will not encounter the second.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg?1783938314",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Conclave Naturalists
+{
+    "name": "Conclave Naturalists",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "When this creature enters, you may destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment"
+                    },
+                    "id": "target artifact or enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Your swords and wards have no power here.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg?1783938324"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Demonic Pact
@@ -523,6 +1236,102 @@
     ]
 }
 
+// Elemental Bond
+{
+    "name": "Elemental Bond",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control with power 3 or greater enters, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow>=3 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "David Gaillet",
+        "flavorText": "\"I want to help Zendikar. Show me the way.\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg?1783938323",
+        "rulings": [
+            {
+                "date": "2025-10-02",
+                "text": "The creature must have power 3 or greater as it enters, or Elemental Bond's ability won't trigger. Static abilities that raise (or lower) a creature's power are taken into account. However, you can't have a creature with power 2 or less enter and try to raise its power with a spell, an activated ability, or a triggered ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Enlightened Ascetic
+{
+    "name": "Enlightened Ascetic",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Monk",
+    "oracleText": "When this creature enters, you may destroy target enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "enchantment"
+                    },
+                    "id": "target enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "James Zapata",
+        "flavorText": "\"I do not reject the gods. I reject their authority, their pettiness, and their arrogance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg?1783938363"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Eyeblight Assassin
 {
     "name": "Eyeblight Assassin",
@@ -668,6 +1477,107 @@
     ]
 }
 
+// Firefiend Elemental
+{
+    "name": "Firefiend Elemental",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Torstein Nordstrand",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg?1783938330",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ghirapur Aether Grid
+{
+    "name": "Ghirapur Aether Grid",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Tap two untapped artifacts you control: This enchantment deals 1 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "The city of Ghirapur is a living thing, and living things defend themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg?1783938330",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "You may tap any two untapped artifacts you control, including artifact creatures that haven't been under your control continuously since the beginning of your most recent turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Gilt-Leaf Winnower
 {
     "name": "Gilt-Leaf Winnower",
@@ -721,6 +1631,50 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Guardian Automaton
+{
+    "name": "Guardian Automaton",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "When this creature dies, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Vincent Proce",
+        "flavorText": "The wealthy in the city of Ghirapur outfit their lives with grand machines, entrusting even their children to filigree and gears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg?1783938311",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "If Guardian Automaton dies at the same time as your life total is reduced to 0 or less, you'll lose the game before the triggered ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Harbinger of the Tides
@@ -782,6 +1736,124 @@
     ]
 }
 
+// Heavy Infantry
+{
+    "name": "Heavy Infantry",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "David Gaillet",
+        "flavorText": "Doors, walls, skulls . . . it matters not. All barriers will be broken.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg?1783938361"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Herald of the Pantheon
+{
+    "name": "Herald of the Pantheon",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Centaur Shaman",
+    "oracleText": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "enchantment"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "flavorText": "The distinction of bearing the gods' banner is nothing compared to the glory of being closer to Nyx.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg?1783938322",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Herald of the Pantheon's first ability can't reduce the colored mana requirement of an enchantment spell."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If there are additional costs to cast an enchantment spell, apply those before applying cost reductions."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Herald of the Pantheon can reduce alternative costs such as bestow costs."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hitchclaw Recluse
 {
     "name": "Hitchclaw Recluse",
@@ -803,6 +1875,90 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Iroas's Champion
+{
+    "name": "Iroas's Champion",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Double strike (This creature deals both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Nelor",
+        "flavorText": "Accustomed to battling before an audience in the arena, Iroas's champions know how to put on a good show.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg?1783938314"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Jhessian Thief
+{
+    "name": "Jhessian Thief",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Miles Johnston",
+        "flavorText": "\"Where's the fun in an escape if it's not at least a little daring?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg?1783938350",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -857,6 +2013,127 @@
     ]
 }
 
+// Knight of the Pilgrim's Road
+{
+    "name": "Knight of the Pilgrim's Road",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "David Gaillet",
+        "flavorText": "\"To be a knight, Gideon, is to be the shield for the meek against the cruel.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg?1783938360",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kytheon's Irregulars
+{
+    "name": "Kytheon's Irregulars",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{W}{W}: Tap target creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Mark Winters",
+        "flavorText": "Kytheon and his irregulars worked outside the law to bring justice to the streets of Akros.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg?1783938360",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Languish
 {
     "name": "Languish",
@@ -898,6 +2175,93 @@
     ]
 }
 
+// Lightning Javelin
+{
+    "name": "Lightning Javelin",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Seb McKinnon",
+        "flavorText": "The harpies descended without mercy upon Akros, only to find their attack put them within range of the javelineers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg?1783938329"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Magmatic Insight
+{
+    "name": "Magmatic Insight",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, discard a land card.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomDiscard",
+                    "filter": "land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Barger",
+        "flavorText": "Chief among the tenets of Purphoros is that one must destroy in order to create.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg?1783938328",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "You must discard exactly one land card to cast Magmatic Insight. You can't cast it without discarding a land card, and you can't discard additional cards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Managorger Hydra
 {
     "name": "Managorger Hydra",
@@ -935,6 +2299,258 @@
         "rarity": "RARE",
         "artist": "Lucas Graciano",
         "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1783938321"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Mantle of Webs
+{
+    "name": "Mantle of Webs",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 3
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Why does everything the Golgari touch end up sticky?\"\n—Arrester Lavinia, Tenth Precinct",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg?1783938320"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Molten Vortex
+{
+    "name": "Molten Vortex",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "{R}, Discard a land card: This enchantment deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "RARE",
+        "artist": "Philip Straub",
+        "flavorText": "If you can't take the heat . . . well, that's going to be a problem.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg?1783938327"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Nivix Barrier
+{
+    "name": "Nivix Barrier",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Illusion Wall",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nDefender (This creature can't attack.)\nWhen this creature enters, target attacking creature gets -4/-0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "target attacking creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg?1783938350"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Outland Colossus
+{
+    "name": "Outland Colossus",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)\nThis creature can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 6
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg?1783938318",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Pharika's Disciple
+{
+    "name": "Pharika's Disciple",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Karl Kopinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg?1783938319",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -1138,6 +2754,147 @@
     ]
 }
 
+// Rhox Maulers
+{
+    "name": "Rhox Maulers",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Rhino Soldier",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg?1783938318",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ringwarden Owl
+{
+    "name": "Ringwarden Owl",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "PROWESS"
+    ],
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Titus Lunter",
+        "flavorText": "The owls learn of mana from the mages who know it best.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg?1783938348",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Separatist Voidmage
+{
+    "name": "Separatist Voidmage",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, you may return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Jason Rainville",
+        "flavorText": "\"As long as each side thinks it can win, the balance holds, and the mage-rings stand.\"\n—Alhammarret",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg?1783938348",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Separatist Voidmage's ability can target itself."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shambling Ghoul
 {
     "name": "Shambling Ghoul",
@@ -1189,6 +2946,229 @@
     ]
 }
 
+// Skysnare Spider
+{
+    "name": "Skysnare Spider",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "The only thing more ill-tempered than a griffin in a web is the spider that must subdue it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg?1783938318"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Somberwald Alpha
+{
+    "name": "Somberwald Alpha",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.\n{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg?1783938317",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Somberwald Alpha's first ability will give each creature you control that becomes blocked +1/+1 until end of turn. It doesn't matter how many of your opponent's creatures are blocking each of your creatures."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Soulblade Djinn
+{
+    "name": "Soulblade Djinn",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Djinn",
+    "oracleText": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Viktor Titov",
+        "flavorText": "He grants endless wishes, as long as you always wish for a blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg?1783938347",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Any spell you cast that doesn't have the type creature will cause Soulblade Djinn's ability to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause the ability to trigger. Playing a land also won't cause it to trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Soulblade Djinn's ability goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stalwart Aven
+{
+    "name": "Stalwart Aven",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Scott Murphy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg?1783938357",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Subterranean Scout
 {
     "name": "Subterranean Scout",
@@ -1234,6 +3214,155 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Thunderclap Wyvern
+{
+    "name": "Thunderclap Wyvern",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nOther creatures you control with flying get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "Thunder doesn't always mean rain. Sometimes it means ruin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg?1783938312"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Topan Freeblade
+{
+    "name": "Topan Freeblade",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Johannes Voss",
+        "flavorText": "\"My scars are my sigils. I will wear them with pride long after you're gone.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg?1783938358",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Undercity Troll
+{
+    "name": "Undercity Troll",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Troll",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{2}{G}: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg?1783938316",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1293,6 +3422,310 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Veteran's Sidearm
+{
+    "name": "Veteran's Sidearm",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Aaron Miller",
+        "flavorText": "\"I've broken three swords, eighteen lances, and countless shields, but this little blade has survived every battle, just like I have.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg?1783938307"
+    },
+    "colorIdentityOverride": []
+}
+
+// Vine Snare
+{
+    "name": "Vine Snare",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly",
+            "direction": "FromTarget",
+            "sourceFilter": {
+                "type": "FromGroup",
+                "filter": {
+                    "baseFilter": "creature pow<=4"
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Nissa found that the vines of the marsh could ensnare just as well as forest vines could—maybe even better.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg?1783938317",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Check the power of each creature as it would deal combat damage to determine if that damage is prevented. It doesn't matter what any creature's power is as Vine Snare resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Volcanic Rambler
+{
+    "name": "Volcanic Rambler",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{2}{R}: This creature deals 1 damage to target player or planeswalker.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Vincent Proce",
+        "flavorText": "It moves through lava with the force of an erupting volcano.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg?1783938326"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Vryn Wingmare
+{
+    "name": "Vryn Wingmare",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying\nNoncreature spells cost {1} more to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": "noncreature"
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "RARE",
+        "artist": "Seb McKinnon",
+        "flavorText": "It's the favored mount of military commanders as well as anyone with a flair for the dramatic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg?1783938356",
+        "rulings": [
+            {
+                "date": "2020-06-23",
+                "text": "The ability affects each spell that's not a creature spell, including your own. Creature spells with another type, such as artifact creature spells, aren't affected."
+            },
+            {
+                "date": "2020-06-23",
+                "text": "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases (such as that of Vryn Wingmare), then apply any cost reductions. The mana value of the spell remains unchanged, no matter what the total cost to cast it was."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// War Horn
+{
+    "name": "War Horn",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Attacking creatures you control get +1/+0.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "The reverberations course through the warriors' veins, beat with their hearts, and pound with their footfalls as they charge into battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg?1783938307"
+    },
+    "colorIdentityOverride": []
+}
+
+// War Oracle
+{
+    "name": "War Oracle",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "\"When you are felled by my mace, you shall know it was divine fate.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg?1783938356",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Renown won't trigger when a creature deals combat damage to a planeswalker or another creature. It also won't trigger when a creature deals noncombat damage to a player."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a creature with renown deals combat damage to its controller because that damage was redirected, renown will trigger."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If a renown ability triggers, but the creature leaves the battlefield before that ability resolves, the creature doesn't become renowned. Any ability that triggers \"whenever a creature becomes renowned\" won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Zendikar Incarnate
+{
+    "name": "Zendikar Incarnate",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Zendikar Incarnate's power is equal to the number of lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            }
+        },
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"Her people angered Zendikar, and they faced the land's wrath. That is why Nissa is the last of the animists.\"\n—Numa, Joraga chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg?1783938312",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "The ability defining Zendikar Incarnate's power works in all zones, not just the battlefield. Zendikar Incarnate's power changes as the number of lands you control does."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -106,6 +106,53 @@
     ]
 }
 
+// Bellows Lizard
+{
+    "name": "Bellows Lizard",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Jack Wang",
+        "flavorText": "As the price of wood and coal rose, smiths found creative ways to keep their forges burning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg?1783940357"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Brushstrider
 {
     "name": "Brushstrider",


### PR DESCRIPTION
> **Stacked on #2051** (renown engine support). Base is `worktree-ori-renown`; it retargets to `main` once #2051 merges.

Every card Argentum Assay reads whole that Magic Origins hadn't authored. `just assay-ready ORI` went **65 → 0**, re-run on the branch (never inferred).

## The four-way split

| Bucket | Count | What happened |
|---|---|---|
| `original` | 47 | authored here — ORI is the earliest real printing |
| `elsewhere` | 10 | canonical authored in the earlier set, `Printing` row here |
| `row-only` | 3 | canonical already in the corpus (Auramancer/ODY, Meteorite/M15, Sigil of the Empty Throne/CON) — row only |
| `basic` | 5 | `basicLand(...)` vals, 4 art variants each (collector numbers 253–272) |

The `elsewhere` canonicals landed in **APC** (Sylvan Messenger), **BNG** (Stratus Walk, Weight of the Underworld), **ISD** (Skaab Goliath), **JOU** (Eagle of the Watch, Gold-Forged Sentinel), **M13** (Watercourser, Yeva's Forcemage), **M14** (Charging Griffin) and **RTR** (Bellows Lizard).

## The reprint tail

Authoring a canonical is what lets `check-card-printing` see that the card's *other* scaffolded printings have no rows either — so the tail grew from the 8 rows the pre-flight predicted to **29 rows across 13 sets**, all in this PR:

```
ORI 13 | KHC 2 | M21 2 | PC2 2 | TLE 2 | ANB 1 | C15 1
C17 1  | CMR 1 | DDL 1 | J22 1 | M12 1 | M14 1
```

Scoped with `--cards-from` so the run only considered this sweep's canonicals; the printing caches were refreshed first (a stale cache is skipped silently). `generate-reprints.py` reported **0 misplaced canonicals, 0 stale cache**.

## Authored to the compile, not the oracle text

Every card was written against `oracle-assay compile <name>`'s JSON — the exact SDK model Assay's grammar builds. Metadata came from each card's own Scryfall printing rather than the compile, because the compile's `setCode` is whatever the Oracle bulk happened to carry: Topan Freeblade compiles tagged `GN2`, Undercity Troll `IMA`, Zendikar Incarnate `C18`.

That paid off exactly as the skill predicts — **zero divergences from all 57 canonicals**.

## Verification

| Gate | Result |
|---|---|
| `assay differential` | 5658 / 5609 / **49** before → 5715 / 5666 / **49** after — +57 compared, +57 confirmed, **no new divergences** |
| `just assay-ready ORI` | 65 → **0**, re-run on the branch |
| `check-card-printing` | all 57 canonicals report "ok: canonical is in the card's earliest real printing and all scaffolded reprints have rows" |
| `just rebless-cards` | 47 cards added to `ORI.json`; **no existing card block changed** (verified by parsing both snapshots and diffing per-card) |
| `just build` | green |
| `just test-rules` | green |
| `:mtg-sets:test`, `:game-server:test` | green |

## Notes from the sweep

- **Renown was the whole reason this needed two PRs.** 12 of the 47 originals are renown creatures, and `Keyword.RENOWN` was display-only — grep found zero references in `rules-engine`. #2051 makes it live; these 12 declare `KeywordAbility.renown(n)` and nothing else.
- **Zendikar Incarnate is a CDA**, so it lands outside `CardScript` as `dynamicPower(DynamicAmount.AggregateBattlefield(...))`, not a `power =` literal.
- **Stratus Walk hit the `CanOnlyBlockCreaturesWith` default trap** that Air Bladder's KDoc already documents: the family defaults `filter` to `GroupFilter.source()` (the Aura, which never blocks) where its neighbour `GrantKeyword` defaults to the attached creature. Passed `GroupFilter.attachedCreature()` explicitly.
- **A `TwoHeadedGiantTeamPriorityTest` case failed once mid-run and passed on every re-run** — in this worktree and in a clean checkout, in isolation and in the full suite. Flaky under concurrent builds, not caused by this change; flagging it rather than sitting on it.

## What is left in ORI

133 cards, **0 Assay-ready**: 125 `LINE_DECLINED`, 5 `MULTI_FACE`, 3 `LINES_DO_NOT_FOLD`. As `assay-ready` puts it — this set's tail is grammar work, not authoring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UAGMiExMUpb1akGeEgr2j