### PR TITLE
Multiplayer CR audit 2/N: the second head's turn-keyed state in a shared team turn (CR 805.4 / 805.8)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -93,8 +93,9 @@ class BeginningPhaseManager(
             events.addAll(dayNightEvents)
         }
 
-        // Check if the player has a SkipUntapComponent
-        val skipUntap = newState.getEntity(activePlayer)?.get<SkipUntapComponent>()
+        // Each active-team member's own "doesn't untap" marker applies to the permanents *they*
+        // control — in a shared team turn (CR 805.4) both heads untap, each under their own marker.
+        val skipUntapByPlayer = activeTeam.associateWith { newState.getEntity(it)?.get<SkipUntapComponent>() }
 
         // Use projected state for controller checks (control-changing effects like Annex).
         // Recomputed from newState so just-phased-in permanents are visible.
@@ -105,7 +106,8 @@ class BeginningPhaseManager(
             projected.getController(entityId) in activeTeam &&
                 container.has<TappedComponent>()
         }.keys.filter { entityId ->
-            // If there's a skip untap component, check if this permanent should be skipped
+            // If the controller has a skip untap component, check if this permanent should be skipped
+            val skipUntap = skipUntapByPlayer[projected.getController(entityId)]
             if (skipUntap != null) {
                 val cardComponent = newState.getEntity(entityId)?.get<CardComponent>()
                 val typeLine = cardComponent?.typeLine
@@ -121,9 +123,10 @@ class BeginningPhaseManager(
             }
         }
 
-        // Remove the SkipUntapComponent after processing (it's been consumed)
-        if (skipUntap != null) {
-            newState = newState.updateEntity(activePlayer) { container ->
+        // Remove the SkipUntapComponents after processing (they've been consumed)
+        for ((member, skipUntap) in skipUntapByPlayer) {
+            if (skipUntap == null) continue
+            newState = newState.updateEntity(member) { container ->
                 container.without<SkipUntapComponent>()
             }
         }
@@ -378,14 +381,18 @@ class BeginningPhaseManager(
 
     /**
      * Add a lore counter to each Saga the active player controls (Rule 714.3c).
-     * This is a turn-based action that happens at the beginning of precombat main phase.
+     * This is a turn-based action that happens at the beginning of precombat main phase. In a
+     * shared team turn (CR 805.4) the precombat main phase belongs to both heads, so each
+     * teammate's Sagas advance; outside shared team turns the team is the active player alone.
      */
     fun addLoreCountersToSagas(state: GameState, activePlayer: EntityId): ExecutionResult {
         var newState = state
         val events = mutableListOf<GameEvent>()
 
-        val battlefieldZone = ZoneKey(activePlayer, Zone.BATTLEFIELD)
-        for (entityId in newState.getZone(battlefieldZone)) {
+        val sagaIds = state.sharedTurnTeam(activePlayer).flatMap { member ->
+            newState.getZone(ZoneKey(member, Zone.BATTLEFIELD))
+        }
+        for (entityId in sagaIds) {
             val container = newState.getEntity(entityId) ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
             val sagaComponent = container.get<SagaComponent>() ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -199,20 +199,24 @@ class CleanupPhaseManager(
      * controller rather than to a step of any player's turn.
      */
     fun expireUntilYourNextTurnEffects(state: GameState, activePlayer: EntityId): GameState {
+        // "Your next turn" is the next turn of the player's *team* in a shared team turn (CR
+        // 805.4): both heads' "until your next turn" effects wear off on the team's untap. Outside
+        // shared team turns this set is just [activePlayer].
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         // Event-based delayed triggers scoped "until your next turn" (Tamiyo, Field Researcher's
         // +1). Keyed to the delayed trigger's own controller, so an opponent's rider is untouched
         // by this player's untap step.
         val remainingDelayed = state.delayedTriggers.filter { delayed ->
             !(delayed.expiry is DelayedTriggerExpiry.UntilControllersNextTurn &&
-                delayed.controllerId == activePlayer)
+                delayed.controllerId in activeTeam)
         }
         val remainingFloating = state.floatingEffects.filter { floatingEffect ->
             !(floatingEffect.duration is Duration.UntilYourNextTurn &&
-                floatingEffect.controllerId == activePlayer)
+                floatingEffect.controllerId in activeTeam)
         }
         val remainingGlobal = state.globalGrantedTriggeredAbilities.filter { grant ->
             !(grant.duration is Duration.UntilYourNextTurn &&
-                grant.controllerId == activePlayer)
+                grant.controllerId in activeTeam)
         }
         // Granted *activated* abilities with UntilYourNextTurn duration (Hydro-Man's temporary
         // "{T}: Add {U}"). The record carries no expiry-player, so key the expiry to the granted
@@ -222,7 +226,7 @@ class CleanupPhaseManager(
             !(grant.duration is Duration.UntilYourNextTurn &&
                 state.getEntity(grant.entityId)
                     ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
-                    ?.playerId == activePlayer)
+                    ?.playerId in activeTeam)
         }
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
@@ -240,13 +244,15 @@ class CleanupPhaseManager(
         }
         // Player-component "until your next turn" effects (The One Ring's protection) expire on
         // the same post-untap hook as floating UntilYourNextTurn effects.
-        val protection = result.getEntity(activePlayer)?.get<PlayerProtectionComponent>()
-        if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
-            result = result.updateEntity(activePlayer) { it.without<PlayerProtectionComponent>() }
-        }
-        val cantGainLife = result.getEntity(activePlayer)?.get<CantGainLifeComponent>()
-        if (cantGainLife?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
-            result = result.updateEntity(activePlayer) { it.without<CantGainLifeComponent>() }
+        for (member in activeTeam) {
+            val protection = result.getEntity(member)?.get<PlayerProtectionComponent>()
+            if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
+                result = result.updateEntity(member) { it.without<PlayerProtectionComponent>() }
+            }
+            val cantGainLife = result.getEntity(member)?.get<CantGainLifeComponent>()
+            if (cantGainLife?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
+                result = result.updateEntity(member) { it.without<CantGainLifeComponent>() }
+            }
         }
         // Memory Vessel's "they can't play cards from their hand until your next turn" expires on
         // the same post-untap hook. The window keys off the *activating* player (every affected
@@ -257,7 +263,7 @@ class CleanupPhaseManager(
             val cantPlay = result.getEntity(playerId)?.get<PlayerCantPlayFromHandComponent>() ?: continue
             if (cantPlay.removeOn != PlayerEffectRemoval.UntilYourNextTurn) continue
             val expiryPlayer = cantPlay.expiresForPlayerId ?: playerId
-            if (expiryPlayer == activePlayer) {
+            if (expiryPlayer in activeTeam) {
                 result = result.updateEntity(playerId) { it.without<PlayerCantPlayFromHandComponent>() }
             }
         }
@@ -268,7 +274,7 @@ class CleanupPhaseManager(
             val restricted = result.getEntity(playerId)?.get<CantCastFromNonHandZonesComponent>() ?: continue
             if (restricted.removeOn != PlayerEffectRemoval.UntilYourNextTurn) continue
             val expiryPlayer = restricted.expiresForPlayerId ?: playerId
-            if (expiryPlayer == activePlayer) {
+            if (expiryPlayer in activeTeam) {
                 result = result.updateEntity(playerId) { it.without<CantCastFromNonHandZonesComponent>() }
             }
         }
@@ -280,7 +286,7 @@ class CleanupPhaseManager(
         // is back in time to trigger again.
         for ((entityId, container) in result.entities) {
             val marker = container.get<RevertCopyAtYourNextTurnComponent>() ?: continue
-            if (marker.playerId != activePlayer) continue
+            if (marker.playerId !in activeTeam) continue
             val originalCard = container.get<CopyOfComponent>()?.originalCardComponent
             result = result.updateEntity(entityId) { c ->
                 var reverted = c.without<RevertCopyAtYourNextTurnComponent>()
@@ -305,13 +311,15 @@ class CleanupPhaseManager(
      * carries the new turn's timestamp and survives this same-step expiry on the following turn.
      */
     fun expireUntilYourNextUpkeepEffects(state: GameState, activePlayer: EntityId): GameState {
+        // The team's upkeep is each head's upkeep in a shared team turn (CR 805.4).
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         val remainingFloating = state.floatingEffects.filter { floatingEffect ->
             !(floatingEffect.duration is Duration.UntilYourNextUpkeep &&
-                floatingEffect.controllerId == activePlayer)
+                floatingEffect.controllerId in activeTeam)
         }
         val remainingGlobal = state.globalGrantedTriggeredAbilities.filter { grant ->
             !(grant.duration is Duration.UntilYourNextUpkeep &&
-                grant.controllerId == activePlayer)
+                grant.controllerId in activeTeam)
         }
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
@@ -377,10 +385,13 @@ class CleanupPhaseManager(
     ): Pair<GameState, List<GameEvent>> {
         var newState = state
         val events = mutableListOf<GameEvent>()
+        // CR 701.15a "until the next turn of the controller" — in a shared team turn (CR 805.4)
+        // that turn belongs to both heads, so a goad by either one lapses here.
+        val activeTeam = newState.sharedTurnTeam(activePlayer).toHashSet()
         for (entityId in newState.getBattlefield()) {
             val goaded = newState.getEntity(entityId)?.get<GoadedComponent>() ?: continue
-            if (activePlayer !in goaded.goaderIds) continue
-            val remaining = goaded.goaderIds - activePlayer
+            if (goaded.goaderIds.none { it in activeTeam }) continue
+            val remaining = goaded.goaderIds - activeTeam
             newState = newState.updateEntity(entityId) { container ->
                 if (remaining.isEmpty()) container.without<GoadedComponent>()
                 else container.with(GoadedComponent(remaining))
@@ -403,11 +414,14 @@ class CleanupPhaseManager(
      */
     fun expireAffectedControllersNextUntapEffects(state: GameState, activePlayer: EntityId): GameState {
         val projected = state.projectedState
+        // Both heads untap on the team's turn (CR 805.4), so either head counts as "the
+        // affected creature's controller just had their untap step".
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         val remaining = state.floatingEffects.filter { floatingEffect ->
             if (floatingEffect.duration !is Duration.UntilAfterAffectedControllersNextUntap) return@filter true
-            // Expire if any affected entity is controlled by the active player
+            // Expire if any affected entity is controlled by the active team
             val affectedByActivePlayer = floatingEffect.effect.affectedEntities.any { entityId ->
-                projected.getController(entityId) == activePlayer
+                projected.getController(entityId) in activeTeam
             }
             !affectedByActivePlayer
         }
@@ -534,7 +548,7 @@ class CleanupPhaseManager(
                         // turn" effect rather than stranding a control change permanently.
                         null -> false
                         else -> !(newState.turnNumber >= floor &&
-                            newState.activePlayerId == floatingEffect.controllerId)
+                            newState.isActiveTurnFor(floatingEffect.controllerId))
                     }
                 }
                 is Duration.UntilYourNextUpkeep -> true  // Keep until upkeep
@@ -1045,7 +1059,7 @@ class CleanupPhaseManager(
                     !permission.permanent && when {
                         permission.expiresAfterTurn != null ->
                             newState.turnNumber >= permission.expiresAfterTurn &&
-                                newState.activePlayerId == (permission.expiryControllerId ?: permission.controllerId)
+                                newState.isActiveTurnFor(permission.expiryControllerId ?: permission.controllerId)
                         else -> true
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -313,10 +313,16 @@ class TurnManager(
      * `COMBAT_PHASE` skips all five combat steps one after another as this is consulted per step,
      * and `MAIN_PHASE` skips both main phases (CR 505.1).
      */
-    private fun skipsTurnPart(state: GameState, step: Step, playerId: EntityId): Boolean {
-        val parts = state.getEntity(playerId)?.get<SkippedTurnPartsComponent>()?.parts ?: return false
-        return parts.any { it.covers(step) }
-    }
+    /**
+     * Whether [playerId]'s turn skips [step]. CR 805.8 — in a shared team turn a step one teammate
+     * is made to skip is skipped by the team, so the marker is read off every member of the active
+     * team; outside shared team turns [GameState.sharedTurnTeam] is just the player.
+     */
+    private fun skipsTurnPart(state: GameState, step: Step, playerId: EntityId): Boolean =
+        state.sharedTurnTeam(playerId).any { member ->
+            state.getEntity(member)?.get<SkippedTurnPartsComponent>()?.parts
+                ?.any { it.covers(step) } == true
+        }
 
     private fun advanceStepFromEndedStep(incomingState: GameState): ExecutionResult {
         val currentStep = incomingState.step
@@ -715,11 +721,14 @@ class TurnManager(
                 // an attacking creature only during the end of combat step (e.g. Desert) still
                 // have legal targets.
 
-                // Remove MustAttackPlayerComponent after combat (Taunt effect is consumed)
-                val mustAttack = newState.getEntity(activePlayer)?.get<MustAttackPlayerComponent>()
-                if (mustAttack != null && mustAttack.activeThisTurn) {
-                    newState = newState.updateEntity(activePlayer) { container ->
-                        container.without<MustAttackPlayerComponent>()
+                // Remove MustAttackPlayerComponent after combat (Taunt effect is consumed). Read
+                // off every member of the active team: a shared team turn is either head's turn.
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val mustAttack = newState.getEntity(member)?.get<MustAttackPlayerComponent>()
+                    if (mustAttack != null && mustAttack.activeThisTurn) {
+                        newState = newState.updateEntity(member) { container ->
+                            container.without<MustAttackPlayerComponent>()
+                        }
                     }
                 }
 
@@ -731,14 +740,19 @@ class TurnManager(
                 // alongside the paired "return it at the beginning of the next end step" triggers.
                 newState = cleanupPhaseManager.performNextEndStepExpiry(newState)
 
-                val loseComponent = newState.getEntity(activePlayer)?.get<LoseAtEndStepComponent>()
-                if (loseComponent != null) {
+                // "At the beginning of the next end step, you lose the game" (Final Fortune) is
+                // keyed to whoever took the extra turn. In a shared team turn (CR 805.8) that is
+                // either head, so every member of the active team is checked — not just the seat
+                // that happens to be [activePlayer]; outside shared team turns the team is the
+                // active player alone.
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val loseComponent = newState.getEntity(member)?.get<LoseAtEndStepComponent>() ?: continue
                     if (loseComponent.turnsUntilLoss <= 0) {
-                        newState = newState.updateEntity(activePlayer) { container ->
+                        newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(PlayerLostComponent(LossReason.CARD_EFFECT))
                         }
-                        events.add(PlayerLostEvent(activePlayer, GameEndReason.CARD_EFFECT, loseComponent.message))
+                        events.add(PlayerLostEvent(member, GameEndReason.CARD_EFFECT, loseComponent.message))
                         val sbaResult = sbaChecker.checkAndApply(newState)
                         if (sbaResult.isPaused) {
                             return ExecutionResult.paused(
@@ -754,7 +768,7 @@ class TurnManager(
                             return ExecutionResult.success(newState, events)
                         }
                     } else {
-                        newState = newState.updateEntity(activePlayer) { container ->
+                        newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(LoseAtEndStepComponent(loseComponent.turnsUntilLoss - 1, loseComponent.message))
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -483,11 +483,13 @@ class TriggerDetector(
      * Returns the pending triggers and the IDs of consumed delayed triggers.
      */
     fun detectDelayedTriggers(state: GameState, step: Step): Pair<List<PendingTrigger>, Set<String>> {
-        val activePlayer = state.activePlayerId
         val matching = state.delayedTriggers.filter { delayed ->
             delayed.trigger == null &&
                 delayed.fireAtStep == step &&
-                (delayed.fireOnPlayerId == null || delayed.fireOnPlayerId == activePlayer) &&
+                // "your next end step" is the team's in a shared team turn (CR 805.4) — the
+                // non-representative head is never `activePlayerId`, so equality would strand
+                // every one of their step-keyed delayed triggers.
+                (delayed.fireOnPlayerId == null || state.isActiveTurnFor(delayed.fireOnPlayerId)) &&
                 (delayed.notBeforeTurn == null || state.turnNumber >= delayed.notBeforeTurn)
         }
         if (matching.isEmpty()) return emptyList<PendingTrigger>() to emptySet()
@@ -2659,8 +2661,9 @@ class TriggerDetector(
         val activePlayer = state.activePlayerId ?: return
 
         for (entry in index.getEntitiesForCategory(TriggerCategory.UNTAPPED)) {
-            // "your untap step" — the observer must be the active player whose untap step just ran.
-            if (entry.controllerId != activePlayer) continue
+            // "your untap step" — the observer must be on the active team whose untap step just ran
+            // (both heads untap in a shared team turn, CR 805.4).
+            if (!state.isActiveTurnFor(entry.controllerId)) continue
             for (ability in entry.abilities) {
                 val trigger = ability.trigger
                 if (trigger !is EventPattern.UntapEvent || !trigger.batch) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -116,7 +116,8 @@ class TriggerMatcher(
             }
             is EventPattern.YouAttackEvent -> {
                 if (event !is AttackersDeclaredEvent) return false
-                if (state.activePlayerId != controllerId) return false
+                // "Whenever you attack" — the controller's team is attacking (CR 805.10a).
+                if (!state.isActiveTurnFor(controllerId)) return false
                 val filter = trigger.attackerFilter
                 if (filter != null) {
                     // Count attackers matching the filter
@@ -935,7 +936,7 @@ class TriggerMatcher(
 
         val drawer = event.playerId
         // Exemption only applies in the drawing player's own draw step.
-        val inOwnDrawStep = state.activePlayerId == drawer && state.step == Step.DRAW
+        val inOwnDrawStep = state.isActiveTurnFor(drawer) && state.step == Step.DRAW
         if (!inOwnDrawStep) return total
 
         val countAfter = (state.getEntity(drawer)?.get<CardsDrawnThisTurnComponent>()?.count ?: 0) -

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/OrderBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/OrderBlockersHandler.kt
@@ -20,7 +20,7 @@ class OrderBlockersHandler : ActionHandler<OrderBlockers> {
     override val actionType: KClass<OrderBlockers> = OrderBlockers::class
 
     override fun validate(state: GameState, action: OrderBlockers): String? {
-        if (state.activePlayerId != action.playerId) {
+        if (!state.isActiveTurnFor(action.playerId)) {
             return "You can only order blockers on your turn"
         }
         if (state.step != Step.DECLARE_BLOCKERS) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -124,7 +124,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         val notBeforeTurn = when (effect.timing) {
             DelayedTriggerTiming.NEXT_TURN -> state.turnNumber + 1
             DelayedTriggerTiming.NEXT_END_STEP -> {
-                val onControllersTurn = context.controllerId == state.activePlayerId
+                val onControllersTurn = state.isActiveTurnFor(context.controllerId)
                 val endStepAlreadyStarted = state.step == Step.END || state.step == Step.CLEANUP
                 if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -305,7 +305,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
      * at cleanup — so we map any step in the turn to that turn's cleanup.
      *
      * This is a *floor*, not an exact turn: the expiry check in [CleanupPhaseManager] also requires
-     * `activePlayerId == controllerId`, so the permission dies at the cleanup of the first turn the
+     * `isActiveTurnFor(controllerId)`, so the permission dies at the cleanup of the first turn the
      * controller actually takes at or after this number. That pairing is what keeps the answer right
      * across skipped turns, extra turns and eliminated seats — none of which a turn count computed
      * from seat positions would survive.
@@ -320,7 +320,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
         controllerId: EntityId,
         expiry: MayPlayExpiry.UntilControllerStep
     ): Int {
-        val onControllerTurn = state.activePlayerId == controllerId
+        val onControllerTurn = state.isActiveTurnFor(controllerId)
         val targetReachedThisTurn = state.step.ordinal >= expiry.step.ordinal
         val thisTurnStillCounts = onControllerTurn && expiry.includeCurrentTurn && !targetReachedThisTurn
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
@@ -33,7 +33,7 @@ object SneakWindow {
      */
     fun isWindowOpen(state: GameState, playerId: EntityId): Boolean =
         state.step == Step.DECLARE_BLOCKERS &&
-            state.activePlayerId == playerId &&
+            state.isActiveTurnFor(playerId) &&
             blockersDeclared(state, playerId) &&
             unblockedAttackers(state, playerId).isNotEmpty()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1575,13 +1575,13 @@ class CostCalculator(
                     if (controllerId != casterId) continue
                 }
                 if (ability.firstSpellOfTurnOnly) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) continue
                 }
                 // `oncePerTurn` (Zaffai and the Tempests): only during the caster's own turn, and
                 // only while this specific source hasn't already been used this turn.
                 if (ability.oncePerTurn) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if (container.has<com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent>()) continue
                 }
                 // The permission may be scoped to a spell type (e.g. Dracogenesis — Dragons only).
@@ -1715,7 +1715,7 @@ class CostCalculator(
                     !matchesCardDefinition(spellCardDef, ability.spellFilter, entityId, state, state.projectedState)
                 ) continue
                 if (ability.oncePerTurn) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if (container.has<com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent>()) continue
                     if (oncePerTurnCandidate == null) oncePerTurnCandidate = entityId
                 } else {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -1,0 +1,205 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.event.DelayedTriggeredAbility
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.player.LoseAtEndStepComponent
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TurnPart
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — the *second* head's turn-keyed state (CR 805.4 / 805.8).
+ *
+ * `GameState.getNextTeam` always hands the turn to a team's first still-in member, so in a shared
+ * team turn `activePlayerId` is permanently seat p0 and seat p1 is never "the active player" even
+ * though the turn is theirs too. Every site that used to compare against `activePlayerId` — "at the
+ * beginning of the next end step you lose the game", step-keyed delayed triggers, "until your next
+ * turn" durations, Saga lore counters, "skip your combat phase" — silently skipped p1. These tests
+ * pin the team-wide reading for the head that isn't the representative.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order: p0,p1 = team 0 (starting);
+ * p2,p3 = team 1.
+ */
+class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().also { it.register(TestCards.all) }
+
+    fun boot(): Triple<GameState, List<EntityId>, ActionProcessor> {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return Triple(result.state, result.playerIds, ActionProcessor(registry()))
+    }
+
+    fun handSize(state: GameState, p: EntityId) = state.getZone(ZoneKey(p, Zone.HAND)).size
+
+    /** Pass priority (answering any discard decision) until [predicate] holds or the cap is hit. */
+    fun drive(start: GameState, proc: ActionProcessor, cap: Int = 400, predicate: (GameState) -> Boolean): GameState {
+        var state = start
+        var n = 0
+        while (!predicate(state)) {
+            check(++n < cap) { "drive never reached target (step=${state.step}, active=${state.activePlayerId}, turn=${state.turnNumber})" }
+            if (state.gameOver) break
+            val pending = state.pendingDecision
+            if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                val resp = com.wingedsheep.engine.core.CardsSelectedResponse(pending.id, pending.options.take(pending.minSelections))
+                state = proc.process(state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, resp)).result.newState
+                continue
+            }
+            val prio = state.priorityPlayerId ?: break
+            // An attacking player who hasn't declared yet must declare (here: nothing) before passing.
+            if (state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(prio) &&
+                state.getEntity(prio)?.has<AttackersDeclaredThisCombatComponent>() != true
+            ) {
+                state = proc.process(state, DeclareAttackers(prio, emptyMap())).result.newState
+                continue
+            }
+            val result = proc.process(state, PassPriority(prio)).result
+            check(result.isSuccess || result.isPaused) { "pass by $prio at ${state.step} failed: ${result.error}" }
+            state = result.newState
+        }
+        return state
+    }
+
+    /** A vanilla permanent on [owner]'s battlefield with the given type line. */
+    fun GameState.withPermanent(owner: EntityId, name: String, typeLine: String, extra: ComponentContainer.() -> ComponentContainer = { this }): Pair<GameState, EntityId> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = name,
+                name = name,
+                manaCost = ManaCost.parse("{1}"),
+                typeLine = TypeLine.parse(typeLine),
+                ownerId = owner
+            ),
+            OwnerComponent(owner),
+            ControllerComponent(owner)
+        ).extra()
+        return withEntity(id, container).addToZone(ZoneKey(owner, Zone.BATTLEFIELD), id) to id
+    }
+
+    test("the second head's 'lose at the next end step' fires on the team's end step (Final Fortune, CR 805.8)") {
+        val (base, p, proc) = boot()
+        base.activePlayerId shouldBe p[0]
+        val armed = base.updateEntity(p[1]) { it.with(LoseAtEndStepComponent(turnsUntilLoss = 0)) }
+
+        val atEnd = drive(armed, proc) { it.gameOver || (it.step == Step.END && it.activePlayerId != p[0]) }
+
+        // p1 lost at team 0's end step, which takes the whole team down (CR 810.8a).
+        atEnd.getEntity(p[1])?.has<PlayerLostComponent>() shouldBe true
+        atEnd.getEntity(p[0])?.has<PlayerLostComponent>() shouldBe true
+        atEnd.gameOver.shouldBeTrue()
+    }
+
+    test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
+        val (base, p, proc) = boot()
+        val delayed = DelayedTriggeredAbility(
+            id = "second-head-delayed",
+            effect = Effects.DrawCards(1),
+            fireAtStep = Step.END,
+            sourceId = p[1],
+            sourceName = "Second Head Rider",
+            controllerId = p[1],
+            fireOnPlayerId = p[1]
+        )
+        val armed = base.copy(delayedTriggers = base.delayedTriggers + delayed)
+        val mainHand = handSize(drive(armed, proc) { it.step == Step.PRECOMBAT_MAIN }, p[1])
+
+        // Reach the end step with the trigger consumed and its draw resolved.
+        val atEnd = drive(armed, proc) {
+            it.step == Step.END && it.delayedTriggers.none { d -> d.id == "second-head-delayed" } && it.stack.isEmpty()
+        }
+        atEnd.activePlayerId shouldBe p[0]
+        handSize(atEnd, p[1]) shouldBe mainHand + 1
+    }
+
+    test("the second head's 'until your next turn' effect expires when the team's next turn begins") {
+        val (base, p, proc) = boot()
+        val (withBear, bear) = base.withPermanent(p[1], "Team Bear", "Creature — Bear")
+        val fx = ActiveFloatingEffect(
+            id = EntityId.generate(),
+            effect = FloatingEffectData(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(3, 3),
+                affectedEntities = setOf(bear)
+            ),
+            duration = Duration.UntilYourNextTurn,
+            sourceId = null,
+            controllerId = p[1],
+            timestamp = withBear.timestamp
+        )
+        val armed = withBear.copy(floatingEffects = withBear.floatingEffects + fx)
+
+        // It survives the rest of team 0's turn and all of team 1's turn …
+        val onTeam1Turn = drive(armed, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        onTeam1Turn.floatingEffects.any { it.id == fx.id } shouldBe true
+        // … and wears off once team 0's next turn has untapped.
+        val backOnTeam0 = drive(onTeam1Turn, proc) { it.activePlayerId == p[0] && it.step == Step.UPKEEP }
+        backOnTeam0.floatingEffects.any { it.id == fx.id }.shouldBeFalse()
+    }
+
+    test("the second head's Saga gets a lore counter at the team's precombat main phase (CR 714.3c)") {
+        val (base, p, proc) = boot()
+        val (withSaga, saga) = base.withPermanent(p[1], "Team Saga", "Enchantment — Saga") { with(SagaComponent()) }
+        withSaga.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe null
+
+        // The game boots at the top of team 0's first turn: its precombat main adds the first
+        // counter, and team 0's next turn adds the second — never team 1's turn in between.
+        val turn1Main = drive(withSaga, proc) { it.step == Step.PRECOMBAT_MAIN }
+        turn1Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        val team1Main = drive(turn1Main, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        team1Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        val nextTeam0Main = drive(team1Main, proc) { it.activePlayerId == p[0] && it.step == Step.PRECOMBAT_MAIN }
+        nextTeam0Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 2
+    }
+
+    test("'skip your combat phase' aimed at the second head skips the team's combat (CR 805.8)") {
+        val (base, p, proc) = boot()
+        val armed = base.updateEntity(p[1]) { it.with(SkippedTurnPartsComponent(setOf(TurnPart.COMBAT_PHASE))) }
+
+        val visited = mutableListOf<Step>()
+        drive(armed, proc) { visited += it.step; it.activePlayerId == p[2] }
+        visited.filter { it == Step.DECLARE_ATTACKERS || it == Step.BEGIN_COMBAT }.shouldBeEmpty()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
@@ -81,6 +81,9 @@ class TwoHeadedGiantTeamPriorityTest : FunSpec({
                 teams = teams,
                 startingPlayerIndex = 0,
                 skipMulligans = true,
+                // Pinned: the chain test needs two Sprouts in p0's opening hand and one in p1's;
+                // an unseeded shuffle misses that roughly one run in twenty.
+                seed = 2026_08_27L,
             )
         )
         return Triple(result.state, result.playerIds, ActionProcessor(registry()))


### PR DESCRIPTION
Part 2 of the stacked multiplayer-CR-audit series. **Based on #2055** — merge that first; this diff is only the second commit.

## Defect
`GameState.getNextTeam` always hands the turn to a team's *first* still-in member, so in Two-Headed Giant `activePlayerId` is permanently the first head and the second head is never "the active player" even though the turn is theirs too (CR 805.4). Every engine site that compared a player against `activePlayerId` silently skipped that head:

- Final Fortune / Last Chance cast by the second head: the team took the extra turn and **never lost** (`TurnManager` end step)
- their step-keyed delayed triggers never fired — a "return it at the beginning of the next end step" flicker exiled permanently (`TriggerDetector.detectDelayedTriggers`)
- their "until your next turn" / "until your next upkeep" effects, protection, can't-gain-life, Memory Vessel / Avatar's Wrath restrictions, copy reverts and goads never expired (`CleanupPhaseManager`)
- their Sagas never got lore counters; "skip your combat phase" aimed at them was a no-op (CR 805.8); their own "doesn't untap" marker was read off the teammate; "whenever you attack", first-spell / once-per-turn free casts, Bowmasters' draw-step exemption, the sneak window and `OrderBlockers` were refused

## Fix
Every such site reads `GameState.isActiveTurnFor(player)` or iterates `sharedTurnTeam(activePlayer)`. Both reduce to plain equality / a singleton outside a shared-team-turns format, so 1v1, FFA and Team vs. Team are byte-identical. Hijack (Mindslaver on the team, CR 805.8 last sentence) and the second attack declaration are separate PRs in this stack.

## Verification
`:rules-engine:test` — 536 classes, 0 failures. New `TwoHeadedGiantSecondHeadTurnTest` (5 tests) pins: lose-at-end-step, step-keyed delayed trigger, until-your-next-turn expiry across the enemy turn, Saga lore on the team's main phases only, skip-combat aimed at the second head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)