### PR TITLE
Multiplayer CR audit 12/N: 'lose at the next end step' respects can't-lose grants (CR 104.3 / 810.8a)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -748,6 +748,13 @@ class TurnManager(
                 for (member in newState.sharedTurnTeam(activePlayer)) {
                     val loseComponent = newState.getEntity(member)?.get<LoseAtEndStepComponent>() ?: continue
                     if (loseComponent.turnsUntilLoss <= 0) {
+                        // "You can't lose the game" (Platinum Angel — CR 104.3, and team-wide in
+                        // 2HG per CR 810.8a) stops this loss like every other: the delayed
+                        // trigger resolves and does nothing, so the marker is still consumed.
+                        if (com.wingedsheep.engine.mechanics.sba.player.playerCantLoseGame(newState, member)) {
+                            newState = newState.updateEntity(member) { it.without<LoseAtEndStepComponent>() }
+                            continue
+                        }
                         newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(PlayerLostComponent(LossReason.CARD_EFFECT))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -132,6 +132,27 @@ class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
         atEnd.gameOver.shouldBeTrue()
     }
 
+    test("'lose at the next end step' is stopped by a can't-lose grant, including a teammate's (CR 104.3 / 810.8a)") {
+        val (base, p, proc) = boot()
+        // Platinum Angel-style grant under p0; Final Fortune's marker on the teammate p1.
+        val (withAngel, _) = base.withPermanent(p[0], "Team Angel", "Artifact") {
+            with(com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent())
+        }
+        val armed = withAngel.updateEntity(p[1]) { it.with(LoseAtEndStepComponent(turnsUntilLoss = 0)) }
+
+        val atEnd = drive(armed, proc) { it.gameOver || (it.step == Step.END && it.activePlayerId == p[0]) }
+
+        io.kotest.assertions.withClue(
+            "lost: " + p.map { it to atEnd.getEntity(it)?.get<PlayerLostComponent>()?.reason } +
+                " step=${atEnd.step} active=${atEnd.activePlayerId} turn=${atEnd.turnNumber}"
+        ) {
+            atEnd.gameOver.shouldBeFalse()
+        }
+        atEnd.getEntity(p[1])?.has<PlayerLostComponent>() shouldBe false
+        // The delayed loss resolved and did nothing — it doesn't lie in wait for the next end step.
+        atEnd.getEntity(p[1])?.has<LoseAtEndStepComponent>() shouldBe false
+    }
+
     test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
         val (base, p, proc) = boot()
         val delayed = DelayedTriggeredAbility(


### PR DESCRIPTION
Part 12 of the stacked multiplayer-CR-audit series. **Based on #2066** — this diff is only the last commit.

## Defect
Final Fortune / Last Chance's delayed loss was applied in `TurnManager`'s end step by stamping `PlayerLostComponent` directly, without consulting `playerCantLoseGame`. Platinum Angel ("you can't lose the game") did not stop it — not your own, and in Two-Headed Giant not your teammate's either (CR 810.8a), after which `TeamLossPropagationCheck` took the protected team down. Not 2HG-specific, but that is where it hurts most.

## Fix
The end-step check consults `playerCantLoseGame` (same gate as the life, poison, decking and `LoseGame` paths). The marker is still consumed — the delayed trigger resolves and does nothing rather than lying in wait for the next end step.

## Verification
`TwoHeadedGiantSecondHeadTurnTest` — new test: a can't-lose grant under one head stops the teammate's end-step loss; the marker is gone afterwards. Full class green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)