### PR TITLE
Multiplayer CR audit 14/N: a hijack controls the whole shared-turn team (CR 805.8)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -205,22 +205,26 @@ class TurnManager(
         // ruling, a scheduled hijack waits through any skipped turns and engages on the next turn
         // the affected player actually takes. Combat-phase-scoped hijacks (Secret of Bloodbending)
         // are ignored here — they engage at beginning of combat (see advanceStep) instead.
-        val scheduledHijack = newState.getEntity(playerId)?.get<PlayerTurnHijackedComponent>()
-        if (scheduledHijack != null &&
-            scheduledHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
-            scheduledHijack.scope == HijackScope.NextTurn
-        ) {
-            newState = newState.updateEntity(playerId) { container ->
-                container.with(
-                    scheduledHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+        // The turn is the whole active team's in a shared team turn (CR 805.4), and a hijack
+        // controls the team (CR 805.8), so every member's scheduled hijack engages — the second
+        // head is never `playerId` here, and reading only that seat left them un-hijacked.
+        for (member in newState.sharedTurnTeam(playerId)) {
+            val scheduledHijack = newState.getEntity(member)?.get<PlayerTurnHijackedComponent>() ?: continue
+            if (scheduledHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
+                scheduledHijack.scope == HijackScope.NextTurn
+            ) {
+                newState = newState.updateEntity(member) { container ->
+                    container.with(
+                        scheduledHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                    )
+                }
+                events += TurnHijackedEvent(
+                    controllerId = scheduledHijack.controllerId,
+                    hijackedPlayerId = member,
+                    sourceId = member,
+                    sourceName = "Hijack engaged"
                 )
             }
-            events += TurnHijackedEvent(
-                controllerId = scheduledHijack.controllerId,
-                hijackedPlayerId = playerId,
-                sourceId = playerId,
-                sourceName = "Hijack engaged"
-            )
         }
 
         return ExecutionResult.success(newState, events)
@@ -335,12 +339,15 @@ class TurnManager(
         // combat phase follows — "their next combat phase" is a single phase, never the extra ones.
         var state = incomingState
         if (currentStep == Step.END_COMBAT) {
-            val combatHijack = state.getEntity(activePlayer)?.get<PlayerTurnHijackedComponent>()
-            if (combatHijack != null &&
-                combatHijack.state == PlayerTurnHijackedComponent.HijackState.ACTIVE &&
-                combatHijack.scope == HijackScope.NextCombatPhase
-            ) {
-                state = state.updateEntity(activePlayer) { it.without<PlayerTurnHijackedComponent>() }
+            // Every member of the active team — a combat hijack controls the team (CR 805.8).
+            for (member in state.sharedTurnTeam(activePlayer)) {
+                val combatHijack = state.getEntity(member)?.get<PlayerTurnHijackedComponent>()
+                if (combatHijack != null &&
+                    combatHijack.state == PlayerTurnHijackedComponent.HijackState.ACTIVE &&
+                    combatHijack.scope == HijackScope.NextCombatPhase
+                ) {
+                    state = state.updateEntity(member) { it.without<PlayerTurnHijackedComponent>() }
+                }
             }
         }
 
@@ -630,24 +637,26 @@ class TurnManager(
                 // active player: their combat phase is now beginning, so input authority moves to
                 // the hijacker for the duration of this phase. A hijack scheduled while combat was
                 // skipped stays SCHEDULED and waits for a combat phase they actually reach here.
-                val combatHijack = newState.getEntity(activePlayer)?.get<PlayerTurnHijackedComponent>()
-                if (combatHijack != null &&
-                    combatHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
-                    combatHijack.scope == HijackScope.NextCombatPhase
-                ) {
-                    newState = newState.updateEntity(activePlayer) { container ->
-                        container.with(
-                            combatHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                // Every member of the active team — a combat hijack controls the team (CR 805.8).
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val combatHijack = newState.getEntity(member)?.get<PlayerTurnHijackedComponent>() ?: continue
+                    if (combatHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
+                        combatHijack.scope == HijackScope.NextCombatPhase
+                    ) {
+                        newState = newState.updateEntity(member) { container ->
+                            container.with(
+                                combatHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                            )
+                        }
+                        events.add(
+                            TurnHijackedEvent(
+                                controllerId = combatHijack.controllerId,
+                                hijackedPlayerId = member,
+                                sourceId = member,
+                                sourceName = "Combat hijack engaged"
+                            )
                         )
                     }
-                    events.add(
-                        TurnHijackedEvent(
-                            controllerId = combatHijack.controllerId,
-                            hijackedPlayerId = activePlayer,
-                            sourceId = activePlayer,
-                            sourceName = "Combat hijack engaged"
-                        )
-                    )
                 }
                 newState = newState.withPriority(activePlayer)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/HijackNextTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/HijackNextTurnExecutor.kt
@@ -41,14 +41,21 @@ class HijackNextTurnExecutor : EffectExecutor<HijackNextTurnEffect> {
         val sourceId = context.sourceId ?: hijackedPlayerId
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Hijack"
 
-        val newState = state.updateEntity(hijackedPlayerId) { container ->
-            container.with(
-                PlayerTurnHijackedComponent(
-                    controllerId = context.controllerId,
-                    state = PlayerTurnHijackedComponent.HijackState.SCHEDULED,
-                    scope = effect.scope
+        // CR 805.8 — "If an effect causes a player to control another player, the first player
+        // controls the affected player's team." In a shared team turn the hijacked turn is the
+        // whole team's, so every member is scheduled; outside shared team turns the team is the
+        // targeted player alone.
+        var newState = state
+        for (member in state.sharedTurnTeam(hijackedPlayerId)) {
+            newState = newState.updateEntity(member) { container ->
+                container.with(
+                    PlayerTurnHijackedComponent(
+                        controllerId = context.controllerId,
+                        state = PlayerTurnHijackedComponent.HijackState.SCHEDULED,
+                        scope = effect.scope
+                    )
                 )
-            )
+            }
         }
 
         return EffectResult.success(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -153,6 +153,39 @@ class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
         atEnd.getEntity(p[1])?.has<LoseAtEndStepComponent>() shouldBe false
     }
 
+    test("hijacking one head controls the whole team on its next turn (CR 805.8)") {
+        val (base, p, proc) = boot()
+        // p2 resolves a Mindslaver aimed at p1 (the second head). The executor schedules the
+        // hijack on p1's whole shared-turn team.
+        val scheduled = com.wingedsheep.engine.handlers.effects.player.HijackNextTurnExecutor().execute(
+            base,
+            com.wingedsheep.sdk.scripting.effects.HijackNextTurnEffect(
+                target = com.wingedsheep.sdk.scripting.targets.EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.You)
+            ),
+            com.wingedsheep.engine.handlers.EffectContext(sourceId = null, controllerId = p[1])
+        ).newState
+        // (Player.You resolves to p1 here; the controller field is what the hijack records.)
+        p.take(2).forEach { head ->
+            scheduled.getEntity(head)?.get<com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent>()
+                ?.state shouldBe com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent.HijackState.SCHEDULED
+        }
+        // Re-point the recorded controller at the opposing head so the engagement below is a real
+        // "opponent drives your team" case.
+        val armed = p.take(2).fold(scheduled) { s, head ->
+            s.updateEntity(head) { c ->
+                val h = c.get<com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent>()!!
+                c.with(h.copy(controllerId = p[2]))
+            }
+        }
+
+        // Team 0's *next* turn: drive through team 1's turn and back.
+        val onTeam1 = drive(armed, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        onTeam1.actorFor(p[0]) shouldBe p[0]
+        val backOnTeam0 = drive(onTeam1, proc) { it.activePlayerId == p[0] && it.step == Step.UPKEEP }
+        backOnTeam0.actorFor(p[0]) shouldBe p[2]
+        backOnTeam0.actorFor(p[1]) shouldBe p[2]
+    }
+
     test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
         val (base, p, proc) = boot()
         val delayed = DelayedTriggeredAbility(


### PR DESCRIPTION
Part 14 of the stacked multiplayer-CR-audit series. **Based on #2068** — this diff is only the last commit.

## Defect
CR 805.8: "If an effect causes a player to control another player, the first player controls the affected player's team." Mindslaver-style control was per player — `HijackNextTurnExecutor` stamped the targeted seat and `TurnManager` engaged only the component on `activePlayerId`. In Two-Headed Giant, hijacking the **second head never engaged at all** (they are never `activePlayerId`), and hijacking the first head left their partner free to act during the "controlled" turn.

## Fix
The executor schedules every member of the target's `sharedTurnTeam`; the turn-start engagement, the begin-combat engagement and the end-of-combat release read every member of the active team. Cleanup already dropped ACTIVE hijacks for every player. Outside shared team turns the team is the player alone.

## Verification
`:rules-engine:test` — 0 failures (incl. `HijackInputRoutingTest`, `PlayerTurnHijackedComponentTest`). New test in `TwoHeadedGiantSecondHeadTurnTest`: a hijack aimed at one head schedules both, and on the team's next turn `actorFor` routes both heads to the hijacker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)