### PR TITLE
Multiplayer CR audit 9/N: no priority window between two defenders' block declarations (CR 802.4)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.handlers.actions.combat
 
 import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
+import com.wingedsheep.engine.mechanics.combat.CombatDefenders
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.PendingTriggersContinuation
 import com.wingedsheep.engine.event.TriggerDetector
@@ -83,12 +85,28 @@ class DeclareBlockersHandler(
             }
 
             return ExecutionResult.success(
-                triggerResult.newState,
+                handToNextUndeclaredDefender(triggerResult.newState),
                 result.events + triggerResult.events
             )
         }
 
-        return result
+        return ExecutionResult.success(handToNextUndeclaredDefender(result.newState), result.events)
+    }
+
+    /**
+     * CR 802.4 / 509.1: with more than one defending player, each declares blockers in APNAP order
+     * and nobody receives priority until every declaration is in. The declare-blockers round is
+     * driven by the priority baton, so after one defender declares, the baton goes straight to the
+     * next defender who still owes a declaration — not on a lap of the table, where a seat that is
+     * not being attacked would get a real priority window (and could Giant Growth the next
+     * defender's would-be blocker) before that defender has declared. Once every defender has
+     * declared the baton stays with the last declarer, exactly as before.
+     */
+    private fun handToNextUndeclaredDefender(state: GameState): GameState {
+        val next = CombatDefenders.defendingPlayersInApnapOrder(state).firstOrNull { defender ->
+            state.getEntity(defender)?.has<BlockersDeclaredThisCombatComponent>() != true
+        } ?: return state
+        return state.withPriority(next)
     }
 
     companion object {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiDefenderCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiDefenderCombatTest.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
@@ -125,6 +126,25 @@ class MultiDefenderCombatTest : FunSpec({
             state, DeclareBlockers(players[1], mapOf(ids["blkB"]!! to listOf(ids["atkB"]!!)))
         ).result
         legal.isSuccess.shouldBeTrue()
+    }
+
+    test("no seat gets a priority window between two defenders' block declarations (CR 802.4)") {
+        val (base, players) = initGame(4) // A active; B, C, D
+        val (s1, _) = base.withBear(players[0], attacking = players[1]) // A attacks B
+        val (s2, _) = s1.withBear(players[0], attacking = players[3])   // A attacks D — C is not attacked
+        val state = s2.copy(step = Step.DECLARE_BLOCKERS, phase = Phase.COMBAT).withPriority(players[1])
+        val processor = ActionProcessor(registry())
+
+        // B declares (nothing). The baton must go straight to D, the next undeclared defender …
+        val afterB = processor.process(state, DeclareBlockers(players[1], emptyMap())).result.newState
+        afterB.priorityPlayerId shouldBe players[3]
+        // … so C — who sits between them and isn't being attacked — has no window to act in.
+        processor.process(afterB, PassPriority(players[2])).result.isSuccess.shouldBeFalse()
+
+        // Once D has declared too, the round is a normal priority round again.
+        val afterD = processor.process(afterB, DeclareBlockers(players[3], emptyMap())).result.newState
+        afterD.priorityPlayerId shouldBe players[3]
+        processor.process(afterD, PassPriority(players[3])).result.isSuccess.shouldBeTrue()
     }
 
     test("both defenders declare blockers (APNAP) and damage lands on the right players") {


### PR DESCRIPTION
Part 9 of the stacked multiplayer-CR-audit series. **Based on #2063** — this diff is only the last commit.

## Defect
CR 802.4: with more than one defending player, each declares blockers in APNAP order, and (CR 509) nobody receives priority until every declaration is in. The declare-blockers round is driven by the priority baton: `TurnManager` seeds it at the first defender and, after that defender declared and passed, `PassPriorityHandler` walked the table. Seats A(active) B C D, A attacks B and D: B declares, passes → **C has real priority** and can Giant Growth D's would-be blocker before D has declared.

## Fix
`DeclareBlockersHandler` hands the baton straight to the next defender who still owes a declaration (`CombatDefenders.defendingPlayersInApnapOrder`). Once every defender has declared, the baton stays with the last declarer exactly as before, so the 1v1 flow is byte-identical. (The block-tax pause path resolves through the continuation resumer and is left as is.)

## Verification
`:rules-engine:test` — 0 failures. New test in `MultiDefenderCombatTest`: after B declares, the baton is on D, C's pass is refused, and once D has declared the normal round resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)