### PR TITLE
Cap delve exiles and convoke taps at what the cost can still absorb

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/AlternativePaymentHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/AlternativePaymentHandler.kt
@@ -276,6 +276,9 @@ class AlternativePaymentHandler(
         val exileZone = ZoneKey(playerId, Zone.EXILE)
 
         for (cardId in delvedCards) {
+            // CR 702.66a: one card per generic mana in the cost. A card past that would leave the
+            // graveyard for nothing, so it stays where it is.
+            if (genericReduction >= cost.genericAmount) break
             // Verify card is in player's graveyard
             if (cardId !in currentState.getZone(graveyardZone)) {
                 continue // Skip invalid cards
@@ -333,20 +336,20 @@ class AlternativePaymentHandler(
             if (container.has<TappedComponent>()) continue
             if (projected.getController(creatureId) != playerId) continue
 
-            // Tap the creature
+            // CR 702.51a: a creature taps "rather than pay that mana" — once no pip it could pay is
+            // left, it doesn't tap at all.
+            val paymentColor = payment.color
+            val afterPayment = if (paymentColor != null) {
+                reduceColoredCost(reducedCost, paymentColor)
+            } else {
+                reduceGenericCost(reducedCost, 1)
+            }
+            if (afterPayment == reducedCost) continue
+
             val (tappedState, tapEvent) = tap(currentState, creatureId)
             currentState = tappedState
             tapEvent?.let(events::add)
-
-            // Apply the payment
-            val paymentColor = payment.color
-            if (paymentColor != null) {
-                // Pay for colored mana
-                reducedCost = reduceColoredCost(reducedCost, paymentColor)
-            } else {
-                // Pay for generic mana
-                reducedCost = reduceGenericCost(reducedCost, 1)
-            }
+            reducedCost = afterPayment
         }
 
         return AlternativePaymentResult(reducedCost, currentState, events)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlternativePaymentValidationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlternativePaymentValidationTest.kt
@@ -297,6 +297,54 @@ class AlternativePaymentValidationTest : FunSpec({
         }
     }
 
+    context("paying more than the cost has room for") {
+
+        test("convoke taps no creature once every pip it could pay is gone") {
+            // Merrow Skyswimmer is {3}{W/U}{W/U}: four creatures offered for generic can pay three.
+            // CR 702.51a — a creature taps *rather than pay that mana*; with no mana left to
+            // replace, the fourth stays untapped instead of tapping for nothing.
+            val board = convokeBoard()
+            val extra = listOf(
+                board.driver.putCreatureOnBattlefield(board.player, "Savannah Lions"),
+                board.driver.putCreatureOnBattlefield(board.player, "Savannah Lions"),
+            )
+            val all = listOf(board.whiteCreature, board.blueCreature) + extra
+            val result = board.cast(
+                AlternativePaymentChoice(convokedCreatures = all.associateWith { ConvokePayment(null) })
+            )
+            result.isSuccess shouldBe true
+            board.driver.stackSize shouldBe 1
+            all.count { board.driver.isTapped(it) } shouldBe 3
+        }
+
+        test("delve exiles no card beyond the generic in the cost") {
+            // Treasure Cruise is {7}{U}: eight cards offered, seven leave the graveyard (CR 702.66a).
+            val driver = createDriver()
+            driver.initMirrorMatch(
+                deck = Deck.of("Island" to 20, "Treasure Cruise" to 4, "Savannah Lions" to 4)
+            )
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            val cruise = driver.putCardInHand(player, "Treasure Cruise")
+            val graveyard = (1..8).map { driver.putCardInGraveyard(player, "Savannah Lions") }
+            driver.putLandOnBattlefield(player, "Island")
+
+            val result = driver.submit(
+                CastSpell(
+                    playerId = player,
+                    cardId = cruise,
+                    targets = emptyList(),
+                    paymentStrategy = PaymentStrategy.AutoPay,
+                    alternativePayment = AlternativePaymentChoice(delvedCards = graveyard),
+                )
+            )
+            result.isSuccess shouldBe true
+            driver.stackSize shouldBe 1
+            driver.getGraveyard(player).size shouldBe 1
+            driver.getGraveyard(player).single() shouldBe graveyard.last()
+        }
+    }
+
     context("delve") {
 
         test("a spell without delve rejects a delve payment instead of ignoring it") {


### PR DESCRIPTION
## Why

Stacked on #2052 (base is its branch; retargets to `main` when it merges). Review finding M1 there:
`applyDelve` exiled every listed card and `applyConvoke` tapped every listed creature even after the
generic — or the last pip the creature could pay — was gone. The cost twins already floored at zero,
so validated and applied *costs* agreed, but the player lost graveyard cards and untapped creatures
for no reduction.

CR 702.66a (delve) and CR 702.51a (convoke) both say the card is exiled / the creature tapped
*"rather than pay that mana"* — with no mana left to replace, nothing should happen.

## What changed

- `AlternativePaymentHandler.applyDelve`: stops exiling once one card per generic mana has been
  exiled.
- `AlternativePaymentHandler.applyConvoke`: computes the reduction first and only taps the
  creature when it changes the cost (a generic payer with no generic left, or a coloured payer
  with no matching pip, stays untapped). Same guard shape `applyTapForGeneric` already had.

## Verification

- `AlternativePaymentValidationTest` +2: four generic-paying creatures into `{3}{W/U}{W/U}` tap
  three; eight graveyard cards into `{7}{U}` exile seven, the eighth stays — 14/14.
- Regression: `:rules-engine *Convoke* *Delve* *Improvise* *Harmonize*`, `:ai *Convoke*`,
  `HeirloomEpicScenarioTest`, `WebOfLifeAndDestinyScenarioTest` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)