### PR TITLE
Multiplayer CR audit 11/N: life reads go through the resolver outside the engine too (CR 810.9a / 810.10a)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -690,9 +690,10 @@ class GamePlayHandler(
             // TournamentManager, Free-for-All pods via FreeForAllHandler (which never creates
             // a TournamentManager). The callback routes by the lobby's game mode.
             // Capture winner's remaining life for tiebreaker calculations
+            // Through the resolver: a team's life is one shared total (CR 810.9a), and only the
+            // canonical member's raw component carries it.
             val winnerLifeRemaining = if (winnerId != null) {
-                gameSession.getStateForTesting()?.getEntity(winnerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                gameSession.getStateForTesting()?.lifeTotal(winnerId) ?: 0
             } else {
                 0
             }
@@ -857,8 +858,7 @@ class GamePlayHandler(
         // Fired before cleanup so it can launch the next bracket game off its own coroutine.
         llmTournamentGameOverCallback?.let { callback ->
             val winnerLife = if (winnerId != null) {
-                gameSession.getStateForTesting()?.getEntity(winnerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                gameSession.getStateForTesting()?.lifeTotal(winnerId) ?: 0
             } else 0
             callback(gameSessionId, winnerId, winnerLife)
         }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayFingerprint.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayFingerprint.kt
@@ -51,7 +51,8 @@ object ReplayFingerprint {
 
         // Life totals in turn order — the single most player-visible number a divergence moves.
         for (playerId in state.turnOrder) {
-            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            // The resolver, not the raw component: a 2HG team's life lives on one member (CR 810.9a).
+            val life = if (state.getEntity(playerId)?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 0
             sb.append(playerId.value).append('=').append(life).append(',')
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -416,9 +416,8 @@ class ScenarioBuilderService(
 
         fun withLifeTotal(playerNumber: Int, life: Int): ScenarioBuilder {
             val playerId = playerFor(playerNumber)
-            state = state.updateEntity(playerId) { container ->
-                container.with(LifeTotalComponent(life))
-            }
+            // Through the resolver so a team's shared total (CR 810.9a) lands on its canonical owner.
+            state = state.withLifeTotal(playerId, life)
             return this
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
@@ -188,8 +188,11 @@ class SpectatorStateBuilder(
         val playerId = seat.playerId
         val playerEntity = state.getEntity(playerId)
 
-        val life = playerEntity?.get<LifeTotalComponent>()?.life ?: 20
-        val poisonCounters = playerEntity?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0
+        // Through the resolvers: in Two-Headed Giant the life total (CR 810.9a) and the poison
+        // count (CR 810.10a) are the team's, carried on one member — a raw read shows the other
+        // head frozen at its starting life for the whole game.
+        val life = if (playerEntity?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 20
+        val poisonCounters = state.teamPoison(playerId)
         val hand = state.getZone(playerId, Zone.HAND)
         val library = state.getZone(playerId, Zone.LIBRARY)
         val battlefield = state.getZone(playerId, Zone.BATTLEFIELD)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -134,7 +134,8 @@ class ObservationBuilder(
     ): PlayerView {
         val container = state.getEntity(playerId)
         val playerComp = container?.get<PlayerComponent>()
-        val life = container?.get<LifeTotalComponent>()?.life ?: 0
+        // Through the resolver — a 2HG team's shared life lives on one member (CR 810.9a).
+        val life = if (container?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 0
         val manaPool = container?.get<ManaPoolComponent>()
         val hasLost = container?.get<PlayerLostComponent>() != null
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
@@ -24,7 +24,8 @@ class LifeTotalReadsThroughResolverTest : FunSpec({
         val valueRead = Regex("""LifeTotalComponent>\(\)[?!.]*\.life""")
         val construct = Regex("""\bLifeTotalComponent\s*\(""")
 
-        val offenders = sourceRoot().walkTopDown()
+        val offenders = sourceRoots().asSequence()
+            .flatMap { it.walkTopDown() }
             .filter { it.isFile && it.extension == "kt" }
             .flatMap { file ->
                 val relative = file.absolutePath.replace('\\', '/')
@@ -54,11 +55,25 @@ class LifeTotalReadsThroughResolverTest : FunSpec({
             "com/wingedsheep/engine/core/GameInitializer.kt",
             // The component's own declaration.
             "com/wingedsheep/engine/state/components/identity/PlayerIdentityComponents.kt",
+            // Scenario setup stamps the initial LifeTotalComponent on every player, like GameInitializer.
+            "com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt",
         )
 
-        private fun sourceRoot(): File =
-            listOf(File("src/main/kotlin"), File("rules-engine/src/main/kotlin"))
-                .firstOrNull { it.isDirectory }
-                ?: error("Could not locate rules-engine/src/main/kotlin from ${File(".").absolutePath}")
+        /**
+         * Every module that reads a [com.wingedsheep.engine.state.GameState] off the engine and
+         * renders a life total — not just the engine. The spectator view, the gym observation and
+         * the replay fingerprint each read the raw component once, and each showed the
+         * non-canonical head of a Two-Headed Giant team frozen at its starting life.
+         */
+        private val SCANNED_MODULES = listOf("rules-engine", "game-server", "gym", "ai")
+
+        private fun sourceRoots(): List<File> {
+            val repoRoot = listOf(File("."), File(".."))
+                .firstOrNull { File(it, "rules-engine/src/main/kotlin").isDirectory }
+                ?: error("Could not locate the repository root from ${File(".").absolutePath}")
+            return SCANNED_MODULES.map { File(repoRoot, "$it/src/main/kotlin") }
+                .filter { it.isDirectory }
+                .also { roots -> check(roots.isNotEmpty()) { "No source roots found under $repoRoot" } }
+        }
     }
 }


### PR DESCRIPTION
Part 11 of the stacked multiplayer-CR-audit series. **Based on #2065** — this diff is only the last commit.

## Defect
`SpectatorStateBuilder`, the gym `ObservationBuilder`, `ReplayFingerprint` and the tournament tiebreaker in `GamePlayHandler` read `LifeTotalComponent.life` directly. A Two-Headed Giant team's life lives on one canonical member (CR 810.9a), so **spectators saw the other head frozen at its starting life** for the whole game — and its individual poison instead of the team's (CR 810.10a). `LifeTotalReadsThroughResolverTest` only scanned `rules-engine`, which is exactly why the engine was clean and these four were not.

## Fix
- Every site reads `state.lifeTotal(playerId)` / `state.teamPoison(playerId)`; the scenario builder's `withLifeTotal` writes through `state.withLifeTotal`.
- The hygiene test now scans `rules-engine`, `game-server`, `gym` and `ai` (scenario setup's initial `LifeTotalComponent(20)` stamping is allowlisted alongside `GameInitializer`'s).

## Verification
`LifeTotalReadsThroughResolverTest` green over all four modules; `:game-server:test` 0 failures; `:gym` and `:ai` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)