### PR TITLE
Learn to Play: four coached games against the AI for first-time players

### DIFF
--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@types/d3-geo": "^3.1.0",
+        "@types/node": "^22.20.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/topojson-client": "^3.1.5",
@@ -982,6 +983,16 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -2263,6 +2274,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@types/d3-geo": "^3.1.0",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/topojson-client": "^3.1.5",

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -30,6 +30,7 @@ import { useNavigate } from 'react-router-dom'
 import { useGameStore } from './store/gameStore'
 import { useConnectName } from './store/useConnectName'
 import { useRematch } from '@/components/lobby/useRematch'
+import { LearnCoach } from '@/components/learn/LearnCoach'
 import { useViewingPlayer, useBattlefieldCards } from './store/selectors'
 import type { ClientAttacker, EntityId } from './types'
 import { GameOverReason } from './types'
@@ -329,6 +330,10 @@ export default function App() {
 
       {/* Opponent decision indicator (shown during game when opponent is deciding) */}
       {showGame && <OpponentDecisionIndicator />}
+
+      {/* Learn-to-play coach — renders nothing unless the course's first game armed it. Mounted
+          through game over too, so it can close with the result. */}
+      {(showGame || gameOverState) && <LearnCoach />}
 
       {/* Disconnect countdown (shown when opponent disconnects during game or mulligan) */}
       {(showGame || mulliganState || waitingForOpponentMulligan) && <DisconnectCountdown />}

--- a/web-client/src/components/learn/CardImage.tsx
+++ b/web-client/src/components/learn/CardImage.tsx
@@ -1,0 +1,11 @@
+import styles from './learn.module.css'
+
+/** A real card, from the catalog's image (or Scryfall's), with an optional caption under it. */
+export function CardImage({ src, name, caption }: { src: string; name: string; caption?: string }) {
+  return (
+    <div>
+      <img src={src} alt={name} className={styles.cardImg} loading="lazy" draggable={false} />
+      {caption !== undefined && <div className={styles.cardName}>{caption}</div>}
+    </div>
+  )
+}

--- a/web-client/src/components/learn/LearnCallout.module.css
+++ b/web-client/src/components/learn/LearnCallout.module.css
@@ -1,0 +1,102 @@
+/* The course pointer on the landing page. Gold is the course's colour everywhere it appears. */
+
+.arrival {
+  width: 100%;
+  max-width: 460px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  text-align: left;
+  font: inherit;
+  color: #efe6cf;
+  background: linear-gradient(180deg, rgba(217, 180, 92, 0.12), rgba(217, 180, 92, 0.05));
+  border: 1px solid rgba(217, 180, 92, 0.4);
+  border-radius: 10px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.arrival:hover {
+  border-color: #d9b45c;
+  background: linear-gradient(180deg, rgba(217, 180, 92, 0.18), rgba(217, 180, 92, 0.08));
+  transform: translateY(-1px);
+}
+
+.arrivalGlyph {
+  font-size: 26px;
+  color: #d9b45c;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(217, 180, 92, 0.12);
+}
+
+.arrivalText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.arrivalTitle {
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+  font-size: 17px;
+  line-height: 1.15;
+}
+
+.arrivalBody {
+  font-size: 12.5px;
+  color: #c9c3b4;
+  line-height: 1.35;
+}
+
+.arrivalArrow {
+  font-size: 18px;
+  color: #d9b45c;
+}
+
+.tier {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-size: var(--font-sm);
+  color: #e6ddc6;
+  background: rgba(217, 180, 92, 0.06);
+  border: 1px solid rgba(217, 180, 92, 0.3);
+  border-radius: var(--radius-lg);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.tier:hover {
+  border-color: rgba(217, 180, 92, 0.7);
+  background: rgba(217, 180, 92, 0.1);
+}
+
+.tierGlyph {
+  color: #d9b45c;
+  font-size: 16px;
+  display: inline-grid;
+  place-items: center;
+}
+
+.tierLabel {
+  flex: 1;
+  font-weight: var(--font-weight-medium);
+}
+
+.tierMeta {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #d9b45c;
+  font-variant-numeric: tabular-nums;
+}

--- a/web-client/src/components/learn/LearnCallout.tsx
+++ b/web-client/src/components/learn/LearnCallout.tsx
@@ -1,0 +1,57 @@
+/**
+ * The landing page's pointer to the course, in two sizes.
+ *
+ * `variant="arrival"` is for the one screen a brand-new visitor sees — the name prompt — and
+ * says the course needs no name. `variant="tier"` is the quieter row inside PLAY for someone
+ * already connected: it shows progress once the course is started and goes away once it is done
+ * (the `/help` guide keeps a link for anyone who wants it back).
+ */
+import { useNavigate } from 'react-router-dom'
+import { COURSE_MINUTES, MISSIONS } from '@/learn/missions'
+import { hasStarted, nextIncomplete, useLearnProgress } from '@/learn/progressStore'
+import styles from './LearnCallout.module.css'
+
+export function LearnCallout({ variant }: { variant: 'arrival' | 'tier' }) {
+  const navigate = useNavigate()
+  const completed = useLearnProgress((s) => s.completed)
+  const started = hasStarted({ completed })
+  const next = nextIncomplete(completed)
+  const finished = next === undefined
+
+  if (variant === 'tier' && finished) return null
+
+  const go = () => navigate('/learn')
+
+  if (variant === 'arrival') {
+    return (
+      <button type="button" className={styles.arrival} onClick={go}>
+        <span className={styles.arrivalGlyph} aria-hidden="true">
+          <i className="ms ms-planeswalker" />
+        </span>
+        <span className={styles.arrivalText}>
+          <span className={styles.arrivalTitle}>
+            {started ? 'Pick up the course where you left off' : 'Never played Magic?'}
+          </span>
+          <span className={styles.arrivalBody}>
+            {started
+              ? `${completed.length} of ${MISSIONS.length} missions done — no name needed to continue.`
+              : `Learn by playing: four short guided games with a coach, about ${COURSE_MINUTES} minutes. No name needed.`}
+          </span>
+        </span>
+        <span className={styles.arrivalArrow} aria-hidden="true">→</span>
+      </button>
+    )
+  }
+
+  return (
+    <button type="button" className={styles.tier} onClick={go}>
+      <span className={styles.tierGlyph} aria-hidden="true">
+        <i className="ms ms-planeswalker" />
+      </span>
+      <span className={styles.tierLabel}>{started ? 'Continue learning to play' : 'New to Magic? Learn to play'}</span>
+      <span className={styles.tierMeta}>
+        {started ? `${completed.length}/${MISSIONS.length}` : `${COURSE_MINUTES} min`}
+      </span>
+    </button>
+  )
+}

--- a/web-client/src/components/learn/LearnCoach.module.css
+++ b/web-client/src/components/learn/LearnCoach.module.css
@@ -1,0 +1,218 @@
+/**
+ * The coach panel on the game board. Bottom-left, clear of the hand (bottom centre), the
+ * pass/controls cluster (bottom right) and the game-log toggle (the 12px corner below it),
+ * above the board's own overlays but under modals.
+ */
+.coach {
+  --coach-accent: #d9b45c;
+  position: fixed;
+  left: 12px;
+  bottom: 52px;
+  z-index: 600;
+  width: min(340px, calc(100vw - 32px));
+  border-radius: 12px;
+  border: 1px solid rgba(239, 230, 207, 0.16);
+  border-left: 3px solid var(--coach-accent);
+  background: rgba(14, 14, 20, 0.94);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55);
+  color: #c9c3b4;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  padding: 10px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.act {
+  --coach-accent: #d9b45c;
+}
+
+.watch {
+  --coach-accent: #4fc3f7;
+}
+
+/* The game-over overlay (App.tsx) dims the board at z 1999–2000; the closing card sits above it
+   so "Next mission" is the first thing a finished player can click. */
+.done {
+  --coach-accent: #7ccf8a;
+  z-index: 2100;
+}
+
+.head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--coach-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.close {
+  background: none;
+  border: none;
+  color: #8d877a;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.close:hover {
+  color: #efe6cf;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.body {
+  animation: coachIn 0.28s ease-out both;
+}
+
+@keyframes coachIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.title {
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+  font-size: 18px;
+  color: #efe6cf;
+  margin-bottom: 4px;
+}
+
+.text {
+  margin: 0;
+}
+
+/* ---- Objectives ---------------------------------------------------------- */
+.objectives {
+  margin: 0;
+  padding: 10px 0 0;
+  list-style: none;
+  border-top: 1px solid rgba(239, 230, 207, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.objective {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 8px;
+  align-items: center;
+  font-size: 12.5px;
+  color: #a8a294;
+  transition: color 0.3s ease;
+}
+
+.objectiveDone {
+  color: #efe6cf;
+}
+
+.tick {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(239, 230, 207, 0.3);
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: #1a1408;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.objectiveDone .tick {
+  background: #d9b45c;
+  border-color: #d9b45c;
+  animation: tickIn 0.35s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes tickIn {
+  from {
+    transform: scale(0.4);
+  }
+  60% {
+    transform: scale(1.25);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+/* ---- Actions ------------------------------------------------------------- */
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.primary {
+  margin-top: 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1408;
+  background: linear-gradient(180deg, #ecc96f 0%, #cfa640 100%);
+  border: 1px solid rgba(255, 240, 200, 0.35);
+  border-radius: 7px;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+
+.primary:hover {
+  filter: brightness(1.05);
+}
+
+.link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--coach-accent);
+  cursor: pointer;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .coach {
+    left: 8px;
+    bottom: 44px;
+    width: min(270px, calc(100vw - 16px));
+    font-size: 12px;
+    padding: 8px 10px 10px;
+  }
+
+  .title {
+    font-size: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .body,
+  .objectiveDone .tick {
+    animation: none;
+  }
+}

--- a/web-client/src/components/learn/LearnCoach.tsx
+++ b/web-client/src/components/learn/LearnCoach.tsx
@@ -1,0 +1,157 @@
+/**
+ * The coach panel for a course mission. Mounted on every game board, renders nothing unless the
+ * course armed it (see `learn/coach.ts`); then shows the mission's objectives ticking off as the
+ * player does them, and one tip for what the board is waiting on. When the game ends it marks
+ * the mission finished and points at the next card in the hand.
+ *
+ * Portalled to `<body>` like the help drawer: `#root` is overflow:hidden and the multiplayer
+ * strip transforms its subtree, both of which break `position: fixed` for descendants.
+ */
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
+import { useGameStore } from '@/store/gameStore'
+import { selectHasPriority, selectIsMyTurn } from '@/store/selectors'
+import { armedMission, coachTip, disarmCoach, introSeen, markIntroSeen, type CoachView } from '@/learn/coach'
+import { learnHref, missionById, nextMission } from '@/learn/missions'
+import { useLearnProgress } from '@/learn/progressStore'
+import styles from './LearnCoach.module.css'
+
+export function LearnCoach() {
+  const [missionId] = useState(armedMission)
+  const mission = useMemo(() => missionById(missionId), [missionId])
+  const [hidden, setHidden] = useState(false)
+  const [showIntro, setShowIntro] = useState(() => !introSeen())
+  // Once the game is over the coach disarms itself, so a remount after that renders nothing —
+  // which is also what stops the mission being finished twice.
+  const [finished, setFinished] = useState(false)
+  const navigate = useNavigate()
+  const finish = useLearnProgress((s) => s.finish)
+  const returnToMenu = useGameStore((s) => s.returnToMenu)
+
+  const gameState = useGameStore((s) => s.gameState)
+  const legalActions = useGameStore((s) => s.legalActions)
+  const pendingDecision = useGameStore((s) => s.pendingDecision)
+  const gameOverState = useGameStore((s) => s.gameOverState)
+  const nextStopPoint = useGameStore((s) => s.nextStopPoint)
+  const isMyTurn = useGameStore(selectIsMyTurn)
+  const hasPriority = useGameStore(selectHasPriority)
+
+  const won = gameOverState ? (gameOverState.result === 'draw' ? null : gameOverState.result === 'win') : null
+
+  const view = useMemo<CoachView | null>(() => {
+    if (!gameState) return null
+    const types = new Set(legalActions.map((a) => a.actionType))
+    return {
+      turnNumber: gameState.turnNumber,
+      step: gameState.currentStep,
+      isMyTurn,
+      hasPriority,
+      canPlayLand: types.has('PlayLand'),
+      canCast: types.has('CastSpell'),
+      canAttack: types.has('DeclareAttackers'),
+      canBlock: types.has('DeclareBlockers'),
+      hasDecision: pendingDecision !== null,
+      attackersIncoming: gameState.combat?.attackers.length ?? 0,
+      passLabel: nextStopPoint ?? 'Pass',
+      isGameOver: gameState.isGameOver || gameOverState !== null,
+      won,
+    }
+  }, [gameState, legalActions, pendingDecision, gameOverState, nextStopPoint, isMyTurn, hasPriority, won])
+
+  const objectives = useMemo(() => {
+    if (!mission || !gameState) return []
+    const ctx = { state: gameState, me: gameState.viewingPlayerId, won }
+    return mission.objectives.map((o) => ({ id: o.id, label: o.label, done: o.done(ctx) }))
+  }, [mission, gameState, won])
+
+  // The game ending is what finishes the mission, win or lose. Disarm so the next game — a
+  // rematch, or anything started from the menu — plays without a coach.
+  useEffect(() => {
+    if (mission && view?.isGameOver && !finished) {
+      finish(mission.id)
+      disarmCoach()
+      setFinished(true)
+    }
+  }, [mission, view?.isGameOver, finished, finish])
+
+  if (!mission || hidden || !view) return null
+  const tip = coachTip(view, mission.hints)
+  const next = nextMission(mission.id)
+  const doneCount = objectives.filter((o) => o.done).length
+
+  const leave = (to: string) => {
+    returnToMenu()
+    navigate(to)
+  }
+
+  return createPortal(
+    <aside className={`${styles.coach} ${styles[tip.tone]}`} aria-live="polite" aria-label="Coach">
+      <div className={styles.head}>
+        <span className={styles.eyebrow}>
+          Mission {mission.number} · {mission.title}
+        </span>
+        <button
+          type="button"
+          className={styles.close}
+          onClick={() => setHidden(true)}
+          aria-label="Hide the coach for the rest of this game"
+          title="Hide the coach for the rest of this game"
+        >
+          ×
+        </button>
+      </div>
+
+      {showIntro && !view.isGameOver ? (
+        <div className={styles.body}>
+          <div className={styles.title}>Welcome to the table.</div>
+          <p className={styles.text}>{mission.intro}</p>
+          <button
+            type="button"
+            className={styles.primary}
+            onClick={() => {
+              markIntroSeen()
+              setShowIntro(false)
+            }}
+          >
+            Let’s go
+          </button>
+        </div>
+      ) : (
+        <div key={tip.key} className={styles.body}>
+          <div className={styles.title}>{tip.title}</div>
+          <p className={styles.text}>{tip.body}</p>
+        </div>
+      )}
+
+      <ol className={styles.objectives} aria-label={`Objectives, ${doneCount} of ${objectives.length} done`}>
+        {objectives.map((o) => (
+          <li key={o.id} className={`${styles.objective} ${o.done ? styles.objectiveDone : ''}`}>
+            <span className={styles.tick} aria-hidden="true">
+              {o.done ? '✓' : ''}
+            </span>
+            <span>{o.label}</span>
+          </li>
+        ))}
+      </ol>
+
+      {view.isGameOver && (
+        <div className={styles.actions}>
+          {next ? (
+            <button type="button" className={styles.primary} onClick={() => leave(learnHref(next.id))}>
+              Next: {next.title} →
+            </button>
+          ) : (
+            <button type="button" className={styles.primary} onClick={() => leave(learnHref())}>
+              Course complete →
+            </button>
+          )}
+          <button type="button" className={styles.link} onClick={() => leave(learnHref(mission.id))}>
+            Play this one again
+          </button>
+        </div>
+      )}
+    </aside>,
+    document.body,
+  )
+}

--- a/web-client/src/components/learn/MissionHand.tsx
+++ b/web-client/src/components/learn/MissionHand.tsx
@@ -1,0 +1,134 @@
+/**
+ * The course as a hand of cards.
+ *
+ * Four mission cards fanned the way a hand is held, each drawn in a Magic frame in the mission's
+ * colour. Finished missions are foil and sealed; the next one to play glows. The same card, at
+ * thumbnail size, is the strip on every brief ({@link MiniHand}).
+ */
+import { Link } from 'react-router-dom'
+import { MISSIONS, learnHref, type Mission, type MissionFrame, type MissionId } from '@/learn/missions'
+import styles from './learn.module.css'
+
+/** The one glyph in each card's art box — mana-font's symbol for what the mission is about. */
+const ART_GLYPH: Record<MissionId, string> = {
+  'first-steps': 'ms-land',
+  blocking: 'ms-creature',
+  instants: 'ms-instant',
+  'real-game': 'ms-planeswalker',
+}
+
+const TYPE_LINE: Record<MissionId, string> = {
+  'first-steps': 'Mission — Lands & creatures',
+  blocking: 'Mission — Combat',
+  instants: 'Mission — The stack',
+  'real-game': 'Game — Full rules',
+}
+
+/** Frames light enough to need dark text. */
+const LIGHT_FRAMES: ReadonlySet<MissionFrame> = new Set<MissionFrame>(['W', 'gold', 'artifact'])
+
+export function frameVar(frame: MissionFrame): string {
+  return `var(--frame-${frame})`
+}
+
+function MissionCardFrame({
+  mission,
+  done,
+  next,
+  later,
+}: {
+  mission: Mission
+  done: boolean
+  next: boolean
+  later: boolean
+}) {
+  const dark = !LIGHT_FRAMES.has(mission.frame)
+  const cls = [
+    styles.card,
+    dark ? styles.cardDark : '',
+    done ? styles.cardDone : '',
+    next ? styles.cardNext : '',
+    later ? styles.cardLocked : '',
+  ].join(' ')
+  return (
+    <Link
+      to={learnHref(mission.id)}
+      className={cls}
+      style={{ ['--frame' as string]: frameVar(mission.frame) }}
+      aria-label={`Mission ${mission.number}: ${mission.title}${done ? ' (complete)' : ''}`}
+    >
+      {done && <span className={styles.cardSeal} aria-hidden="true">✓</span>}
+      <div className={styles.cardTitle}>
+        <span>{mission.title}</span>
+        <span className={styles.cardNumber}>{mission.number}</span>
+      </div>
+      <div className={styles.cardArt}>
+        <i className={`ms ${ART_GLYPH[mission.id]}`} aria-hidden="true" />
+      </div>
+      <div className={styles.cardType}>{TYPE_LINE[mission.id]}</div>
+      <div className={styles.cardText}>{mission.blurb}</div>
+      <div className={styles.cardFoot}>
+        <span>{mission.number} / {MISSIONS.length}</span>
+        <span>~{mission.minutes} min</span>
+      </div>
+    </Link>
+  )
+}
+
+/**
+ * Fan geometry: card `i` of `n` sits `shift` px from centre, tilted `tilt` degrees, dropped by a
+ * parabola so the ends of the hand sit lower than the middle — the shape of held cards.
+ */
+function slotStyle(i: number, n: number): Record<string, string> {
+  const mid = (n - 1) / 2
+  const d = i - mid
+  return { '--shift': `${d * 190}px`, '--tilt': `${d * 6}deg`, '--lift': `${d * d * 14}px` }
+}
+
+export function MissionHand({ completed, next }: { completed: readonly MissionId[]; next: MissionId | undefined }) {
+  const nextNumber = MISSIONS.find((m) => m.id === next)?.number ?? Infinity
+  return (
+    <div className={styles.hand} role="list" aria-label="Missions">
+      {MISSIONS.map((mission, i) => {
+        const done = completed.includes(mission.id)
+        const isNext = mission.id === next
+        // Nothing is locked — you can jump ahead — but cards past the next one sit a little
+        // dimmer so the path reads left to right.
+        const later = !done && !isNext && mission.number > nextNumber
+        return (
+          <div key={mission.id} className={styles.handSlot} style={slotStyle(i, MISSIONS.length)} role="listitem">
+            <MissionCardFrame mission={mission} done={done} next={isNext} later={later} />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function MiniHand({ current, completed }: { current: MissionId; completed: readonly MissionId[] }) {
+  return (
+    <nav className={styles.miniHand} aria-label="All missions">
+      {MISSIONS.map((mission) => {
+        const dark = !LIGHT_FRAMES.has(mission.frame)
+        const cls = [
+          styles.miniCard,
+          dark ? styles.miniCardDark : '',
+          mission.id === current ? styles.miniCardActive : '',
+          completed.includes(mission.id) ? styles.miniCardDone : '',
+        ].join(' ')
+        return (
+          <Link
+            key={mission.id}
+            to={learnHref(mission.id)}
+            className={cls}
+            style={{ ['--frame' as string]: frameVar(mission.frame) }}
+            title={`${mission.number}. ${mission.title}`}
+            aria-label={`Mission ${mission.number}: ${mission.title}`}
+          >
+            {mission.number}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/web-client/src/components/learn/learn.module.css
+++ b/web-client/src/components/learn/learn.module.css
@@ -1,0 +1,789 @@
+/**
+ * Learn to Play — the course home with its hand of mission cards, and the mission briefs.
+ *
+ * Its own palette on purpose. The rest of the client is cool-white glass over land art, tuned
+ * for a board where every pixel is play space. The course is a doorway into that board, so it
+ * gets warm parchment text on the same dark ground, a gold that means "progress" everywhere it
+ * appears, and one serif — the register of a card's name line — for titles only. Everything
+ * else stays quiet so the hand of cards is the one thing you remember.
+ */
+
+.root {
+  --ln-ink: #0b0c12;
+  --ln-paper: #efe6cf;
+  --ln-body: #c9c3b4;
+  --ln-muted: #8d877a;
+  --ln-faint: #5f5a50;
+  --ln-gold: #d9b45c;
+  --ln-gold-glow: rgba(217, 180, 92, 0.22);
+  --ln-line: rgba(239, 230, 207, 0.12);
+  --ln-line-strong: rgba(239, 230, 207, 0.22);
+  --ln-panel: rgba(18, 17, 24, 0.72);
+  --ln-bad: #e0736b;
+
+  /* Frame colours: Magic's five, plus gold and the artifact silver. */
+  --frame-W: #e8e2c6;
+  --frame-U: #2a7bc4;
+  --frame-B: #4a4152;
+  --frame-R: #c93b33;
+  --frame-G: #23854f;
+  --frame-gold: #cfa640;
+  --frame-artifact: #a7afb8;
+
+  --ln-display: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+  --ln-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+  /* The app's type scale is board-sized (12px body). Re-point it for reading. */
+  --font-xs: 12px;
+  --font-sm: 14px;
+  --font-md: 16px;
+
+  /* `#root` is height:100% / overflow:hidden for the board, so this is its own scroll box. */
+  height: 100vh;
+  overflow-y: auto;
+  background:
+    radial-gradient(900px 420px at 50% 108%, var(--ln-gold-glow), transparent 70%),
+    radial-gradient(700px 380px at 8% -8%, rgba(42, 123, 196, 0.12), transparent 65%),
+    var(--ln-ink);
+  color: var(--ln-body);
+  font-family: var(--ln-sans);
+  font-size: var(--font-md);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.root :focus-visible {
+  outline: 2px solid var(--ln-gold);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* =========================================================================
+ * Top bar — shared by the home and every brief
+ * ========================================================================= */
+.topBar {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: rgba(11, 12, 18, 0.78);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  border-bottom: 1px solid var(--ln-line);
+}
+
+.topBarInner {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.topBarLink {
+  background: none;
+  text-decoration: none;
+  border: 1px solid transparent;
+  color: var(--ln-muted);
+  font: inherit;
+  font-size: var(--font-sm);
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.topBarLink:hover {
+  color: var(--ln-paper);
+  border-color: var(--ln-line-strong);
+}
+
+.topBarEyebrow {
+  margin-left: auto;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ln-muted);
+}
+
+/* Progress pips in the top bar: one per mission, gold once complete. */
+.pips {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid var(--ln-line-strong);
+  background: transparent;
+  transition: background var(--transition-normal), border-color var(--transition-normal);
+}
+
+.pipDone {
+  background: var(--ln-gold);
+  border-color: var(--ln-gold);
+  box-shadow: 0 0 8px var(--ln-gold-glow);
+}
+
+.pipCurrent {
+  border-color: var(--ln-paper);
+}
+
+/* =========================================================================
+ * Course home
+ * ========================================================================= */
+.home {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 56px 20px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ln-gold);
+  margin: 0 0 14px;
+}
+
+.headline {
+  font-family: var(--ln-display);
+  font-weight: 400;
+  font-size: clamp(38px, 6vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.015em;
+  color: var(--ln-paper);
+  margin: 0;
+}
+
+.headline em {
+  font-style: italic;
+  color: var(--ln-gold);
+}
+
+.lede {
+  margin: 20px 0 0;
+  max-width: 54ch;
+  font-size: 17px;
+  color: var(--ln-body);
+}
+
+.heroActions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 28px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.cta {
+  font: inherit;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  color: #1a1408;
+  background: linear-gradient(180deg, #ecc96f 0%, #cfa640 100%);
+  border: 1px solid rgba(255, 240, 200, 0.35);
+  border-radius: 8px;
+  padding: 12px 22px;
+  cursor: pointer;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.35) inset,
+    0 8px 24px rgba(207, 166, 64, 0.28);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), filter var(--transition-fast);
+}
+
+.cta:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.4) inset,
+    0 12px 28px rgba(207, 166, 64, 0.36);
+}
+
+.cta:active {
+  transform: translateY(0);
+}
+
+.cta:disabled {
+  cursor: default;
+  filter: saturate(0.4) brightness(0.8);
+  transform: none;
+  box-shadow: none;
+}
+
+.ctaQuiet {
+  font: inherit;
+  text-decoration: none;
+  font-size: 15px;
+  color: var(--ln-body);
+  background: transparent;
+  border: 1px solid var(--ln-line-strong);
+  border-radius: 8px;
+  padding: 12px 18px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast), background var(--transition-fast);
+}
+
+.ctaQuiet:hover {
+  color: var(--ln-paper);
+  border-color: var(--ln-gold);
+  background: rgba(217, 180, 92, 0.06);
+}
+
+.heroNote {
+  margin: 14px 0 0;
+  font-size: var(--font-sm);
+  color: var(--ln-muted);
+}
+
+.heroNote a,
+.textLink {
+  color: var(--ln-gold);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(217, 180, 92, 0.35);
+  cursor: pointer;
+  background: none;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  font: inherit;
+  padding: 0;
+}
+
+.heroNote a:hover,
+.textLink:hover {
+  border-bottom-color: var(--ln-gold);
+}
+
+/* ---- The hand ----------------------------------------------------------
+ * Four mission cards fanned the way a hand is held. Each card is rotated and dropped around a
+ * point well below the row, so the arc reads as fingers, not a carousel. Hover lifts a card
+ * clear of its neighbours; the next mission to play carries a soft glow so the eye lands on it.
+ */
+.hand {
+  position: relative;
+  width: 100%;
+  margin-top: 48px;
+  height: 340px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+}
+
+.handSlot {
+  --tilt: 0deg;
+  --lift: 0px;
+  --shift: 0px;
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  width: 190px;
+  margin-left: -95px;
+  transform: translateX(var(--shift)) translateY(var(--lift)) rotate(var(--tilt));
+  transform-origin: 50% 140%;
+  transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.handSlot:hover,
+.handSlot:focus-within {
+  z-index: 5;
+  transform: translateX(var(--shift)) translateY(calc(var(--lift) - 26px)) rotate(var(--tilt)) scale(1.05);
+}
+
+/* ---- Mission card frame ------------------------------------------------
+ * A Magic-shaped card: coloured frame, dark art box with one glyph, a title line, a text box,
+ * and a bottom line that says where it sits in the course. The frame colour is the mission's.
+ */
+.card {
+  --frame: var(--frame-W);
+  display: flex;
+  flex-direction: column;
+  width: 190px;
+  aspect-ratio: 5 / 7;
+  border-radius: 11px;
+  padding: 7px;
+  box-sizing: border-box;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 45%),
+    var(--frame);
+  border: 1px solid rgba(0, 0, 0, 0.55);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 14px 30px rgba(0, 0, 0, 0.55);
+  color: #1d1a12;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  position: relative;
+  overflow: hidden;
+}
+
+.cardDark {
+  color: #efe6cf;
+}
+
+.cardTitle {
+  font-family: var(--ln-display);
+  font-size: 14px;
+  line-height: 1.1;
+  padding: 5px 7px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+}
+
+.cardDark .cardTitle {
+  background: rgba(0, 0, 0, 0.32);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.cardNumber {
+  font-family: var(--ln-sans);
+  font-size: 10px;
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.cardArt {
+  margin-top: 5px;
+  flex: 1 1 auto;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  background:
+    radial-gradient(70% 60% at 50% 45%, color-mix(in srgb, var(--frame) 55%, transparent), transparent 75%),
+    linear-gradient(180deg, #171821, #0b0c12);
+  display: grid;
+  place-items: center;
+  color: var(--frame);
+  font-size: 58px;
+  text-shadow: 0 0 22px color-mix(in srgb, var(--frame) 60%, transparent);
+}
+
+.cardType {
+  margin-top: 5px;
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardDark .cardType {
+  background: rgba(0, 0, 0, 0.32);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.cardText {
+  margin-top: 5px;
+  height: 76px;
+  font-size: 11px;
+  line-height: 1.32;
+  padding: 5px 7px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  color: #2a2519;
+  overflow: hidden;
+}
+
+.cardDark .cardText {
+  background: rgba(0, 0, 0, 0.36);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: #e6ddc6;
+}
+
+.cardFoot {
+  margin-top: 5px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  opacity: 0.75;
+  padding: 0 2px;
+}
+
+/* A finished mission is foil: a diagonal sheen that slides once when it comes into view. */
+.cardDone::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    rgba(255, 245, 200, 0.28) 45%,
+    rgba(255, 255, 255, 0.45) 50%,
+    rgba(255, 245, 200, 0.28) 55%,
+    transparent 70%
+  );
+  transform: translateX(-110%);
+  animation: foil 1.6s ease-out 0.2s 1 both;
+  pointer-events: none;
+}
+
+@keyframes foil {
+  to {
+    transform: translateX(110%);
+  }
+}
+
+.cardSeal {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--ln-gold);
+  color: #1a1408;
+  display: grid;
+  place-items: center;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+  z-index: 2;
+}
+
+.cardNext {
+  animation: beckon 2.4s ease-in-out infinite;
+}
+
+@keyframes beckon {
+  0%,
+  100% {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.25) inset,
+      0 14px 30px rgba(0, 0, 0, 0.55),
+      0 0 0 2px var(--ln-gold),
+      0 0 24px var(--ln-gold-glow);
+  }
+  50% {
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.25) inset,
+      0 14px 30px rgba(0, 0, 0, 0.55),
+      0 0 0 2px var(--ln-gold),
+      0 0 48px rgba(217, 180, 92, 0.4);
+  }
+}
+
+.cardLocked {
+  filter: saturate(0.55) brightness(0.72);
+}
+
+.handCaption {
+  margin: 8px 0 0;
+  font-size: var(--font-sm);
+  color: var(--ln-muted);
+}
+
+/* Small screens: the fan becomes a scrolling row. */
+@media (max-width: 860px) {
+  .hand {
+    height: auto;
+    margin-top: 36px;
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    padding: 12px 8px 20px;
+    justify-content: flex-start;
+    scroll-snap-type: x mandatory;
+  }
+
+  .handSlot {
+    position: static;
+    margin-left: 0;
+    flex: 0 0 auto;
+    transform: none !important;
+    scroll-snap-align: center;
+  }
+}
+
+/* =========================================================================
+ * Mission brief
+ * ========================================================================= */
+.brief {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 40px 20px 60px;
+}
+
+.briefHeader {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  padding-bottom: 26px;
+  border-bottom: 1px solid var(--ln-line);
+  margin-bottom: 30px;
+}
+
+.lessonKicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ln-muted);
+}
+
+.lessonSwatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--frame);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4) inset;
+}
+
+.lessonTitle {
+  font-family: var(--ln-display);
+  font-weight: 400;
+  font-size: clamp(34px, 5vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  color: var(--ln-paper);
+  margin: 0;
+}
+
+.lessonBlurb {
+  margin: 0;
+  font-size: 17px;
+  color: var(--ln-body);
+  max-width: 56ch;
+}
+
+.briefBody {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 40px;
+  align-items: start;
+}
+
+.briefColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.briefHeading {
+  font-family: var(--ln-display);
+  font-weight: 400;
+  font-size: 22px;
+  color: var(--ln-paper);
+  margin: 10px 0 0;
+}
+
+.briefHeading:first-child {
+  margin-top: 0;
+}
+
+/* The three things you will do — numbered because they are the order you will do them in. */
+.briefList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.briefList li {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 12px;
+  align-items: start;
+  font-size: 15.5px;
+}
+
+.briefIndex {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ln-gold);
+  color: var(--ln-gold);
+  font-size: 11px;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  margin-top: 1px;
+}
+
+.briefNote {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--ln-muted);
+}
+
+.briefCards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.nameField {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.nameInput {
+  font: inherit;
+  font-size: 15px;
+  color: var(--ln-paper);
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--ln-line-strong);
+  border-radius: 8px;
+  padding: 11px 14px;
+  min-width: 200px;
+}
+
+.nameInput:focus {
+  outline: none;
+  border-color: var(--ln-gold);
+}
+
+.errorText {
+  color: var(--ln-bad);
+  font-size: 14px;
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .briefBody {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+/* ---- Real card images ---------------------------------------------------- */
+.cardImg {
+  display: block;
+  width: 100%;
+  aspect-ratio: 488 / 680;
+  border-radius: 4.5% / 3.2%;
+  background: #1a1a22;
+  object-fit: cover;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
+}
+
+.cardName {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--ln-muted);
+  text-align: center;
+}
+
+/* Mini hand: the course's cards as a strip at the foot of each brief. */
+.miniHand {
+  margin-top: 44px;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.miniCard {
+  --frame: var(--frame-W);
+  width: 36px;
+  height: 50px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.25), transparent 50%), var(--frame);
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #1d1a12;
+  cursor: pointer;
+  text-decoration: none;
+  opacity: 0.55;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  position: relative;
+}
+
+.miniCard:hover {
+  opacity: 1;
+  transform: translateY(-3px);
+}
+
+.miniCardDark {
+  color: #efe6cf;
+}
+
+.miniCardActive {
+  opacity: 1;
+  box-shadow: 0 0 0 2px var(--ln-gold);
+}
+
+.miniCardDone::after {
+  content: '✓';
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--ln-gold);
+  color: #1a1408;
+  font-size: 9px;
+  display: grid;
+  place-items: center;
+}
+
+/* =========================================================================
+ * Course complete
+ * ========================================================================= */
+.doneBanner {
+  margin: 36px auto 0;
+  max-width: 560px;
+  padding: 22px 26px;
+  border-radius: 12px;
+  border: 1px solid rgba(217, 180, 92, 0.45);
+  background: rgba(217, 180, 92, 0.07);
+  text-align: center;
+}
+
+.doneBanner h2 {
+  font-family: var(--ln-display);
+  font-weight: 400;
+  font-size: 28px;
+  color: var(--ln-paper);
+  margin: 0 0 8px;
+}
+
+.doneBanner p {
+  margin: 0 0 14px;
+}
+
+/* =========================================================================
+ * Reduced motion
+ * ========================================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .handSlot,
+  .cta {
+    transition: none;
+  }
+
+  .cardDone::after,
+  .cardNext {
+    animation: none;
+  }
+}

--- a/web-client/src/components/learn/useLessonCards.ts
+++ b/web-client/src/components/learn/useLessonCards.ts
@@ -1,0 +1,68 @@
+/**
+ * Real card images for the lessons, by name.
+ *
+ * One request per page for exactly the cards it shows, through the catalog's own search endpoint
+ * (`!"Name" or !"Name"` is the exact-name form the deckbuilder's query language already speaks).
+ * The full `/api/cards` catalog is thousands of cards and the deckbuilder's business; a lesson
+ * needs four. Falls back to the Scryfall-by-name image so a lesson still renders when the server
+ * lacks a printing image — `getCardImageUrl` does that for every other card in the client.
+ */
+import { useEffect, useState } from 'react'
+import type { CardSummary } from '@/components/deckbuilder/cardFilter'
+import { getCardImageUrl } from '@/utils/cardImages'
+
+export interface LessonCard {
+  name: string
+  imageUrl: string
+  summary: CardSummary | null
+}
+
+const cache = new Map<string, Promise<Map<string, CardSummary>>>()
+
+function fetchSummaries(names: readonly string[]): Promise<Map<string, CardSummary>> {
+  const key = [...names].sort().join('|')
+  const cached = cache.get(key)
+  if (cached) return cached
+  const q = names.map((n) => `!"${n.replace(/"/g, '')}"`).join(' or ')
+  const promise = fetch(`/api/cards/search?q=${encodeURIComponent(q)}`)
+    .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+    .then((body: { cards?: CardSummary[] }) => {
+      const index = new Map<string, CardSummary>()
+      for (const card of body.cards ?? []) index.set(card.name, card)
+      return index
+    })
+    .catch(() => new Map<string, CardSummary>())
+  cache.set(key, promise)
+  return promise
+}
+
+/** Resolve a fixed list of card names to images. Stable across renders for the same names. */
+export function useLessonCards(names: readonly string[]): Record<string, LessonCard> {
+  const key = names.join('|')
+  const [cards, setCards] = useState<Record<string, LessonCard>>(() => fallback(names))
+
+  useEffect(() => {
+    let cancelled = false
+    const wanted = key.split('|').filter(Boolean)
+    fetchSummaries(wanted).then((index) => {
+      if (cancelled) return
+      const next: Record<string, LessonCard> = {}
+      for (const name of wanted) {
+        const summary = index.get(name) ?? null
+        next[name] = { name, imageUrl: getCardImageUrl(name, summary?.imageUri ?? undefined, 'normal'), summary }
+      }
+      setCards(next)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [key])
+
+  return cards
+}
+
+function fallback(names: readonly string[]): Record<string, LessonCard> {
+  const out: Record<string, LessonCard> = {}
+  for (const name of names) out[name] = { name, imageUrl: getCardImageUrl(name, undefined, 'normal'), summary: null }
+  return out
+}

--- a/web-client/src/components/ui/HomeScreen.tsx
+++ b/web-client/src/components/ui/HomeScreen.tsx
@@ -27,6 +27,7 @@ import { AuthWidget } from '@/components/auth/AuthWidget'
 import { LoginModal } from '@/components/auth/LoginModal'
 import { DeckMigrationPrompt } from '@/components/auth/DeckMigrationPrompt'
 import { AccountBenefitsCallout } from '@/components/auth/AccountBenefitsCallout'
+import { LearnCallout } from '@/components/learn/LearnCallout'
 import { FullscreenButton } from './FullscreenButton'
 import { PlayWizard } from './PlayWizard'
 import { SetupRail } from './SetupRail'
@@ -331,6 +332,13 @@ export function HomeScreen({
               while the account check is in flight so the prompt can't flash and vanish. */}
           {!nameConfirmed && !connectName && !nameResolving && (
             <div className={styles.inputGroup}>
+              {/* The one screen a first-time visitor sees. Someone who has never played Magic
+                  needs the course before they need a name, so it comes first — unless they arrived
+                  with an invite code or a game token, in which case they are here to join a
+                  table, not to learn. */}
+              {!joinSessionId && !new URLSearchParams(window.location.search).has('token') && (
+                <LearnCallout variant="arrival" />
+              )}
               <label className={styles.inputLabel}>{joinSessionId ? 'Enter your name to join' : 'Enter your name'}</label>
               <input
                 type="text"
@@ -417,6 +425,9 @@ export function HomeScreen({
                   </div>
                 )}
 
+                {/* Quiet row for a connected player who has not finished the course; gone once
+                    they have. The `/help` guide keeps a link for anyone who wants it back. */}
+                <LearnCallout variant="tier" />
                 <AccountBenefitsCallout onCreateAccount={() => setLoginOpen(true)} />
                 <DeckMigrationPrompt />
               </section>

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -81,6 +81,18 @@ export const HELP_SECTIONS: readonly { id: HelpSection; title: string; blurb: st
 export const HELP_TOPICS: readonly HelpTopic[] = [
   // ── Getting started ────────────────────────────────────────────────────
   {
+    id: 'learn-to-play',
+    section: 'getting-started',
+    title: 'New to Magic itself?',
+    summary:
+      'This guide assumes you know the game. If you do not, the Learn to Play course teaches it by playing: four short games against the AI, each from a board set up to teach one thing, with a coach saying what to do next.',
+    body: [
+      { kind: 'p', text: 'The course lives at /learn and needs no name or account. Progress is kept in this browser; the landing page points at it until you have finished.' },
+    ],
+    links: [{ label: 'Learn to play', href: '/learn' }],
+    related: ['first-game'],
+  },
+  {
     id: 'pick-a-name',
     section: 'getting-started',
     title: 'Picking a name',

--- a/web-client/src/learn/coach.test.ts
+++ b/web-client/src/learn/coach.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { coachTip, type CoachView } from './coach'
+
+const base: CoachView = {
+  turnNumber: 3,
+  step: 'PRECOMBAT_MAIN',
+  isMyTurn: true,
+  hasPriority: true,
+  canPlayLand: false,
+  canCast: false,
+  canAttack: false,
+  canBlock: false,
+  hasDecision: false,
+  attackersIncoming: 0,
+  passLabel: 'Pass to Attackers',
+  isGameOver: false,
+  won: null,
+}
+
+describe('coachTip', () => {
+  it('says to play a land before casting when both are possible', () => {
+    expect(coachTip({ ...base, canPlayLand: true, canCast: true }).key).toBe('land-and-cast')
+  })
+
+  it('points at the land when that is the only play', () => {
+    expect(coachTip({ ...base, canPlayLand: true }).key).toBe('land')
+  })
+
+  it('points at castable cards once the land is down', () => {
+    expect(coachTip({ ...base, canCast: true }).key).toBe('cast')
+  })
+
+  it('tells the player to pass out of an empty main phase', () => {
+    expect(coachTip(base).key).toBe('pass-to-combat')
+    expect(coachTip({ ...base, step: 'POSTCOMBAT_MAIN' }).key).toBe('pass')
+  })
+
+  it('ranks the combat prompts above everything but a decision', () => {
+    expect(coachTip({ ...base, canAttack: true, canPlayLand: true, canCast: true }).key).toBe('attack')
+    expect(coachTip({ ...base, isMyTurn: false, canBlock: true, attackersIncoming: 2 }).title).toBe(
+      '2 creatures are attacking you.',
+    )
+    expect(coachTip({ ...base, canBlock: true, hasDecision: true }).key).toBe('decision')
+  })
+
+  it('distinguishes responding on their turn from waiting', () => {
+    expect(coachTip({ ...base, isMyTurn: false }).key).toBe('respond')
+    expect(coachTip({ ...base, isMyTurn: false, canCast: true }).body).toMatch(/instant right now/)
+    expect(coachTip({ ...base, isMyTurn: false, hasPriority: false }).key).toBe('waiting')
+  })
+
+  it('has a first-turn tip while the game is still settling', () => {
+    expect(coachTip({ ...base, turnNumber: 1, hasPriority: false }).key).toBe('first-turn')
+  })
+
+  it('lets a mission re-word a tip by key without changing its tone', () => {
+    const tip = coachTip({ ...base, canPlayLand: true }, { land: { title: 'Play the Forest.', body: 'Click it.' } })
+    expect(tip).toEqual({ key: 'land', title: 'Play the Forest.', body: 'Click it.', tone: 'act' })
+    expect(coachTip({ ...base, canCast: true }, { land: { title: 'x', body: 'y' } }).key).toBe('cast')
+  })
+
+  it('names the real button wherever a tip says to press it', () => {
+    expect(coachTip(base).body).toMatch(/Press Pass to Attackers,/)
+    expect(coachTip({ ...base, step: 'POSTCOMBAT_MAIN', passLabel: 'End Turn' }).body).toMatch(/^Press End Turn\./)
+    expect(coachTip({ ...base, passLabel: 'End Turn' }, { 'pass-to-combat': { title: 'Hit {pass}.', body: 'x' } }).title).toBe('Hit End Turn.')
+  })
+
+  it('closes with the result, whatever it was', () => {
+    expect(coachTip({ ...base, isGameOver: true, won: true }).tone).toBe('done')
+    expect(coachTip({ ...base, isGameOver: true, won: false }).key).toBe('lost')
+    expect(coachTip({ ...base, isGameOver: true, won: null }).key).toBe('draw')
+    // Game over beats every live prompt.
+    expect(coachTip({ ...base, isGameOver: true, won: true, canAttack: true, hasDecision: true }).key).toBe('won')
+  })
+})

--- a/web-client/src/learn/coach.ts
+++ b/web-client/src/learn/coach.ts
@@ -1,0 +1,230 @@
+/**
+ * The in-game coach for the course's missions: one tip at a time, chosen from what the board is
+ * asking of the player right now.
+ *
+ * Pure: {@link coachTip} takes a small projection of the game state and returns the tip to show,
+ * so the rules are testable without a store. A mission can re-word any tip by its key
+ * (`Mission.hints`); the React overlay (`LearnCoach.tsx`) does the projecting and the drawing.
+ *
+ * The coach is armed with a mission id by the brief that starts the game and disarmed when that
+ * game ends — it rides sessionStorage because the hand-off into a scenario game is a full
+ * navigation (`/?token=…`), which drops React state but not the tab.
+ */
+import type { MissionId } from './missions'
+import { missionById } from './missions'
+
+const COACH_KEY = 'argentum.learn.coach'
+const INTRO_KEY = 'argentum.learn.coach.intro'
+
+export function armCoach(mission: MissionId) {
+  try {
+    sessionStorage.setItem(COACH_KEY, mission)
+    sessionStorage.removeItem(INTRO_KEY)
+  } catch {
+    // Storage unavailable — the game still starts, just without a coach.
+  }
+}
+
+/**
+ * The intro card is shown once per game. It rides sessionStorage rather than component state
+ * because the board unmounts and remounts across a reconnect or a resync, and the coach with it.
+ */
+export function introSeen(): boolean {
+  try {
+    return sessionStorage.getItem(INTRO_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function markIntroSeen() {
+  try {
+    sessionStorage.setItem(INTRO_KEY, '1')
+  } catch {
+    // Then the intro shows again after a remount; nothing worse.
+  }
+}
+
+export function disarmCoach() {
+  try {
+    sessionStorage.removeItem(COACH_KEY)
+    sessionStorage.removeItem(INTRO_KEY)
+  } catch {
+    // Nothing to remove.
+  }
+}
+
+/** The mission the coach was armed for, or null when this game was not started by the course. */
+export function armedMission(): MissionId | null {
+  try {
+    return missionById(sessionStorage.getItem(COACH_KEY))?.id ?? null
+  } catch {
+    return null
+  }
+}
+
+/** What the coach needs to know — derived from the client game state and the server's legal actions. */
+export interface CoachView {
+  turnNumber: number
+  step: string
+  isMyTurn: boolean
+  hasPriority: boolean
+  /** Server says a land can be played right now. */
+  canPlayLand: boolean
+  /** Server says at least one spell in hand is castable right now. */
+  canCast: boolean
+  /** The declare-attackers choice is open. */
+  canAttack: boolean
+  /** The declare-blockers choice is open. */
+  canBlock: boolean
+  /** Some other decision (a target, a "may", a discard) is waiting on the player. */
+  hasDecision: boolean
+  attackersIncoming: number
+  /**
+   * What the big button at the bottom right says right now — "Pass", "Pass to Attackers",
+   * "End Turn", "Resolve". The server computes it; the coach names it so the tip and the button
+   * agree.
+   */
+  passLabel: string
+  isGameOver: boolean
+  won: boolean | null
+}
+
+export interface CoachTip {
+  /** Stable key so the overlay can animate only when the tip actually changes. */
+  key: string
+  title: string
+  body: string
+  /** Tone drives the accent colour: what to do now, what is happening, or the end of the game. */
+  tone: 'act' | 'watch' | 'done'
+}
+
+export function coachTip(view: CoachView, overrides: Partial<Record<string, { title: string; body: string }>> = {}): CoachTip {
+  const tip = baseTip(view)
+  const override = overrides[tip.key]
+  const merged = override ? { ...tip, ...override } : tip
+  // `{pass}` in any tip is the button's current label, so "press {pass}" always names the real button.
+  return { ...merged, title: merged.title.replaceAll('{pass}', view.passLabel), body: merged.body.replaceAll('{pass}', view.passLabel) }
+}
+
+function baseTip(view: CoachView): CoachTip {
+  if (view.isGameOver) {
+    if (view.won === true) {
+      return {
+        key: 'won',
+        title: 'You won.',
+        body: 'Mission complete. The next card in the hand is waiting — or play this one again.',
+        tone: 'done',
+      }
+    }
+    if (view.won === false) {
+      return {
+        key: 'lost',
+        title: 'Game over.',
+        body: 'That was a real game, and losing one is how everybody starts. Play it again, or move on — the mission counts either way.',
+        tone: 'done',
+      }
+    }
+    return { key: 'draw', title: 'A draw.', body: 'Rare, but it happens. The mission counts.', tone: 'done' }
+  }
+
+  if (view.hasDecision) {
+    return {
+      key: 'decision',
+      title: 'The game is asking you something.',
+      body: 'Read the prompt — it might want a target, a choice, or a yes/no. Click a highlighted card to pick it.',
+      tone: 'act',
+    }
+  }
+
+  if (view.canBlock) {
+    return {
+      key: 'block',
+      title:
+        view.attackersIncoming > 1
+          ? `${view.attackersIncoming} creatures are attacking you.`
+          : 'A creature is attacking you.',
+      body: 'Drag one of your untapped creatures onto the attacker it should block (or click the creature, then the attacker). A blocked attacker hits your creature instead of you. Then press Confirm Blocks — or No Blocks to take the hit.',
+      tone: 'act',
+    }
+  }
+
+  if (view.canAttack) {
+    return {
+      key: 'attack',
+      title: 'Combat — your creatures can attack.',
+      body: 'Click a creature to send it in, then Attack with N — or Attack All. Attackers tap, so think about what you leave back to block on their turn. Skip Attacking is always allowed.',
+      tone: 'act',
+    }
+  }
+
+  if (view.isMyTurn && view.hasPriority) {
+    if (view.canPlayLand && view.canCast) {
+      return {
+        key: 'land-and-cast',
+        title: 'Your main phase.',
+        body: 'Play a land first — click it in your hand, then Play. Then click a creature or spell you can afford and Cast it; your lands tap for you.',
+        tone: 'act',
+      }
+    }
+    if (view.canPlayLand) {
+      return {
+        key: 'land',
+        title: 'Play a land.',
+        body: 'One per turn, and it never costs anything. Click a land in your hand, then Play — more lands next turn means bigger spells next turn.',
+        tone: 'act',
+      }
+    }
+    if (view.canCast) {
+      return {
+        key: 'cast',
+        title: 'You can cast something.',
+        body: 'Cards you can afford light up in your hand. Click one, then Cast. Nothing worth casting? Press {pass} to move on.',
+        tone: 'act',
+      }
+    }
+    if (view.step === 'PRECOMBAT_MAIN') {
+      return {
+        key: 'pass-to-combat',
+        title: 'Nothing left to play.',
+        body: 'Press {pass}, the blue button at the bottom right. If you have a creature that can attack, the game will stop at combat and ask.',
+        tone: 'act',
+      }
+    }
+    return {
+      key: 'pass',
+      title: 'Nothing to do here.',
+      body: 'Press {pass}. The game moves on, and hands the turn over when yours is done.',
+      tone: 'act',
+    }
+  }
+
+  if (!view.isMyTurn && view.hasPriority) {
+    return {
+      key: 'respond',
+      title: 'Their turn — you have a moment to respond.',
+      body: view.canCast
+        ? 'You can cast an instant right now, before their spell resolves — click it, then Cast. Otherwise, press {pass}.'
+        : 'Nothing you can cast at instant speed, so press {pass} and watch what they do.',
+      tone: 'watch',
+    }
+  }
+
+  if (view.turnNumber <= 1 && view.isMyTurn) {
+    return {
+      key: 'first-turn',
+      title: 'This is your first turn.',
+      body: 'The strip at the top shows where in the turn you are. You get the board back the moment there is something to decide.',
+      tone: 'watch',
+    }
+  }
+
+  return {
+    key: 'waiting',
+    title: view.isMyTurn ? 'The game is working through your turn.' : 'The opponent is thinking.',
+    body: view.isMyTurn
+      ? 'Steps with nothing to decide pass on their own. You get the board back the moment there is something to do.'
+      : 'When they attack you will be asked to block. When they cast a spell you may get a chance to respond.',
+    tone: 'watch',
+  }
+}

--- a/web-client/src/learn/missions.test.ts
+++ b/web-client/src/learn/missions.test.ts
@@ -1,0 +1,163 @@
+/**
+ * A mission is only as good as its card list: a name the corpus does not know makes the server
+ * reject the whole scenario, and the course's card becomes a dead end. So every name is checked
+ * against the card definition files in `mtg-sets/` — the same tree `CardDiscovery` scans.
+ *
+ * Files are named after their card in PascalCase (`GrizzlyBears.kt`, `SerraAngelReprint.kt`),
+ * so the check is on file names alone and never reads a file. Basic lands are the one exception:
+ * `CardDiscovery` generates them, so they are whitelisted here.
+ */
+import { readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { ClientEvent } from '@/types/events'
+import type { ClientCard, ClientGameState } from '@/types/gameState'
+import type { EntityId } from '@/types'
+import { COURSE_MINUTES, MISSIONS, missionById, missionCardNames, nextMission, type ObjectiveContext } from './missions'
+import { hasStarted, nextIncomplete } from './progressStore'
+
+const SETS_ROOT = resolve(__dirname, '../../../mtg-sets')
+const BASICS = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest']
+
+/** `Mons's Goblin Raiders` → `monssgoblinraiders`; `SerraAngelReprint.kt` → `serraangel`. */
+function key(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function corpusKeys(): Set<string> {
+  const keys = new Set<string>(BASICS.map(key))
+  for (const entry of readdirSync(SETS_ROOT, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.kt')) continue
+    const dir = entry.parentPath ?? ''
+    if (!dir.includes('/src/main/') || !dir.includes('/definitions/') || !dir.includes('/cards')) continue
+    keys.add(key(entry.name.replace(/\.kt$/, '').replace(/Reprint$/, '')))
+  }
+  return keys
+}
+
+describe('the missions', () => {
+  it('use only cards the engine has', () => {
+    const known = corpusKeys()
+    expect(known.size).toBeGreaterThan(1000)
+    const unknown = missionCardNames().filter((n) => !known.has(key(n)))
+    expect(unknown).toEqual([])
+  })
+
+  it('are numbered 1..n in order, with unique ids and a win objective each', () => {
+    expect(MISSIONS.map((m) => m.number)).toEqual(MISSIONS.map((_, i) => i + 1))
+    expect(new Set(MISSIONS.map((m) => m.id)).size).toBe(MISSIONS.length)
+    for (const m of MISSIONS) {
+      expect(m.objectives.map((o) => o.id)).toContain('win')
+      expect(m.brief.length).toBe(3)
+      expect(m.openingCards.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('are all two-seat AI games inside the public endpoint limits', () => {
+    for (const m of MISSIONS) {
+      const spec = m.spec('Vincent')
+      expect(spec.mode).toBe('AI')
+      expect(spec.aiPlayer).toBe(2)
+      expect(spec.player1Name).toBe('Vincent')
+      for (const seat of [spec.player1, spec.player2]) {
+        expect(seat?.library?.length ?? 0).toBeLessThanOrEqual(100)
+        expect(seat?.library?.length ?? 0).toBeGreaterThanOrEqual(8)
+      }
+      // The opening cards the brief shows really are in the opening hand or on the board.
+      const opening = new Set([...(spec.player1?.hand ?? []), ...(spec.player1?.battlefield ?? []).map((c) => c.name)])
+      expect(m.openingCards.filter((n) => !opening.has(n))).toEqual([])
+    }
+  })
+
+  it('keeps the promise on the home page honest', () => {
+    expect(COURSE_MINUTES).toBeGreaterThanOrEqual(15)
+    expect(COURSE_MINUTES).toBeLessThanOrEqual(30)
+  })
+
+  it('walks forward', () => {
+    expect(nextMission('first-steps')?.id).toBe('blocking')
+    expect(nextMission('real-game')).toBeUndefined()
+    expect(missionById('nope')).toBeUndefined()
+  })
+})
+
+// ── Objective detection ─────────────────────────────────────────────────────
+
+const ME = 'p1' as unknown as EntityId
+const THEM = 'p2' as unknown as EntityId
+
+function cardOf(id: string, owner: EntityId, types: string[]): ClientCard {
+  return { id, name: id, cardTypes: types, ownerId: owner, controllerId: owner } as unknown as ClientCard
+}
+
+/** Event literals use plain-string ids; the brand is a compile-time fiction the log never sees. */
+function ctx(events: readonly object[], cards: ClientCard[], extra: Partial<ClientGameState> = {}): ObjectiveContext {
+  const state = {
+    viewingPlayerId: ME,
+    cards: Object.fromEntries(cards.map((c) => [c.id, c])),
+    gameLog: events as unknown as ClientEvent[],
+    isGameOver: false,
+    winnerId: null,
+    ...extra,
+  } as unknown as ClientGameState
+  return { state, me: ME, won: null }
+}
+
+const objective = (missionId: string, id: string) => {
+  const o = missionById(missionId)?.objectives.find((x) => x.id === id)
+  if (!o) throw new Error(`no objective ${id} in ${missionId}`)
+  return o
+}
+
+describe('objectives', () => {
+  it('sees a land you played, not one the opponent played', () => {
+    const land = objective('first-steps', 'land')
+    const mine = { type: 'permanentEntered', cardId: 'f1', cardName: 'Forest', controllerId: ME, enteredTapped: false, description: '' } as const
+    expect(land.done(ctx([mine], [cardOf('f1', ME, ['LAND'])]))).toBe(true)
+    expect(land.done(ctx([{ ...mine, controllerId: THEM }], [cardOf('f1', THEM, ['LAND'])]))).toBe(false)
+    // A creature entering is not a land; the server's casing is upper, but either casing must read.
+    expect(land.done(ctx([mine], [cardOf('f1', ME, ['CREATURE'])]))).toBe(false)
+    expect(land.done(ctx([mine], [cardOf('f1', ME, ['Land'])]))).toBe(true)
+  })
+
+  it('tells a creature spell from an instant', () => {
+    const cast = { type: 'spellCast', spellId: 's1', spellName: 'x', casterId: ME, description: '' } as const
+    expect(objective('first-steps', 'creature').done(ctx([cast], [cardOf('s1', ME, ['CREATURE'])]))).toBe(true)
+    expect(objective('first-steps', 'creature').done(ctx([cast], [cardOf('s1', ME, ['INSTANT'])]))).toBe(false)
+    expect(objective('instants', 'instant').done(ctx([cast], [cardOf('s1', ME, ['INSTANT'])]))).toBe(true)
+  })
+
+  it('credits attacks and blocks to the right seat', () => {
+    const attack = { type: 'creatureAttacked', creatureId: 'c1', creatureName: 'x', attackingPlayerId: ME, defendingPlayerId: THEM, description: '' } as const
+    expect(objective('first-steps', 'attack').done(ctx([attack], []))).toBe(true)
+    expect(objective('first-steps', 'attack').done(ctx([{ ...attack, attackingPlayerId: THEM }], []))).toBe(false)
+
+    const block = { type: 'creatureBlocked', blockerId: 'b1', blockerName: 'x', attackerId: 'a1', attackerName: 'y', description: '' } as const
+    expect(objective('blocking', 'block').done(ctx([block], [cardOf('b1', ME, ['CREATURE'])]))).toBe(true)
+    expect(objective('blocking', 'block').done(ctx([block], [cardOf('b1', THEM, ['CREATURE'])]))).toBe(false)
+  })
+
+  it('counts only their creatures dying', () => {
+    const died = { type: 'creatureDied', creatureId: 'c1', creatureName: 'x', description: '' } as const
+    expect(objective('blocking', 'kill').done(ctx([died], [cardOf('c1', THEM, ['CREATURE'])]))).toBe(true)
+    expect(objective('blocking', 'kill').done(ctx([died], [cardOf('c1', ME, ['CREATURE'])]))).toBe(false)
+  })
+
+  it('wins from the store result or the state', () => {
+    const win = objective('real-game', 'win')
+    expect(win.done(ctx([], []))).toBe(false)
+    expect(win.done({ ...ctx([], []), won: true })).toBe(true)
+    expect(win.done(ctx([], [], { isGameOver: true, winnerId: ME }))).toBe(true)
+    expect(win.done(ctx([], [], { isGameOver: true, winnerId: THEM }))).toBe(false)
+  })
+})
+
+describe('progress helpers', () => {
+  it('continues at the first unfinished mission, in course order', () => {
+    expect(nextIncomplete([])).toBe('first-steps')
+    expect(nextIncomplete(['first-steps', 'instants'])).toBe('blocking')
+    expect(nextIncomplete(MISSIONS.map((m) => m.id))).toBeUndefined()
+    expect(hasStarted({ completed: [] })).toBe(false)
+    expect(hasStarted({ completed: ['first-steps'] })).toBe(true)
+  })
+})

--- a/web-client/src/learn/missions.ts
+++ b/web-client/src/learn/missions.ts
@@ -1,0 +1,463 @@
+/**
+ * The Learn to Play course: four short games, each one a card in the hand on `/learn`.
+ *
+ * Nothing here is read. Every mission is a scripted board sent to the production `/api/scenarios`
+ * endpoint with the built-in AI in the other seat, and the teaching happens on the real game
+ * board through the coach panel: a handful of objectives that tick off as the player does them,
+ * and one line at a time saying what the board is waiting for.
+ *
+ * The boards are built so the first decision is a real one. A fresh player at a 60-card table
+ * spends three turns playing lands and learning patience; here both seats start with lands down
+ * and something to do. Libraries are listed top-first (the engine draws `library.first()`), so
+ * the opening draws are scripted — a land, then a creature that costs exactly what the lands make,
+ * then a trick. Every card is a corpus card using only what the mission has already shown.
+ *
+ * Audience: has never played Magic. The `/help` guide deliberately assumes you know the game and
+ * explains *this app*; this course is the other half.
+ */
+import type { ScenarioSpec } from '@/components/scenario/types'
+import type { ClientCard, ClientGameState } from '@/types/gameState'
+import type { EntityId } from '@/types'
+
+export type MissionId = 'first-steps' | 'blocking' | 'instants' | 'real-game'
+
+/**
+ * The frame colour each mission card wears — one of Magic's colours, gold for multicolour,
+ * silver for the artifact frame. The colour wheel is met through the course before it is named.
+ */
+export type MissionFrame = 'W' | 'U' | 'B' | 'R' | 'G' | 'gold' | 'artifact'
+
+/** What the coach needs to judge an objective: the whole client state, and who "you" are. */
+export interface ObjectiveContext {
+  state: ClientGameState
+  me: EntityId
+  /** Set once the game is over, from the store's game-over state. */
+  won: boolean | null
+}
+
+export interface Objective {
+  id: string
+  label: string
+  /** Pure: true once the log (or the board) shows it happened. */
+  done: (ctx: ObjectiveContext) => boolean
+}
+
+/** Mission-specific wording for a coach tip key; the generic tip is used where none is given. */
+export interface HintOverride {
+  title: string
+  body: string
+}
+
+export interface Mission {
+  id: MissionId
+  /** 1-based position in the course; the draw order of the hand. */
+  number: number
+  title: string
+  /** The one-line promise on the mission card. */
+  blurb: string
+  frame: MissionFrame
+  /** Honest playing time. */
+  minutes: number
+  /** What the brief says you will do — three lines, no more. */
+  brief: readonly string[]
+  /** What the board shows first, so the brief can put the cards on the table before the game does. */
+  openingCards: readonly string[]
+  objectives: readonly Objective[]
+  /** Shown once, when the board first appears. */
+  intro: string
+  hints: Partial<Record<string, HintOverride>>
+  spec: (playerName: string) => ScenarioSpec
+}
+
+/** The name the AI seat plays under. A "tutor" is also what Magic calls a card that finds another. */
+export const TUTOR_NAME = 'Tutor'
+
+// ── Objective detectors ─────────────────────────────────────────────────────
+
+function card(ctx: ObjectiveContext, id: EntityId) {
+  return ctx.state.cards[id]
+}
+
+function log(ctx: ObjectiveContext) {
+  return ctx.state.gameLog ?? []
+}
+
+/** The server sends card types upper-case (`LAND`); compare case-blind so a casing change cannot silently blind an objective. */
+function hasType(card: ClientCard | undefined, type: string): boolean {
+  return card !== undefined && card.cardTypes.some((t) => t.toUpperCase() === type)
+}
+
+const playedLand: Objective = {
+  id: 'land',
+  label: 'Play a land',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'permanentEntered' || e.controllerId !== ctx.me) return false
+      return hasType(card(ctx, e.cardId), 'LAND')
+    }),
+}
+
+const castCreature: Objective = {
+  id: 'creature',
+  label: 'Cast a creature',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'spellCast' || e.casterId !== ctx.me) return false
+      return hasType(card(ctx, e.spellId), 'CREATURE')
+    }),
+}
+
+const attacked: Objective = {
+  id: 'attack',
+  label: 'Attack with a creature',
+  done: (ctx) => log(ctx).some((e) => e.type === 'creatureAttacked' && e.attackingPlayerId === ctx.me),
+}
+
+const blocked: Objective = {
+  id: 'block',
+  label: 'Block an attacker',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'creatureBlocked') return false
+      const c = card(ctx, e.blockerId)
+      return c !== undefined && c.ownerId === ctx.me
+    }),
+}
+
+const killedInCombat: Objective = {
+  id: 'kill',
+  label: 'Kill one of their creatures',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'creatureDied') return false
+      const c = card(ctx, e.creatureId)
+      return c !== undefined && c.ownerId !== ctx.me
+    }),
+}
+
+const castInstant: Objective = {
+  id: 'instant',
+  label: 'Cast an instant',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'spellCast' || e.casterId !== ctx.me) return false
+      return hasType(card(ctx, e.spellId), 'INSTANT')
+    }),
+}
+
+const won: Objective = {
+  id: 'win',
+  label: 'Win the game',
+  done: (ctx) => ctx.won === true || (ctx.state.isGameOver && ctx.state.winnerId === ctx.me),
+}
+
+// ── Decks ────────────────────────────────────────────────────────────────────
+
+/** Repeat lands between spells so a list reads as a curve, top-first. */
+function curve(spells: readonly string[], lands: readonly string[]): string[] {
+  const out: string[] = []
+  spells.forEach((spell, i) => {
+    out.push(lands[i % lands.length]!)
+    out.push(spell)
+  })
+  return out
+}
+
+const GREEN_WHITE_SPELLS = [
+  'Centaur Courser',
+  'Giant Growth',
+  'Silvercoat Lion',
+  'Trained Armodon',
+  'Pacifism',
+  'Youthful Knight',
+  'Giant Spider',
+  'Rumbling Baloth',
+  'Titanic Growth',
+  'Serra Angel',
+  'Divine Verdict',
+  'Pillarfield Ox',
+  'Craw Wurm',
+  'Oakenform',
+  'Elvish Warrior',
+]
+
+const RED_BLACK_SPELLS = [
+  'Gray Ogre',
+  'Shock',
+  'Walking Corpse',
+  'Bloodrock Cyclops',
+  'Lightning Strike',
+  'Child of Night',
+  'Scathe Zombies',
+  'Thundering Giant',
+  'Doom Blade',
+  'Raging Goblin',
+  'Mind Rot',
+  'Bog Imp',
+  'Hill Giant',
+  'Volcanic Hammer',
+  'Drudge Skeletons',
+]
+
+const GW_LANDS = ['Forest', 'Plains']
+const RB_LANDS = ['Mountain', 'Swamp']
+
+// ── Missions ────────────────────────────────────────────────────────────────
+
+export const MISSIONS: readonly Mission[] = [
+  {
+    id: 'first-steps',
+    number: 1,
+    title: 'First steps',
+    blurb: 'Play lands, cast creatures, attack. The opponent will not fight back — this one is yours.',
+    frame: 'G',
+    minutes: 4,
+    brief: [
+      'Play one land a turn and tap them for mana — your lands tap on their own when you cast.',
+      'Cast creatures. A creature that just arrived has to wait a turn before it can attack.',
+      'Attack with what can attack. Get the Tutor from 8 life to 0.',
+    ],
+    openingCards: ['Forest', 'Grizzly Bears', 'Runeclaw Bear'],
+    objectives: [playedLand, castCreature, attacked, won],
+    intro:
+      'This is the table. Your cards are at the bottom — the hand you can play from — and your lands and creatures go on the battlefield above them. Up top is the Tutor, on 8 life. Bring that to zero.',
+    hints: {
+      land: {
+        title: 'Play a land.',
+        body: 'Click the Forest in your hand, then Play Forest. Lands are free, one per turn, and every land you have is one more mana next turn.',
+      },
+      'land-and-cast': {
+        title: 'Land first, then a creature.',
+        body: 'Click the Forest in your hand, then Play Forest. Then click Grizzly Bears and Cast it — it costs two mana, and your lands tap for you.',
+      },
+      cast: {
+        title: 'Cast a creature.',
+        body: 'The cards you can afford light up. Click Grizzly Bears, then Cast. It lands on the battlefield, but it cannot attack until your next turn — that is summoning sickness.',
+      },
+      attack: {
+        title: 'Attack!',
+        body: 'Press Attack All — or click a creature and then Attack with 1. The Tutor has nothing to block with, so every point of power goes straight to their life total.',
+      },
+      'pass-to-combat': {
+        title: 'Nothing left to do — press {pass}.',
+        body: 'It is the blue button at the bottom right. The turn moves on; if a creature of yours can attack, the game stops at combat and asks you.',
+      },
+      pass: {
+        title: 'Nothing to do here — press {pass}.',
+        body: 'The Tutor takes a turn, then it is back to you with a fresh card drawn. A creature you cast this turn can attack on the next one.',
+      },
+      waiting: {
+        title: 'The Tutor is taking a turn.',
+        body: 'They will play a land and pass. Watch the phase strip at the top — it comes back to you soon.',
+      },
+    },
+    spec: (name) => ({
+      player1Name: name,
+      player2Name: TUTOR_NAME,
+      player1: {
+        lifeTotal: 20,
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }],
+        hand: ['Forest', 'Grizzly Bears', 'Runeclaw Bear'],
+        library: curve(['Centaur Courser', 'Elvish Warrior', 'Trained Armodon', 'Rumbling Baloth', 'Craw Wurm'], ['Forest']),
+      },
+      player2: {
+        lifeTotal: 8,
+        battlefield: [{ name: 'Mountain' }],
+        hand: ['Mountain', 'Mountain'],
+        library: ['Mountain', 'Swamp', 'Mountain', 'Swamp', 'Mountain', 'Swamp', 'Mountain', 'Swamp', 'Mountain', 'Swamp'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+      priorityPlayer: 1,
+      mode: 'AI',
+      aiPlayer: 2,
+    }),
+  },
+  {
+    id: 'blocking',
+    number: 2,
+    title: 'Holding the line',
+    blurb: 'The Tutor’s Cyclops has to attack every turn. Block well, lose nothing, then turn the game around.',
+    frame: 'W',
+    minutes: 5,
+    brief: [
+      'When they attack, each of your untapped creatures can block one attacker.',
+      'A blocked attacker hits your creature instead of you. Compare power against toughness before you block.',
+      'You start on 14 life with one creature. Their Bloodrock Cyclops must attack every turn — make it pay, then build up and win.',
+    ],
+    openingCards: ['Giant Spider', 'Centaur Courser', 'Benalish Knight'],
+    objectives: [blocked, killedInCombat, won],
+    intro:
+      'It is the Tutor’s turn, and they have two creatures to your one. Their Bloodrock Cyclops (3/3) is forced to attack every combat. Your Giant Spider is a 2/4 — four toughness means it survives three damage. When they attack, put it in front of the biggest thing coming.',
+    hints: {
+      block: {
+        title: 'Choose your blocks.',
+        body: 'Drag Giant Spider onto the Cyclops (or click the Spider, then the Cyclops). It survives 3 damage, so that block costs you nothing; whatever is unblocked hits you. Then press Confirm Blocks.',
+      },
+      'land-and-cast': {
+        title: 'Your turn — build up.',
+        body: 'Click a land in your hand and play it, then click a creature and cast it. Centaur Courser is a 3/3: it kills the Ogre and survives, and trades with the Cyclops.',
+      },
+      attack: {
+        title: 'Attack — but count first.',
+        body: 'Click the creatures to send in, then Attack with N. Anything that attacks is tapped on their turn and cannot block, so keep the Spider home if you still need a wall. Skip Attacking is fine too.',
+      },
+      respond: {
+        title: 'Their turn.',
+        body: 'You have nothing to cast at instant speed, so press {pass}. If they attack, you will be asked to block.',
+      },
+    },
+    spec: (name) => ({
+      player1Name: name,
+      player2Name: TUTOR_NAME,
+      player1: {
+        // Two unblocked swings (5 a turn) must not end the mission on the spot: 14 leaves room for one mistake.
+        lifeTotal: 14,
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }, { name: 'Plains' }, { name: 'Giant Spider', summoningSickness: false }],
+        hand: ['Plains', 'Centaur Courser', 'Benalish Knight'],
+        library: curve(['Trained Armodon', 'Silvercoat Lion', 'Rumbling Baloth', 'Pacifism', 'Serra Angel', 'Craw Wurm', 'Pillarfield Ox'], GW_LANDS),
+      },
+      player2: {
+        lifeTotal: 10,
+        battlefield: [
+          { name: 'Mountain' },
+          { name: 'Mountain' },
+          { name: 'Swamp' },
+          // "Attacks each combat if able" — the lesson's attack is guaranteed, not left to the AI's judgement.
+          { name: 'Bloodrock Cyclops', summoningSickness: false },
+          { name: 'Gray Ogre', summoningSickness: false },
+        ],
+        hand: ['Mountain', 'Goblin Piker'],
+        library: curve(['Walking Corpse', 'Hill Giant', 'Scathe Zombies', 'Raging Goblin', 'Bog Imp', 'Drudge Skeletons', 'Thundering Giant'], RB_LANDS),
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 2,
+      priorityPlayer: 2,
+      mode: 'AI',
+      aiPlayer: 2,
+    }),
+  },
+  {
+    id: 'instants',
+    number: 3,
+    title: 'In response',
+    blurb: 'The Tutor has burn spells. You have Giant Growth. Learn why the last spell cast happens first.',
+    frame: 'U',
+    minutes: 5,
+    brief: [
+      'Instants can be cast at almost any time — including while an opponent’s spell is waiting to resolve.',
+      'Spells go on the stack and resolve top-down: your response happens before the spell it answers.',
+      'When Lightning Bolt targets your bear, save it with Giant Growth. Then win.',
+    ],
+    openingCards: ['Grizzly Bears', 'Giant Growth', 'Centaur Courser'],
+    objectives: [castInstant, attacked, won],
+    intro:
+      'You have Grizzly Bears on the battlefield and Giant Growth in hand — an instant that gives +3/+3 until end of turn. It is the Tutor’s turn, and they have three Mountains. When a spell of theirs appears in the middle of the table, that is the stack, and the game will stop to ask if you want to respond.',
+    hints: {
+      respond: {
+        title: 'Respond!',
+        body: 'Their spell is on the stack and has not happened yet. Click Giant Growth in your hand, Cast it, and pick Grizzly Bears as the target. Yours resolves first, because it was cast last.',
+      },
+      'land-and-cast': {
+        title: 'Your turn.',
+        body: 'Play the Forest, then cast Centaur Courser. Keep Giant Growth in hand when you can — a trick you have not cast is one your opponent has to fear.',
+      },
+      attack: {
+        title: 'Attack.',
+        body: 'Click a creature, then Attack with N. Even when they have a blocker, an instant in hand turns a bad fight into a good one — cast it after blocks are declared.',
+      },
+    },
+    spec: (name) => ({
+      player1Name: name,
+      player2Name: TUTOR_NAME,
+      player1: {
+        lifeTotal: 12,
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }, { name: 'Forest' }, { name: 'Grizzly Bears', summoningSickness: false }],
+        hand: ['Giant Growth', 'Forest', 'Centaur Courser'],
+        library: curve(['Titanic Growth', 'Runeclaw Bear', 'Giant Growth', 'Trained Armodon', 'Giant Spider', 'Rumbling Baloth', 'Craw Wurm'], ['Forest']),
+      },
+      player2: {
+        lifeTotal: 8,
+        battlefield: [{ name: 'Mountain' }, { name: 'Mountain' }, { name: 'Mountain' }],
+        hand: ['Lightning Bolt', 'Shock', 'Mountain'],
+        library: curve(['Goblin Piker', 'Volcanic Hammer', 'Gray Ogre', 'Lightning Strike', 'Hill Giant', 'Raging Goblin', 'Bloodrock Cyclops'], ['Mountain']),
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 2,
+      priorityPlayer: 2,
+      mode: 'AI',
+      aiPlayer: 2,
+    }),
+  },
+  {
+    id: 'real-game',
+    number: 4,
+    title: 'A real game',
+    blurb: 'Twenty life each, full decks, everything at once. The coach stays — but the game is yours.',
+    frame: 'artifact',
+    minutes: 10,
+    brief: [
+      'Green-white creatures and tricks against red-black goblins, giants and burn.',
+      'Play a land every turn, spend your mana, and count before you attack or block.',
+      'Win or lose, finishing this game finishes the course.',
+    ],
+    openingCards: ['Grizzly Bears', 'Benalish Knight', 'Runeclaw Bear'],
+    objectives: [playedLand, castCreature, attacked, won],
+    intro:
+      'A real game: twenty life each, a creature apiece already on the board, and a full deck to draw from. The coach keeps saying what the board is waiting for; the decisions are yours.',
+    hints: {},
+    spec: (name) => ({
+      player1Name: name,
+      player2Name: TUTOR_NAME,
+      player1: {
+        lifeTotal: 20,
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }, { name: 'Plains' }, { name: 'Grizzly Bears', summoningSickness: false }],
+        hand: ['Forest', 'Benalish Knight', 'Runeclaw Bear', 'Plains'],
+        library: curve(GREEN_WHITE_SPELLS, GW_LANDS),
+      },
+      player2: {
+        lifeTotal: 20,
+        battlefield: [{ name: 'Mountain' }, { name: 'Swamp' }, { name: 'Mountain' }, { name: 'Goblin Piker', summoningSickness: false }],
+        hand: ['Swamp', 'Hill Giant', 'Typhoid Rats', 'Mountain'],
+        library: curve(RED_BLACK_SPELLS, RB_LANDS),
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+      priorityPlayer: 1,
+      mode: 'AI',
+      aiPlayer: 2,
+    }),
+  },
+]
+
+export const MISSION_IDS: readonly MissionId[] = MISSIONS.map((m) => m.id)
+
+export function missionById(id: string | undefined | null): Mission | undefined {
+  return MISSIONS.find((m) => m.id === id)
+}
+
+export function nextMission(id: MissionId): Mission | undefined {
+  const index = MISSIONS.findIndex((m) => m.id === id)
+  return index >= 0 ? MISSIONS[index + 1] : undefined
+}
+
+export function learnHref(id?: MissionId): string {
+  return id ? `/learn/${id}` : '/learn'
+}
+
+/** Playing time for the whole course — what the home page promises. */
+export const COURSE_MINUTES = MISSIONS.reduce((sum, m) => sum + m.minutes, 0)
+
+/** Every card name any mission can put in play — what the catalog test checks. */
+export function missionCardNames(): readonly string[] {
+  const names = new Set<string>()
+  for (const mission of MISSIONS) {
+    const spec = mission.spec('x')
+    for (const seat of [spec.player1, spec.player2]) {
+      seat?.battlefield?.forEach((c) => names.add(c.name))
+      seat?.hand?.forEach((n) => names.add(n))
+      seat?.library?.forEach((n) => names.add(n))
+    }
+  }
+  return [...names]
+}

--- a/web-client/src/learn/progressStore.ts
+++ b/web-client/src/learn/progressStore.ts
@@ -1,0 +1,74 @@
+/**
+ * Course progress, kept in this browser. A mission is complete once its game reached its end —
+ * won or lost; playing it through is the point, not the result.
+ *
+ * localStorage rather than the account: the course is aimed at someone who has not picked a name
+ * yet, let alone signed in, and losing "2 of 4" on a new device is no real loss.
+ */
+import { create } from 'zustand'
+import { MISSIONS, type MissionId } from './missions'
+
+const STORAGE_KEY = 'argentum.learn.progress'
+
+export interface StoredProgress {
+  completed: MissionId[]
+  /** Mission id → how many times its game was finished, for the "play again" wording. */
+  plays: Record<string, number>
+}
+
+function load(): StoredProgress {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { completed: [], plays: {} }
+    const parsed = JSON.parse(raw) as Partial<StoredProgress>
+    const known = new Set<string>(MISSIONS.map((m) => m.id))
+    return {
+      completed: (parsed.completed ?? []).filter((id): id is MissionId => known.has(id)),
+      plays: parsed.plays ?? {},
+    }
+  } catch {
+    return { completed: [], plays: {} }
+  }
+}
+
+function save(progress: StoredProgress) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(progress))
+  } catch {
+    // Private mode / quota — progress just does not persist this session.
+  }
+}
+
+interface LearnProgressState extends StoredProgress {
+  /** A mission's game ended. Marks it complete and counts the play. */
+  finish: (id: MissionId) => void
+  reset: () => void
+}
+
+export const useLearnProgress = create<LearnProgressState>((set, get) => ({
+  ...load(),
+  finish: (id) => {
+    const { completed, plays } = get()
+    const next: StoredProgress = {
+      completed: completed.includes(id) ? completed : [...completed, id],
+      plays: { ...plays, [id]: (plays[id] ?? 0) + 1 },
+    }
+    save(next)
+    set(next)
+  },
+  reset: () => {
+    const next: StoredProgress = { completed: [], plays: {} }
+    save(next)
+    set(next)
+  },
+}))
+
+/** The first mission not yet completed — where "Continue" goes. Undefined once the course is done. */
+export function nextIncomplete(completed: readonly MissionId[]): MissionId | undefined {
+  return MISSIONS.find((m) => !completed.includes(m.id))?.id
+}
+
+/** True once any mission has been finished in this browser — what decides the landing pointer's wording. */
+export function hasStarted(progress: Pick<StoredProgress, 'completed'>): boolean {
+  return progress.completed.length > 0
+}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -47,6 +47,9 @@ const FriendsPage = lazy(() =>
 const StatsPage = lazy(() =>
   import('./pages/StatsPage').then(({ StatsPage }) => ({ default: StatsPage }))
 )
+const LearnPage = lazy(() =>
+  import('./pages/LearnPage').then(({ LearnPage }) => ({ default: LearnPage }))
+)
 const HelpPage = lazy(() =>
   import('./pages/HelpPage').then(({ HelpPage }) => ({ default: HelpPage }))
 )
@@ -81,6 +84,8 @@ createRoot(rootElement).render(
           <Route path="/friends" element={<FriendsPage />} />
           <Route path="/help" element={<HelpPage />} />
           <Route path="/help/:section" element={<HelpPage />} />
+          <Route path="/learn" element={<LearnPage />} />
+          <Route path="/learn/:missionId" element={<LearnPage />} />
           <Route path="/llm-tournament" element={<LlmTournamentPage />} />
           <Route path="/llm-tournament/:id" element={<LlmTournamentPage />} />
           <Route path="/ai-sandbox" element={<AiSandboxPage />} />

--- a/web-client/src/pages/LearnPage.tsx
+++ b/web-client/src/pages/LearnPage.tsx
@@ -1,0 +1,277 @@
+/**
+ * `/learn` — the course home, a hand of four mission cards — and `/learn/:missionId`, the brief
+ * for one mission: three lines on what you will do, the cards you start with, and the button
+ * that puts you at the table.
+ *
+ * The course content is `learn/missions.ts`; this file is the frame around it. Starting a game
+ * posts the mission's scenario to `/api/scenarios`, arms the coach with the mission id, and hands
+ * off with a full navigation (`/?token=…`) so the app makes a clean token-based connect — the
+ * same hand-off the scenario builder uses.
+ */
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { COURSE_MINUTES, MISSIONS, TUTOR_NAME, learnHref, missionById, type Mission, type MissionId } from '@/learn/missions'
+import { armCoach } from '@/learn/coach'
+import { hasStarted, nextIncomplete, useLearnProgress } from '@/learn/progressStore'
+import { useAuthStore } from '@/store/authStore'
+import type { ScenarioCreateResponse } from '@/components/scenario/types'
+import { MissionHand, MiniHand, frameVar } from '@/components/learn/MissionHand'
+import { CardImage } from '@/components/learn/CardImage'
+import { useLessonCards } from '@/components/learn/useLessonCards'
+import styles from '@/components/learn/learn.module.css'
+
+const NAME_KEY = 'argentum-player-name'
+
+function storedName(): string {
+  const account = useAuthStore.getState().user?.displayName?.trim()
+  if (account) return account
+  try {
+    return localStorage.getItem(NAME_KEY)?.trim() ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function LearnPage() {
+  const { missionId } = useParams<{ missionId?: string }>()
+  const mission = missionById(missionId)
+  return <div className={styles.root}>{mission ? <Brief mission={mission} /> : <CourseHome />}</div>
+}
+
+function TopBar({ current }: { current?: MissionId }) {
+  const navigate = useNavigate()
+  const completed = useLearnProgress((s) => s.completed)
+  return (
+    <div className={styles.topBar}>
+      <div className={styles.topBarInner}>
+        <button type="button" className={styles.topBarLink} onClick={() => navigate('/')}>
+          ← Menu
+        </button>
+        {current && (
+          <Link to={learnHref()} className={styles.topBarLink}>
+            All missions
+          </Link>
+        )}
+        <span className={styles.topBarEyebrow}>Learn to play</span>
+        <div className={styles.pips} aria-label={`${completed.length} of ${MISSIONS.length} missions complete`}>
+          {MISSIONS.map((m) => (
+            <span
+              key={m.id}
+              className={[
+                styles.pip,
+                completed.includes(m.id) ? styles.pipDone : '',
+                m.id === current ? styles.pipCurrent : '',
+              ].join(' ')}
+              title={`${m.number}. ${m.title}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CourseHome() {
+  const navigate = useNavigate()
+  const completed = useLearnProgress((s) => s.completed)
+  const reset = useLearnProgress((s) => s.reset)
+  const next = nextIncomplete(completed)
+  const started = hasStarted({ completed })
+  const finished = next === undefined
+
+  useEffect(() => {
+    document.title = 'Learn to play — Argentum'
+    return () => {
+      document.title = 'Argentum Engine'
+    }
+  }, [])
+
+  return (
+    <>
+      <TopBar />
+      <main className={styles.home}>
+        <p className={styles.eyebrow}>Never played Magic?</p>
+        <h1 className={styles.headline}>
+          Learn it
+          <br />
+          <em>by playing it.</em>
+        </h1>
+        <p className={styles.lede}>
+          Four short games against the AI, each from a board set up to teach one thing, with a coach at your
+          elbow saying what to do next. About {COURSE_MINUTES} minutes all told. Nothing to read first,
+          nothing to sign up for.
+        </p>
+        <div className={styles.heroActions}>
+          {finished ? (
+            <>
+              <button type="button" className={styles.cta} onClick={() => navigate('/')}>
+                Go play for real
+              </button>
+              <Link to={learnHref('real-game')} className={styles.ctaQuiet}>
+                Another practice game
+              </Link>
+            </>
+          ) : (
+            <>
+              <button type="button" className={styles.cta} onClick={() => navigate(learnHref(next))}>
+                {started ? `Continue — mission ${missionById(next)?.number ?? 1}` : 'Start mission 1'}
+              </button>
+              {started && (
+                <Link to={learnHref('first-steps')} className={styles.ctaQuiet}>
+                  Start over from the top
+                </Link>
+              )}
+            </>
+          )}
+        </div>
+        <p className={styles.heroNote}>
+          Already know how to play? <Link to="/">Skip to the table</Link> — or read the{' '}
+          <Link to="/help">guide to Argentum</Link> instead.
+        </p>
+
+        <MissionHand completed={completed} next={next} />
+        <p className={styles.handCaption}>Pick a card. They play best in order, and the last one is the real thing.</p>
+
+        {finished && (
+          <div className={styles.doneBanner}>
+            <h2>Course complete.</h2>
+            <p>
+              You have played Magic. From here the PLAY menu has quick games against the AI, drafts, and other
+              people; the deckbuilder lets you make something of your own.
+            </p>
+            <button type="button" className={styles.textLink} onClick={reset}>
+              Reset my progress
+            </button>
+          </div>
+        )}
+      </main>
+    </>
+  )
+}
+
+function Brief({ mission }: { mission: Mission }) {
+  const completed = useLearnProgress((s) => s.completed)
+  const plays = useLearnProgress((s) => s.plays)
+  const done = completed.includes(mission.id)
+  const cards = useLessonCards(mission.openingCards)
+  const [name, setName] = useState(storedName)
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    document.querySelector(`.${styles.root}`)?.scrollTo({ top: 0 })
+    document.title = `${mission.number}. ${mission.title} — Learn to play`
+    return () => {
+      document.title = 'Argentum Engine'
+    }
+  }, [mission])
+
+  const start = async () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    setStarting(true)
+    setError(null)
+    try {
+      localStorage.setItem(NAME_KEY, trimmed)
+    } catch {
+      // The name still goes into the scenario; only the memory of it is lost.
+    }
+    try {
+      const res = await fetch('/api/scenarios', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(mission.spec(trimmed)),
+      })
+      if (!res.ok) {
+        const body: unknown = await res.json().catch(() => null)
+        const errors =
+          body && typeof body === 'object' && Array.isArray((body as { errors?: unknown }).errors)
+            ? (body as { errors: string[] }).errors
+            : [`The server could not start the game (HTTP ${res.status}).`]
+        setError(errors.join(' '))
+        setStarting(false)
+        return
+      }
+      const data = (await res.json()) as ScenarioCreateResponse
+      const human = data.player1.token && data.player1.token !== '(AI)' ? data.player1 : data.player2
+      armCoach(mission.id)
+      window.location.href = `/?token=${encodeURIComponent(human.token)}`
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not reach the server.')
+      setStarting(false)
+    }
+  }
+
+  const playCount = plays[mission.id] ?? 0
+
+  return (
+    <>
+      <TopBar current={mission.id} />
+      <main className={styles.brief}>
+        <header className={styles.briefHeader} style={{ ['--frame' as string]: frameVar(mission.frame) }}>
+          <div className={styles.lessonKicker}>
+            <span className={styles.lessonSwatch} aria-hidden="true" />
+            Mission {mission.number} of {MISSIONS.length} · about {mission.minutes} min
+            {done && ' · complete'}
+          </div>
+          <h1 className={styles.lessonTitle}>{mission.title}</h1>
+          <p className={styles.lessonBlurb}>{mission.blurb}</p>
+        </header>
+
+        <div className={styles.briefBody}>
+          <section className={styles.briefColumn}>
+            <h2 className={styles.briefHeading}>What you’ll do</h2>
+            <ol className={styles.briefList}>
+              {mission.brief.map((line, i) => (
+                <li key={line}>
+                  <span className={styles.briefIndex}>{i + 1}</span>
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ol>
+
+            <h2 className={styles.briefHeading}>Take a seat</h2>
+            <p className={styles.briefNote}>
+              You play against {TUTOR_NAME}, the built-in AI. What should the table call you?
+            </p>
+            <div className={styles.nameField}>
+              <input
+                type="text"
+                className={styles.nameInput}
+                value={name}
+                maxLength={20}
+                placeholder="Your name"
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void start()
+                }}
+                aria-label="Your name"
+              />
+              <button
+                type="button"
+                className={styles.cta}
+                disabled={!name.trim() || starting}
+                onClick={() => void start()}
+              >
+                {starting ? 'Setting up the table…' : playCount > 0 ? 'Play again' : 'Play'}
+              </button>
+            </div>
+            {error && <p className={styles.errorText}>{error}</p>}
+          </section>
+
+          <aside className={styles.briefColumn} aria-label="Your opening cards">
+            <h2 className={styles.briefHeading}>Your opening cards</h2>
+            <div className={styles.briefCards}>
+              {mission.openingCards.map((n) => (
+                <CardImage key={n} src={cards[n]?.imageUrl ?? ''} name={n} caption={n} />
+              ))}
+            </div>
+            <p className={styles.briefNote}>Hover any card at the table to read it in full.</p>
+          </aside>
+        </div>
+
+        <MiniHand current={mission.id} completed={completed} />
+      </main>
+    </>
+  )
+}

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -20,6 +20,8 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
 
+    "types": ["node"],
+
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Learn to Play — four coached games against the AI

A first-time visitor has never had anywhere to go: `/help` deliberately assumes you know Magic and explains *Argentum*. This adds the other half — a course at `/learn` that teaches the game **by playing it**, on the real board, with nothing to read first.

### What a new visitor sees

The landing page's name prompt now opens with a pointer to the course (it needs no name). Once connected, a quiet row in PLAY carries progress until the course is finished; `/help` keeps a topic pointing at it afterwards.

![Landing page for a first-time visitor](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/landing-arrival.png)

### The course

`/learn` is a hand of four mission cards, each in a Magic frame in the mission's colour. Finished missions go foil and get a seal; the next one glows.

![Course home](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/learn-home.png)

![Course home with two missions done](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/learn-home-progress.png)

Each mission has a one-screen brief — three lines, the opening cards, a name field — and a Play button.

![Mission brief](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/brief-first-steps.png)

### On the board

Play posts the mission's scripted board to the production `/api/scenarios` endpoint (AI in seat two) and hands off exactly the way the scenario builder does. A **coach panel** then sits bottom-left: the mission's objectives tick off as the player does them, and one tip says what the board is waiting on — worded with the Pass button's real, server-computed label ("Pass to Attackers", "End Turn", …) so the tip and the button always agree. Each mission can re-word any tip for its own board. The panel can be closed; it never touches game logic.

![Coach intro on the board](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/game-instants-intro.png)

![Blocking mission with an objective ticked](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-to-play-screenshots/game-blocking-block-assigned.png)

| # | Mission | Board | Objectives |
|---|---|---|---|
| 1 | First steps | Two lands down, bears in hand; the Tutor has a lands-only deck and 8 life | Play a land · Cast a creature · Attack · Win |
| 2 | Holding the line | Their **Bloodrock Cyclops** (attacks each combat if able) + Gray Ogre vs your Giant Spider; starts on their turn | Block · Kill one of theirs · Win |
| 3 | In response | Grizzly Bears on board, Giant Growth in hand; the Tutor opens with Lightning Bolt | Cast an instant · Attack · Win |
| 4 | A real game | 20 life each, one creature apiece, full G/W vs R/B decks | Play a land · Cast · Attack · Win |

The boards are built so the first decision is a real one, and the libraries are listed top-first (the engine draws `library.first()`) so the opening draws are scripted. Mission 2 uses the Cyclops specifically because the AI, correctly, would not attack into an untapped 2/4 on its own — the forced attack makes the block lesson happen on turn one every time.

A mission counts as finished when its game ends, win or lose; progress lives in `localStorage` (the audience has no account yet). The game ending also disarms the coach, so a rematch or a menu game plays without it.

### Objectives are derived, not tracked

The server resends the full per-player game log on every state update, so "you played a land / attacked / blocked / cast an instant / killed one of theirs" is a pure function of `gameState.gameLog` + `gameState.cards` — no new store state, no event subscription. (Card types arrive upper-case, `LAND`; the objectives compare case-blind — the existing `isLand`/`isCreature` helpers in `types/gameState.ts` compare against `Land` and would never match, which is worth a look separately.)

### Tests

- `learn/coach.test.ts` — tip selection order, mission overrides, `{pass}` label substitution, game-over handling.
- `learn/missions.test.ts` — every mission card name exists in `mtg-sets/` (file-name check, basics whitelisted); two-seat AI specs inside the public endpoint limits; opening cards really are in the opening hand; objective detectors against synthetic logs with owner/caster attribution.
- `help/topics.test.ts` covers the new help topic.

`@types/node` is added as a dev dependency (and `"types": ["node"]` in `tsconfig.json` — TS 6 no longer auto-includes `@types`) so the missions test can walk the corpus tree.

### Verified

- `npm run typecheck` clean; `npx vitest run` 51 files / 713 tests green.
- Missions 1–3 played through against the running server with Playwright: the coach's tips follow the board, objectives tick on the live log, mission 1 reaches "You won" with the next-mission link, mission 2's Cyclops attacks on turn one and a drag-block registers, mission 3 opens with the Tutor's Bolt and Giant Growth in response ticks "Cast an instant".

Screenshots are on the throwaway `learn-to-play-screenshots` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173Xm5K5s6kieSoA9yk1afM
