### PR TITLE
Multiplayer CR audit 7/N: no combat damage to a player who has left; departed seats aren't attack targets (CR 800.4e / 800.4a)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -66,10 +66,13 @@ internal class AttackPhaseManager(
     ): ExecutionResult {
         // Validate each attacker
         val projected = state.projectedState
-        // CR 805.10a/b — a creature attacks the opposing team; never a teammate. Exclude the whole
-        // attacking team from legal player targets (in a non-team game this is just the attacker).
+        // CR 805.10a/b — a creature attacks the opposing team; never a teammate. [getOpponents]
+        // excludes the whole attacking team (in a non-team game just the attacker) and — unlike the
+        // raw turn order — every seat that has left the game (CR 800.4a): a departed player is no
+        // longer anyone's opponent, so they can't be attacked. The enumerator already reads the
+        // same set; the handler has to agree with it because actions are client-supplied.
         val attackingTeam = state.teamOf(attackingPlayer)
-        val opponents = state.turnOrder.filter { it !in attackingTeam }
+        val opponents = state.getOpponents(attackingPlayer)
 
         // Validate band declarations (CR 702.22c).
         val bandValidation = validateBands(state, attackers, bands, projected)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRule.kt
@@ -41,7 +41,8 @@ interface AttackDefenderRule {
      * Used by [getValidAttackers] for must-attack requirement validation.
      */
     fun restrictsAllDefenders(ctx: AttackCheckContext): Boolean {
-        val opponents = ctx.state.turnOrder.filter { it != ctx.attackingPlayer }
+        // Real opponents only: not a teammate (CR 805.10b), not a seat that has left (CR 800.4a).
+        val opponents = ctx.state.getOpponents(ctx.attackingPlayer)
         val projected = ctx.projected
         // Collect all valid defenders: opponent players + their planeswalkers
         val allDefenders = opponents.toMutableList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.engine.core.GameEndReason
 import com.wingedsheep.engine.core.PlayerLeftGameEvent
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.mechanics.combat.CombatRemovalHelper
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockedComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -85,6 +87,13 @@ object PlayerLeavesGameProcessor {
         //    vanish, the rest of combat proceeds).
         s = clearCombatReferences(s, toRemove)
 
+        // 3b. CR 800.4e — combat damage that would be assigned to a player who has left isn't.
+        //     Creatures attacking the leaver (or a planeswalker / battle of theirs, which has just
+        //     left too) are removed from combat: nothing is left for them to hit, and leaving
+        //     them "attacking" a seat that is gone would still fire lifelink and
+        //     "deals combat damage to a player" triggers off a dead life total in the damage step.
+        s = removeAttackersAimedAt(s, leaver, toRemove)
+
         // 4. Remove the objects from the game entirely.
         for (id in toRemove) {
             s = s.removeEntity(id)
@@ -135,6 +144,22 @@ object PlayerLeavesGameProcessor {
             .clearPendingDecision()
             .copy(continuationStack = emptyList())
             .withPriority(state.activePlayerId)
+    }
+
+    /**
+     * Remove from combat every remaining attacker whose declared defender is [leaver] or one of
+     * the [removed] objects (their planeswalkers and battles). Their own attackers are already
+     * gone, so this only ever touches other players' creatures.
+     */
+    private fun removeAttackersAimedAt(state: GameState, leaver: EntityId, removed: Set<EntityId>): GameState {
+        var s = state
+        for (id in s.getBattlefield()) {
+            val defender = s.getEntity(id)?.get<AttackingComponent>()?.defenderId ?: continue
+            if (defender == leaver || defender in removed) {
+                s = CombatRemovalHelper.removeFromCombat(s, id)
+            }
+        }
+        return s
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
@@ -84,6 +84,7 @@ class LeaveTheGameTest : FunSpec({
                 name = "Leave Test Bear",
                 manaCost = ManaCost.parse("{1}{G}"),
                 typeLine = TypeLine.parse("Creature — Bear"),
+                baseStats = bear.creatureStats,
                 ownerId = owner
             ),
             ControllerComponent(controller)
@@ -239,6 +240,42 @@ class LeaveTheGameTest : FunSpec({
         afterLeave.getEntity(attackerId).shouldBeNull()
         // The blocker no longer references the departed attacker (combat can proceed).
         afterLeave.getEntity(blockerId)?.has<BlockingComponent>() shouldBe false
+    }
+
+    test("attackers aimed at the leaver are removed from combat; the rest of the attack stands (CR 800.4e)") {
+        val (base, players) = initGame(4)
+        // players[0] attacks players[1] with one bear and players[2] with another.
+        val (s1, atB) = base.withCreature(owner = players[0])
+        val (s2, atC) = s1.withCreature(owner = players[0])
+        val state = s2
+            .updateEntity(atB) { it.with(AttackingComponent(defenderId = players[1])) }
+            .updateEntity(atC) { it.with(AttackingComponent(defenderId = players[2])) }
+
+        val afterLeave = PlayerLeavesGameProcessor.process(state, players[2], GameEndReason.CONCESSION).newState
+
+        // Nothing is left for the second bear to deal damage to — it is out of combat …
+        afterLeave.getEntity(atC)?.has<AttackingComponent>() shouldBe false
+        // … while the attack on players[1] is untouched.
+        afterLeave.getEntity(atB)?.get<AttackingComponent>()?.defenderId shouldBe players[1]
+    }
+
+    test("a player who has left the game is not a legal attack target (CR 800.4a)") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val (withBear, bear) = base.withCreature(owner = players[0])
+        val gone = processor.process(withBear, Concede(players[2])).result.newState
+        val declaring = gone.copy(
+            step = com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS,
+            phase = com.wingedsheep.sdk.core.Phase.COMBAT
+        ).withPriority(players[0])
+
+        // The enumerator never offers the departed seat; the handler must refuse it too.
+        processor.process(
+            declaring, com.wingedsheep.engine.core.DeclareAttackers(players[0], mapOf(bear to players[2]))
+        ).result.isSuccess shouldBe false
+        processor.process(
+            declaring, com.wingedsheep.engine.core.DeclareAttackers(players[0], mapOf(bear to players[1]))
+        ).result.error.shouldBeNull()
     }
 
     test("priority held by the leaver passes to the next player still in the game (CR 800.4a)") {


### PR DESCRIPTION
Part 7 of the stacked multiplayer-CR-audit series. **Based on #2061** — this diff is only the last commit.

## Defects
- **CR 800.4e** — leave-the-game processing scrubbed the leaver's *own* attackers and blockers, but other players' creatures kept `AttackingComponent(defenderId = leaver)`, and `CombatDamageManager` only asks for a `LifeTotalComponent`, which the departed player entity keeps. In the damage step those creatures still dealt combat damage to a seat that was gone: lifelink gained life, "deals combat damage to a player" triggers fired, damage was tracked.
- **CR 800.4a** — `AttackPhaseManager.declareAttackers` validated the declared defender against the raw `turnOrder` (which keeps departed seats for history), so a client-supplied `DeclareAttackers` aimed at an eliminated player was accepted — unblockable, attack triggers, then the damage above — while `CombatEnumerator` never offered it. `AttackRestrictionRule.restrictsAllDefenders` had the same raw read.

## Fix
- `PlayerLeavesGameProcessor` removes from combat every remaining attacker whose declared defender is the leaver or one of their departed planeswalkers/battles (`CombatRemovalHelper.removeFromCombat`); the rest of the attack stands.
- The handler and the requirement rule read `getOpponents` (excludes departed seats and, in a team game, teammates), agreeing with the enumerator.

## Verification
`:rules-engine:test` — 0 failures (the one failure during development was the new test's own fixture: the leave-test creature had no base stats and didn't count as a creature; fixed in the fixture). Two new tests in `LeaveTheGameTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)