### PR TITLE
Multiplayer CR audit 13/N: a teammate is told when their partner drops or returns

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -177,7 +177,8 @@ class ConnectionHandler(
             }
         }
 
-        // Cancel in-game disconnect timer and notify every opponent (2-player = the one opponent)
+        // Cancel in-game disconnect timer and notify every other seat — opponents and, in a team
+        // game, the returning player's partner (2-player = the one opponent)
         if (identity.gameDisconnectTimer != null) {
             identity.gameDisconnectTimer?.cancel(false)
             identity.gameDisconnectTimer = null
@@ -186,7 +187,7 @@ class ConnectionHandler(
             if (gameSessionId != null) {
                 val gameSession = gameRepository.findById(gameSessionId)
                 if (gameSession != null) {
-                    gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                    gameSession.getOtherPlayerIds(identity.playerId).forEach { opponentId ->
                         val opponentSession = gameSession.getPlayerSession(opponentId)
                         if (opponentSession?.isConnected == true) {
                             sender.send(opponentSession.webSocketSession, ServerMessage.OpponentReconnected)
@@ -388,8 +389,10 @@ class ConnectionHandler(
                 if (gameSessionId != null) {
                     val gameSession = gameRepository.findById(gameSessionId)
                     if (gameSession != null && !gameSession.isGameOver()) {
-                        // Notify every opponent that this seat dropped (2-player = the one opponent)
-                        gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                        // Notify every other seat that this one dropped — a Two-Headed Giant partner
+                        // needs to know at least as much as an opponent does, since their team
+                        // forfeits with them if the timer runs out (2-player = the one opponent)
+                        gameSession.getOtherPlayerIds(identity.playerId).forEach { opponentId ->
                             val opponentSession = gameSession.getPlayerSession(opponentId)
                             if (opponentSession?.isConnected == true) {
                                 sender.send(opponentSession.webSocketSession,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -402,6 +402,14 @@ class GameSession(
     }
 
     /**
+     * Every *other* seat at the table — opponents and teammates alike. For table-wide notices
+     * (a seat dropped, a seat came back) that a partner needs at least as much as an opponent
+     * does; [getOpponentIds] is for anything that must stop at the team boundary.
+     */
+    fun getOtherPlayerIds(playerId: EntityId): List<EntityId> =
+        players.keys.filter { it != playerId }
+
+    /**
      * Get the player session for a player ID.
      */
     fun getPlayerSession(playerId: EntityId): PlayerSession? = players[playerId]


### PR DESCRIPTION
Part 13 of the stacked multiplayer-CR-audit series. **Based on #2067** — this diff is only the last commit.

## Defect
`OpponentDisconnected` / `OpponentReconnected` were sent to `getOpponentIds`, which stops at the team boundary. A Two-Headed Giant partner was never told their teammate had dropped — even though their team forfeits with them (CR 810.8b) if the two-minute timer runs out.

## Fix
`GameSession.getOtherPlayerIds` (every other seat at the table) for the two notices; `getOpponentIds` stays for anything that must stop at the team boundary.

## Verification
`:game-server:test` — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)