### PR TITLE
Multiplayer CR audit 10/N: the whole winning team is reported as winning (CR 810.8a)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -632,7 +632,7 @@ class ConnectionHandler(
                 if (opponentSession?.isConnected == true) {
                     sender.send(
                         opponentSession.webSocketSession,
-                        ServerMessage.GameOver(opponentId, GameOverReason.DISCONNECTION)
+                        ServerMessage.GameOver(opponentId, GameOverReason.DISCONNECTION, winnerIds = listOf(opponentId))
                     )
                 }
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -456,11 +456,14 @@ class FreeForAllHandler(
         val seatedIds = gameSession?.getPlayers()?.map { it.playerId }
             ?: lobby.players.keys.toList()
         val eliminated = gameSession?.getEliminationOrder() ?: emptyList()
+        // A team wins together (CR 810.8a): every winning seat is placed first, in seat order,
+        // never the representative alone with their partner filed among the survivors.
+        val winners = gameSession?.getWinnerIds()?.takeIf { it.isNotEmpty() } ?: listOfNotNull(winnerId)
 
         val placementOrder = buildList {
-            if (winnerId != null) add(winnerId)
-            addAll(seatedIds.filter { it != winnerId && it !in eliminated })
-            addAll(eliminated.reversed().filter { it != winnerId })
+            addAll(winners)
+            addAll(seatedIds.filter { it !in winners && it !in eliminated })
+            addAll(eliminated.reversed().filter { it !in winners })
         }
 
         return placementOrder.mapIndexed { index, playerId ->

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -660,13 +660,14 @@ class GamePlayHandler(
 
     fun handleGameOver(gameSession: GameSession, reason: GameOverReason? = null, events: List<GameEvent> = emptyList()) {
         val winnerId = gameSession.getWinnerId()
+        val winnerIds = gameSession.getWinnerIds()
         val gameOverReason = reason ?: gameSession.getGameOverReason() ?: GameOverReason.LIFE_ZERO
         // Extract custom message from PlayerLostEvent if present. A game the server abandoned for
         // lack of progress explains itself first — its stock reason is a bare "Draw", which reads
         // like a rules outcome the players brought about rather than a loop nobody could break.
         val customMessage = gameSession.stallMessage()
             ?: events.filterIsInstance<PlayerLostEvent>().firstOrNull()?.message
-        val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId)
+        val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId, winnerIds)
 
         gameSession.getPlayers().forEach { sender.send(it.webSocketSession, message) }
 
@@ -808,7 +809,7 @@ class GamePlayHandler(
                         com.wingedsheep.gameserver.stats.RecordedParticipant(
                             userId = identity?.userId,
                             playerName = player.playerName,
-                            won = winnerId != null && player.playerId == winnerId,
+                            won = player.playerId in winnerIds,
                             colors = profile?.colors,
                             setCodes = profile?.setCodes,
                             isAi = isAi,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -198,7 +198,13 @@ sealed interface ServerMessage {
         val winnerId: EntityId?,
         val reason: GameOverReason,
         val message: String? = null,
-        val gameId: String? = null
+        val gameId: String? = null,
+        /**
+         * Every seat that won — the winning team in a team game (CR 810.8a), else just [winnerId].
+         * Clients decide "did I win?" from this; [winnerId] is one representative and stays for
+         * the spectator / replay readers that predate teams. Empty for a draw.
+         */
+        val winnerIds: List<EntityId> = emptyList()
     ) : ServerMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1312,9 +1312,25 @@ class GameSession(
     fun isGameOver(): Boolean = gameState?.gameOver == true
 
     /**
-     * Get the winner ID if the game is over.
+     * Get the winner ID if the game is over. In a team game this is a *representative* of the
+     * winning team (the engine records one seat); use [getWinnerIds] for everyone who won.
      */
     fun getWinnerId(): EntityId? = gameState?.winnerId
+
+    /**
+     * Every seat that won: the winner's whole still-in team (CR 810.8a — a team wins together), or
+     * just the winner outside a team game. Empty for a draw or an unfinished game. Anything that
+     * labels a seat as having won or lost — the GameOver message, match history, standings — has
+     * to read this rather than compare against the single [getWinnerId], or the winning team's
+     * other head is told they lost.
+     */
+    fun getWinnerIds(): List<EntityId> {
+        val state = gameState ?: return emptyList()
+        val winner = state.winnerId ?: return emptyList()
+        return state.teamOf(winner).filter {
+            state.getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
+        }
+    }
 
     /**
      * Determine the reason for game over.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
@@ -65,6 +65,15 @@ class TwoHeadedGiantSessionTest : ScenarioTestBase() {
             (teamOf[ids[0].value] == teamOf[ids[2].value]) shouldBe false
         }
 
+        test("both heads of the surviving team are winners, not just the representative (CR 810.8a)") {
+            val (session, ids) = started2hg()
+            // Team 1 (ids[2], ids[3]) concedes; one concession takes the whole team out (CR 810.8b).
+            session.playerConcedes(ids[2])
+            session.isGameOver() shouldBe true
+            session.getWinnerIds() shouldBe listOf(ids[0], ids[1])
+            session.getWinnerId() shouldBe ids[0]
+        }
+
         test("a teammate is not an opponent (CR 810): getOpponentIds returns only the other team") {
             val (session, ids) = started2hg()
 

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -742,8 +742,14 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
       // Ignore a game-over for a game we already left — e.g. an eliminated FFA player who
       // returned to the lobby still holds a seat server-side and receives the final GameOver.
       if (msg.gameId && sessionId !== msg.gameId) return
-      const result: 'win' | 'lose' | 'draw' =
-        msg.winnerId === null ? 'draw' : msg.winnerId === playerId ? 'win' : 'lose'
+      // "Did I win?" is a team question in Two-Headed Giant (CR 810.8a): the server names every
+      // winning seat in winnerIds; winnerId is one representative and would tell the other head
+      // of the winning team they lost. Older servers send winnerId alone, so fall back to it.
+      const won =
+        msg.winnerIds && msg.winnerIds.length > 0
+          ? playerId !== null && msg.winnerIds.includes(playerId)
+          : msg.winnerId === playerId
+      const result: 'win' | 'lose' | 'draw' = msg.winnerId === null ? 'draw' : won ? 'win' : 'lose'
       trackEvent('game_over', { result, reason: msg.reason })
       setInGame(false)
       set({

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1240,7 +1240,10 @@ export interface WaitingForOpponentMulliganMessage {
  */
 export interface GameOverMessage {
   readonly type: 'gameOver'
+  /** One representative of the winning side; kept for readers that predate teams. */
   readonly winnerId: EntityId | null
+  /** Every seat that won — the whole winning team in Two-Headed Giant (CR 810.8a). Empty for a draw. */
+  readonly winnerIds?: readonly EntityId[]
   readonly reason: GameOverReason
   readonly message?: string
   readonly gameId?: string


### PR DESCRIPTION
Part 10 of the stacked multiplayer-CR-audit series. **Based on #2064** — this diff is only the last commit.

## Defect
`GameEndCheck` records a single `winnerId` — the first surviving member of the winning team — and everything downstream compared seats against it: the client's win/lose label (`gameplayHandlers.ts`), match history's `won` flag (`GamePlayHandler`), and the Free-for-All standings (`FreeForAllHandler.buildStandings`). In Two-Headed Giant the winning team's **other head was told "Defeat"**, recorded as a loss, and placed among the survivors instead of first.

## Fix
- `GameSession.getWinnerIds()` — the winner's whole still-in team (CR 810.8a: "if either player on a team wins the game, the entire team wins"); just the winner outside a team game; empty for a draw.
- `ServerMessage.GameOver` gains an additive `winnerIds` field (`winnerId` stays for spectator/replay readers); the disconnection game-over fills it too.
- Client: won = winnerIds includes me, falling back to `winnerId` for older servers.
- History marks every winning seat; FFA standings place all winners first, in seat order.

## Verification
`:game-server:test` — 0 failures (new test in `TwoHeadedGiantSessionTest`: after the other team concedes, `getWinnerIds()` is both surviving heads). `tsc --noEmit` clean on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)