### PR TITLE
Multiplayer CR audit 4/N: an AI teammate no longer re-passes every tick while its partner holds the baton (CR 805.5)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -279,6 +279,19 @@ class AiWebSocketSession(
             return
         }
 
+        // Team priority (CR 805.5) offers a bot its own actions while its human partner holds the
+        // baton. The bot takes its window in baton order instead — GameState.hasPriority's KDoc:
+        // widening permission never took a window away, and a bot racing its partner for every
+        // response would spend windows the human never got to see. So outside a decision addressed
+        // to us, act only when the seat these actions belong to is the baton holder (a hijacked
+        // seat we drive still qualifies: its actions carry that seat's id, which IS the baton).
+        // `priorityPlayerId` is kept current by applyDelta, so it is safe to read here.
+        val actingSeat = legalActions.firstOrNull()?.action?.playerId
+        if (!isOurDecision && actingSeat != null && actingSeat != state.priorityPlayerId) {
+            logger.info("AI skipping — team priority window belongs to the baton holder {}", state.priorityPlayerId)
+            return
+        }
+
         if (legalActions.isNotEmpty()) {
             logger.info("AI has {} legal actions: {}", legalActions.size,
                 legalActions.joinToString(", ") { "${it.actionType}${if (it.description.isNotBlank()) "(${it.description})" else ""}" })

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
@@ -51,6 +51,15 @@ class PassPriorityHandler(
         if (!state.hasPriority(action.playerId)) {
             return "You don't have priority"
         }
+        // Under team priority (CR 805.5) a teammate may pass out of baton order, and their pass
+        // then stands until someone acts (which re-arms every seat). Passing *again* in the same
+        // round does nothing — the baton stays put and the round doesn't advance — so refuse it
+        // rather than let a client (an AI partner polling its legal actions) spin on it forever.
+        // The baton holder is never in [GameState.priorityPassedBy], so this only ever bites a
+        // seat that already declined; no non-team game can reach it.
+        if (action.playerId in state.priorityPassedBy && action.playerId != state.priorityPlayerId) {
+            return "You have already passed priority this round"
+        }
         // Cannot pass priority while there's a pending decision
         val pendingDecision = state.pendingDecision
         if (pendingDecision != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PassPriorityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PassPriorityEnumerator.kt
@@ -7,6 +7,13 @@ import com.wingedsheep.engine.legalactions.LegalAction
 
 class PassPriorityEnumerator : ActionEnumerator {
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
+        val state = context.state
+        // A teammate who already passed this round (CR 805.5 team priority) has nothing to pass
+        // again until someone acts and re-arms the round — mirror PassPriorityHandler's gate so the
+        // client is never offered an action the engine will refuse. Never true for the baton holder.
+        if (context.playerId in state.priorityPassedBy && context.playerId != state.priorityPlayerId) {
+            return emptyList()
+        }
         return listOf(
             LegalAction(
                 action = PassPriority(context.playerId),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
@@ -259,6 +259,35 @@ class TwoHeadedGiantTeamPriorityTest : FunSpec({
         state.priorityPassedBy shouldBe setOf(p[0], p[1])
     }
 
+    test("a teammate who already passed this round can't pass again until someone acts") {
+        val (booted, p, proc) = boot2hg()
+        var state = toPrecombatMain(booted, proc)
+
+        // p1 passes out of baton order; p0 still holds the baton.
+        state = proc.process(state, PassPriority(p[1])).result.newState
+        state.priorityPlayerId shouldBe p[0]
+        state.priorityPassedBy shouldBe setOf(p[1])
+
+        // A second pass from p1 is refused — it would leave the state exactly as it is, which is
+        // the loop an AI partner polling its legal actions fell into.
+        val again = proc.process(state, PassPriority(p[1])).result
+        again.isSuccess shouldBe false
+        // And it is no longer offered: the enumerator mirrors the handler.
+        val services = com.wingedsheep.engine.core.EngineServices(registry())
+        val enumerator = com.wingedsheep.engine.legalactions.LegalActionEnumerator(
+            services.cardRegistry, services.manaSolver, services.costCalculator,
+            services.predicateEvaluator, services.conditionEvaluator, services.turnManager
+        )
+        enumerator.enumerate(state, p[1]).none { it.actionType == "PassPriority" } shouldBe true
+        // The baton holder's own pass is untouched.
+        enumerator.enumerate(state, p[0]).count { it.actionType == "PassPriority" } shouldBe 1
+
+        // Once p0 acts, the round is re-armed and p1 may pass again.
+        state = proc.process(state, CastSpell(p[0], state.handCard(p[0], hunch.name))).result.newState
+        state.priorityPassedBy.shouldBeEmpty()
+        proc.process(state, PassPriority(p[1])).result.isSuccess shouldBe true
+    }
+
     test("nextUnpassedPriorityAfter is plain getNextPlayer while nobody has passed") {
         val (booted, p, proc) = boot2hg()
         val state = toPrecombatMain(booted, proc)


### PR DESCRIPTION
Part 4 of the stacked multiplayer-CR-audit series. **Based on #2057** — this diff is only the last commit.

## Defect
Under team priority (CR 805.5) a teammate may pass out of baton order, and their pass stands until someone acts. Passing *again* did nothing — `nextPriorityAfterPass` left the baton put and the round didn't advance — yet the pass was accepted and the state rebroadcast. `GameSession.getLegalActions` kept offering the already-passed teammate a `PassPriority`, and `AiWebSocketSession` acts whenever its legal actions are non-empty, so an **AI partner re-passed every `thinkingDelayMs`** while its human partner held the baton: replay bloat, and every tick counted toward `GameStallGuard`'s 2000-actions-per-turn draw. It also let a bot race its human partner for every response, contrary to the design note on `GameState.hasPriority`.

## Fix (engine first, server authoritative)
- `PassPriorityHandler.validate` refuses a pass from a seat already in `priorityPassedBy` (never the baton holder → no non-team game changes).
- `PassPriorityEnumerator` mirrors that gate so the client is never offered the refused action.
- `AiWebSocketSession.handleStateUpdate` acts only when the actions' seat is the baton holder (a hijacked seat it drives still qualifies) or a decision is addressed to it — a bot teammate takes its window in baton order.

## Verification
`:rules-engine:test :game-server:test` — 0 failures. New test in `TwoHeadedGiantTeamPriorityTest`: the second pass is refused, not enumerated for the teammate but still enumerated for the baton holder, and allowed again once the partner acts and re-arms the round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)