### PR TITLE
Multiplayer CR audit 8/N: a leaver's resolved effects persist; their 'until your next turn' effects end when that turn would have begun (CR 611.2c / 800.4m)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -831,6 +831,11 @@ class TurnManager(
             nextPlayer = cleanedState.getNextTeam(nextPlayer)
         }
 
+        // CR 800.4m — a departed player's "until your next turn" effects last until that turn
+        // would have begun. Their turn is skipped (800.4k), and this is the moment it would have
+        // started: the seat walk from the finished turn to the next one passes them over.
+        cleanedState = expireEffectsOfDepartedSeatsWhoseTurnWouldBeginNow(cleanedState, currentPlayer, nextPlayer)
+
         // Start the new turn (sets step to UNTAP with no priority)
         val turnResult = startTurn(cleanedState, nextPlayer)
         if (!turnResult.isSuccess) return turnResult
@@ -863,6 +868,59 @@ class TurnManager(
             advanceResult.newState,
             turnResult.events + untapResult.events + goadEvents + advanceResult.events
         )
+    }
+
+    /**
+     * CR 800.4m: when the turn passes from [from]'s team to [to]'s team, every player who has left
+     * the game and sits between them in seat order — plus any departed member of [to]'s own team,
+     * whose shared turn is beginning (CR 805.4) — is a player whose next turn "would have begun"
+     * right now. Their "until your next turn" / "until your next upkeep" / "until the end of your
+     * next turn" effects, their goads and their may-play permissions end here, the same hooks a
+     * living player's untap step runs for them. Nothing to do while nobody has left.
+     */
+    private fun expireEffectsOfDepartedSeatsWhoseTurnWouldBeginNow(
+        state: GameState,
+        from: EntityId,
+        to: EntityId
+    ): GameState {
+        val order = state.turnOrder
+        val departed = order.filter { state.getEntity(it)?.has<PlayerLostComponent>() == true }
+        if (departed.isEmpty()) return state
+
+        val fromTeam = state.teamOf(from).toHashSet()
+        val toTeam = state.teamOf(to).toHashSet()
+        val startIdx = order.indexOf(from)
+        if (startIdx < 0) return state
+        val passedOver = mutableListOf<EntityId>()
+        // Walk the seats after the finished team until the next team is reached.
+        for (step in 1 until order.size) {
+            val seat = order[(startIdx + step) % order.size]
+            if (seat in fromTeam) continue
+            if (seat in toTeam) break
+            if (seat in departed) passedOver += seat
+        }
+        // A departed member of the team now taking its turn: their turn is beginning too.
+        passedOver += toTeam.filter { it in departed && it !in fromTeam }
+
+        var s = state
+        for (leaver in passedOver.distinct()) {
+            s = cleanupPhaseManager.expireUntilYourNextTurnEffects(s, leaver)
+            s = cleanupPhaseManager.expireUntilYourNextUpkeepEffects(s, leaver)
+            s = cleanupPhaseManager.expireGoadedDesignationFor(s, leaver).first
+            // "Until the end of your next turn" is keyed to a turn the leaver will never take
+            // (a turn-number floor plus a controller guard); CR 800.4m ends it here as well.
+            s = s.copy(
+                floatingEffects = s.floatingEffects.filterNot { fe ->
+                    fe.duration is com.wingedsheep.sdk.scripting.Duration.EndOfYourNextTurn &&
+                        fe.controllerId == leaver
+                },
+                mayPlayPermissions = s.mayPlayPermissions.filterNot { permission ->
+                    !permission.permanent && permission.expiresAfterTurn != null &&
+                        (permission.expiryControllerId ?: permission.controllerId) == leaver
+                }
+            )
+        }
+        return s
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
 
 /**
  * Applies the "leaving the game" processing for a player who has lost (CR 800.4a–c).
@@ -99,11 +100,27 @@ object PlayerLeavesGameProcessor {
             s = s.removeEntity(id)
         }
 
-        // 5. End floating effects the leaver controlled or that were sourced by an object
-        //    that just left (their continuous effects end with them — CR 800.4a).
+        // 5. End the continuous effects that depended on a departed object. Only those: the
+        //    effect of a spell or ability the leaver already *resolved* persists (CR 611.2c) — a
+        //    Giant Growth on someone else's creature outlives its caster's concession — so nothing
+        //    is dropped for having the leaver as its controller. What ends is an effect whose
+        //    duration is tied to its source staying on the battlefield (611.2b/611.3) when that
+        //    source just left, or one that lasts while the leaver controls the affected object,
+        //    which they no longer do. The leaver's "until your next turn" effects are neither —
+        //    CR 800.4m has them last until that turn would have begun (TurnManager.endTurn).
         s = s.copy(
             floatingEffects = s.floatingEffects.filterNot { fe ->
-                fe.controllerId == leaver || (fe.sourceId != null && fe.sourceId in toRemove)
+                val sourceLeft = fe.sourceId != null && fe.sourceId in toRemove
+                when (fe.duration) {
+                    is Duration.WhileSourceOnBattlefield,
+                    is Duration.WhileYouControlSource,
+                    is Duration.WhileSourceTapped,
+                    is Duration.WhileSourceTappedAndAffectedPowerAtMostSource,
+                    is Duration.WhileYouControlSourceAndSourceTapped,
+                    Duration.WhileSourceAttachedToAffected -> sourceLeft
+                    Duration.WhileControlledByController -> fe.controllerId == leaver
+                    else -> false
+                }
             }
         )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
@@ -278,6 +278,78 @@ class LeaveTheGameTest : FunSpec({
         ).result.error.shouldBeNull()
     }
 
+    /** A floating P/T effect on [target], controlled by [controller], sourced by [sourceId], with [duration]. */
+    fun GameState.pumpEffect(
+        target: EntityId,
+        controller: EntityId,
+        sourceId: EntityId?,
+        duration: Duration
+    ): Pair<GameState, EntityId> {
+        val fx = ActiveFloatingEffect(
+            id = EntityId.generate(),
+            effect = FloatingEffectData(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(3, 3),
+                affectedEntities = setOf(target)
+            ),
+            duration = duration,
+            sourceId = sourceId,
+            controllerId = controller,
+            timestamp = timestamp
+        )
+        return copy(floatingEffects = floatingEffects + fx) to fx.id
+    }
+
+    test("a resolved spell's effect outlives its caster's departure (CR 611.2c) — only source-bound durations end (CR 800.4a)") {
+        val (base, players) = initGame(4)
+        val (s1, ownCreature) = base.withCreature(owner = players[0])
+        // players[1] cast a Giant Growth (the card is theirs and leaves with them) on players[0]'s creature.
+        val (s2, giantGrowthCard) = s1.withCreature(owner = players[1])
+        val (s3, pump) = s2.pumpEffect(ownCreature, controller = players[1], sourceId = giantGrowthCard, duration = Duration.EndOfTurn)
+        // players[1] also control a permanent whose static-style effect lasts while it is on the battlefield.
+        val (s4, anthemSource) = s3.withCreature(owner = players[1])
+        val (state, anthem) = s4.pumpEffect(ownCreature, controller = players[1], sourceId = anthemSource, duration = Duration.WhileSourceOnBattlefield())
+
+        val afterLeave = PlayerLeavesGameProcessor.process(state, players[1], GameEndReason.CONCESSION).newState
+
+        afterLeave.floatingEffects.any { it.id == pump } shouldBe true
+        afterLeave.floatingEffects.any { it.id == anthem } shouldBe false
+    }
+
+    test("a departed player's 'until your next turn' effect lasts until that turn would have begun (CR 800.4m)") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val (s1, creature) = base.withCreature(owner = players[0])
+        val (armed, fx) = s1.pumpEffect(creature, controller = players[1], sourceId = null, duration = Duration.UntilYourNextTurn)
+
+        // players[1] concedes during players[0]'s turn. The effect neither ends now …
+        var state = processor.process(armed, Concede(players[1])).result.newState
+        state.floatingEffects.any { it.id == fx } shouldBe true
+
+        // … nor lasts forever: players[1]'s turn would have come right after players[0]'s, so it
+        // ends when players[2]'s turn begins instead.
+        var safety = 0
+        while (state.activePlayerId == players[0]) {
+            check(++safety < 500) { "stuck at ${state.step}" }
+            val prio = state.priorityPlayerId ?: break
+            val pending = state.pendingDecision
+            if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                val resp = com.wingedsheep.engine.core.CardsSelectedResponse(pending.id, pending.options.take(pending.minSelections))
+                state = processor.process(state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, resp)).result.newState
+                continue
+            }
+            if (state.step == com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS && state.isActiveTurnFor(prio) &&
+                state.getEntity(prio)?.has<com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent>() != true
+            ) {
+                state = processor.process(state, com.wingedsheep.engine.core.DeclareAttackers(prio, emptyMap())).result.newState
+                continue
+            }
+            state = processor.process(state, PassPriority(prio)).result.newState
+        }
+        state.activePlayerId shouldBe players[2]
+        state.floatingEffects.any { it.id == fx } shouldBe false
+    }
+
     test("priority held by the leaver passes to the next player still in the game (CR 800.4a)") {
         val (base, players) = initGame(4)
         // Give players[1] priority, then mark them lost (priority is still on them at this point).


### PR DESCRIPTION
Part 8 of the stacked multiplayer-CR-audit series. **Based on #2062** — this diff is only the last commit.

## Defects
- **CR 800.4a vs 611.2c** — `PlayerLeavesGameProcessor` dropped every floating effect the leaver *controlled* or that was *sourced by* one of their objects. The CR removes the leaver's objects, not the effects of spells and abilities they already resolved: a Giant Growth on someone else's creature vanished mid-combat when its caster conceded.
- **CR 800.4m** — "continuous effects with durations that last until that player's next turn … last until that turn would have begun. They neither expire immediately nor last indefinitely." They expired immediately (via the drop above); with the drop narrowed they would have lasted forever, because every expiry hook is keyed to a turn the leaver never takes.

## Fix
- Step 5 of the processor ends only durations tied to a departed source (`WhileSourceOnBattlefield`, `WhileYouControlSource`, `WhileSourceTapped*`, `WhileSourceAttachedToAffected`) or to the leaver controlling the affected object (`WhileControlledByController`).
- `TurnManager.endTurn` gains `expireEffectsOfDepartedSeatsWhoseTurnWouldBeginNow`: when the turn passes from team A to team B, every departed seat between them in seat order (plus a departed member of B's own team, whose shared turn starts) has its `UntilYourNextTurn` / `UntilYourNextUpkeep` / goad expiry run — the same hooks a living player's untap runs — and its `EndOfYourNextTurn` effects and floor-keyed may-play permissions dropped. A player who leaves during their *own* turn is passed over one full rotation later, exactly as the CR describes. No-op while nobody has left.

## Verification
`:rules-engine:test` — 0 failures. Two new tests in `LeaveTheGameTest`: the Giant-Growth-style effect survives while a `WhileSourceOnBattlefield` one ends; an `UntilYourNextTurn` effect survives the concession, survives the rest of the current turn, and is gone when the next seat's turn begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)