### PR TITLE
Multiplayer CR audit 15/N: Team vs. Team first seat per CR 808.4

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -263,7 +263,19 @@ class GameInitializer(
                 state = shuffledState
                 shuffled
             }
-            orderedTeams.flatten()
+            val seating = orderedTeams.flatten()
+            if (startTeam == null && !config.format.sharesTeamTurns) {
+                // CR 808.4 (Team vs. Team): the randomly chosen team's first player is its *centre*
+                // seat when the team is odd-sized and the seat to the left of its midpoint when it
+                // is even — index size/2 either way, since turn order runs to the left (CR 103.7b).
+                // Turn order then continues around the table from that seat, so the rest of that
+                // team comes last. With shared team turns (CR 805) the team takes one turn and its
+                // first-listed member is just the representative, so the seating stays as built.
+                val firstSeat = orderedTeams.first().size / 2
+                seating.subList(firstSeat, seating.size) + seating.subList(0, firstSeat)
+            } else {
+                seating
+            }
         } else if (config.startingPlayerIndex != null) {
             val idx = config.startingPlayerIndex
             playerIds.subList(idx, playerIds.size) + playerIds.subList(0, idx)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
@@ -96,6 +96,32 @@ class TeamVsTeamTest : FunSpec({
     // Life: each player has their own total (CR 808.5) — not a shared pool.
     // ---------------------------------------------------------------------------------------------
 
+    test("a randomly chosen first team starts with the seat left of its midpoint, and turn order wraps the table (CR 808.4)") {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TeamVsTeam(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of(forest to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = null,
+                skipMulligans = true,
+                seed = 42L,
+            )
+        )
+        val p = result.playerIds
+        val order = result.state.turnOrder
+        val teamA = listOf(p[0], p[1])
+        val teamB = listOf(p[2], p[3])
+        val startTeam = if (order.first() in teamA) teamA else teamB
+        val otherTeam = if (startTeam === teamA) teamB else teamA
+        // Even-sized team: the player to the left of its midpoint (its second seat) goes first …
+        order.first() shouldBe startTeam[1]
+        // … turn order goes to the left through the other team, still seated together …
+        order.subList(1, 3) shouldBe otherTeam
+        // … and comes back round to the starting team's first seat last.
+        order.last() shouldBe startTeam[0]
+        result.state.activePlayerId shouldBe startTeam[1]
+    }
+
     test("each player has their own life total; damaging one teammate doesn't touch the other (CR 808.5)") {
         val (state, p, _) = boot()
         state.lifeTotal(p[0]) shouldBe 20


### PR DESCRIPTION
Part 15 (last) of the stacked multiplayer-CR-audit series. **Based on #2069** — this diff is only the last commit.

## Defect
CR 808.4: "randomly choose a team. If that team has an odd number of players, the player in its center seat goes first. If … even, the player to the left of its midpoint goes first. Turn order goes to the players' left." With no explicit starting player, `GameInitializer` chose the team at random but always started with its **first-listed** member, so the rest of the team played second rather than last.

## Fix
For a team game *without* shared team turns and without a named starting player, the seating circle (built team-by-team as before) is rotated to start at the chosen team's `size / 2` seat — centre for odd, left of midpoint for even — so turn order runs A2, B1, B2, A1 for 2v2. Shared-team-turn formats are untouched (the team takes one turn; its first member is only the representative), as is any game that names its starting player (every existing fixture).

## Verification
`:rules-engine:test` — 0 failures. New seeded test in `TeamVsTeamTest` pins the seat order.

## Not changed in this stack
After a spell resolves, priority goes to the resolved object's *controller* (`PassPriorityHandler.resolveTopOfStack`), where CR 117.3b / 805.5b give it to the active player (team). That is a 1v1 behaviour change too, so it is left for a decision rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)