### PR TITLE
Multiplayer CR audit 1/N: abandon a departed player's pending decision (CR 800.4f–h)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
@@ -33,13 +33,24 @@ import com.wingedsheep.sdk.model.EntityId
  * [PlayerLeftGameComponent]) so it remains in [GameState.turnOrder] for history and the
  * game-end SBA. The turn-order iteration helpers already skip players who have left.
  *
+ * - **CR 800.4f–h (a choice the leaver was mid-way through making)** — a pending decision
+ *   addressed to the leaver is abandoned: the decision is cleared, the continuation frames
+ *   waiting on it are dropped, and priority goes to the active player (CR 117.3b, redirected
+ *   if they too have left). Almost every such decision belongs to the leaver's own spell or
+ *   ability, which has just left the game with them, so the resolution simply ends; a "may
+ *   pay" prompt is answered by not paying (800.4f). The one divergence is a choice another
+ *   player's object asked the leaver to make (800.4g — the controller should pick a
+ *   substitute chooser): that resolution ends early too. Without this the table deadlocks —
+ *   only the leaver could ever answer, and every other seat's pass is refused while a
+ *   decision is pending.
+ *
  * Deliberately not modelled here (documented simplifications of the deeper CR 800.4
  * sub-rules, none of which the current corpus exercises): firing the remaining players'
  * "leaves the battlefield" triggers off these mass removals (CR 800.4a vs 800.4d — the
- * leaver's own triggers must never fire), delegating a choice a leaver was mid-way through
- * making (CR 800.4g–h), and exiling an object the leaver controlled via a *static* ability
- * on a permanent owned by another player (CR 800.4c). Floating control effects — the common
- * case (theft like Control Magic, "gain control until end of turn") — are handled.
+ * leaver's own triggers must never fire), and exiling an object the leaver controlled via a
+ * *static* ability on a permanent owned by another player (CR 800.4c). Floating control
+ * effects — the common case (theft like Control Magic, "gain control until end of turn") —
+ * are handled.
  */
 object PlayerLeavesGameProcessor {
 
@@ -87,7 +98,11 @@ object PlayerLeavesGameProcessor {
             }
         )
 
-        // 6. If the leaver (or any departed player) holds priority, hand it to the next
+        // 6. A decision only the leaver could answer can never be answered now — abandon it
+        //    (CR 800.4f–h; see the class KDoc for what that means for the paused resolution).
+        s = abandonLeaversDecision(s, leaver)
+
+        // 7. If the leaver (or any departed player) holds priority, hand it to the next
         //    player still in the game. withPriority performs the redirect (CR 800.4a).
         val priorityHolder = s.priorityPlayerId
         if (priorityHolder != null &&
@@ -96,13 +111,30 @@ object PlayerLeavesGameProcessor {
             s = s.withPriority(priorityHolder)
         }
 
-        // 7. Mark the leave processing done so the SBA loop never re-applies it.
+        // 8. Mark the leave processing done so the SBA loop never re-applies it.
         s = s.updateEntity(leaver) { it.with(PlayerLeftGameComponent) }
 
         return ExecutionResult.success(
             s,
             listOf(PlayerLeftGameEvent(leaver, reason, toRemove.size))
         )
+    }
+
+    /**
+     * Abandon a pending decision addressed to [leaver]. The decision is cleared, every
+     * continuation frame is dropped (the frames beneath the one waiting on this decision
+     * belong to the same paused resolution — or to triggers deferred behind it — and none of
+     * them can be resumed without the answer), and priority returns to the active player as
+     * it would after a completed resolution (CR 117.3b). A decision addressed to anyone else
+     * is left alone: the game is still waiting on a player who is still here.
+     */
+    private fun abandonLeaversDecision(state: GameState, leaver: EntityId): GameState {
+        val pending = state.pendingDecision ?: return state
+        if (pending.playerId != leaver) return state
+        return state
+            .clearPendingDecision()
+            .copy(continuationStack = emptyList())
+            .withPriority(state.activePlayerId)
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
@@ -2,6 +2,11 @@ package com.wingedsheep.engine.multiplayer
 
 import com.wingedsheep.engine.core.ActionProcessor
 import com.wingedsheep.engine.core.Concede
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.EffectContinuation
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.GameEndReason
 import com.wingedsheep.engine.core.GameInitializer
@@ -273,5 +278,63 @@ class LeaveTheGameTest : FunSpec({
             state = result.newState
         }
         state.activePlayerId shouldBe players[1]
+    }
+
+    /** Pause the game on a yes/no decision addressed to [chooser], with a resolution frame beneath it. */
+    fun GameState.pausedOn(chooser: EntityId): GameState = withPendingDecision(
+        YesNoDecision(
+            id = "leave-test-decision",
+            playerId = chooser,
+            prompt = "You may pay 2 life.",
+            context = DecisionContext()
+        )
+    ).pushContinuation(
+        EffectContinuation(
+            decisionId = "leave-test-decision",
+            remainingEffects = emptyList(),
+            effectContext = EffectContext(sourceId = null, controllerId = chooser)
+        )
+    )
+
+    test("conceding while owning the pending decision abandons it instead of deadlocking the table (CR 800.4f–h)") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val paused = base.pausedOn(players[1])
+
+        // Sanity: while the decision is pending nobody else may pass.
+        processor.process(paused, PassPriority(players[0])).result.isSuccess shouldBe false
+
+        val result = processor.process(paused, Concede(players[1])).result
+        result.isSuccess.shouldBeTrue()
+        val state = result.newState
+        state.gameOver shouldBe false
+        state.pendingDecision.shouldBeNull()
+        state.continuationStack shouldContainExactly emptyList()
+        // Priority is back with the active player, who can carry the game forward.
+        state.priorityPlayerId shouldBe players[0]
+        processor.process(state, PassPriority(players[0])).result.isSuccess.shouldBeTrue()
+    }
+
+    test("a pending decision addressed to another player survives the leaver's departure") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val paused = base.pausedOn(players[2])
+
+        val state = processor.process(paused, Concede(players[1])).result.newState
+        state.pendingDecision?.playerId shouldBe players[2]
+        state.continuationStack.size shouldBe 1
+    }
+
+    test("the abandoned decision's priority skips an active player who has also left") {
+        val (base, players) = initGame(4)
+        // players[0] (active) is already out; players[1] leaves while owning the decision.
+        val state = base.pausedOn(players[1]).updateEntity(players[0]) {
+            it.with(PlayerLostComponent(com.wingedsheep.engine.state.components.player.LossReason.CONCESSION))
+        }.updateEntity(players[1]) {
+            it.with(PlayerLostComponent(com.wingedsheep.engine.state.components.player.LossReason.CONCESSION))
+        }
+        val afterLeave = PlayerLeavesGameProcessor.process(state, players[1], GameEndReason.CONCESSION).newState
+        afterLeave.pendingDecision.shouldBeNull()
+        afterLeave.priorityPlayerId shouldBe players[2]
     }
 })


