### PR TITLE
Multiplayer CR audit 3/N: one combined attack per team (CR 805.10b) + team-aware auto-pass/AI combat gates

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -115,7 +115,7 @@ class AIPlayer(
             if (result.error != null) {
                 // Action was illegal — submit a safe fallback action
                 val fallback = when {
-                    current.step == Step.DECLARE_ATTACKERS && current.activePlayerId == playerId -> {
+                    current.step == Step.DECLARE_ATTACKERS && current.isActiveTurnFor(playerId) -> {
                         // Include mandatory attackers to avoid rejection
                         val legalActions = simulator.getLegalActions(current, playerId)
                         val attackAction = legalActions.find { it.actionType == "DeclareAttackers" }
@@ -130,7 +130,7 @@ class AIPlayer(
                         } else emptyMap()
                         DeclareAttackers(playerId, attackerMap)
                     }
-                    current.step == Step.DECLARE_BLOCKERS && current.activePlayerId != playerId -> {
+                    current.step == Step.DECLARE_BLOCKERS && !current.isActiveTurnFor(playerId) -> {
                         // Include mandatory blockers to avoid rejection
                         val legalActions = simulator.getLegalActions(current, playerId)
                         val blockerAction = legalActions.find { it.actionType == "DeclareBlockers" }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -281,7 +281,7 @@ class Strategist(
         // while a pump that is about to wear off in cleanup gets a penalty instead of an
         // encouragement. Keeping both would double-count the first and cancel the second.
         val adjustedPassScore =
-            if (!holdPolicy.isEnabled && state.activePlayerId != playerId && state.step == Step.END) {
+            if (!holdPolicy.isEnabled && !state.isActiveTurnFor(playerId) && state.step == Step.END) {
                 passScore - 1.5
             } else {
                 passScore
@@ -370,7 +370,7 @@ class Strategist(
                 turnNumber = state.turnNumber,
                 step = state.step.name,
                 activePlayerId = state.activePlayerId,
-                onOwnTurn = state.activePlayerId == playerId,
+                onOwnTurn = state.isActiveTurnFor(playerId),
                 baselineLabel = "Pass priority",
                 baselineScore = adjustedPassScore,
                 chosenLabel = options.firstOrNull { it.chosen }?.label ?: "Pass priority",
@@ -576,7 +576,7 @@ class Strategist(
                 turnNumber = state.turnNumber,
                 step = state.step.name,
                 activePlayerId = state.activePlayerId,
-                onOwnTurn = state.activePlayerId == playerId,
+                onOwnTurn = state.isActiveTurnFor(playerId),
                 baselineLabel = baselineLabel,
                 baselineScore = baselineScore,
                 chosenLabel = chosenLabel,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
@@ -51,11 +51,11 @@ private fun isCombatStep(state: GameState): Boolean =
 
 /** True when it's the AI's own main phase. */
 private fun isOwnMainPhase(state: GameState, playerId: EntityId): Boolean =
-    state.activePlayerId == playerId && state.step.isMainPhase
+    state.isActiveTurnFor(playerId) && state.step.isMainPhase
 
 /** True when it's the opponent's turn. */
 private fun isOpponentsTurn(state: GameState, playerId: EntityId): Boolean =
-    state.activePlayerId != playerId
+    !state.isActiveTurnFor(playerId)
 
 /** Sum of creature board value for a player. */
 private fun creatureBoardValue(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
@@ -309,7 +309,7 @@ object CounterspellAdvisor : CardAdvisor {
         if (isOpponentsTurn(state, playerId) && state.stack.isNotEmpty()) return null
 
         // Own turn: heavily penalize — hold it
-        if (state.activePlayerId == playerId) {
+        if (state.isActiveTurnFor(playerId)) {
             return context.passScore - 2.0
         }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
@@ -184,7 +184,7 @@ internal object ExpiringGrantWindow {
      * mistake, not the missed window.
      */
     private fun laterWindowIsStillAhead(state: GameState, playerId: EntityId): Boolean =
-        if (state.activePlayerId == playerId) state.step in BEFORE_OUR_ATTACK
+        if (state.isActiveTurnFor(playerId)) state.step in BEFORE_OUR_ATTACK
         else state.step in BEFORE_THEIR_ATTACK
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1140,7 +1140,7 @@ class GameSession(
         }
 
         val effectiveOverrides = if (hasNonBattlefieldAbility) {
-            val isMyTurn = state.activePlayerId == priorityPlayer
+            val isMyTurn = state.isActiveTurnFor(priorityPlayer)
             if (isMyTurn) {
                 overrides.copy(myTurnStops = overrides.myTurnStops + state.step)
             } else {
@@ -1263,12 +1263,15 @@ class GameSession(
 
         // During combat declaration steps, submit an empty declaration instead of PassPriority.
         // The engine requires declarations before allowing priority to pass.
+        // Turn ownership is team-wide in a shared team turn (CR 805.10a) — the same gate the
+        // engine's PassPriorityHandler / DeclareBlockersHandler use — so the active player's
+        // teammate isn't handed a DeclareBlockers (or a bare pass) the engine will refuse.
         val action: GameAction = when {
-            state.step == Step.DECLARE_ATTACKERS && playerId == state.activePlayerId &&
+            state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(playerId) &&
                 state.getEntity(playerId)?.get<AttackersDeclaredThisCombatComponent>() == null ->
                 DeclareAttackers(playerId, emptyMap())
 
-            state.step == Step.DECLARE_BLOCKERS && playerId != state.activePlayerId &&
+            state.step == Step.DECLARE_BLOCKERS && !state.isActiveTurnFor(playerId) &&
                 state.getEntity(playerId)?.get<BlockersDeclaredThisCombatComponent>() == null ->
                 DeclareBlockers(playerId, emptyMap())
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.actions.combat
 
 import com.wingedsheep.engine.core.AbilityTriggeredEvent
 import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.event.TriggerDetector
@@ -34,6 +35,12 @@ class DeclareAttackersHandler(
         }
         if (state.step != Step.DECLARE_ATTACKERS) {
             return "You can only declare attackers during the declare attackers step"
+        }
+        // One declaration per combat (CR 508.1; in a shared team turn the team's one combined
+        // attack, CR 805.10b). The marker is stamped on every attacking player, so a teammate
+        // can't append a second wave after the first head has declared.
+        if (state.getEntity(action.playerId)?.has<AttackersDeclaredThisCombatComponent>() == true) {
+            return "Attackers have already been declared this combat"
         }
         // Additional validation is done by CombatManager
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -235,28 +235,36 @@ internal class AttackPhaseManager(
         // so the fact is stamped here. `defenderId in turnOrder` is the player-identity idiom.
         val attackersAgainstPlayer = attackers.filterValues { it in state.turnOrder }.keys
 
-        newState = newState.updateEntity(attackingPlayer) { container ->
-            // Both markers are stamped even for an empty declaration: they record that the step
-            // happened, which is what tells "declared nothing" apart from "never got the chance".
-            var updated = container
-                .with(AttackersDeclaredThisCombatComponent)
-                .with(AttackersDeclaredThisTurnComponent)
-            if (attackers.isNotEmpty()) {
-                updated = updated.with(PlayerAttackedThisTurnComponent)
-                val previous = container.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
-                updated = updated.with(PlayerAttackersThisTurnComponent(previous + attackers.keys))
-                if (defendingPlayers.isNotEmpty()) {
-                    val previousDefenders = container
-                        .get<com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent>()
-                        ?.defendingPlayerIds ?: emptySet()
-                    updated = updated.with(
-                        com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent(
-                            previousDefenders + defendingPlayers
+        // CR 805.10b — the active team has ONE combined attack, and CR 805.10a makes every
+        // player on it an attacking player. So the declaration is recorded on every member of
+        // the attacking team, not just the seat that submitted it: the teammate is not asked to
+        // declare a second wave (PassPriorityHandler / CombatEnumerator read this marker), and
+        // "you attacked this turn" is true for both heads. Outside shared team turns the team
+        // is the declaring player alone.
+        for (member in state.sharedTurnTeam(attackingPlayer)) {
+            newState = newState.updateEntity(member) { container ->
+                // Both markers are stamped even for an empty declaration: they record that the step
+                // happened, which is what tells "declared nothing" apart from "never got the chance".
+                var updated = container
+                    .with(AttackersDeclaredThisCombatComponent)
+                    .with(AttackersDeclaredThisTurnComponent)
+                if (attackers.isNotEmpty()) {
+                    updated = updated.with(PlayerAttackedThisTurnComponent)
+                    val previous = container.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
+                    updated = updated.with(PlayerAttackersThisTurnComponent(previous + attackers.keys))
+                    if (defendingPlayers.isNotEmpty()) {
+                        val previousDefenders = container
+                            .get<com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent>()
+                            ?.defendingPlayerIds ?: emptySet()
+                        updated = updated.with(
+                            com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent(
+                                previousDefenders + defendingPlayers
+                            )
                         )
-                    )
+                    }
                 }
+                updated
             }
-            updated
         }
 
         val attackerNames = attackers.keys.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Creature" }
@@ -618,7 +626,10 @@ internal class AttackPhaseManager(
         attackingPlayer: EntityId,
         attackers: Map<EntityId, EntityId>
     ): String? {
-        val mustAttack = state.getEntity(attackingPlayer)?.get<MustAttackPlayerComponent>()
+        // Taunt marks the player it was aimed at; in a shared team turn the team's one combined
+        // attack (CR 805.10b) has to satisfy a requirement placed on either head.
+        val mustAttack = state.sharedTurnTeam(attackingPlayer)
+            .firstNotNullOfOrNull { member -> state.getEntity(member)?.get<MustAttackPlayerComponent>() }
             ?: return null
 
         if (!mustAttack.activeThisTurn) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
@@ -118,6 +118,28 @@ class TwoHeadedGiantCombatTest : FunSpec({
         result.newState.getEntity(atk1)!!.get<AttackingComponent>()!!.defenderId shouldBe p[3]
     }
 
+    test("one declaration is the whole team's — the teammate may pass and can't add a second wave (CR 805.10b)") {
+        val (base, p) = init2hg()
+        val (s1, atk0) = base.withBear(p[0])
+        val (s2, atk1) = s1.withBear(p[1])
+        val state = s2.copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT).withPriority(p[0])
+        val proc = ActionProcessor(registry())
+
+        // p0 attacks with their own bear only; p1's bear stays home.
+        val declared = proc.process(state, DeclareAttackers(p[0], mapOf(atk0 to p[2]))).result
+        declared.isSuccess.shouldBeTrue()
+        // The declaration is recorded on BOTH heads …
+        declared.newState.getEntity(p[1])?.has<AttackersDeclaredThisCombatComponent>() shouldBe true
+        // … so p1 is not made to declare before passing …
+        val afterP0Pass = proc.process(declared.newState, com.wingedsheep.engine.core.PassPriority(p[0])).result.newState
+        afterP0Pass.priorityPlayerId shouldBe p[1]
+        proc.process(afterP0Pass, com.wingedsheep.engine.core.PassPriority(p[1])).result.isSuccess.shouldBeTrue()
+        // … and can't send a second wave in after the fact.
+        val secondWave = proc.process(afterP0Pass, DeclareAttackers(p[1], mapOf(atk1 to p[3]))).result
+        secondWave.isSuccess.shouldBeFalse()
+        secondWave.newState.getEntity(atk1)?.has<AttackingComponent>() shouldBe false
+    }
+
     test("the whole nonactive team defends — even an un-attacked teammate is a defending player (CR 805.10a)") {
         val (base, p) = init2hg()
         val (state, _) = base.withBear(p[0], attacking = p[2]) // p0 attacks p2 only


### PR DESCRIPTION
Part 3 of the stacked multiplayer-CR-audit series. **Based on #2056** (which is based on #2055) — this diff is only the third commit.

## Defect
CR 805.10b: the active team makes **one** combined attack. `AttackersDeclaredThisCombatComponent` was stamped only on the seat that submitted the declaration, so once the first head declared:
- the second head was still *required* to declare before passing (`PassPriorityHandler`) and still offered `DeclareAttackers` (`CombatEnumerator`)
- they could add a second wave → two `AttackersDeclaredEvent`s per combat ("whenever you attack" twice, Dueling Grounds / "attacks alone" evaluated per wave, requirements checked per declarer)
- `GameSession.executeAutoPass` / `getAutoPassPlayer` and the AI's combat fallbacks gated on `activePlayerId ==`, so the second head's seat got a `DeclareBlockers`/bare `PassPriority` the engine refuses — a stalled auto-pass loop and a manual click every combat.

## Fix
- `AttackPhaseManager.declareAttackers` records the declaration (and the "you attacked this turn" facts — CR 805.10a makes every team member an attacking player) on every `sharedTurnTeam` member.
- `DeclareAttackersHandler.validate` refuses a second declaration in the same combat (the marker is cleared for everyone at `endCombat`, so additional combat phases still work).
- `validateMustAttackRequirements` honours a Taunt placed on either head.
- Server auto-pass and the AI (`AIPlayer`, `Strategist`, `ExpiringGrantWindow`, `BloomburrowAdvisorModule`) read `isActiveTurnFor`.

Everything reduces to the previous behaviour outside a shared-team-turns format.

## Verification
`:rules-engine:test :game-server:test` — 0 failures; `:ai:compileKotlin` green. New test in `TwoHeadedGiantCombatTest`: after the first head declares, the marker is on both heads, the teammate may pass, and a second wave is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)