### PR TITLE
Multiplayer CR audit 6/N: 'don't lose for 0 life' and 'can't gain life' reach the whole team (CR 810.8a / 810.9g)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1170,9 +1170,14 @@ object DamageUtils {
      */
     fun isLifeGainPrevented(state: GameState, playerId: EntityId): Boolean {
         // Durable, source-independent lock conferred directly on the player
-        // (LockLifeGainEffect — Screaming Nemesis).
-        if (state.getEntity(playerId)
-                ?.has<com.wingedsheep.engine.state.components.player.CantGainLifeComponent>() == true
+        // (LockLifeGainEffect — Screaming Nemesis). CR 810.9g: where the life total is the team's,
+        // "that player can't gain life" means no player on their team can — a lock on either head
+        // closes the shared pool. Outside a shared-life format the team is the player alone.
+        val lockedSeats = if (state.format.sharesTeamLife) state.teamOf(playerId) else listOf(playerId)
+        if (lockedSeats.any { seat ->
+                state.getEntity(seat)
+                    ?.has<com.wingedsheep.engine.state.components.player.CantGainLifeComponent>() == true
+            }
         ) {
             return true
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -62,13 +62,21 @@ internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
 }
 
 /**
- * Narrow sibling of [playerCantLoseGame]: true when [playerId] controls a permanent granting
- * "you don't lose the game for having 0 or less life" (Marina Vendrell's Grimoire). Consulted only
- * by the 704.5a life-loss check, so poison / empty-library / effect losses are unaffected. Scoped
- * to the controller itself — it is not a team-wide "can't lose" grant.
+ * Narrow sibling of [playerCantLoseGame]: true when [playerId] — or, where players win and lose
+ * as a team, a teammate — controls a permanent granting "you don't lose the game for having 0 or
+ * less life" (Transcendence, Marina Vendrell's Grimoire). Consulted only by the 704.5a life-loss
+ * check, so poison / empty-library / effect losses are unaffected.
+ *
+ * The team reach is CR 810.8a's own example: a Two-Headed Giant team at 0 or less life with
+ * Transcendence on one head doesn't lose. The life total is the team's (810.4), so a grant that
+ * excuses one head from the 0-life loss has to excuse the other — otherwise the unprotected head
+ * is marked, TeamLossPropagationCheck drags the protected one down, and the grant did nothing.
  */
-internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean =
-    ControllerGrants.grantedTo<GrantsCantLoseGameFromLifeComponent>(state, playerId)
+internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean {
+    val team = (if (state.format.playersWinLoseAsTeam) state.teamOf(playerId) else listOf(playerId))
+        .toHashSet()
+    return ControllerGrants.anyGranting<GrantsCantLoseGameFromLifeComponent>(state) { it in team }
+}
 
 /**
  * True when [playerId] can't win the game because one of its opponents controls a permanent

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
@@ -88,6 +88,18 @@ class TwoHeadedGiantSharedLifeTest : FunSpec({
         after.lifeTotal(p[1]) shouldBe 34
     }
 
+    test("a 'can't gain life' lock on one head closes the shared pool for the teammate too (CR 810.9g)") {
+        val (state, p) = boot()
+        val locked = state.updateEntity(p[0]) {
+            it.with(com.wingedsheep.engine.state.components.player.CantGainLifeComponent())
+        }
+        val (afterTeammateGain, event) = DamageUtils.gainLife(locked, p[1], 4)
+        event shouldBe null
+        afterTeammateGain.lifeTotal(p[1]) shouldBe 30
+        // The opposing team is untouched by team 0's lock.
+        DamageUtils.gainLife(locked, p[2], 4).first.lifeTotal(p[2]) shouldBe 34
+    }
+
     test("damage to a teammate reduces the shared team total") {
         val (state, p) = boot()
         val result = DamageUtils.dealDamageToTarget(state, p[0], 6, sourceId = null)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
@@ -153,6 +153,28 @@ class TwoHeadedGiantTeamLossTest : FunSpec({
         s.gameOver shouldBe false
     }
 
+    test("'you don't lose for having 0 or less life' on either head protects the whole team (CR 810.8a example)") {
+        val (state, p) = boot()
+        // Transcendence-style grant under p1's control (teammate of p0).
+        val (permId, withId) = state.newEntity()
+        val protectedState = withId
+            .withEntity(
+                permId,
+                ComponentContainer.of(
+                    ControllerComponent(p[1]),
+                    com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent()
+                )
+            )
+            .addToZone(ZoneKey(p[1], Zone.BATTLEFIELD), permId)
+        val zeroed = DamageUtils.loseLife(protectedState, p[0], 30, LifeChangeReason.LIFE_LOSS).first
+
+        val s = checker().checkAndApply(zeroed).newState
+        // CR 810.8a: "If that player's team's life total is 0 or less, that team doesn't lose."
+        lost(s, p[0]) shouldBe false
+        lost(s, p[1]) shouldBe false
+        s.gameOver shouldBe false
+    }
+
     test("'you win the game' wins for your whole team and defeats only opposing teams (CR 810.8a)") {
         val (state, p) = boot()
         val result = WinGameExecutor().execute(


### PR DESCRIPTION
Part 6 of the stacked multiplayer-CR-audit series. **Based on #2060** — this diff is only the last commit.

## Defects
1. **CR 810.8a's own example**: a Two-Headed Giant team at 0 or less life with Transcendence on one head doesn't lose. `playerCantLoseGameFromLife` was scoped to its controller, so the *unprotected* head was marked `LIFE_ZERO` and `TeamLossPropagationCheck` dragged the protected head down with it — the grant did nothing.
2. **CR 810.9g** "if an effect says a player can't gain life, no player on that player's team can gain life": Screaming Nemesis's `CantGainLifeComponent` locked one head while the teammate kept feeding the shared pool.

## Fix
- `playerCantLoseGameFromLife` gets the same `playersWinLoseAsTeam ? teamOf(p) : [p]` reach `playerCantLoseGame` already has.
- `DamageUtils.isLifeGainPrevented` reads the lock off every member of a `sharesTeamLife` team.

Both gates are format-flagged, so 1v1 / FFA / Team vs. Team are unchanged.

## Verification
`:rules-engine:test` — 0 failures. New tests: `TwoHeadedGiantTeamLossTest` (grant on the teammate protects the team at 0 life), `TwoHeadedGiantSharedLifeTest` (a lock on one head blocks the teammate's gain; the opposing team is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)