### PR DESCRIPTION
Part 1 of a stacked series fixing the defects found by auditing FFA / Team vs. Team / Two-Headed Giant against CR 800–810 (2026-08-19 text). Each PR in the stack is one defect, most severe first; each is based on the previous one.

## Defect
Conceding — or being forfeited on disconnect — while owning the pending decision **deadlocked the whole table**: `pendingDecision.playerId` stayed on the departed seat, `SubmitDecisionHandler` only accepts that seat, and `PassPriorityHandler` refuses every other seat's pass while a decision is pending. The game stalled until the stall guard drew it.

## Fix
`PlayerLeavesGameProcessor` gains a step for CR 800.4f–h: a decision addressed to the leaver is cleared, the continuation frames waiting on it are dropped, and priority goes to the active player (CR 117.3b, redirected if they too have left). In practice the decision almost always belongs to the leaver's own spell/ability, which has just left the game with them, so the resolution simply ends; a "may pay" prompt is answered by not paying (800.4f). A choice *another* player's object asked the leaver to make (800.4g — the controller should name a substitute chooser) is not delegated; that resolution ends early too. Decisions addressed to anyone else are untouched.

## Verification
`just test-class LeaveTheGameTest` — 12/12 (3 new: the deadlock regression, another player's decision surviving, priority redirect when the active player is also gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)