### PR TITLE
Multiplayer CR 800–810 audit fixes (re-land of the mp-cr/02–15 stack)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -115,7 +115,7 @@ class AIPlayer(
             if (result.error != null) {
                 // Action was illegal — submit a safe fallback action
                 val fallback = when {
-                    current.step == Step.DECLARE_ATTACKERS && current.activePlayerId == playerId -> {
+                    current.step == Step.DECLARE_ATTACKERS && current.isActiveTurnFor(playerId) -> {
                         // Include mandatory attackers to avoid rejection
                         val legalActions = simulator.getLegalActions(current, playerId)
                         val attackAction = legalActions.find { it.actionType == "DeclareAttackers" }
@@ -130,7 +130,7 @@ class AIPlayer(
                         } else emptyMap()
                         DeclareAttackers(playerId, attackerMap)
                     }
-                    current.step == Step.DECLARE_BLOCKERS && current.activePlayerId != playerId -> {
+                    current.step == Step.DECLARE_BLOCKERS && !current.isActiveTurnFor(playerId) -> {
                         // Include mandatory blockers to avoid rejection
                         val legalActions = simulator.getLegalActions(current, playerId)
                         val blockerAction = legalActions.find { it.actionType == "DeclareBlockers" }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -281,7 +281,7 @@ class Strategist(
         // while a pump that is about to wear off in cleanup gets a penalty instead of an
         // encouragement. Keeping both would double-count the first and cancel the second.
         val adjustedPassScore =
-            if (!holdPolicy.isEnabled && state.activePlayerId != playerId && state.step == Step.END) {
+            if (!holdPolicy.isEnabled && !state.isActiveTurnFor(playerId) && state.step == Step.END) {
                 passScore - 1.5
             } else {
                 passScore
@@ -370,7 +370,7 @@ class Strategist(
                 turnNumber = state.turnNumber,
                 step = state.step.name,
                 activePlayerId = state.activePlayerId,
-                onOwnTurn = state.activePlayerId == playerId,
+                onOwnTurn = state.isActiveTurnFor(playerId),
                 baselineLabel = "Pass priority",
                 baselineScore = adjustedPassScore,
                 chosenLabel = options.firstOrNull { it.chosen }?.label ?: "Pass priority",
@@ -576,7 +576,7 @@ class Strategist(
                 turnNumber = state.turnNumber,
                 step = state.step.name,
                 activePlayerId = state.activePlayerId,
-                onOwnTurn = state.activePlayerId == playerId,
+                onOwnTurn = state.isActiveTurnFor(playerId),
                 baselineLabel = baselineLabel,
                 baselineScore = baselineScore,
                 chosenLabel = chosenLabel,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
@@ -51,11 +51,11 @@ private fun isCombatStep(state: GameState): Boolean =
 
 /** True when it's the AI's own main phase. */
 private fun isOwnMainPhase(state: GameState, playerId: EntityId): Boolean =
-    state.activePlayerId == playerId && state.step.isMainPhase
+    state.isActiveTurnFor(playerId) && state.step.isMainPhase
 
 /** True when it's the opponent's turn. */
 private fun isOpponentsTurn(state: GameState, playerId: EntityId): Boolean =
-    state.activePlayerId != playerId
+    !state.isActiveTurnFor(playerId)
 
 /** Sum of creature board value for a player. */
 private fun creatureBoardValue(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
@@ -309,7 +309,7 @@ object CounterspellAdvisor : CardAdvisor {
         if (isOpponentsTurn(state, playerId) && state.stack.isNotEmpty()) return null
 
         // Own turn: heavily penalize — hold it
-        if (state.activePlayerId == playerId) {
+        if (state.isActiveTurnFor(playerId)) {
             return context.passScore - 2.0
         }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
@@ -184,7 +184,7 @@ internal object ExpiringGrantWindow {
      * mistake, not the missed window.
      */
     private fun laterWindowIsStillAhead(state: GameState, playerId: EntityId): Boolean =
-        if (state.activePlayerId == playerId) state.step in BEFORE_OUR_ATTACK
+        if (state.isActiveTurnFor(playerId)) state.step in BEFORE_OUR_ATTACK
         else state.step in BEFORE_THEIR_ATTACK
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -279,6 +279,19 @@ class AiWebSocketSession(
             return
         }
 
+        // Team priority (CR 805.5) offers a bot its own actions while its human partner holds the
+        // baton. The bot takes its window in baton order instead — GameState.hasPriority's KDoc:
+        // widening permission never took a window away, and a bot racing its partner for every
+        // response would spend windows the human never got to see. So outside a decision addressed
+        // to us, act only when the seat these actions belong to is the baton holder (a hijacked
+        // seat we drive still qualifies: its actions carry that seat's id, which IS the baton).
+        // `priorityPlayerId` is kept current by applyDelta, so it is safe to read here.
+        val actingSeat = legalActions.firstOrNull()?.action?.playerId
+        if (!isOurDecision && actingSeat != null && actingSeat != state.priorityPlayerId) {
+            logger.info("AI skipping — team priority window belongs to the baton holder {}", state.priorityPlayerId)
+            return
+        }
+
         if (legalActions.isNotEmpty()) {
             logger.info("AI has {} legal actions: {}", legalActions.size,
                 legalActions.joinToString(", ") { "${it.actionType}${if (it.description.isNotBlank()) "(${it.description})" else ""}" })

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -632,7 +632,7 @@ class ConnectionHandler(
                 if (opponentSession?.isConnected == true) {
                     sender.send(
                         opponentSession.webSocketSession,
-                        ServerMessage.GameOver(opponentId, GameOverReason.DISCONNECTION)
+                        ServerMessage.GameOver(opponentId, GameOverReason.DISCONNECTION, winnerIds = listOf(opponentId))
                     )
                 }
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -177,7 +177,8 @@ class ConnectionHandler(
             }
         }
 
-        // Cancel in-game disconnect timer and notify every opponent (2-player = the one opponent)
+        // Cancel in-game disconnect timer and notify every other seat — opponents and, in a team
+        // game, the returning player's partner (2-player = the one opponent)
         if (identity.gameDisconnectTimer != null) {
             identity.gameDisconnectTimer?.cancel(false)
             identity.gameDisconnectTimer = null
@@ -186,7 +187,7 @@ class ConnectionHandler(
             if (gameSessionId != null) {
                 val gameSession = gameRepository.findById(gameSessionId)
                 if (gameSession != null) {
-                    gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                    gameSession.getOtherPlayerIds(identity.playerId).forEach { opponentId ->
                         val opponentSession = gameSession.getPlayerSession(opponentId)
                         if (opponentSession?.isConnected == true) {
                             sender.send(opponentSession.webSocketSession, ServerMessage.OpponentReconnected)
@@ -388,8 +389,10 @@ class ConnectionHandler(
                 if (gameSessionId != null) {
                     val gameSession = gameRepository.findById(gameSessionId)
                     if (gameSession != null && !gameSession.isGameOver()) {
-                        // Notify every opponent that this seat dropped (2-player = the one opponent)
-                        gameSession.getOpponentIds(identity.playerId).forEach { opponentId ->
+                        // Notify every other seat that this one dropped — a Two-Headed Giant partner
+                        // needs to know at least as much as an opponent does, since their team
+                        // forfeits with them if the timer runs out (2-player = the one opponent)
+                        gameSession.getOtherPlayerIds(identity.playerId).forEach { opponentId ->
                             val opponentSession = gameSession.getPlayerSession(opponentId)
                             if (opponentSession?.isConnected == true) {
                                 sender.send(opponentSession.webSocketSession,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -456,11 +456,14 @@ class FreeForAllHandler(
         val seatedIds = gameSession?.getPlayers()?.map { it.playerId }
             ?: lobby.players.keys.toList()
         val eliminated = gameSession?.getEliminationOrder() ?: emptyList()
+        // A team wins together (CR 810.8a): every winning seat is placed first, in seat order,
+        // never the representative alone with their partner filed among the survivors.
+        val winners = gameSession?.getWinnerIds()?.takeIf { it.isNotEmpty() } ?: listOfNotNull(winnerId)
 
         val placementOrder = buildList {
-            if (winnerId != null) add(winnerId)
-            addAll(seatedIds.filter { it != winnerId && it !in eliminated })
-            addAll(eliminated.reversed().filter { it != winnerId })
+            addAll(winners)
+            addAll(seatedIds.filter { it !in winners && it !in eliminated })
+            addAll(eliminated.reversed().filter { it !in winners })
         }
 
         return placementOrder.mapIndexed { index, playerId ->

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -660,13 +660,14 @@ class GamePlayHandler(
 
     fun handleGameOver(gameSession: GameSession, reason: GameOverReason? = null, events: List<GameEvent> = emptyList()) {
         val winnerId = gameSession.getWinnerId()
+        val winnerIds = gameSession.getWinnerIds()
         val gameOverReason = reason ?: gameSession.getGameOverReason() ?: GameOverReason.LIFE_ZERO
         // Extract custom message from PlayerLostEvent if present. A game the server abandoned for
         // lack of progress explains itself first — its stock reason is a bare "Draw", which reads
         // like a rules outcome the players brought about rather than a loop nobody could break.
         val customMessage = gameSession.stallMessage()
             ?: events.filterIsInstance<PlayerLostEvent>().firstOrNull()?.message
-        val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId)
+        val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId, winnerIds)
 
         gameSession.getPlayers().forEach { sender.send(it.webSocketSession, message) }
 
@@ -808,7 +809,7 @@ class GamePlayHandler(
                         com.wingedsheep.gameserver.stats.RecordedParticipant(
                             userId = identity?.userId,
                             playerName = player.playerName,
-                            won = winnerId != null && player.playerId == winnerId,
+                            won = player.playerId in winnerIds,
                             colors = profile?.colors,
                             setCodes = profile?.setCodes,
                             isAi = isAi,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -690,9 +690,10 @@ class GamePlayHandler(
             // TournamentManager, Free-for-All pods via FreeForAllHandler (which never creates
             // a TournamentManager). The callback routes by the lobby's game mode.
             // Capture winner's remaining life for tiebreaker calculations
+            // Through the resolver: a team's life is one shared total (CR 810.9a), and only the
+            // canonical member's raw component carries it.
             val winnerLifeRemaining = if (winnerId != null) {
-                gameSession.getStateForTesting()?.getEntity(winnerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                gameSession.getStateForTesting()?.lifeTotal(winnerId) ?: 0
             } else {
                 0
             }
@@ -857,8 +858,7 @@ class GamePlayHandler(
         // Fired before cleanup so it can launch the next bracket game off its own coroutine.
         llmTournamentGameOverCallback?.let { callback ->
             val winnerLife = if (winnerId != null) {
-                gameSession.getStateForTesting()?.getEntity(winnerId)
-                    ?.get<LifeTotalComponent>()?.life ?: 0
+                gameSession.getStateForTesting()?.lifeTotal(winnerId) ?: 0
             } else 0
             callback(gameSessionId, winnerId, winnerLife)
         }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -198,7 +198,13 @@ sealed interface ServerMessage {
         val winnerId: EntityId?,
         val reason: GameOverReason,
         val message: String? = null,
-        val gameId: String? = null
+        val gameId: String? = null,
+        /**
+         * Every seat that won — the winning team in a team game (CR 810.8a), else just [winnerId].
+         * Clients decide "did I win?" from this; [winnerId] is one representative and stays for
+         * the spectator / replay readers that predate teams. Empty for a draw.
+         */
+        val winnerIds: List<EntityId> = emptyList()
     ) : ServerMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayFingerprint.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayFingerprint.kt
@@ -51,7 +51,8 @@ object ReplayFingerprint {
 
         // Life totals in turn order — the single most player-visible number a divergence moves.
         for (playerId in state.turnOrder) {
-            val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+            // The resolver, not the raw component: a 2HG team's life lives on one member (CR 810.9a).
+            val life = if (state.getEntity(playerId)?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 0
             sb.append(playerId.value).append('=').append(life).append(',')
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -416,9 +416,8 @@ class ScenarioBuilderService(
 
         fun withLifeTotal(playerNumber: Int, life: Int): ScenarioBuilder {
             val playerId = playerFor(playerNumber)
-            state = state.updateEntity(playerId) { container ->
-                container.with(LifeTotalComponent(life))
-            }
+            // Through the resolver so a team's shared total (CR 810.9a) lands on its canonical owner.
+            state = state.withLifeTotal(playerId, life)
             return this
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1312,9 +1312,25 @@ class GameSession(
     fun isGameOver(): Boolean = gameState?.gameOver == true
 
     /**
-     * Get the winner ID if the game is over.
+     * Get the winner ID if the game is over. In a team game this is a *representative* of the
+     * winning team (the engine records one seat); use [getWinnerIds] for everyone who won.
      */
     fun getWinnerId(): EntityId? = gameState?.winnerId
+
+    /**
+     * Every seat that won: the winner's whole still-in team (CR 810.8a — a team wins together), or
+     * just the winner outside a team game. Empty for a draw or an unfinished game. Anything that
+     * labels a seat as having won or lost — the GameOver message, match history, standings — has
+     * to read this rather than compare against the single [getWinnerId], or the winning team's
+     * other head is told they lost.
+     */
+    fun getWinnerIds(): List<EntityId> {
+        val state = gameState ?: return emptyList()
+        val winner = state.winnerId ?: return emptyList()
+        return state.teamOf(winner).filter {
+            state.getEntity(it)?.has<com.wingedsheep.engine.state.components.player.PlayerLostComponent>() != true
+        }
+    }
 
     /**
      * Determine the reason for game over.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -402,6 +402,14 @@ class GameSession(
     }
 
     /**
+     * Every *other* seat at the table — opponents and teammates alike. For table-wide notices
+     * (a seat dropped, a seat came back) that a partner needs at least as much as an opponent
+     * does; [getOpponentIds] is for anything that must stop at the team boundary.
+     */
+    fun getOtherPlayerIds(playerId: EntityId): List<EntityId> =
+        players.keys.filter { it != playerId }
+
+    /**
      * Get the player session for a player ID.
      */
     fun getPlayerSession(playerId: EntityId): PlayerSession? = players[playerId]

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1140,7 +1140,7 @@ class GameSession(
         }
 
         val effectiveOverrides = if (hasNonBattlefieldAbility) {
-            val isMyTurn = state.activePlayerId == priorityPlayer
+            val isMyTurn = state.isActiveTurnFor(priorityPlayer)
             if (isMyTurn) {
                 overrides.copy(myTurnStops = overrides.myTurnStops + state.step)
             } else {
@@ -1263,12 +1263,15 @@ class GameSession(
 
         // During combat declaration steps, submit an empty declaration instead of PassPriority.
         // The engine requires declarations before allowing priority to pass.
+        // Turn ownership is team-wide in a shared team turn (CR 805.10a) — the same gate the
+        // engine's PassPriorityHandler / DeclareBlockersHandler use — so the active player's
+        // teammate isn't handed a DeclareBlockers (or a bare pass) the engine will refuse.
         val action: GameAction = when {
-            state.step == Step.DECLARE_ATTACKERS && playerId == state.activePlayerId &&
+            state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(playerId) &&
                 state.getEntity(playerId)?.get<AttackersDeclaredThisCombatComponent>() == null ->
                 DeclareAttackers(playerId, emptyMap())
 
-            state.step == Step.DECLARE_BLOCKERS && playerId != state.activePlayerId &&
+            state.step == Step.DECLARE_BLOCKERS && !state.isActiveTurnFor(playerId) &&
                 state.getEntity(playerId)?.get<BlockersDeclaredThisCombatComponent>() == null ->
                 DeclareBlockers(playerId, emptyMap())
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
@@ -188,8 +188,11 @@ class SpectatorStateBuilder(
         val playerId = seat.playerId
         val playerEntity = state.getEntity(playerId)
 
-        val life = playerEntity?.get<LifeTotalComponent>()?.life ?: 20
-        val poisonCounters = playerEntity?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0
+        // Through the resolvers: in Two-Headed Giant the life total (CR 810.9a) and the poison
+        // count (CR 810.10a) are the team's, carried on one member — a raw read shows the other
+        // head frozen at its starting life for the whole game.
+        val life = if (playerEntity?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 20
+        val poisonCounters = state.teamPoison(playerId)
         val hand = state.getZone(playerId, Zone.HAND)
         val library = state.getZone(playerId, Zone.LIBRARY)
         val battlefield = state.getZone(playerId, Zone.BATTLEFIELD)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/TwoHeadedGiantSessionTest.kt
@@ -65,6 +65,15 @@ class TwoHeadedGiantSessionTest : ScenarioTestBase() {
             (teamOf[ids[0].value] == teamOf[ids[2].value]) shouldBe false
         }
 
+        test("both heads of the surviving team are winners, not just the representative (CR 810.8a)") {
+            val (session, ids) = started2hg()
+            // Team 1 (ids[2], ids[3]) concedes; one concession takes the whole team out (CR 810.8b).
+            session.playerConcedes(ids[2])
+            session.isGameOver() shouldBe true
+            session.getWinnerIds() shouldBe listOf(ids[0], ids[1])
+            session.getWinnerId() shouldBe ids[0]
+        }
+
         test("a teammate is not an opponent (CR 810): getOpponentIds returns only the other team") {
             val (session, ids) = started2hg()
 

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -134,7 +134,8 @@ class ObservationBuilder(
     ): PlayerView {
         val container = state.getEntity(playerId)
         val playerComp = container?.get<PlayerComponent>()
-        val life = container?.get<LifeTotalComponent>()?.life ?: 0
+        // Through the resolver — a 2HG team's shared life lives on one member (CR 810.9a).
+        val life = if (container?.get<LifeTotalComponent>() != null) state.lifeTotal(playerId) else 0
         val manaPool = container?.get<ManaPoolComponent>()
         val hasLost = container?.get<PlayerLostComponent>() != null
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -93,8 +93,9 @@ class BeginningPhaseManager(
             events.addAll(dayNightEvents)
         }
 
-        // Check if the player has a SkipUntapComponent
-        val skipUntap = newState.getEntity(activePlayer)?.get<SkipUntapComponent>()
+        // Each active-team member's own "doesn't untap" marker applies to the permanents *they*
+        // control — in a shared team turn (CR 805.4) both heads untap, each under their own marker.
+        val skipUntapByPlayer = activeTeam.associateWith { newState.getEntity(it)?.get<SkipUntapComponent>() }
 
         // Use projected state for controller checks (control-changing effects like Annex).
         // Recomputed from newState so just-phased-in permanents are visible.
@@ -105,7 +106,8 @@ class BeginningPhaseManager(
             projected.getController(entityId) in activeTeam &&
                 container.has<TappedComponent>()
         }.keys.filter { entityId ->
-            // If there's a skip untap component, check if this permanent should be skipped
+            // If the controller has a skip untap component, check if this permanent should be skipped
+            val skipUntap = skipUntapByPlayer[projected.getController(entityId)]
             if (skipUntap != null) {
                 val cardComponent = newState.getEntity(entityId)?.get<CardComponent>()
                 val typeLine = cardComponent?.typeLine
@@ -121,9 +123,10 @@ class BeginningPhaseManager(
             }
         }
 
-        // Remove the SkipUntapComponent after processing (it's been consumed)
-        if (skipUntap != null) {
-            newState = newState.updateEntity(activePlayer) { container ->
+        // Remove the SkipUntapComponents after processing (they've been consumed)
+        for ((member, skipUntap) in skipUntapByPlayer) {
+            if (skipUntap == null) continue
+            newState = newState.updateEntity(member) { container ->
                 container.without<SkipUntapComponent>()
             }
         }
@@ -378,14 +381,18 @@ class BeginningPhaseManager(
 
     /**
      * Add a lore counter to each Saga the active player controls (Rule 714.3c).
-     * This is a turn-based action that happens at the beginning of precombat main phase.
+     * This is a turn-based action that happens at the beginning of precombat main phase. In a
+     * shared team turn (CR 805.4) the precombat main phase belongs to both heads, so each
+     * teammate's Sagas advance; outside shared team turns the team is the active player alone.
      */
     fun addLoreCountersToSagas(state: GameState, activePlayer: EntityId): ExecutionResult {
         var newState = state
         val events = mutableListOf<GameEvent>()
 
-        val battlefieldZone = ZoneKey(activePlayer, Zone.BATTLEFIELD)
-        for (entityId in newState.getZone(battlefieldZone)) {
+        val sagaIds = state.sharedTurnTeam(activePlayer).flatMap { member ->
+            newState.getZone(ZoneKey(member, Zone.BATTLEFIELD))
+        }
+        for (entityId in sagaIds) {
             val container = newState.getEntity(entityId) ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
             val sagaComponent = container.get<SagaComponent>() ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -199,20 +199,24 @@ class CleanupPhaseManager(
      * controller rather than to a step of any player's turn.
      */
     fun expireUntilYourNextTurnEffects(state: GameState, activePlayer: EntityId): GameState {
+        // "Your next turn" is the next turn of the player's *team* in a shared team turn (CR
+        // 805.4): both heads' "until your next turn" effects wear off on the team's untap. Outside
+        // shared team turns this set is just [activePlayer].
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         // Event-based delayed triggers scoped "until your next turn" (Tamiyo, Field Researcher's
         // +1). Keyed to the delayed trigger's own controller, so an opponent's rider is untouched
         // by this player's untap step.
         val remainingDelayed = state.delayedTriggers.filter { delayed ->
             !(delayed.expiry is DelayedTriggerExpiry.UntilControllersNextTurn &&
-                delayed.controllerId == activePlayer)
+                delayed.controllerId in activeTeam)
         }
         val remainingFloating = state.floatingEffects.filter { floatingEffect ->
             !(floatingEffect.duration is Duration.UntilYourNextTurn &&
-                floatingEffect.controllerId == activePlayer)
+                floatingEffect.controllerId in activeTeam)
         }
         val remainingGlobal = state.globalGrantedTriggeredAbilities.filter { grant ->
             !(grant.duration is Duration.UntilYourNextTurn &&
-                grant.controllerId == activePlayer)
+                grant.controllerId in activeTeam)
         }
         // Granted *activated* abilities with UntilYourNextTurn duration (Hydro-Man's temporary
         // "{T}: Add {U}"). The record carries no expiry-player, so key the expiry to the granted
@@ -222,7 +226,7 @@ class CleanupPhaseManager(
             !(grant.duration is Duration.UntilYourNextTurn &&
                 state.getEntity(grant.entityId)
                     ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
-                    ?.playerId == activePlayer)
+                    ?.playerId in activeTeam)
         }
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
@@ -240,13 +244,15 @@ class CleanupPhaseManager(
         }
         // Player-component "until your next turn" effects (The One Ring's protection) expire on
         // the same post-untap hook as floating UntilYourNextTurn effects.
-        val protection = result.getEntity(activePlayer)?.get<PlayerProtectionComponent>()
-        if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
-            result = result.updateEntity(activePlayer) { it.without<PlayerProtectionComponent>() }
-        }
-        val cantGainLife = result.getEntity(activePlayer)?.get<CantGainLifeComponent>()
-        if (cantGainLife?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
-            result = result.updateEntity(activePlayer) { it.without<CantGainLifeComponent>() }
+        for (member in activeTeam) {
+            val protection = result.getEntity(member)?.get<PlayerProtectionComponent>()
+            if (protection?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
+                result = result.updateEntity(member) { it.without<PlayerProtectionComponent>() }
+            }
+            val cantGainLife = result.getEntity(member)?.get<CantGainLifeComponent>()
+            if (cantGainLife?.removeOn == PlayerEffectRemoval.UntilYourNextTurn) {
+                result = result.updateEntity(member) { it.without<CantGainLifeComponent>() }
+            }
         }
         // Memory Vessel's "they can't play cards from their hand until your next turn" expires on
         // the same post-untap hook. The window keys off the *activating* player (every affected
@@ -257,7 +263,7 @@ class CleanupPhaseManager(
             val cantPlay = result.getEntity(playerId)?.get<PlayerCantPlayFromHandComponent>() ?: continue
             if (cantPlay.removeOn != PlayerEffectRemoval.UntilYourNextTurn) continue
             val expiryPlayer = cantPlay.expiresForPlayerId ?: playerId
-            if (expiryPlayer == activePlayer) {
+            if (expiryPlayer in activeTeam) {
                 result = result.updateEntity(playerId) { it.without<PlayerCantPlayFromHandComponent>() }
             }
         }
@@ -268,7 +274,7 @@ class CleanupPhaseManager(
             val restricted = result.getEntity(playerId)?.get<CantCastFromNonHandZonesComponent>() ?: continue
             if (restricted.removeOn != PlayerEffectRemoval.UntilYourNextTurn) continue
             val expiryPlayer = restricted.expiresForPlayerId ?: playerId
-            if (expiryPlayer == activePlayer) {
+            if (expiryPlayer in activeTeam) {
                 result = result.updateEntity(playerId) { it.without<CantCastFromNonHandZonesComponent>() }
             }
         }
@@ -280,7 +286,7 @@ class CleanupPhaseManager(
         // is back in time to trigger again.
         for ((entityId, container) in result.entities) {
             val marker = container.get<RevertCopyAtYourNextTurnComponent>() ?: continue
-            if (marker.playerId != activePlayer) continue
+            if (marker.playerId !in activeTeam) continue
             val originalCard = container.get<CopyOfComponent>()?.originalCardComponent
             result = result.updateEntity(entityId) { c ->
                 var reverted = c.without<RevertCopyAtYourNextTurnComponent>()
@@ -305,13 +311,15 @@ class CleanupPhaseManager(
      * carries the new turn's timestamp and survives this same-step expiry on the following turn.
      */
     fun expireUntilYourNextUpkeepEffects(state: GameState, activePlayer: EntityId): GameState {
+        // The team's upkeep is each head's upkeep in a shared team turn (CR 805.4).
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         val remainingFloating = state.floatingEffects.filter { floatingEffect ->
             !(floatingEffect.duration is Duration.UntilYourNextUpkeep &&
-                floatingEffect.controllerId == activePlayer)
+                floatingEffect.controllerId in activeTeam)
         }
         val remainingGlobal = state.globalGrantedTriggeredAbilities.filter { grant ->
             !(grant.duration is Duration.UntilYourNextUpkeep &&
-                grant.controllerId == activePlayer)
+                grant.controllerId in activeTeam)
         }
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
@@ -377,10 +385,13 @@ class CleanupPhaseManager(
     ): Pair<GameState, List<GameEvent>> {
         var newState = state
         val events = mutableListOf<GameEvent>()
+        // CR 701.15a "until the next turn of the controller" — in a shared team turn (CR 805.4)
+        // that turn belongs to both heads, so a goad by either one lapses here.
+        val activeTeam = newState.sharedTurnTeam(activePlayer).toHashSet()
         for (entityId in newState.getBattlefield()) {
             val goaded = newState.getEntity(entityId)?.get<GoadedComponent>() ?: continue
-            if (activePlayer !in goaded.goaderIds) continue
-            val remaining = goaded.goaderIds - activePlayer
+            if (goaded.goaderIds.none { it in activeTeam }) continue
+            val remaining = goaded.goaderIds - activeTeam
             newState = newState.updateEntity(entityId) { container ->
                 if (remaining.isEmpty()) container.without<GoadedComponent>()
                 else container.with(GoadedComponent(remaining))
@@ -403,11 +414,14 @@ class CleanupPhaseManager(
      */
     fun expireAffectedControllersNextUntapEffects(state: GameState, activePlayer: EntityId): GameState {
         val projected = state.projectedState
+        // Both heads untap on the team's turn (CR 805.4), so either head counts as "the
+        // affected creature's controller just had their untap step".
+        val activeTeam = state.sharedTurnTeam(activePlayer).toHashSet()
         val remaining = state.floatingEffects.filter { floatingEffect ->
             if (floatingEffect.duration !is Duration.UntilAfterAffectedControllersNextUntap) return@filter true
-            // Expire if any affected entity is controlled by the active player
+            // Expire if any affected entity is controlled by the active team
             val affectedByActivePlayer = floatingEffect.effect.affectedEntities.any { entityId ->
-                projected.getController(entityId) == activePlayer
+                projected.getController(entityId) in activeTeam
             }
             !affectedByActivePlayer
         }
@@ -534,7 +548,7 @@ class CleanupPhaseManager(
                         // turn" effect rather than stranding a control change permanently.
                         null -> false
                         else -> !(newState.turnNumber >= floor &&
-                            newState.activePlayerId == floatingEffect.controllerId)
+                            newState.isActiveTurnFor(floatingEffect.controllerId))
                     }
                 }
                 is Duration.UntilYourNextUpkeep -> true  // Keep until upkeep
@@ -1045,7 +1059,7 @@ class CleanupPhaseManager(
                     !permission.permanent && when {
                         permission.expiresAfterTurn != null ->
                             newState.turnNumber >= permission.expiresAfterTurn &&
-                                newState.activePlayerId == (permission.expiryControllerId ?: permission.controllerId)
+                                newState.isActiveTurnFor(permission.expiryControllerId ?: permission.controllerId)
                         else -> true
                     }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -263,7 +263,19 @@ class GameInitializer(
                 state = shuffledState
                 shuffled
             }
-            orderedTeams.flatten()
+            val seating = orderedTeams.flatten()
+            if (startTeam == null && !config.format.sharesTeamTurns) {
+                // CR 808.4 (Team vs. Team): the randomly chosen team's first player is its *centre*
+                // seat when the team is odd-sized and the seat to the left of its midpoint when it
+                // is even — index size/2 either way, since turn order runs to the left (CR 103.7b).
+                // Turn order then continues around the table from that seat, so the rest of that
+                // team comes last. With shared team turns (CR 805) the team takes one turn and its
+                // first-listed member is just the representative, so the seating stays as built.
+                val firstSeat = orderedTeams.first().size / 2
+                seating.subList(firstSeat, seating.size) + seating.subList(0, firstSeat)
+            } else {
+                seating
+            }
         } else if (config.startingPlayerIndex != null) {
             val idx = config.startingPlayerIndex
             playerIds.subList(idx, playerIds.size) + playerIds.subList(0, idx)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -831,6 +831,11 @@ class TurnManager(
             nextPlayer = cleanedState.getNextTeam(nextPlayer)
         }
 
+        // CR 800.4m — a departed player's "until your next turn" effects last until that turn
+        // would have begun. Their turn is skipped (800.4k), and this is the moment it would have
+        // started: the seat walk from the finished turn to the next one passes them over.
+        cleanedState = expireEffectsOfDepartedSeatsWhoseTurnWouldBeginNow(cleanedState, currentPlayer, nextPlayer)
+
         // Start the new turn (sets step to UNTAP with no priority)
         val turnResult = startTurn(cleanedState, nextPlayer)
         if (!turnResult.isSuccess) return turnResult
@@ -863,6 +868,59 @@ class TurnManager(
             advanceResult.newState,
             turnResult.events + untapResult.events + goadEvents + advanceResult.events
         )
+    }
+
+    /**
+     * CR 800.4m: when the turn passes from [from]'s team to [to]'s team, every player who has left
+     * the game and sits between them in seat order — plus any departed member of [to]'s own team,
+     * whose shared turn is beginning (CR 805.4) — is a player whose next turn "would have begun"
+     * right now. Their "until your next turn" / "until your next upkeep" / "until the end of your
+     * next turn" effects, their goads and their may-play permissions end here, the same hooks a
+     * living player's untap step runs for them. Nothing to do while nobody has left.
+     */
+    private fun expireEffectsOfDepartedSeatsWhoseTurnWouldBeginNow(
+        state: GameState,
+        from: EntityId,
+        to: EntityId
+    ): GameState {
+        val order = state.turnOrder
+        val departed = order.filter { state.getEntity(it)?.has<PlayerLostComponent>() == true }
+        if (departed.isEmpty()) return state
+
+        val fromTeam = state.teamOf(from).toHashSet()
+        val toTeam = state.teamOf(to).toHashSet()
+        val startIdx = order.indexOf(from)
+        if (startIdx < 0) return state
+        val passedOver = mutableListOf<EntityId>()
+        // Walk the seats after the finished team until the next team is reached.
+        for (step in 1 until order.size) {
+            val seat = order[(startIdx + step) % order.size]
+            if (seat in fromTeam) continue
+            if (seat in toTeam) break
+            if (seat in departed) passedOver += seat
+        }
+        // A departed member of the team now taking its turn: their turn is beginning too.
+        passedOver += toTeam.filter { it in departed && it !in fromTeam }
+
+        var s = state
+        for (leaver in passedOver.distinct()) {
+            s = cleanupPhaseManager.expireUntilYourNextTurnEffects(s, leaver)
+            s = cleanupPhaseManager.expireUntilYourNextUpkeepEffects(s, leaver)
+            s = cleanupPhaseManager.expireGoadedDesignationFor(s, leaver).first
+            // "Until the end of your next turn" is keyed to a turn the leaver will never take
+            // (a turn-number floor plus a controller guard); CR 800.4m ends it here as well.
+            s = s.copy(
+                floatingEffects = s.floatingEffects.filterNot { fe ->
+                    fe.duration is com.wingedsheep.sdk.scripting.Duration.EndOfYourNextTurn &&
+                        fe.controllerId == leaver
+                },
+                mayPlayPermissions = s.mayPlayPermissions.filterNot { permission ->
+                    !permission.permanent && permission.expiresAfterTurn != null &&
+                        (permission.expiryControllerId ?: permission.controllerId) == leaver
+                }
+            )
+        }
+        return s
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -313,10 +313,16 @@ class TurnManager(
      * `COMBAT_PHASE` skips all five combat steps one after another as this is consulted per step,
      * and `MAIN_PHASE` skips both main phases (CR 505.1).
      */
-    private fun skipsTurnPart(state: GameState, step: Step, playerId: EntityId): Boolean {
-        val parts = state.getEntity(playerId)?.get<SkippedTurnPartsComponent>()?.parts ?: return false
-        return parts.any { it.covers(step) }
-    }
+    /**
+     * Whether [playerId]'s turn skips [step]. CR 805.8 — in a shared team turn a step one teammate
+     * is made to skip is skipped by the team, so the marker is read off every member of the active
+     * team; outside shared team turns [GameState.sharedTurnTeam] is just the player.
+     */
+    private fun skipsTurnPart(state: GameState, step: Step, playerId: EntityId): Boolean =
+        state.sharedTurnTeam(playerId).any { member ->
+            state.getEntity(member)?.get<SkippedTurnPartsComponent>()?.parts
+                ?.any { it.covers(step) } == true
+        }
 
     private fun advanceStepFromEndedStep(incomingState: GameState): ExecutionResult {
         val currentStep = incomingState.step
@@ -715,11 +721,14 @@ class TurnManager(
                 // an attacking creature only during the end of combat step (e.g. Desert) still
                 // have legal targets.
 
-                // Remove MustAttackPlayerComponent after combat (Taunt effect is consumed)
-                val mustAttack = newState.getEntity(activePlayer)?.get<MustAttackPlayerComponent>()
-                if (mustAttack != null && mustAttack.activeThisTurn) {
-                    newState = newState.updateEntity(activePlayer) { container ->
-                        container.without<MustAttackPlayerComponent>()
+                // Remove MustAttackPlayerComponent after combat (Taunt effect is consumed). Read
+                // off every member of the active team: a shared team turn is either head's turn.
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val mustAttack = newState.getEntity(member)?.get<MustAttackPlayerComponent>()
+                    if (mustAttack != null && mustAttack.activeThisTurn) {
+                        newState = newState.updateEntity(member) { container ->
+                            container.without<MustAttackPlayerComponent>()
+                        }
                     }
                 }
 
@@ -731,14 +740,19 @@ class TurnManager(
                 // alongside the paired "return it at the beginning of the next end step" triggers.
                 newState = cleanupPhaseManager.performNextEndStepExpiry(newState)
 
-                val loseComponent = newState.getEntity(activePlayer)?.get<LoseAtEndStepComponent>()
-                if (loseComponent != null) {
+                // "At the beginning of the next end step, you lose the game" (Final Fortune) is
+                // keyed to whoever took the extra turn. In a shared team turn (CR 805.8) that is
+                // either head, so every member of the active team is checked — not just the seat
+                // that happens to be [activePlayer]; outside shared team turns the team is the
+                // active player alone.
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val loseComponent = newState.getEntity(member)?.get<LoseAtEndStepComponent>() ?: continue
                     if (loseComponent.turnsUntilLoss <= 0) {
-                        newState = newState.updateEntity(activePlayer) { container ->
+                        newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(PlayerLostComponent(LossReason.CARD_EFFECT))
                         }
-                        events.add(PlayerLostEvent(activePlayer, GameEndReason.CARD_EFFECT, loseComponent.message))
+                        events.add(PlayerLostEvent(member, GameEndReason.CARD_EFFECT, loseComponent.message))
                         val sbaResult = sbaChecker.checkAndApply(newState)
                         if (sbaResult.isPaused) {
                             return ExecutionResult.paused(
@@ -754,7 +768,7 @@ class TurnManager(
                             return ExecutionResult.success(newState, events)
                         }
                     } else {
-                        newState = newState.updateEntity(activePlayer) { container ->
+                        newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(LoseAtEndStepComponent(loseComponent.turnsUntilLoss - 1, loseComponent.message))
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -748,6 +748,13 @@ class TurnManager(
                 for (member in newState.sharedTurnTeam(activePlayer)) {
                     val loseComponent = newState.getEntity(member)?.get<LoseAtEndStepComponent>() ?: continue
                     if (loseComponent.turnsUntilLoss <= 0) {
+                        // "You can't lose the game" (Platinum Angel — CR 104.3, and team-wide in
+                        // 2HG per CR 810.8a) stops this loss like every other: the delayed
+                        // trigger resolves and does nothing, so the marker is still consumed.
+                        if (com.wingedsheep.engine.mechanics.sba.player.playerCantLoseGame(newState, member)) {
+                            newState = newState.updateEntity(member) { it.without<LoseAtEndStepComponent>() }
+                            continue
+                        }
                         newState = newState.updateEntity(member) { container ->
                             container.without<LoseAtEndStepComponent>()
                                 .with(PlayerLostComponent(LossReason.CARD_EFFECT))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -205,22 +205,26 @@ class TurnManager(
         // ruling, a scheduled hijack waits through any skipped turns and engages on the next turn
         // the affected player actually takes. Combat-phase-scoped hijacks (Secret of Bloodbending)
         // are ignored here — they engage at beginning of combat (see advanceStep) instead.
-        val scheduledHijack = newState.getEntity(playerId)?.get<PlayerTurnHijackedComponent>()
-        if (scheduledHijack != null &&
-            scheduledHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
-            scheduledHijack.scope == HijackScope.NextTurn
-        ) {
-            newState = newState.updateEntity(playerId) { container ->
-                container.with(
-                    scheduledHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+        // The turn is the whole active team's in a shared team turn (CR 805.4), and a hijack
+        // controls the team (CR 805.8), so every member's scheduled hijack engages — the second
+        // head is never `playerId` here, and reading only that seat left them un-hijacked.
+        for (member in newState.sharedTurnTeam(playerId)) {
+            val scheduledHijack = newState.getEntity(member)?.get<PlayerTurnHijackedComponent>() ?: continue
+            if (scheduledHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
+                scheduledHijack.scope == HijackScope.NextTurn
+            ) {
+                newState = newState.updateEntity(member) { container ->
+                    container.with(
+                        scheduledHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                    )
+                }
+                events += TurnHijackedEvent(
+                    controllerId = scheduledHijack.controllerId,
+                    hijackedPlayerId = member,
+                    sourceId = member,
+                    sourceName = "Hijack engaged"
                 )
             }
-            events += TurnHijackedEvent(
-                controllerId = scheduledHijack.controllerId,
-                hijackedPlayerId = playerId,
-                sourceId = playerId,
-                sourceName = "Hijack engaged"
-            )
         }
 
         return ExecutionResult.success(newState, events)
@@ -335,12 +339,15 @@ class TurnManager(
         // combat phase follows — "their next combat phase" is a single phase, never the extra ones.
         var state = incomingState
         if (currentStep == Step.END_COMBAT) {
-            val combatHijack = state.getEntity(activePlayer)?.get<PlayerTurnHijackedComponent>()
-            if (combatHijack != null &&
-                combatHijack.state == PlayerTurnHijackedComponent.HijackState.ACTIVE &&
-                combatHijack.scope == HijackScope.NextCombatPhase
-            ) {
-                state = state.updateEntity(activePlayer) { it.without<PlayerTurnHijackedComponent>() }
+            // Every member of the active team — a combat hijack controls the team (CR 805.8).
+            for (member in state.sharedTurnTeam(activePlayer)) {
+                val combatHijack = state.getEntity(member)?.get<PlayerTurnHijackedComponent>()
+                if (combatHijack != null &&
+                    combatHijack.state == PlayerTurnHijackedComponent.HijackState.ACTIVE &&
+                    combatHijack.scope == HijackScope.NextCombatPhase
+                ) {
+                    state = state.updateEntity(member) { it.without<PlayerTurnHijackedComponent>() }
+                }
             }
         }
 
@@ -630,24 +637,26 @@ class TurnManager(
                 // active player: their combat phase is now beginning, so input authority moves to
                 // the hijacker for the duration of this phase. A hijack scheduled while combat was
                 // skipped stays SCHEDULED and waits for a combat phase they actually reach here.
-                val combatHijack = newState.getEntity(activePlayer)?.get<PlayerTurnHijackedComponent>()
-                if (combatHijack != null &&
-                    combatHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
-                    combatHijack.scope == HijackScope.NextCombatPhase
-                ) {
-                    newState = newState.updateEntity(activePlayer) { container ->
-                        container.with(
-                            combatHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                // Every member of the active team — a combat hijack controls the team (CR 805.8).
+                for (member in newState.sharedTurnTeam(activePlayer)) {
+                    val combatHijack = newState.getEntity(member)?.get<PlayerTurnHijackedComponent>() ?: continue
+                    if (combatHijack.state == PlayerTurnHijackedComponent.HijackState.SCHEDULED &&
+                        combatHijack.scope == HijackScope.NextCombatPhase
+                    ) {
+                        newState = newState.updateEntity(member) { container ->
+                            container.with(
+                                combatHijack.copy(state = PlayerTurnHijackedComponent.HijackState.ACTIVE)
+                            )
+                        }
+                        events.add(
+                            TurnHijackedEvent(
+                                controllerId = combatHijack.controllerId,
+                                hijackedPlayerId = member,
+                                sourceId = member,
+                                sourceName = "Combat hijack engaged"
+                            )
                         )
                     }
-                    events.add(
-                        TurnHijackedEvent(
-                            controllerId = combatHijack.controllerId,
-                            hijackedPlayerId = activePlayer,
-                            sourceId = activePlayer,
-                            sourceName = "Combat hijack engaged"
-                        )
-                    )
                 }
                 newState = newState.withPriority(activePlayer)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -199,7 +199,7 @@ class AttachmentTriggerDetector(
                 // the aura/equipment's controller, as everywhere else here.
                 val tapper = trigger.tapper ?: return true
                 val tappedById = event.tappedById ?: return false
-                matcher.matchesPlayer(tapper, tappedById, auraControllerId)
+                matcher.matchesPlayer(state, tapper, tappedById, auraControllerId)
             }
             // "Whenever equipped creature becomes untapped" (Fishing Pole). UntapEvent carries no
             // filter, so identity with the attached permanent is the whole match.
@@ -209,7 +209,7 @@ class AttachmentTriggerDetector(
             is EventPattern.AbilityActivatedEvent -> {
                 if (event !is AbilityActivatedEvent) return false
                 if (event.sourceId != attachedEntityId) return false
-                if (!matcher.matchesPlayer(trigger.player, event.controllerId, auraControllerId)) return false
+                if (!matcher.matchesPlayer(state, trigger.player, event.controllerId, auraControllerId)) return false
                 // Mirror the main matcher's two wordings (see TriggerMatcher.AbilityActivatedEvent):
                 // "without {T} in its activation cost" vs. "isn't a mana ability".
                 when {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2582,7 +2582,7 @@ class TriggerDetector(
                     if (reason != null && event.reason != reason) return@filter false
                     if (tapper == null) return@filter true
                     event.tappedById != null &&
-                        matcher.matchesPlayer(tapper, event.tappedById, entry.controllerId)
+                        matcher.matchesPlayer(state, tapper, event.tappedById, entry.controllerId)
                 }.map { it.entityId }
                 if (tappedIds.isEmpty()) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -483,11 +483,13 @@ class TriggerDetector(
      * Returns the pending triggers and the IDs of consumed delayed triggers.
      */
     fun detectDelayedTriggers(state: GameState, step: Step): Pair<List<PendingTrigger>, Set<String>> {
-        val activePlayer = state.activePlayerId
         val matching = state.delayedTriggers.filter { delayed ->
             delayed.trigger == null &&
                 delayed.fireAtStep == step &&
-                (delayed.fireOnPlayerId == null || delayed.fireOnPlayerId == activePlayer) &&
+                // "your next end step" is the team's in a shared team turn (CR 805.4) — the
+                // non-representative head is never `activePlayerId`, so equality would strand
+                // every one of their step-keyed delayed triggers.
+                (delayed.fireOnPlayerId == null || state.isActiveTurnFor(delayed.fireOnPlayerId)) &&
                 (delayed.notBeforeTurn == null || state.turnNumber >= delayed.notBeforeTurn)
         }
         if (matching.isEmpty()) return emptyList<PendingTrigger>() to emptySet()
@@ -2659,8 +2661,9 @@ class TriggerDetector(
         val activePlayer = state.activePlayerId ?: return
 
         for (entry in index.getEntitiesForCategory(TriggerCategory.UNTAPPED)) {
-            // "your untap step" — the observer must be the active player whose untap step just ran.
-            if (entry.controllerId != activePlayer) continue
+            // "your untap step" — the observer must be on the active team whose untap step just ran
+            // (both heads untap in a shared team turn, CR 805.4).
+            if (!state.isActiveTurnFor(entry.controllerId)) continue
             for (ability in entry.abilities) {
                 val trigger = ability.trigger
                 if (trigger !is EventPattern.UntapEvent || !trigger.batch) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -116,7 +116,8 @@ class TriggerMatcher(
             }
             is EventPattern.YouAttackEvent -> {
                 if (event !is AttackersDeclaredEvent) return false
-                if (state.activePlayerId != controllerId) return false
+                // "Whenever you attack" — the controller's team is attacking (CR 805.10a).
+                if (!state.isActiveTurnFor(controllerId)) return false
                 val filter = trigger.attackerFilter
                 if (filter != null) {
                     // Count attackers matching the filter
@@ -935,7 +936,7 @@ class TriggerMatcher(
 
         val drawer = event.playerId
         // Exemption only applies in the drawing player's own draw step.
-        val inOwnDrawStep = state.activePlayerId == drawer && state.step == Step.DRAW
+        val inOwnDrawStep = state.isActiveTurnFor(drawer) && state.step == Step.DRAW
         if (!inOwnDrawStep) return total
 
         val countAfter = (state.getEntity(drawer)?.get<CardsDrawnThisTurnComponent>()?.count ?: 0) -

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -74,7 +74,7 @@ class TriggerMatcher(
             }
             is EventPattern.ZoneChangeEvent -> matchesZoneChangeTrigger(trigger, binding, event, sourceId, controllerId, state)
             is EventPattern.DrawEvent -> {
-                event is CardsDrawnEvent && matchesPlayer(trigger.player, event.playerId, controllerId)
+                event is CardsDrawnEvent && matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             // MillEvent is a replacement-only pattern (ModifyMillAmount); it never matches a
             // triggered ability. Applied at the mill announcement by MillAmountModifier.
@@ -90,7 +90,7 @@ class TriggerMatcher(
                 // we have countAfter = CardsDrawnThisTurnComponent.count and
                 // countBefore = countAfter - event.count.
                 if (event !is CardsDrawnEvent) return false
-                if (!matchesPlayer(trigger.player, event.playerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.playerId, controllerId)) return false
                 val countAfter = state.getEntity(event.playerId)
                     ?.get<CardsDrawnThisTurnComponent>()
                     ?.count ?: 0
@@ -240,7 +240,7 @@ class TriggerMatcher(
             }
             is EventPattern.SpellCastEvent -> {
                 event is SpellCastEvent &&
-                    matchesPlayer(trigger.player, event.casterId, controllerId) &&
+                    matchesPlayer(state, trigger.player, event.casterId, controllerId) &&
                     matchesSpellFilter(trigger.spellFilter, event, state, sourceId) &&
                     trigger.requires.all { matchesSpellCastPredicate(it, event, state, sourceId, controllerId) }
             }
@@ -248,7 +248,7 @@ class TriggerMatcher(
                 // Fires on SpellCastEvent when the casting player's per-turn spell count
                 // reaches exactly the specified threshold (e.g., 2 for "second spell").
                 if (event !is SpellCastEvent) return false
-                if (!matchesPlayer(trigger.player, event.casterId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.casterId, controllerId)) return false
                 val spellFilter = trigger.spellFilter
                 val currentCount = if (spellFilter == null) {
                     state.playerSpellsCastThisTurn[event.casterId] ?: 0
@@ -274,7 +274,7 @@ class TriggerMatcher(
                 // crosses the threshold. Fires on SpellCastEvent only.
                 // Detects the "crossing": previous total < threshold <= new total.
                 if (event !is SpellCastEvent) return false
-                if (!matchesPlayer(trigger.player, event.casterId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.casterId, controllerId)) return false
 
                 val playerEntity = state.getEntity(event.casterId) ?: return false
                 val manaComponent = playerEntity.get<ManaSpentOnSpellsThisTurnComponent>()
@@ -300,7 +300,7 @@ class TriggerMatcher(
             }
             is EventPattern.AbilityActivatedEvent -> {
                 if (event !is AbilityActivatedEvent) return false
-                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.controllerId, controllerId)) return false
                 if (trigger.requireExhaust) {
                     if (!event.isExhaust) return false
                     // Plain "whenever you activate an exhaust ability" counts an exhaust mana
@@ -348,7 +348,7 @@ class TriggerMatcher(
             }
             is EventPattern.AbilityTriggeredEvent -> {
                 if (event !is AbilityTriggeredEvent) return false
-                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.controllerId, controllerId)) return false
                 // "attacking causes a triggered ability of that creature to trigger": only fire for
                 // abilities the engine stamped as attack-caused (SELF-bound attacks triggers).
                 if (trigger.requireAttackCause && !event.causedByAttack) return false
@@ -368,16 +368,16 @@ class TriggerMatcher(
             }
             is EventPattern.CycleEvent -> {
                 event is CardCycledEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId) &&
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId) &&
                     (binding != TriggerBinding.SELF || event.cardId == sourceId)
             }
             is EventPattern.GiftGivenEvent -> {
                 event is GiftGivenEvent &&
-                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.controllerId, controllerId)
             }
             is EventPattern.CommitCrimeEvent -> {
                 event is CommitCrimeEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.BecomesPlottedEvent -> {
                 // "When this card becomes plotted" triggers fire on a card that is now in exile,
@@ -435,7 +435,7 @@ class TriggerMatcher(
                 // is the source, e.g. Assimilation Aegis).
                 if (binding == TriggerBinding.SELF && event.attachmentId != sourceId) return false
                 // The controller of the attachment (CR — "an Aura you control").
-                if (!matchesPlayer(trigger.attachmentController, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.attachmentController, event.controllerId, controllerId)) return false
                 // The attachment must match the attachment filter (e.g. Aura, Equipment).
                 val attachmentCtx = com.wingedsheep.engine.handlers.PredicateContext(
                     controllerId = controllerId,
@@ -466,7 +466,7 @@ class TriggerMatcher(
                 if (binding == TriggerBinding.SELF && event.attachmentId != sourceId) return false
                 // The attachment's controller as of the unattach — carried on the event because the
                 // leave-the-battlefield path has already stripped ControllerComponent by now.
-                if (!matchesPlayer(trigger.attachmentController, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.attachmentController, event.controllerId, controllerId)) return false
                 val attachmentCtx = com.wingedsheep.engine.handlers.PredicateContext(
                     controllerId = controllerId,
                     sourceId = sourceId,
@@ -494,11 +494,11 @@ class TriggerMatcher(
             }
             is EventPattern.TargetsChosenEvent -> {
                 event is com.wingedsheep.engine.core.TargetsChosenEvent &&
-                    matchesPlayer(trigger.player, event.chooserId, controllerId)
+                    matchesPlayer(state, trigger.player, event.chooserId, controllerId)
             }
             is EventPattern.RoomFullyUnlockedEvent -> {
                 event is RoomFullyUnlockedEvent &&
-                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.controllerId, controllerId)
             }
             is EventPattern.DoorUnlockedEvent -> {
                 // Face-scoped "When you unlock this door" triggers (CR 709.5h) are handled
@@ -525,7 +525,7 @@ class TriggerMatcher(
                 val tapper = trigger.tapper
                 if (tapper != null) {
                     val tappedById = event.tappedById ?: return false
-                    if (!matchesPlayer(tapper, tappedById, controllerId)) return false
+                    if (!matchesPlayer(state, tapper, tappedById, controllerId)) return false
                 }
                 val filter = trigger.filter
                 if (filter != null) {
@@ -575,7 +575,7 @@ class TriggerMatcher(
             is EventPattern.LandTappedForMana -> {
                 if (event !is LandTappedForManaEvent) return false
                 if (binding == TriggerBinding.SELF && event.landId != sourceId) return false
-                if (!matchesPlayer(trigger.player, event.tapperId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.tapperId, controllerId)) return false
                 val filter = trigger.landFilter
                 if (filter != null) {
                     val predicateEvaluator = PredicateEvaluator()
@@ -591,49 +591,49 @@ class TriggerMatcher(
             is EventPattern.LifeGainEvent -> {
                 event is LifeChangedEvent &&
                     event.reason == com.wingedsheep.engine.core.LifeChangeReason.LIFE_GAIN &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId) &&
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId) &&
                     (!trigger.firstTimeEachTurn || event.firstThisTurn)
             }
             is EventPattern.RingTemptedEvent -> {
                 event is com.wingedsheep.engine.core.RingTemptedEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId) &&
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId) &&
                     (!trigger.requireBearerChosen || event.bearerId != null)
             }
             is EventPattern.ScriedEvent -> {
                 event is com.wingedsheep.engine.core.ScriedEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.SurveiledEvent -> {
                 event is com.wingedsheep.engine.core.SurveiledEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.ScriedOrSurveiledEvent -> when (event) {
                 is com.wingedsheep.engine.core.ScriedEvent ->
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
                 is com.wingedsheep.engine.core.SurveiledEvent ->
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
                 else -> false
             }
             is EventPattern.DiscoveredEvent -> {
                 event is com.wingedsheep.engine.core.DiscoveredEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.EvidenceCollectedEvent -> {
                 event is com.wingedsheep.engine.core.EvidenceCollectedEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.ForagedEvent -> {
                 // The forager rides the event rather than being read off the source: a forage paid
                 // as a cost belongs to whoever paid, which need not be the source's controller.
                 event is com.wingedsheep.engine.core.ForagedEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.CaseSolvedEvent -> {
                 // The solving player rides the event (the Case's controller when its "To solve"
                 // trigger resolved), so a Case sacrificed by its own Solved ability still credits
                 // the right player here.
                 event is com.wingedsheep.engine.core.CaseSolvedEvent &&
-                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.controllerId, controllerId)
             }
             is EventPattern.ExploredEvent -> {
                 if (event !is com.wingedsheep.engine.core.PermanentExploredEvent) return false
@@ -676,7 +676,7 @@ class TriggerMatcher(
                 if (binding == TriggerBinding.SELF && event.exploiterId != sourceId) return false
                 if (binding == TriggerBinding.OTHER && event.exploiterId == sourceId) return false
                 // "a creature you control exploits ..." scopes on the EXPLOITER's controller.
-                if (!matchesPlayer(trigger.player, event.exploiterControllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.exploiterControllerId, controllerId)) return false
                 // "exploits a NONTOKEN creature" (Skull Skaab): reject when the sacrificed
                 // permanent was a token (last-known info captured before the zone change).
                 if (trigger.requireNontokenExploited && event.sacrificedWasToken) return false
@@ -695,11 +695,11 @@ class TriggerMatcher(
             is EventPattern.BendPerformedEvent -> {
                 event is com.wingedsheep.engine.core.BendPerformedEvent &&
                     event.bendType in trigger.types &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.ManifestedDreadEvent -> {
                 event is com.wingedsheep.engine.core.ManifestedDreadEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.BecomesTargetEvent -> {
                 event is BecomesTargetEvent && matchesBecomesTargetTrigger(trigger, binding, event, sourceId, controllerId, state)
@@ -709,7 +709,7 @@ class TriggerMatcher(
             }
             is EventPattern.CreatureTurnedFaceUpEvent -> {
                 if (event !is TurnFaceUpEvent) return false
-                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.controllerId, controllerId)) return false
                 // "a Detective you control is turned face up" — the filter reads the permanent's
                 // post-flip characteristics, which is what the projected state already holds by
                 // detection time (the flip has happened; the event is the notification).
@@ -760,7 +760,7 @@ class TriggerMatcher(
                 event is LifeChangedEvent &&
                     event.reason != com.wingedsheep.engine.core.LifeChangeReason.LIFE_GAIN &&
                     event.oldLife > event.newLife &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             // Replacement-effect-only: a life payment reaches triggers as the LifeChangedEvent it
             // produces (matched by LifeLossEvent above), never as a payment event of its own.
@@ -768,11 +768,11 @@ class TriggerMatcher(
             is EventPattern.LifeGainOrLossEvent -> {
                 event is LifeChangedEvent &&
                     event.oldLife != event.newLife &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.PlayerLostGameEvent -> {
                 event is com.wingedsheep.engine.core.PlayerLostEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.DiscardEvent -> {
                 event is CardsDiscardedEvent &&
@@ -780,14 +780,14 @@ class TriggerMatcher(
             }
             is EventPattern.SearchLibraryEvent -> {
                 event is com.wingedsheep.engine.core.LibrarySearchedEvent &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             is EventPattern.ShuffleLibraryEvent -> {
                 // "a *spell or ability* causes a player to shuffle" — the game-rules shuffles
                 // (game setup, mulligan) carry their own cause and must never fire this.
                 event is com.wingedsheep.engine.core.LibraryShuffledEvent &&
                     event.cause == com.wingedsheep.engine.core.ShuffleCause.SPELL_OR_ABILITY &&
-                    matchesPlayer(trigger.player, event.playerId, controllerId)
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId)
             }
             // ExtraTurnEvent is only used as a replacement effect filter, not a trigger
             is EventPattern.ExtraTurnEvent -> false
@@ -854,7 +854,7 @@ class TriggerMatcher(
                 if (event !is SagaChapterResolvedEvent) return false
                 // "of a Saga you control" — the resolving Saga's controller must match the
                 // observer (Tom's controller). Player.You is the only meaningful selector here.
-                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                if (!matchesPlayer(state, trigger.player, event.controllerId, controllerId)) return false
                 if (trigger.finalChapterOnly && !event.isFinalChapter) return false
                 true
             }
@@ -883,7 +883,7 @@ class TriggerMatcher(
         controllerId: EntityId,
         state: GameState
     ): List<EntityId> {
-        if (!matchesPlayer(trigger.player, event.playerId, controllerId)) return emptyList()
+        if (!matchesPlayer(state, trigger.player, event.playerId, controllerId)) return emptyList()
         val filter = trigger.cardFilter ?: return event.cardIds
         val projected = state.projectedState
         val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
@@ -930,7 +930,7 @@ class TriggerMatcher(
         state: GameState,
         samePlayerDrawsLaterInBatch: Int = 0
     ): Int {
-        if (!matchesPlayer(trigger.player, event.playerId, controllerId)) return 0
+        if (!matchesPlayer(state, trigger.player, event.playerId, controllerId)) return 0
         val total = event.count
         if (!trigger.exceptFirstInDrawStep || total == 0) return total
 
@@ -1413,13 +1413,15 @@ class TriggerMatcher(
     }
 
     /**
-     * Check if a Player filter matches the event's player.
+     * Check if a Player filter matches the event's player. `EachOpponent` is a real opponent test
+     * ([GameState.isOpponentOf]) — in a team game the controller's teammate is not "an opponent",
+     * so "whenever an opponent gains life" must not fire off your own partner (CR 102.3).
      */
-    fun matchesPlayer(player: Player, eventPlayerId: EntityId, controllerId: EntityId): Boolean {
+    fun matchesPlayer(state: GameState, player: Player, eventPlayerId: EntityId, controllerId: EntityId): Boolean {
         return when (player) {
             Player.You -> eventPlayerId == controllerId
             Player.Each -> true
-            Player.EachOpponent -> eventPlayerId != controllerId
+            Player.EachOpponent -> state.isOpponentOf(eventPlayerId, controllerId)
             else -> true
         }
     }
@@ -1846,7 +1848,7 @@ class TriggerMatcher(
         }
         // "a spell they don't own" — owner vs. the player who *cast* it, not vs. the trigger's
         // controller. The two coincide for the "whenever you cast a spell you don't own" wording
-        // (Nita, Vaan), where `matchesPlayer(Player.You, …)` has already pinned casterId ==
+        // (Nita, Vaan), where `matchesPlayer(state, Player.You, …)` has already pinned casterId ==
         // controllerId; they diverge for "whenever *a player* casts a spell they don't own"
         // (Gonti, Night Minister), which observes every seat.
         SpellCastPredicate.NotOwnedByController -> {
@@ -2335,7 +2337,7 @@ class TriggerMatcher(
         // engine didn't attribute to a placer (null) never satisfies a non-null selector.
         trigger.placedBy?.let { placer ->
             val placedBy = event.placedBy ?: return false
-            if (!matchesPlayer(placer, placedBy, controllerId)) return false
+            if (!matchesPlayer(state, placer, placedBy, controllerId)) return false
         }
         // Check filter: the permanent receiving counters must match. Battlefield recipients are read
         // through projected state, so a Hero by virtue of a type-changing effect counts.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareAttackersHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.actions.combat
 
 import com.wingedsheep.engine.core.AbilityTriggeredEvent
 import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.event.TriggerDetector
@@ -34,6 +35,12 @@ class DeclareAttackersHandler(
         }
         if (state.step != Step.DECLARE_ATTACKERS) {
             return "You can only declare attackers during the declare attackers step"
+        }
+        // One declaration per combat (CR 508.1; in a shared team turn the team's one combined
+        // attack, CR 805.10b). The marker is stamped on every attacking player, so a teammate
+        // can't append a second wave after the first head has declared.
+        if (state.getEntity(action.playerId)?.has<AttackersDeclaredThisCombatComponent>() == true) {
+            return "Attackers have already been declared this combat"
         }
         // Additional validation is done by CombatManager
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/DeclareBlockersHandler.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.handlers.actions.combat
 
 import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
+import com.wingedsheep.engine.mechanics.combat.CombatDefenders
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.PendingTriggersContinuation
 import com.wingedsheep.engine.event.TriggerDetector
@@ -83,12 +85,28 @@ class DeclareBlockersHandler(
             }
 
             return ExecutionResult.success(
-                triggerResult.newState,
+                handToNextUndeclaredDefender(triggerResult.newState),
                 result.events + triggerResult.events
             )
         }
 
-        return result
+        return ExecutionResult.success(handToNextUndeclaredDefender(result.newState), result.events)
+    }
+
+    /**
+     * CR 802.4 / 509.1: with more than one defending player, each declares blockers in APNAP order
+     * and nobody receives priority until every declaration is in. The declare-blockers round is
+     * driven by the priority baton, so after one defender declares, the baton goes straight to the
+     * next defender who still owes a declaration — not on a lap of the table, where a seat that is
+     * not being attacked would get a real priority window (and could Giant Growth the next
+     * defender's would-be blocker) before that defender has declared. Once every defender has
+     * declared the baton stays with the last declarer, exactly as before.
+     */
+    private fun handToNextUndeclaredDefender(state: GameState): GameState {
+        val next = CombatDefenders.defendingPlayersInApnapOrder(state).firstOrNull { defender ->
+            state.getEntity(defender)?.has<BlockersDeclaredThisCombatComponent>() != true
+        } ?: return state
+        return state.withPriority(next)
     }
 
     companion object {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/OrderBlockersHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/combat/OrderBlockersHandler.kt
@@ -20,7 +20,7 @@ class OrderBlockersHandler : ActionHandler<OrderBlockers> {
     override val actionType: KClass<OrderBlockers> = OrderBlockers::class
 
     override fun validate(state: GameState, action: OrderBlockers): String? {
-        if (state.activePlayerId != action.playerId) {
+        if (!state.isActiveTurnFor(action.playerId)) {
             return "You can only order blockers on your turn"
         }
         if (state.step != Step.DECLARE_BLOCKERS) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
@@ -51,6 +51,15 @@ class PassPriorityHandler(
         if (!state.hasPriority(action.playerId)) {
             return "You don't have priority"
         }
+        // Under team priority (CR 805.5) a teammate may pass out of baton order, and their pass
+        // then stands until someone acts (which re-arms every seat). Passing *again* in the same
+        // round does nothing — the baton stays put and the round doesn't advance — so refuse it
+        // rather than let a client (an AI partner polling its legal actions) spin on it forever.
+        // The baton holder is never in [GameState.priorityPassedBy], so this only ever bites a
+        // seat that already declined; no non-team game can reach it.
+        if (action.playerId in state.priorityPassedBy && action.playerId != state.priorityPlayerId) {
+            return "You have already passed priority this round"
+        }
         // Cannot pass priority while there's a pending decision
         val pendingDecision = state.pendingDecision
         if (pendingDecision != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1170,9 +1170,14 @@ object DamageUtils {
      */
     fun isLifeGainPrevented(state: GameState, playerId: EntityId): Boolean {
         // Durable, source-independent lock conferred directly on the player
-        // (LockLifeGainEffect — Screaming Nemesis).
-        if (state.getEntity(playerId)
-                ?.has<com.wingedsheep.engine.state.components.player.CantGainLifeComponent>() == true
+        // (LockLifeGainEffect — Screaming Nemesis). CR 810.9g: where the life total is the team's,
+        // "that player can't gain life" means no player on their team can — a lock on either head
+        // closes the shared pool. Outside a shared-life format the team is the player alone.
+        val lockedSeats = if (state.format.sharesTeamLife) state.teamOf(playerId) else listOf(playerId)
+        if (lockedSeats.any { seat ->
+                state.getEntity(seat)
+                    ?.has<com.wingedsheep.engine.state.components.player.CantGainLifeComponent>() == true
+            }
         ) {
             return true
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1190,9 +1190,10 @@ object DamageUtils {
                 when (lifeGainEvent.player) {
                     Player.Each, Player.Any -> return true
                     Player.You -> if (playerId == sourceControllerId) return true
-                    // "Your opponents can't gain life." — Gríma Wormtongue (LTR).
+                    // "Your opponents can't gain life." — Gríma Wormtongue (LTR). A real opponent
+                    // test: the controller's teammate is not their opponent (CR 102.3 / 810.9g).
                     Player.EachOpponent ->
-                        if (playerId != sourceControllerId) return true
+                        if (sourceControllerId != null && state.isOpponentOf(playerId, sourceControllerId)) return true
                     // "Enchanted player can't gain life." — Grievous Wound. The host is an Aura
                     // attached to the locked player; compare against its attachment target.
                     Player.EnchantedPlayer -> {
@@ -2461,7 +2462,8 @@ object DamageUtils {
                 val playerMatches = when (pattern.player) {
                     Player.Each, Player.Any -> true
                     Player.You -> losingPlayerId == sourceControllerId
-                    Player.EachOpponent -> losingPlayerId != sourceControllerId
+                    // Not `!= sourceControllerId`: a teammate is not an opponent (CR 102.3).
+                    Player.EachOpponent -> state.isOpponentOf(losingPlayerId, sourceControllerId)
                     else -> false
                 }
                 if (!playerMatches) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/LifeGainModifiers.kt
@@ -58,7 +58,8 @@ object LifeGainModifiers {
                 val recipientMatches = when (lifeGainEvent.player) {
                     Player.Each -> true
                     Player.You -> recipientId == sourceControllerId
-                    Player.EachOpponent, Player.TargetOpponent -> recipientId != sourceControllerId
+                    // A real opponent test — the controller's teammate is not an opponent (CR 102.3).
+                    Player.EachOpponent, Player.TargetOpponent -> state.isOpponentOf(recipientId, sourceControllerId)
                     else -> recipientId == sourceControllerId
                 }
                 if (!recipientMatches) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -124,7 +124,7 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
         val notBeforeTurn = when (effect.timing) {
             DelayedTriggerTiming.NEXT_TURN -> state.turnNumber + 1
             DelayedTriggerTiming.NEXT_END_STEP -> {
-                val onControllersTurn = context.controllerId == state.activePlayerId
+                val onControllersTurn = state.isActiveTurnFor(context.controllerId)
                 val endStepAlreadyStarted = state.step == Step.END || state.step == Step.CLEANUP
                 if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -305,7 +305,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
      * at cleanup — so we map any step in the turn to that turn's cleanup.
      *
      * This is a *floor*, not an exact turn: the expiry check in [CleanupPhaseManager] also requires
-     * `activePlayerId == controllerId`, so the permission dies at the cleanup of the first turn the
+     * `isActiveTurnFor(controllerId)`, so the permission dies at the cleanup of the first turn the
      * controller actually takes at or after this number. That pairing is what keeps the answer right
      * across skipped turns, extra turns and eliminated seats — none of which a turn count computed
      * from seat positions would survive.
@@ -320,7 +320,7 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
         controllerId: EntityId,
         expiry: MayPlayExpiry.UntilControllerStep
     ): Int {
-        val onControllerTurn = state.activePlayerId == controllerId
+        val onControllerTurn = state.isActiveTurnFor(controllerId)
         val targetReachedThisTurn = state.step.ordinal >= expiry.step.ordinal
         val thisTurnStillCounts = onControllerTurn && expiry.includeCurrentTurn && !targetReachedThisTurn
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifePaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifePaymentService.kt
@@ -102,7 +102,8 @@ object LifePaymentService {
                 val applies = when (pattern.player) {
                     Player.Each, Player.Any -> true
                     Player.You -> payerId == sourceControllerId
-                    Player.EachOpponent -> payerId != sourceControllerId
+                    // Not `!= sourceControllerId`: a teammate is not an opponent (CR 102.3).
+                    Player.EachOpponent -> state.isOpponentOf(payerId, sourceControllerId)
                     else -> false
                 }
                 if (applies) return true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/HijackNextTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/HijackNextTurnExecutor.kt
@@ -41,14 +41,21 @@ class HijackNextTurnExecutor : EffectExecutor<HijackNextTurnEffect> {
         val sourceId = context.sourceId ?: hijackedPlayerId
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Hijack"
 
-        val newState = state.updateEntity(hijackedPlayerId) { container ->
-            container.with(
-                PlayerTurnHijackedComponent(
-                    controllerId = context.controllerId,
-                    state = PlayerTurnHijackedComponent.HijackState.SCHEDULED,
-                    scope = effect.scope
+        // CR 805.8 — "If an effect causes a player to control another player, the first player
+        // controls the affected player's team." In a shared team turn the hijacked turn is the
+        // whole team's, so every member is scheduled; outside shared team turns the team is the
+        // targeted player alone.
+        var newState = state
+        for (member in state.sharedTurnTeam(hijackedPlayerId)) {
+            newState = newState.updateEntity(member) { container ->
+                container.with(
+                    PlayerTurnHijackedComponent(
+                        controllerId = context.controllerId,
+                        state = PlayerTurnHijackedComponent.HijackState.SCHEDULED,
+                        scope = effect.scope
+                    )
                 )
-            )
+            }
         }
 
         return EffectResult.success(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PassPriorityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PassPriorityEnumerator.kt
@@ -7,6 +7,13 @@ import com.wingedsheep.engine.legalactions.LegalAction
 
 class PassPriorityEnumerator : ActionEnumerator {
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
+        val state = context.state
+        // A teammate who already passed this round (CR 805.5 team priority) has nothing to pass
+        // again until someone acts and re-arms the round — mirror PassPriorityHandler's gate so the
+        // client is never offered an action the engine will refuse. Never true for the baton holder.
+        if (context.playerId in state.priorityPassedBy && context.playerId != state.priorityPlayerId) {
+            return emptyList()
+        }
         return listOf(
             LegalAction(
                 action = PassPriority(context.playerId),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SneakWindow.kt
@@ -33,7 +33,7 @@ object SneakWindow {
      */
     fun isWindowOpen(state: GameState, playerId: EntityId): Boolean =
         state.step == Step.DECLARE_BLOCKERS &&
-            state.activePlayerId == playerId &&
+            state.isActiveTurnFor(playerId) &&
             blockersDeclared(state, playerId) &&
             unblockedAttackers(state, playerId).isNotEmpty()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -66,10 +66,13 @@ internal class AttackPhaseManager(
     ): ExecutionResult {
         // Validate each attacker
         val projected = state.projectedState
-        // CR 805.10a/b — a creature attacks the opposing team; never a teammate. Exclude the whole
-        // attacking team from legal player targets (in a non-team game this is just the attacker).
+        // CR 805.10a/b — a creature attacks the opposing team; never a teammate. [getOpponents]
+        // excludes the whole attacking team (in a non-team game just the attacker) and — unlike the
+        // raw turn order — every seat that has left the game (CR 800.4a): a departed player is no
+        // longer anyone's opponent, so they can't be attacked. The enumerator already reads the
+        // same set; the handler has to agree with it because actions are client-supplied.
         val attackingTeam = state.teamOf(attackingPlayer)
-        val opponents = state.turnOrder.filter { it !in attackingTeam }
+        val opponents = state.getOpponents(attackingPlayer)
 
         // Validate band declarations (CR 702.22c).
         val bandValidation = validateBands(state, attackers, bands, projected)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -235,28 +235,36 @@ internal class AttackPhaseManager(
         // so the fact is stamped here. `defenderId in turnOrder` is the player-identity idiom.
         val attackersAgainstPlayer = attackers.filterValues { it in state.turnOrder }.keys
 
-        newState = newState.updateEntity(attackingPlayer) { container ->
-            // Both markers are stamped even for an empty declaration: they record that the step
-            // happened, which is what tells "declared nothing" apart from "never got the chance".
-            var updated = container
-                .with(AttackersDeclaredThisCombatComponent)
-                .with(AttackersDeclaredThisTurnComponent)
-            if (attackers.isNotEmpty()) {
-                updated = updated.with(PlayerAttackedThisTurnComponent)
-                val previous = container.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
-                updated = updated.with(PlayerAttackersThisTurnComponent(previous + attackers.keys))
-                if (defendingPlayers.isNotEmpty()) {
-                    val previousDefenders = container
-                        .get<com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent>()
-                        ?.defendingPlayerIds ?: emptySet()
-                    updated = updated.with(
-                        com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent(
-                            previousDefenders + defendingPlayers
+        // CR 805.10b — the active team has ONE combined attack, and CR 805.10a makes every
+        // player on it an attacking player. So the declaration is recorded on every member of
+        // the attacking team, not just the seat that submitted it: the teammate is not asked to
+        // declare a second wave (PassPriorityHandler / CombatEnumerator read this marker), and
+        // "you attacked this turn" is true for both heads. Outside shared team turns the team
+        // is the declaring player alone.
+        for (member in state.sharedTurnTeam(attackingPlayer)) {
+            newState = newState.updateEntity(member) { container ->
+                // Both markers are stamped even for an empty declaration: they record that the step
+                // happened, which is what tells "declared nothing" apart from "never got the chance".
+                var updated = container
+                    .with(AttackersDeclaredThisCombatComponent)
+                    .with(AttackersDeclaredThisTurnComponent)
+                if (attackers.isNotEmpty()) {
+                    updated = updated.with(PlayerAttackedThisTurnComponent)
+                    val previous = container.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
+                    updated = updated.with(PlayerAttackersThisTurnComponent(previous + attackers.keys))
+                    if (defendingPlayers.isNotEmpty()) {
+                        val previousDefenders = container
+                            .get<com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent>()
+                            ?.defendingPlayerIds ?: emptySet()
+                        updated = updated.with(
+                            com.wingedsheep.engine.state.components.combat.PlayerAttackedPlayersThisTurnComponent(
+                                previousDefenders + defendingPlayers
+                            )
                         )
-                    )
+                    }
                 }
+                updated
             }
-            updated
         }
 
         val attackerNames = attackers.keys.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Creature" }
@@ -618,7 +626,10 @@ internal class AttackPhaseManager(
         attackingPlayer: EntityId,
         attackers: Map<EntityId, EntityId>
     ): String? {
-        val mustAttack = state.getEntity(attackingPlayer)?.get<MustAttackPlayerComponent>()
+        // Taunt marks the player it was aimed at; in a shared team turn the team's one combined
+        // attack (CR 805.10b) has to satisfy a requirement placed on either head.
+        val mustAttack = state.sharedTurnTeam(attackingPlayer)
+            .firstNotNullOfOrNull { member -> state.getEntity(member)?.get<MustAttackPlayerComponent>() }
             ?: return null
 
         if (!mustAttack.activeThisTurn) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRule.kt
@@ -41,7 +41,8 @@ interface AttackDefenderRule {
      * Used by [getValidAttackers] for must-attack requirement validation.
      */
     fun restrictsAllDefenders(ctx: AttackCheckContext): Boolean {
-        val opponents = ctx.state.turnOrder.filter { it != ctx.attackingPlayer }
+        // Real opponents only: not a teammate (CR 805.10b), not a seat that has left (CR 800.4a).
+        val opponents = ctx.state.getOpponents(ctx.attackingPlayer)
         val projected = ctx.projected
         // Collect all valid defenders: opponent players + their planeswalkers
         val allDefenders = opponents.toMutableList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1575,13 +1575,13 @@ class CostCalculator(
                     if (controllerId != casterId) continue
                 }
                 if (ability.firstSpellOfTurnOnly) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if ((state.playerSpellsCastThisTurn[casterId] ?: 0) > 0) continue
                 }
                 // `oncePerTurn` (Zaffai and the Tempests): only during the caster's own turn, and
                 // only while this specific source hasn't already been used this turn.
                 if (ability.oncePerTurn) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if (container.has<com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent>()) continue
                 }
                 // The permission may be scoped to a spell type (e.g. Dracogenesis — Dragons only).
@@ -1715,7 +1715,7 @@ class CostCalculator(
                     !matchesCardDefinition(spellCardDef, ability.spellFilter, entityId, state, state.projectedState)
                 ) continue
                 if (ability.oncePerTurn) {
-                    if (state.activePlayerId != casterId) continue
+                    if (!state.isActiveTurnFor(casterId)) continue
                     if (container.has<com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent>()) continue
                     if (oncePerTurnCandidate == null) oncePerTurnCandidate = entityId
                 } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.engine.core.GameEndReason
 import com.wingedsheep.engine.core.PlayerLeftGameEvent
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.mechanics.combat.CombatRemovalHelper
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockedComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -85,6 +87,13 @@ object PlayerLeavesGameProcessor {
         //    vanish, the rest of combat proceeds).
         s = clearCombatReferences(s, toRemove)
 
+        // 3b. CR 800.4e — combat damage that would be assigned to a player who has left isn't.
+        //     Creatures attacking the leaver (or a planeswalker / battle of theirs, which has just
+        //     left too) are removed from combat: nothing is left for them to hit, and leaving
+        //     them "attacking" a seat that is gone would still fire lifelink and
+        //     "deals combat damage to a player" triggers off a dead life total in the damage step.
+        s = removeAttackersAimedAt(s, leaver, toRemove)
+
         // 4. Remove the objects from the game entirely.
         for (id in toRemove) {
             s = s.removeEntity(id)
@@ -135,6 +144,22 @@ object PlayerLeavesGameProcessor {
             .clearPendingDecision()
             .copy(continuationStack = emptyList())
             .withPriority(state.activePlayerId)
+    }
+
+    /**
+     * Remove from combat every remaining attacker whose declared defender is [leaver] or one of
+     * the [removed] objects (their planeswalkers and battles). Their own attackers are already
+     * gone, so this only ever touches other players' creatures.
+     */
+    private fun removeAttackersAimedAt(state: GameState, leaver: EntityId, removed: Set<EntityId>): GameState {
+        var s = state
+        for (id in s.getBattlefield()) {
+            val defender = s.getEntity(id)?.get<AttackingComponent>()?.defenderId ?: continue
+            if (defender == leaver || defender in removed) {
+                s = CombatRemovalHelper.removeFromCombat(s, id)
+            }
+        }
+        return s
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLeavesGameProcessor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
 
 /**
  * Applies the "leaving the game" processing for a player who has lost (CR 800.4a–c).
@@ -99,11 +100,27 @@ object PlayerLeavesGameProcessor {
             s = s.removeEntity(id)
         }
 
-        // 5. End floating effects the leaver controlled or that were sourced by an object
-        //    that just left (their continuous effects end with them — CR 800.4a).
+        // 5. End the continuous effects that depended on a departed object. Only those: the
+        //    effect of a spell or ability the leaver already *resolved* persists (CR 611.2c) — a
+        //    Giant Growth on someone else's creature outlives its caster's concession — so nothing
+        //    is dropped for having the leaver as its controller. What ends is an effect whose
+        //    duration is tied to its source staying on the battlefield (611.2b/611.3) when that
+        //    source just left, or one that lasts while the leaver controls the affected object,
+        //    which they no longer do. The leaver's "until your next turn" effects are neither —
+        //    CR 800.4m has them last until that turn would have begun (TurnManager.endTurn).
         s = s.copy(
             floatingEffects = s.floatingEffects.filterNot { fe ->
-                fe.controllerId == leaver || (fe.sourceId != null && fe.sourceId in toRemove)
+                val sourceLeft = fe.sourceId != null && fe.sourceId in toRemove
+                when (fe.duration) {
+                    is Duration.WhileSourceOnBattlefield,
+                    is Duration.WhileYouControlSource,
+                    is Duration.WhileSourceTapped,
+                    is Duration.WhileSourceTappedAndAffectedPowerAtMostSource,
+                    is Duration.WhileYouControlSourceAndSourceTapped,
+                    Duration.WhileSourceAttachedToAffected -> sourceLeft
+                    Duration.WhileControlledByController -> fe.controllerId == leaver
+                    else -> false
+                }
             }
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -62,13 +62,21 @@ internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
 }
 
 /**
- * Narrow sibling of [playerCantLoseGame]: true when [playerId] controls a permanent granting
- * "you don't lose the game for having 0 or less life" (Marina Vendrell's Grimoire). Consulted only
- * by the 704.5a life-loss check, so poison / empty-library / effect losses are unaffected. Scoped
- * to the controller itself — it is not a team-wide "can't lose" grant.
+ * Narrow sibling of [playerCantLoseGame]: true when [playerId] — or, where players win and lose
+ * as a team, a teammate — controls a permanent granting "you don't lose the game for having 0 or
+ * less life" (Transcendence, Marina Vendrell's Grimoire). Consulted only by the 704.5a life-loss
+ * check, so poison / empty-library / effect losses are unaffected.
+ *
+ * The team reach is CR 810.8a's own example: a Two-Headed Giant team at 0 or less life with
+ * Transcendence on one head doesn't lose. The life total is the team's (810.4), so a grant that
+ * excuses one head from the 0-life loss has to excuse the other — otherwise the unprotected head
+ * is marked, TeamLossPropagationCheck drags the protected one down, and the grant did nothing.
  */
-internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean =
-    ControllerGrants.grantedTo<GrantsCantLoseGameFromLifeComponent>(state, playerId)
+internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean {
+    val team = (if (state.format.playersWinLoseAsTeam) state.teamOf(playerId) else listOf(playerId))
+        .toHashSet()
+    return ControllerGrants.anyGranting<GrantsCantLoseGameFromLifeComponent>(state) { it in team }
+}
 
 /**
  * True when [playerId] can't win the game because one of its opponents controls a permanent

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -615,6 +615,16 @@ data class GameState(
         return activePlayers.filter { it !in ownTeam }
     }
 
+    /**
+     * Whether [playerId] is an opponent of [ofPlayerId] (CR 102.3) — the predicate form of
+     * [getOpponents], for the `Player.EachOpponent` branch of every "does this player match the
+     * pattern?" check. Never spell that branch as `playerId != controllerId`: in a team game the
+     * controller's teammate is not their opponent, and "your opponents can't gain life" must not
+     * lock your own partner. A player who has left the game is nobody's opponent any more.
+     */
+    fun isOpponentOf(playerId: EntityId, ofPlayerId: EntityId): Boolean =
+        playerId in getOpponents(ofPlayerId)
+
     // =========================================================================
     // Teams (Two-Headed Giant and other team variants — CR 810)
     //

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/LifeTotalReadsThroughResolverTest.kt
@@ -24,7 +24,8 @@ class LifeTotalReadsThroughResolverTest : FunSpec({
         val valueRead = Regex("""LifeTotalComponent>\(\)[?!.]*\.life""")
         val construct = Regex("""\bLifeTotalComponent\s*\(""")
 
-        val offenders = sourceRoot().walkTopDown()
+        val offenders = sourceRoots().asSequence()
+            .flatMap { it.walkTopDown() }
             .filter { it.isFile && it.extension == "kt" }
             .flatMap { file ->
                 val relative = file.absolutePath.replace('\\', '/')
@@ -54,11 +55,25 @@ class LifeTotalReadsThroughResolverTest : FunSpec({
             "com/wingedsheep/engine/core/GameInitializer.kt",
             // The component's own declaration.
             "com/wingedsheep/engine/state/components/identity/PlayerIdentityComponents.kt",
+            // Scenario setup stamps the initial LifeTotalComponent on every player, like GameInitializer.
+            "com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt",
         )
 
-        private fun sourceRoot(): File =
-            listOf(File("src/main/kotlin"), File("rules-engine/src/main/kotlin"))
-                .firstOrNull { it.isDirectory }
-                ?: error("Could not locate rules-engine/src/main/kotlin from ${File(".").absolutePath}")
+        /**
+         * Every module that reads a [com.wingedsheep.engine.state.GameState] off the engine and
+         * renders a life total — not just the engine. The spectator view, the gym observation and
+         * the replay fingerprint each read the raw component once, and each showed the
+         * non-canonical head of a Two-Headed Giant team frozen at its starting life.
+         */
+        private val SCANNED_MODULES = listOf("rules-engine", "game-server", "gym", "ai")
+
+        private fun sourceRoots(): List<File> {
+            val repoRoot = listOf(File("."), File(".."))
+                .firstOrNull { File(it, "rules-engine/src/main/kotlin").isDirectory }
+                ?: error("Could not locate the repository root from ${File(".").absolutePath}")
+            return SCANNED_MODULES.map { File(repoRoot, "$it/src/main/kotlin") }
+                .filter { it.isDirectory }
+                .also { roots -> check(roots.isNotEmpty()) { "No source roots found under $repoRoot" } }
+        }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
@@ -84,6 +84,7 @@ class LeaveTheGameTest : FunSpec({
                 name = "Leave Test Bear",
                 manaCost = ManaCost.parse("{1}{G}"),
                 typeLine = TypeLine.parse("Creature — Bear"),
+                baseStats = bear.creatureStats,
                 ownerId = owner
             ),
             ControllerComponent(controller)
@@ -239,6 +240,42 @@ class LeaveTheGameTest : FunSpec({
         afterLeave.getEntity(attackerId).shouldBeNull()
         // The blocker no longer references the departed attacker (combat can proceed).
         afterLeave.getEntity(blockerId)?.has<BlockingComponent>() shouldBe false
+    }
+
+    test("attackers aimed at the leaver are removed from combat; the rest of the attack stands (CR 800.4e)") {
+        val (base, players) = initGame(4)
+        // players[0] attacks players[1] with one bear and players[2] with another.
+        val (s1, atB) = base.withCreature(owner = players[0])
+        val (s2, atC) = s1.withCreature(owner = players[0])
+        val state = s2
+            .updateEntity(atB) { it.with(AttackingComponent(defenderId = players[1])) }
+            .updateEntity(atC) { it.with(AttackingComponent(defenderId = players[2])) }
+
+        val afterLeave = PlayerLeavesGameProcessor.process(state, players[2], GameEndReason.CONCESSION).newState
+
+        // Nothing is left for the second bear to deal damage to — it is out of combat …
+        afterLeave.getEntity(atC)?.has<AttackingComponent>() shouldBe false
+        // … while the attack on players[1] is untouched.
+        afterLeave.getEntity(atB)?.get<AttackingComponent>()?.defenderId shouldBe players[1]
+    }
+
+    test("a player who has left the game is not a legal attack target (CR 800.4a)") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val (withBear, bear) = base.withCreature(owner = players[0])
+        val gone = processor.process(withBear, Concede(players[2])).result.newState
+        val declaring = gone.copy(
+            step = com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS,
+            phase = com.wingedsheep.sdk.core.Phase.COMBAT
+        ).withPriority(players[0])
+
+        // The enumerator never offers the departed seat; the handler must refuse it too.
+        processor.process(
+            declaring, com.wingedsheep.engine.core.DeclareAttackers(players[0], mapOf(bear to players[2]))
+        ).result.isSuccess shouldBe false
+        processor.process(
+            declaring, com.wingedsheep.engine.core.DeclareAttackers(players[0], mapOf(bear to players[1]))
+        ).result.error.shouldBeNull()
     }
 
     test("priority held by the leaver passes to the next player still in the game (CR 800.4a)") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/LeaveTheGameTest.kt
@@ -278,6 +278,78 @@ class LeaveTheGameTest : FunSpec({
         ).result.error.shouldBeNull()
     }
 
+    /** A floating P/T effect on [target], controlled by [controller], sourced by [sourceId], with [duration]. */
+    fun GameState.pumpEffect(
+        target: EntityId,
+        controller: EntityId,
+        sourceId: EntityId?,
+        duration: Duration
+    ): Pair<GameState, EntityId> {
+        val fx = ActiveFloatingEffect(
+            id = EntityId.generate(),
+            effect = FloatingEffectData(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(3, 3),
+                affectedEntities = setOf(target)
+            ),
+            duration = duration,
+            sourceId = sourceId,
+            controllerId = controller,
+            timestamp = timestamp
+        )
+        return copy(floatingEffects = floatingEffects + fx) to fx.id
+    }
+
+    test("a resolved spell's effect outlives its caster's departure (CR 611.2c) — only source-bound durations end (CR 800.4a)") {
+        val (base, players) = initGame(4)
+        val (s1, ownCreature) = base.withCreature(owner = players[0])
+        // players[1] cast a Giant Growth (the card is theirs and leaves with them) on players[0]'s creature.
+        val (s2, giantGrowthCard) = s1.withCreature(owner = players[1])
+        val (s3, pump) = s2.pumpEffect(ownCreature, controller = players[1], sourceId = giantGrowthCard, duration = Duration.EndOfTurn)
+        // players[1] also control a permanent whose static-style effect lasts while it is on the battlefield.
+        val (s4, anthemSource) = s3.withCreature(owner = players[1])
+        val (state, anthem) = s4.pumpEffect(ownCreature, controller = players[1], sourceId = anthemSource, duration = Duration.WhileSourceOnBattlefield())
+
+        val afterLeave = PlayerLeavesGameProcessor.process(state, players[1], GameEndReason.CONCESSION).newState
+
+        afterLeave.floatingEffects.any { it.id == pump } shouldBe true
+        afterLeave.floatingEffects.any { it.id == anthem } shouldBe false
+    }
+
+    test("a departed player's 'until your next turn' effect lasts until that turn would have begun (CR 800.4m)") {
+        val (base, players) = initGame(4)
+        val processor = ActionProcessor(registry())
+        val (s1, creature) = base.withCreature(owner = players[0])
+        val (armed, fx) = s1.pumpEffect(creature, controller = players[1], sourceId = null, duration = Duration.UntilYourNextTurn)
+
+        // players[1] concedes during players[0]'s turn. The effect neither ends now …
+        var state = processor.process(armed, Concede(players[1])).result.newState
+        state.floatingEffects.any { it.id == fx } shouldBe true
+
+        // … nor lasts forever: players[1]'s turn would have come right after players[0]'s, so it
+        // ends when players[2]'s turn begins instead.
+        var safety = 0
+        while (state.activePlayerId == players[0]) {
+            check(++safety < 500) { "stuck at ${state.step}" }
+            val prio = state.priorityPlayerId ?: break
+            val pending = state.pendingDecision
+            if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                val resp = com.wingedsheep.engine.core.CardsSelectedResponse(pending.id, pending.options.take(pending.minSelections))
+                state = processor.process(state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, resp)).result.newState
+                continue
+            }
+            if (state.step == com.wingedsheep.sdk.core.Step.DECLARE_ATTACKERS && state.isActiveTurnFor(prio) &&
+                state.getEntity(prio)?.has<com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent>() != true
+            ) {
+                state = processor.process(state, com.wingedsheep.engine.core.DeclareAttackers(prio, emptyMap())).result.newState
+                continue
+            }
+            state = processor.process(state, PassPriority(prio)).result.newState
+        }
+        state.activePlayerId shouldBe players[2]
+        state.floatingEffects.any { it.id == fx } shouldBe false
+    }
+
     test("priority held by the leaver passes to the next player still in the game (CR 800.4a)") {
         val (base, players) = initGame(4)
         // Give players[1] priority, then mark them lost (priority is still on them at this point).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiDefenderCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiDefenderCombatTest.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
@@ -125,6 +126,25 @@ class MultiDefenderCombatTest : FunSpec({
             state, DeclareBlockers(players[1], mapOf(ids["blkB"]!! to listOf(ids["atkB"]!!)))
         ).result
         legal.isSuccess.shouldBeTrue()
+    }
+
+    test("no seat gets a priority window between two defenders' block declarations (CR 802.4)") {
+        val (base, players) = initGame(4) // A active; B, C, D
+        val (s1, _) = base.withBear(players[0], attacking = players[1]) // A attacks B
+        val (s2, _) = s1.withBear(players[0], attacking = players[3])   // A attacks D — C is not attacked
+        val state = s2.copy(step = Step.DECLARE_BLOCKERS, phase = Phase.COMBAT).withPriority(players[1])
+        val processor = ActionProcessor(registry())
+
+        // B declares (nothing). The baton must go straight to D, the next undeclared defender …
+        val afterB = processor.process(state, DeclareBlockers(players[1], emptyMap())).result.newState
+        afterB.priorityPlayerId shouldBe players[3]
+        // … so C — who sits between them and isn't being attacked — has no window to act in.
+        processor.process(afterB, PassPriority(players[2])).result.isSuccess.shouldBeFalse()
+
+        // Once D has declared too, the round is a normal priority round again.
+        val afterD = processor.process(afterB, DeclareBlockers(players[3], emptyMap())).result.newState
+        afterD.priorityPlayerId shouldBe players[3]
+        processor.process(afterD, PassPriority(players[3])).result.isSuccess.shouldBeTrue()
     }
 
     test("both defenders declare blockers (APNAP) and damage lands on the right players") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/ReplacementTeamAwarenessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/ReplacementTeamAwarenessTest.kt
@@ -23,6 +23,8 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.ModifyDrawAmount
 import com.wingedsheep.sdk.scripting.PreventDraw
+import com.wingedsheep.sdk.scripting.PreventLifeGain
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
 import com.wingedsheep.sdk.scripting.ReplacementEffect
 import com.wingedsheep.sdk.scripting.references.Player
 import io.kotest.assertions.withClue
@@ -142,6 +144,55 @@ class ReplacementTeamAwarenessTest : FunSpec({
         ) {
             processor.gatherReplacements(state, PendingGameEvent.DrawAmountPending(teammate, 1)).size shouldBe 0
         }
+    }
+
+    test("PreventLifeGain(EachOpponent) locks the opposing team, never the controller's teammate (CR 810.9g)") {
+        val booted = boot2hg()
+        val players = booted.playerIds
+        val (source, teammate) = players[0] to players[1]
+        val opponent = players[2]
+        val state = booted.state.withReplacementPermanent(
+            source, "Opposing Lifegain Lock",
+            PreventLifeGain(appliesTo = EventPattern.LifeGainEvent(player = Player.EachOpponent))
+        )
+        com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented(state, opponent) shouldBe true
+        com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented(state, source) shouldBe false
+        withClue("CR 102.3 — the teammate is not an opponent, so Gríma-style locks must not reach them") {
+            com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented(state, teammate) shouldBe false
+        }
+    }
+
+    test("ModifyLifeGain(EachOpponent) scales the opposing team's gains, not the teammate's") {
+        val booted = boot2hg()
+        val players = booted.playerIds
+        val (source, teammate) = players[0] to players[1]
+        val opponent = players[2]
+        val state = booted.state.withReplacementPermanent(
+            source, "Opposing Lifegain Doubler",
+            ModifyLifeGain(multiplier = 2, appliesTo = EventPattern.LifeGainEvent(player = Player.EachOpponent))
+        )
+        com.wingedsheep.engine.handlers.effects.LifeGainModifiers.apply(state, opponent, 3) shouldBe 6
+        com.wingedsheep.engine.handlers.effects.LifeGainModifiers.apply(state, teammate, 3) shouldBe 3
+        com.wingedsheep.engine.handlers.effects.LifeGainModifiers.apply(state, source, 3) shouldBe 3
+    }
+
+    test("'whenever an opponent gains life' does not trigger off a teammate's gain") {
+        val booted = boot2hg()
+        val players = booted.playerIds
+        val (source, teammate) = players[0] to players[1]
+        val opponent = players[2]
+        val matcher = com.wingedsheep.engine.event.TriggerMatcher(
+            com.wingedsheep.engine.handlers.PredicateEvaluator(),
+            com.wingedsheep.engine.handlers.ConditionEvaluator()
+        )
+        fun gainBy(player: EntityId) = com.wingedsheep.engine.core.LifeChangedEvent(
+            player, 30, 32, com.wingedsheep.engine.core.LifeChangeReason.LIFE_GAIN
+        )
+        val pattern = EventPattern.LifeGainEvent(player = Player.EachOpponent)
+        val binding = com.wingedsheep.sdk.scripting.TriggerBinding.ANY
+        matcher.matchesTrigger(pattern, binding, gainBy(opponent), source, source, booted.state) shouldBe true
+        matcher.matchesTrigger(pattern, binding, gainBy(teammate), source, source, booted.state) shouldBe false
+        matcher.matchesTrigger(pattern, binding, gainBy(source), source, source, booted.state) shouldBe false
     }
 
     test("EachOpponent still matches every other seat in a non-team game") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
@@ -96,6 +96,32 @@ class TeamVsTeamTest : FunSpec({
     // Life: each player has their own total (CR 808.5) — not a shared pool.
     // ---------------------------------------------------------------------------------------------
 
+    test("a randomly chosen first team starts with the seat left of its midpoint, and turn order wraps the table (CR 808.4)") {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TeamVsTeam(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of(forest to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = null,
+                skipMulligans = true,
+                seed = 42L,
+            )
+        )
+        val p = result.playerIds
+        val order = result.state.turnOrder
+        val teamA = listOf(p[0], p[1])
+        val teamB = listOf(p[2], p[3])
+        val startTeam = if (order.first() in teamA) teamA else teamB
+        val otherTeam = if (startTeam === teamA) teamB else teamA
+        // Even-sized team: the player to the left of its midpoint (its second seat) goes first …
+        order.first() shouldBe startTeam[1]
+        // … turn order goes to the left through the other team, still seated together …
+        order.subList(1, 3) shouldBe otherTeam
+        // … and comes back round to the starting team's first seat last.
+        order.last() shouldBe startTeam[0]
+        result.state.activePlayerId shouldBe startTeam[1]
+    }
+
     test("each player has their own life total; damaging one teammate doesn't touch the other (CR 808.5)") {
         val (state, p, _) = boot()
         state.lifeTotal(p[0]) shouldBe 20

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantCombatTest.kt
@@ -118,6 +118,28 @@ class TwoHeadedGiantCombatTest : FunSpec({
         result.newState.getEntity(atk1)!!.get<AttackingComponent>()!!.defenderId shouldBe p[3]
     }
 
+    test("one declaration is the whole team's — the teammate may pass and can't add a second wave (CR 805.10b)") {
+        val (base, p) = init2hg()
+        val (s1, atk0) = base.withBear(p[0])
+        val (s2, atk1) = s1.withBear(p[1])
+        val state = s2.copy(step = Step.DECLARE_ATTACKERS, phase = Phase.COMBAT).withPriority(p[0])
+        val proc = ActionProcessor(registry())
+
+        // p0 attacks with their own bear only; p1's bear stays home.
+        val declared = proc.process(state, DeclareAttackers(p[0], mapOf(atk0 to p[2]))).result
+        declared.isSuccess.shouldBeTrue()
+        // The declaration is recorded on BOTH heads …
+        declared.newState.getEntity(p[1])?.has<AttackersDeclaredThisCombatComponent>() shouldBe true
+        // … so p1 is not made to declare before passing …
+        val afterP0Pass = proc.process(declared.newState, com.wingedsheep.engine.core.PassPriority(p[0])).result.newState
+        afterP0Pass.priorityPlayerId shouldBe p[1]
+        proc.process(afterP0Pass, com.wingedsheep.engine.core.PassPriority(p[1])).result.isSuccess.shouldBeTrue()
+        // … and can't send a second wave in after the fact.
+        val secondWave = proc.process(afterP0Pass, DeclareAttackers(p[1], mapOf(atk1 to p[3]))).result
+        secondWave.isSuccess.shouldBeFalse()
+        secondWave.newState.getEntity(atk1)?.has<AttackingComponent>() shouldBe false
+    }
+
     test("the whole nonactive team defends — even an un-attacked teammate is a defending player (CR 805.10a)") {
         val (base, p) = init2hg()
         val (state, _) = base.withBear(p[0], attacking = p[2]) // p0 attacks p2 only

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -153,6 +153,39 @@ class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
         atEnd.getEntity(p[1])?.has<LoseAtEndStepComponent>() shouldBe false
     }
 
+    test("hijacking one head controls the whole team on its next turn (CR 805.8)") {
+        val (base, p, proc) = boot()
+        // p2 resolves a Mindslaver aimed at p1 (the second head). The executor schedules the
+        // hijack on p1's whole shared-turn team.
+        val scheduled = com.wingedsheep.engine.handlers.effects.player.HijackNextTurnExecutor().execute(
+            base,
+            com.wingedsheep.sdk.scripting.effects.HijackNextTurnEffect(
+                target = com.wingedsheep.sdk.scripting.targets.EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.You)
+            ),
+            com.wingedsheep.engine.handlers.EffectContext(sourceId = null, controllerId = p[1])
+        ).newState
+        // (Player.You resolves to p1 here; the controller field is what the hijack records.)
+        p.take(2).forEach { head ->
+            scheduled.getEntity(head)?.get<com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent>()
+                ?.state shouldBe com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent.HijackState.SCHEDULED
+        }
+        // Re-point the recorded controller at the opposing head so the engagement below is a real
+        // "opponent drives your team" case.
+        val armed = p.take(2).fold(scheduled) { s, head ->
+            s.updateEntity(head) { c ->
+                val h = c.get<com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent>()!!
+                c.with(h.copy(controllerId = p[2]))
+            }
+        }
+
+        // Team 0's *next* turn: drive through team 1's turn and back.
+        val onTeam1 = drive(armed, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        onTeam1.actorFor(p[0]) shouldBe p[0]
+        val backOnTeam0 = drive(onTeam1, proc) { it.activePlayerId == p[0] && it.step == Step.UPKEEP }
+        backOnTeam0.actorFor(p[0]) shouldBe p[2]
+        backOnTeam0.actorFor(p[1]) shouldBe p[2]
+    }
+
     test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
         val (base, p, proc) = boot()
         val delayed = DelayedTriggeredAbility(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -132,6 +132,27 @@ class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
         atEnd.gameOver.shouldBeTrue()
     }
 
+    test("'lose at the next end step' is stopped by a can't-lose grant, including a teammate's (CR 104.3 / 810.8a)") {
+        val (base, p, proc) = boot()
+        // Platinum Angel-style grant under p0; Final Fortune's marker on the teammate p1.
+        val (withAngel, _) = base.withPermanent(p[0], "Team Angel", "Artifact") {
+            with(com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent())
+        }
+        val armed = withAngel.updateEntity(p[1]) { it.with(LoseAtEndStepComponent(turnsUntilLoss = 0)) }
+
+        val atEnd = drive(armed, proc) { it.gameOver || (it.step == Step.END && it.activePlayerId == p[0]) }
+
+        io.kotest.assertions.withClue(
+            "lost: " + p.map { it to atEnd.getEntity(it)?.get<PlayerLostComponent>()?.reason } +
+                " step=${atEnd.step} active=${atEnd.activePlayerId} turn=${atEnd.turnNumber}"
+        ) {
+            atEnd.gameOver.shouldBeFalse()
+        }
+        atEnd.getEntity(p[1])?.has<PlayerLostComponent>() shouldBe false
+        // The delayed loss resolved and did nothing — it doesn't lie in wait for the next end step.
+        atEnd.getEntity(p[1])?.has<LoseAtEndStepComponent>() shouldBe false
+    }
+
     test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
         val (base, p, proc) = boot()
         val delayed = DelayedTriggeredAbility(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSecondHeadTurnTest.kt
@@ -1,0 +1,205 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.event.DelayedTriggeredAbility
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.player.LoseAtEndStepComponent
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Format
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TurnPart
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Two-Headed Giant — the *second* head's turn-keyed state (CR 805.4 / 805.8).
+ *
+ * `GameState.getNextTeam` always hands the turn to a team's first still-in member, so in a shared
+ * team turn `activePlayerId` is permanently seat p0 and seat p1 is never "the active player" even
+ * though the turn is theirs too. Every site that used to compare against `activePlayerId` — "at the
+ * beginning of the next end step you lose the game", step-keyed delayed triggers, "until your next
+ * turn" durations, Saga lore counters, "skip your combat phase" — silently skipped p1. These tests
+ * pin the team-wide reading for the head that isn't the representative.
+ *
+ * Teams are [[0,1],[2,3]] with turn order pinned to player order: p0,p1 = team 0 (starting);
+ * p2,p3 = team 1.
+ */
+class TwoHeadedGiantSecondHeadTurnTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().also { it.register(TestCards.all) }
+
+    fun boot(): Triple<GameState, List<EntityId>, ActionProcessor> {
+        val result = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                format = Format.TwoHeadedGiant(),
+                players = (1..4).map { PlayerConfig("Player $it", Deck.of("Forest" to 40)) },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                startingPlayerIndex = 0,
+                skipMulligans = true,
+            )
+        )
+        return Triple(result.state, result.playerIds, ActionProcessor(registry()))
+    }
+
+    fun handSize(state: GameState, p: EntityId) = state.getZone(ZoneKey(p, Zone.HAND)).size
+
+    /** Pass priority (answering any discard decision) until [predicate] holds or the cap is hit. */
+    fun drive(start: GameState, proc: ActionProcessor, cap: Int = 400, predicate: (GameState) -> Boolean): GameState {
+        var state = start
+        var n = 0
+        while (!predicate(state)) {
+            check(++n < cap) { "drive never reached target (step=${state.step}, active=${state.activePlayerId}, turn=${state.turnNumber})" }
+            if (state.gameOver) break
+            val pending = state.pendingDecision
+            if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                val resp = com.wingedsheep.engine.core.CardsSelectedResponse(pending.id, pending.options.take(pending.minSelections))
+                state = proc.process(state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, resp)).result.newState
+                continue
+            }
+            val prio = state.priorityPlayerId ?: break
+            // An attacking player who hasn't declared yet must declare (here: nothing) before passing.
+            if (state.step == Step.DECLARE_ATTACKERS && state.isActiveTurnFor(prio) &&
+                state.getEntity(prio)?.has<AttackersDeclaredThisCombatComponent>() != true
+            ) {
+                state = proc.process(state, DeclareAttackers(prio, emptyMap())).result.newState
+                continue
+            }
+            val result = proc.process(state, PassPriority(prio)).result
+            check(result.isSuccess || result.isPaused) { "pass by $prio at ${state.step} failed: ${result.error}" }
+            state = result.newState
+        }
+        return state
+    }
+
+    /** A vanilla permanent on [owner]'s battlefield with the given type line. */
+    fun GameState.withPermanent(owner: EntityId, name: String, typeLine: String, extra: ComponentContainer.() -> ComponentContainer = { this }): Pair<GameState, EntityId> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = name,
+                name = name,
+                manaCost = ManaCost.parse("{1}"),
+                typeLine = TypeLine.parse(typeLine),
+                ownerId = owner
+            ),
+            OwnerComponent(owner),
+            ControllerComponent(owner)
+        ).extra()
+        return withEntity(id, container).addToZone(ZoneKey(owner, Zone.BATTLEFIELD), id) to id
+    }
+
+    test("the second head's 'lose at the next end step' fires on the team's end step (Final Fortune, CR 805.8)") {
+        val (base, p, proc) = boot()
+        base.activePlayerId shouldBe p[0]
+        val armed = base.updateEntity(p[1]) { it.with(LoseAtEndStepComponent(turnsUntilLoss = 0)) }
+
+        val atEnd = drive(armed, proc) { it.gameOver || (it.step == Step.END && it.activePlayerId != p[0]) }
+
+        // p1 lost at team 0's end step, which takes the whole team down (CR 810.8a).
+        atEnd.getEntity(p[1])?.has<PlayerLostComponent>() shouldBe true
+        atEnd.getEntity(p[0])?.has<PlayerLostComponent>() shouldBe true
+        atEnd.gameOver.shouldBeTrue()
+    }
+
+    test("a step-keyed delayed trigger owned by the second head fires at the team's end step") {
+        val (base, p, proc) = boot()
+        val delayed = DelayedTriggeredAbility(
+            id = "second-head-delayed",
+            effect = Effects.DrawCards(1),
+            fireAtStep = Step.END,
+            sourceId = p[1],
+            sourceName = "Second Head Rider",
+            controllerId = p[1],
+            fireOnPlayerId = p[1]
+        )
+        val armed = base.copy(delayedTriggers = base.delayedTriggers + delayed)
+        val mainHand = handSize(drive(armed, proc) { it.step == Step.PRECOMBAT_MAIN }, p[1])
+
+        // Reach the end step with the trigger consumed and its draw resolved.
+        val atEnd = drive(armed, proc) {
+            it.step == Step.END && it.delayedTriggers.none { d -> d.id == "second-head-delayed" } && it.stack.isEmpty()
+        }
+        atEnd.activePlayerId shouldBe p[0]
+        handSize(atEnd, p[1]) shouldBe mainHand + 1
+    }
+
+    test("the second head's 'until your next turn' effect expires when the team's next turn begins") {
+        val (base, p, proc) = boot()
+        val (withBear, bear) = base.withPermanent(p[1], "Team Bear", "Creature — Bear")
+        val fx = ActiveFloatingEffect(
+            id = EntityId.generate(),
+            effect = FloatingEffectData(
+                layer = Layer.POWER_TOUGHNESS,
+                modification = SerializableModification.ModifyPowerToughness(3, 3),
+                affectedEntities = setOf(bear)
+            ),
+            duration = Duration.UntilYourNextTurn,
+            sourceId = null,
+            controllerId = p[1],
+            timestamp = withBear.timestamp
+        )
+        val armed = withBear.copy(floatingEffects = withBear.floatingEffects + fx)
+
+        // It survives the rest of team 0's turn and all of team 1's turn …
+        val onTeam1Turn = drive(armed, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        onTeam1Turn.floatingEffects.any { it.id == fx.id } shouldBe true
+        // … and wears off once team 0's next turn has untapped.
+        val backOnTeam0 = drive(onTeam1Turn, proc) { it.activePlayerId == p[0] && it.step == Step.UPKEEP }
+        backOnTeam0.floatingEffects.any { it.id == fx.id }.shouldBeFalse()
+    }
+
+    test("the second head's Saga gets a lore counter at the team's precombat main phase (CR 714.3c)") {
+        val (base, p, proc) = boot()
+        val (withSaga, saga) = base.withPermanent(p[1], "Team Saga", "Enchantment — Saga") { with(SagaComponent()) }
+        withSaga.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe null
+
+        // The game boots at the top of team 0's first turn: its precombat main adds the first
+        // counter, and team 0's next turn adds the second — never team 1's turn in between.
+        val turn1Main = drive(withSaga, proc) { it.step == Step.PRECOMBAT_MAIN }
+        turn1Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        val team1Main = drive(turn1Main, proc) { it.activePlayerId == p[2] && it.step == Step.PRECOMBAT_MAIN }
+        team1Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        val nextTeam0Main = drive(team1Main, proc) { it.activePlayerId == p[0] && it.step == Step.PRECOMBAT_MAIN }
+        nextTeam0Main.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 2
+    }
+
+    test("'skip your combat phase' aimed at the second head skips the team's combat (CR 805.8)") {
+        val (base, p, proc) = boot()
+        val armed = base.updateEntity(p[1]) { it.with(SkippedTurnPartsComponent(setOf(TurnPart.COMBAT_PHASE))) }
+
+        val visited = mutableListOf<Step>()
+        drive(armed, proc) { visited += it.step; it.activePlayerId == p[2] }
+        visited.filter { it == Step.DECLARE_ATTACKERS || it == Step.BEGIN_COMBAT }.shouldBeEmpty()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantSharedLifeTest.kt
@@ -88,6 +88,18 @@ class TwoHeadedGiantSharedLifeTest : FunSpec({
         after.lifeTotal(p[1]) shouldBe 34
     }
 
+    test("a 'can't gain life' lock on one head closes the shared pool for the teammate too (CR 810.9g)") {
+        val (state, p) = boot()
+        val locked = state.updateEntity(p[0]) {
+            it.with(com.wingedsheep.engine.state.components.player.CantGainLifeComponent())
+        }
+        val (afterTeammateGain, event) = DamageUtils.gainLife(locked, p[1], 4)
+        event shouldBe null
+        afterTeammateGain.lifeTotal(p[1]) shouldBe 30
+        // The opposing team is untouched by team 0's lock.
+        DamageUtils.gainLife(locked, p[2], 4).first.lifeTotal(p[2]) shouldBe 34
+    }
+
     test("damage to a teammate reduces the shared team total") {
         val (state, p) = boot()
         val result = DamageUtils.dealDamageToTarget(state, p[0], 6, sourceId = null)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
@@ -153,6 +153,28 @@ class TwoHeadedGiantTeamLossTest : FunSpec({
         s.gameOver shouldBe false
     }
 
+    test("'you don't lose for having 0 or less life' on either head protects the whole team (CR 810.8a example)") {
+        val (state, p) = boot()
+        // Transcendence-style grant under p1's control (teammate of p0).
+        val (permId, withId) = state.newEntity()
+        val protectedState = withId
+            .withEntity(
+                permId,
+                ComponentContainer.of(
+                    ControllerComponent(p[1]),
+                    com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent()
+                )
+            )
+            .addToZone(ZoneKey(p[1], Zone.BATTLEFIELD), permId)
+        val zeroed = DamageUtils.loseLife(protectedState, p[0], 30, LifeChangeReason.LIFE_LOSS).first
+
+        val s = checker().checkAndApply(zeroed).newState
+        // CR 810.8a: "If that player's team's life total is 0 or less, that team doesn't lose."
+        lost(s, p[0]) shouldBe false
+        lost(s, p[1]) shouldBe false
+        s.gameOver shouldBe false
+    }
+
     test("'you win the game' wins for your whole team and defeats only opposing teams (CR 810.8a)") {
         val (state, p) = boot()
         val result = WinGameExecutor().execute(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
@@ -81,6 +81,9 @@ class TwoHeadedGiantTeamPriorityTest : FunSpec({
                 teams = teams,
                 startingPlayerIndex = 0,
                 skipMulligans = true,
+                // Pinned: the chain test needs two Sprouts in p0's opening hand and one in p1's;
+                // an unseeded shuffle misses that roughly one run in twenty.
+                seed = 2026_08_27L,
             )
         )
         return Triple(result.state, result.playerIds, ActionProcessor(registry()))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamPriorityTest.kt
@@ -259,6 +259,35 @@ class TwoHeadedGiantTeamPriorityTest : FunSpec({
         state.priorityPassedBy shouldBe setOf(p[0], p[1])
     }
 
+    test("a teammate who already passed this round can't pass again until someone acts") {
+        val (booted, p, proc) = boot2hg()
+        var state = toPrecombatMain(booted, proc)
+
+        // p1 passes out of baton order; p0 still holds the baton.
+        state = proc.process(state, PassPriority(p[1])).result.newState
+        state.priorityPlayerId shouldBe p[0]
+        state.priorityPassedBy shouldBe setOf(p[1])
+
+        // A second pass from p1 is refused — it would leave the state exactly as it is, which is
+        // the loop an AI partner polling its legal actions fell into.
+        val again = proc.process(state, PassPriority(p[1])).result
+        again.isSuccess shouldBe false
+        // And it is no longer offered: the enumerator mirrors the handler.
+        val services = com.wingedsheep.engine.core.EngineServices(registry())
+        val enumerator = com.wingedsheep.engine.legalactions.LegalActionEnumerator(
+            services.cardRegistry, services.manaSolver, services.costCalculator,
+            services.predicateEvaluator, services.conditionEvaluator, services.turnManager
+        )
+        enumerator.enumerate(state, p[1]).none { it.actionType == "PassPriority" } shouldBe true
+        // The baton holder's own pass is untouched.
+        enumerator.enumerate(state, p[0]).count { it.actionType == "PassPriority" } shouldBe 1
+
+        // Once p0 acts, the round is re-armed and p1 may pass again.
+        state = proc.process(state, CastSpell(p[0], state.handCard(p[0], hunch.name))).result.newState
+        state.priorityPassedBy.shouldBeEmpty()
+        proc.process(state, PassPriority(p[1])).result.isSuccess shouldBe true
+    }
+
     test("nextUnpassedPriorityAfter is plain getNextPlayer while nobody has passed") {
         val (booted, p, proc) = boot2hg()
         val state = toPrecombatMain(booted, proc)

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -742,8 +742,14 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
       // Ignore a game-over for a game we already left — e.g. an eliminated FFA player who
       // returned to the lobby still holds a seat server-side and receives the final GameOver.
       if (msg.gameId && sessionId !== msg.gameId) return
-      const result: 'win' | 'lose' | 'draw' =
-        msg.winnerId === null ? 'draw' : msg.winnerId === playerId ? 'win' : 'lose'
+      // "Did I win?" is a team question in Two-Headed Giant (CR 810.8a): the server names every
+      // winning seat in winnerIds; winnerId is one representative and would tell the other head
+      // of the winning team they lost. Older servers send winnerId alone, so fall back to it.
+      const won =
+        msg.winnerIds && msg.winnerIds.length > 0
+          ? playerId !== null && msg.winnerIds.includes(playerId)
+          : msg.winnerId === playerId
+      const result: 'win' | 'lose' | 'draw' = msg.winnerId === null ? 'draw' : won ? 'win' : 'lose'
       trackEvent('game_over', { result, reason: msg.reason })
       setInGame(false)
       set({

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1240,7 +1240,10 @@ export interface WaitingForOpponentMulliganMessage {
  */
 export interface GameOverMessage {
   readonly type: 'gameOver'
+  /** One representative of the winning side; kept for readers that predate teams. */
   readonly winnerId: EntityId | null
+  /** Every seat that won — the whole winning team in Two-Headed Giant (CR 810.8a). Empty for a draw. */
+  readonly winnerIds?: readonly EntityId[]
   readonly reason: GameOverReason
   readonly message?: string
   readonly gameId?: string


### PR DESCRIPTION
Re-lands the multiplayer CR 800–810 audit fixes that never reached `main`.

The original 15-PR stack was opened with each PR based on the *previous branch*, so #2056–#2070
merged into each other and only #2055 (`mp-cr/01`, concede-with-pending-decision) landed on `main`.
This branch is the same work, unchanged: the 14 remaining commits plus the test seed pin, linear on
top of `main`. Every other `mp-cr/*` branch adds only a merge commit — no content is left behind.

Commits (each is one of the original PRs):

| Was | Change |
|-----|--------|
| #2056 | Read turn-keyed player state off the whole active team in a shared team turn (CR 805.4 / 805.8) |
| — | Pin the seed in `TwoHeadedGiantTeamPriorityTest` |
| #2057 | One combined attack declaration per team in a shared team turn (CR 805.10b) |
| #2059 | Refuse a redundant pass from a teammate who already passed this round (CR 805.5) |
| #2060 | `Player.EachOpponent` is a real opponent test in the life paths (CR 102.3 / 810.9g-h) |
| #2061 | Team-wide "don't lose for 0 life" and "can't gain life" (CR 810.8a / 810.9g) |
| #2062 | Attackers aimed at a departed player leave combat (CR 800.4e / 800.4a) |
| #2063 | A departed player's resolved effects persist (CR 611.2c / 800.4m) |
| #2064 | Hand the baton to the next undeclared defender during the block round (CR 802.4) |
| #2065 | Report every winning seat, not one representative (CR 810.8a) |
| #2066 | Read life through the resolver outside the engine too |
| #2067 | "Lose the game at the next end step" respects can't-lose grants |
| #2068 | Tell a teammate, not just the opponents, when a seat drops or returns |
| #2069 | A hijack controls the affected player's whole shared-turn team |
| #2070 | Team vs. Team: the random first team starts from its centre / left |

## Why this matters right now

A live Two-Headed Giant game against 3 AI showed "You conceded the game" without anyone conceding.
The chain: on `main` the team's *second head* hits a rejected action every combat (`activePlayerId`
is permanently the team's first seat, and the declared-attackers marker is stamped per seat), the
server force-concedes an AI seat after 10 consecutive rejected actions with no legal fallback
(`GamePlayHandler` + `GameStallGuard.MAX_CONSECUTIVE_REJECTIONS`), and in 2HG one concession takes
the whole team out (`TeamLossPropagationCheck`) — so the human partner is told they conceded.
#2057 and #2059 are the fixes for the wedge; #2065 fixes the winning second head being shown
"Defeat".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSiiCJ1DvEC7tM9UcS3XrA
