### PR TITLE
Learn to Play: teach the table, not just the game

### DIFF
--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1656,13 +1656,19 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             alignItems: responsive.isMobile ? 'flex-end' : 'stretch',
             gap: responsive.isMobile ? 6 : 8,
           }}>
-            <div style={{
-              display: 'flex',
-              gap: 4,
-              alignItems: 'stretch',
-              justifyContent: 'flex-end',
-            }}>
+            <div
+              // `data-learn` marks are anchors for the Learn-to-Play coach's spotlight — see
+              // `learn/spots.ts`. Attributes only; they change nothing about layout or behaviour.
+              data-learn="controls"
+              style={{
+                display: 'flex',
+                gap: 4,
+                alignItems: 'stretch',
+                justifyContent: 'flex-end',
+              }}
+            >
               <button
+                data-learn="undo"
                 onClick={requestUndo}
                 disabled={!undoAvailable}
                 title="Undo"
@@ -1695,6 +1701,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 <i className="ms ms-land" style={{ fontSize: 14 }} />
               </button>
               <button
+                data-learn="priority-mode"
                 onClick={cyclePriorityMode}
                 title={
                   serverPriorityMode === 'fullControl'
@@ -1732,6 +1739,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
               <HelpDrawerButton />
             </div>
             <button
+              data-learn="pass"
               disabled={!passEnabled}
               onClick={() => {
                 submitAction({
@@ -1896,7 +1904,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
       {/* Combat buttons (bottom-right) */}
       {isInCombatMode && combatState?.mode === 'declareAttackers' && (
-        <div style={styles.combatButtonContainer}>
+        <div data-learn="combat-buttons" style={styles.combatButtonContainer}>
           {combatState.selectedAttackers.length === 0 ? (
             <>
               <button
@@ -1963,7 +1971,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       )}
 
       {isInCombatMode && combatState?.mode === 'declareBlockers' && (
-        <div style={styles.combatButtonContainer}>
+        <div data-learn="combat-buttons" style={styles.combatButtonContainer}>
           {Object.keys(combatState.blockerAssignments).length === 0 ? (
             <>
               <button

--- a/web-client/src/components/game/GameLog.tsx
+++ b/web-client/src/components/game/GameLog.tsx
@@ -34,6 +34,7 @@ export function GameLog() {
   if (!expanded) {
     return (
       <button
+        data-learn="log"
         onClick={() => setExpanded(true)}
         style={styles.toggleButton}
       >

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -466,7 +466,7 @@ export function StackDisplay() {
 
   return (
     <>
-    <div style={{
+    <div data-learn="stack" style={{
       position: 'fixed',
       left: responsive.isMobile ? 12 : 120,
       top: '50%',

--- a/web-client/src/components/learn/CardImage.tsx
+++ b/web-client/src/components/learn/CardImage.tsx
@@ -1,11 +1,55 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import styles from './learn.module.css'
 
-/** A real card, from the catalog's image (or Scryfall's), with an optional caption under it. */
-export function CardImage({ src, name, caption }: { src: string; name: string; caption?: string }) {
+/**
+ * A real card, from the catalog's image (or Scryfall's), with an optional caption and note
+ * under it. Hovering lifts it; clicking opens it full-size — the same "read the card" the table
+ * offers, so the gesture is learned before the game starts.
+ */
+export function CardImage({
+  src,
+  name,
+  caption,
+  note,
+}: {
+  src: string
+  name: string
+  caption?: string
+  note?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
   return (
-    <div>
-      <img src={src} alt={name} className={styles.cardImg} loading="lazy" draggable={false} />
+    <div className={styles.cardTile}>
+      <button
+        type="button"
+        className={styles.cardButton}
+        onClick={() => setOpen(true)}
+        aria-label={`Read ${name} in full`}
+      >
+        <img src={src} alt={name} className={styles.cardImg} loading="lazy" draggable={false} />
+      </button>
       {caption !== undefined && <div className={styles.cardName}>{caption}</div>}
+      {note !== undefined && <p className={styles.cardNote}>{note}</p>}
+      {open &&
+        createPortal(
+          <div className={styles.lightbox} onClick={() => setOpen(false)} role="dialog" aria-label={name}>
+            <img src={src} alt={name} className={styles.lightboxImg} draggable={false} />
+            {note !== undefined && <p className={styles.lightboxNote}>{note}</p>}
+            <p className={styles.lightboxHint}>Click anywhere to close</p>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/web-client/src/components/learn/LearnCoach.module.css
+++ b/web-client/src/components/learn/LearnCoach.module.css
@@ -276,26 +276,36 @@
 /* A ring around the board element a tip or tour step names. Pointer-transparent, under the
    coach panel and every modal, over the board itself. */
 .spotlight {
+  --spot: #ffd76a;
   position: fixed;
   z-index: 590;
   pointer-events: none;
   border-radius: 12px;
-  border: 2px solid rgba(217, 180, 92, 0.55);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 18px rgba(217, 180, 92, 0.25);
-  animation: spotIn 0.3s ease-out both, spotPulse 2.4s ease-in-out 0.3s infinite;
+  border: 2.5px solid var(--spot);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.5),
+    0 0 22px 2px rgba(255, 215, 106, 0.55),
+    inset 0 0 14px rgba(255, 215, 106, 0.25);
+  animation: spotIn 0.3s ease-out both, spotPulse 1.6s ease-in-out 0.3s infinite;
   transition: top 0.2s ease, left 0.2s ease, width 0.2s ease, height 0.2s ease;
 }
 
+/* The tour's ring dims everything else: a cut-out spotlight, so the one thing being named is the
+   one bright thing on the screen. The coach panel (z 600) stays above the dim. */
 .spotlightStrong {
-  border-color: #efd27a;
   border-width: 3px;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.5), 0 0 28px rgba(239, 210, 122, 0.45);
+  /* Same as the animation's resting frame, so the dim survives prefers-reduced-motion. */
+  box-shadow:
+    0 0 0 9999px rgba(4, 4, 8, 0.6),
+    0 0 22px 2px rgba(255, 215, 106, 0.6),
+    inset 0 0 16px rgba(255, 215, 106, 0.25);
+  animation: spotIn 0.3s ease-out both, spotPulseStrong 1.6s ease-in-out 0.3s infinite;
 }
 
 @keyframes spotIn {
   from {
     opacity: 0;
-    transform: scale(1.04);
+    transform: scale(1.06);
   }
   to {
     opacity: 1;
@@ -306,10 +316,32 @@
 @keyframes spotPulse {
   0%,
   100% {
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 14px rgba(217, 180, 92, 0.2);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.5),
+      0 0 18px 1px rgba(255, 215, 106, 0.45),
+      inset 0 0 12px rgba(255, 215, 106, 0.2);
   }
   50% {
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 26px rgba(217, 180, 92, 0.45);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.5),
+      0 0 40px 8px rgba(255, 215, 106, 0.8),
+      inset 0 0 20px rgba(255, 215, 106, 0.4);
+  }
+}
+
+@keyframes spotPulseStrong {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 9999px rgba(4, 4, 8, 0.6),
+      0 0 22px 2px rgba(255, 215, 106, 0.6),
+      inset 0 0 16px rgba(255, 215, 106, 0.25);
+  }
+  50% {
+    box-shadow:
+      0 0 0 9999px rgba(4, 4, 8, 0.6),
+      0 0 46px 10px rgba(255, 215, 106, 0.95),
+      inset 0 0 24px rgba(255, 215, 106, 0.45);
   }
 }
 

--- a/web-client/src/components/learn/LearnCoach.module.css
+++ b/web-client/src/components/learn/LearnCoach.module.css
@@ -196,7 +196,129 @@
   text-decoration: underline;
 }
 
+/* ---- Tour ---------------------------------------------------------------- */
+.tourCount {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8d877a;
+  margin-bottom: 6px;
+}
+
+.tourNav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.tourNav .primary {
+  margin-top: 6px;
+}
+
+/* ---- What you learned ---------------------------------------------------- */
+.lessonsHead {
+  margin-top: 10px;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--coach-accent);
+}
+
+.lessons {
+  margin: 4px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: #c9c3b4;
+  font-size: 12.5px;
+}
+
+/* ---- Collapsed pill ------------------------------------------------------ */
+.pill {
+  --coach-accent: #d9b45c;
+  position: fixed;
+  left: 12px;
+  bottom: 52px;
+  z-index: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #efe6cf;
+  background: rgba(14, 14, 20, 0.94);
+  border: 1px solid rgba(239, 230, 207, 0.16);
+  border-left: 3px solid var(--coach-accent);
+  border-radius: 999px;
+  padding: 7px 14px 7px 10px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
+.pill:hover {
+  border-color: rgba(239, 230, 207, 0.35);
+}
+
+.pillDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--coach-accent);
+  box-shadow: 0 0 8px var(--coach-accent);
+}
+
+/* ---- Spotlight ----------------------------------------------------------- */
+/* A ring around the board element a tip or tour step names. Pointer-transparent, under the
+   coach panel and every modal, over the board itself. */
+.spotlight {
+  position: fixed;
+  z-index: 590;
+  pointer-events: none;
+  border-radius: 12px;
+  border: 2px solid rgba(217, 180, 92, 0.55);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 18px rgba(217, 180, 92, 0.25);
+  animation: spotIn 0.3s ease-out both, spotPulse 2.4s ease-in-out 0.3s infinite;
+  transition: top 0.2s ease, left 0.2s ease, width 0.2s ease, height 0.2s ease;
+}
+
+.spotlightStrong {
+  border-color: #efd27a;
+  border-width: 3px;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.5), 0 0 28px rgba(239, 210, 122, 0.45);
+}
+
+@keyframes spotIn {
+  from {
+    opacity: 0;
+    transform: scale(1.04);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes spotPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 14px rgba(217, 180, 92, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 26px rgba(217, 180, 92, 0.45);
+  }
+}
+
 @media (max-width: 640px) {
+  .pill {
+    left: 8px;
+    bottom: 44px;
+  }
+
   .coach {
     left: 8px;
     bottom: 44px;
@@ -212,7 +334,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .body,
-  .objectiveDone .tick {
+  .objectiveDone .tick,
+  .spotlight {
     animation: none;
   }
 }

--- a/web-client/src/components/learn/LearnCoach.tsx
+++ b/web-client/src/components/learn/LearnCoach.tsx
@@ -1,8 +1,13 @@
 /**
  * The coach panel for a course mission. Mounted on every game board, renders nothing unless the
- * course armed it (see `learn/coach.ts`); then shows the mission's objectives ticking off as the
- * player does them, and one tip for what the board is waiting on. When the game ends it marks
- * the mission finished and points at the next card in the hand.
+ * course armed it (see `learn/coach.ts`). Three states:
+ *
+ * - **Tour** — when the board first appears, a few steps that each ring one part of the table
+ *   (hand, battlefield, turn strip, the pass button …) and say what it is for. Skippable.
+ * - **Tip** — one line for what the board is waiting on, worded with the real button label and
+ *   this device's gestures, with a quiet ring on the thing it names; the mission's objectives
+ *   tick off underneath as the player does them.
+ * - **Done** — the game ended: what you learned, and the next card in the hand.
  *
  * Portalled to `<body>` like the help drawer: `#root` is overflow:hidden and the multiplayer
  * strip transforms its subtree, both of which break `position: fixed` for descendants.
@@ -11,17 +16,30 @@ import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { useGameStore } from '@/store/gameStore'
-import { selectHasPriority, selectIsMyTurn } from '@/store/selectors'
-import { armedMission, coachTip, disarmCoach, introSeen, markIntroSeen, type CoachView } from '@/learn/coach'
+import { selectHasPriority, selectIsMyTurn, useStackCards } from '@/store/selectors'
+import { armedMission, coachTip, disarmCoach, markTourSeen, tourSeen, wordTip, type CoachView } from '@/learn/coach'
 import { learnHref, missionById, nextMission } from '@/learn/missions'
+import type { SpotContext } from '@/learn/spots'
+import type { EntityId } from '@/types'
 import { useLearnProgress } from '@/learn/progressStore'
+import { LearnSpotlight } from './LearnSpotlight'
 import styles from './LearnCoach.module.css'
+
+/** A mouse or trackpad: hover previews work and "click" is the word. Touch screens get long-press and "tap". */
+function deviceHasHover(): boolean {
+  try {
+    return window.matchMedia('(hover: hover) and (pointer: fine)').matches
+  } catch {
+    return true
+  }
+}
 
 export function LearnCoach() {
   const [missionId] = useState(armedMission)
   const mission = useMemo(() => missionById(missionId), [missionId])
-  const [hidden, setHidden] = useState(false)
-  const [showIntro, setShowIntro] = useState(() => !introSeen())
+  const [collapsed, setCollapsed] = useState(false)
+  const [tourStep, setTourStep] = useState<number | null>(() => (tourSeen() ? null : 0))
+  const [hasHover] = useState(deviceHasHover)
   // Once the game is over the coach disarms itself, so a remount after that renders nothing —
   // which is also what stops the mission being finished twice.
   const [finished, setFinished] = useState(false)
@@ -32,10 +50,12 @@ export function LearnCoach() {
   const gameState = useGameStore((s) => s.gameState)
   const legalActions = useGameStore((s) => s.legalActions)
   const pendingDecision = useGameStore((s) => s.pendingDecision)
+  const isTargeting = useGameStore((s) => s.targetingState !== null)
   const gameOverState = useGameStore((s) => s.gameOverState)
   const nextStopPoint = useGameStore((s) => s.nextStopPoint)
   const isMyTurn = useGameStore(selectIsMyTurn)
   const hasPriority = useGameStore(selectHasPriority)
+  const stackSize = useStackCards().length
 
   const won = gameOverState ? (gameOverState.result === 'draw' ? null : gameOverState.result === 'win') : null
 
@@ -52,12 +72,25 @@ export function LearnCoach() {
       canAttack: types.has('DeclareAttackers'),
       canBlock: types.has('DeclareBlockers'),
       hasDecision: pendingDecision !== null,
+      isTargeting,
+      stackSize,
       attackersIncoming: gameState.combat?.attackers.length ?? 0,
       passLabel: nextStopPoint ?? 'Pass',
+      hasHover,
       isGameOver: gameState.isGameOver || gameOverState !== null,
       won,
     }
-  }, [gameState, legalActions, pendingDecision, gameOverState, nextStopPoint, isMyTurn, hasPriority, won])
+  }, [gameState, legalActions, pendingDecision, isTargeting, gameOverState, nextStopPoint, isMyTurn, hasPriority, stackSize, hasHover, won])
+
+  const me = gameState?.viewingPlayerId
+  const players = gameState?.players
+  const spotCtx = useMemo<SpotContext>(
+    () => ({
+      me: me ?? ('' as EntityId),
+      opponent: players?.find((p) => p.playerId !== me)?.playerId,
+    }),
+    [me, players],
+  )
 
   const objectives = useMemo(() => {
     if (!mission || !gameState) return []
@@ -75,83 +108,138 @@ export function LearnCoach() {
     }
   }, [mission, view?.isGameOver, finished, finish])
 
-  if (!mission || hidden || !view) return null
+  if (!mission || !view) return null
+
   const tip = coachTip(view, mission.hints)
   const next = nextMission(mission.id)
   const doneCount = objectives.filter((o) => o.done).length
+  const touring = tourStep !== null && !view.isGameOver && tourStep < mission.tour.length
+  const step = touring ? mission.tour[tourStep] : undefined
+
+  const endTour = () => {
+    markTourSeen()
+    setTourStep(null)
+  }
 
   const leave = (to: string) => {
     returnToMenu()
     navigate(to)
   }
 
+  if (collapsed && !view.isGameOver) {
+    return createPortal(
+      <button
+        type="button"
+        className={`${styles.pill} ${styles[tip.tone]}`}
+        onClick={() => setCollapsed(false)}
+        aria-label="Show the coach"
+      >
+        <span className={styles.pillDot} aria-hidden="true" />
+        Coach · {doneCount}/{objectives.length}
+      </button>,
+      document.body,
+    )
+  }
+
+  const tone = touring ? 'watch' : tip.tone
+  const spot = touring ? step?.spot : tip.tone === 'act' ? tip.spot : undefined
+
   return createPortal(
-    <aside className={`${styles.coach} ${styles[tip.tone]}`} aria-live="polite" aria-label="Coach">
-      <div className={styles.head}>
-        <span className={styles.eyebrow}>
-          Mission {mission.number} · {mission.title}
-        </span>
-        <button
-          type="button"
-          className={styles.close}
-          onClick={() => setHidden(true)}
-          aria-label="Hide the coach for the rest of this game"
-          title="Hide the coach for the rest of this game"
-        >
-          ×
-        </button>
-      </div>
-
-      {showIntro && !view.isGameOver ? (
-        <div className={styles.body}>
-          <div className={styles.title}>Welcome to the table.</div>
-          <p className={styles.text}>{mission.intro}</p>
-          <button
-            type="button"
-            className={styles.primary}
-            onClick={() => {
-              markIntroSeen()
-              setShowIntro(false)
-            }}
-          >
-            Let’s go
-          </button>
-        </div>
-      ) : (
-        <div key={tip.key} className={styles.body}>
-          <div className={styles.title}>{tip.title}</div>
-          <p className={styles.text}>{tip.body}</p>
-        </div>
-      )}
-
-      <ol className={styles.objectives} aria-label={`Objectives, ${doneCount} of ${objectives.length} done`}>
-        {objectives.map((o) => (
-          <li key={o.id} className={`${styles.objective} ${o.done ? styles.objectiveDone : ''}`}>
-            <span className={styles.tick} aria-hidden="true">
-              {o.done ? '✓' : ''}
-            </span>
-            <span>{o.label}</span>
-          </li>
-        ))}
-      </ol>
-
-      {view.isGameOver && (
-        <div className={styles.actions}>
-          {next ? (
-            <button type="button" className={styles.primary} onClick={() => leave(learnHref(next.id))}>
-              Next: {next.title} →
-            </button>
-          ) : (
-            <button type="button" className={styles.primary} onClick={() => leave(learnHref())}>
-              Course complete →
+    <>
+      <LearnSpotlight spot={spot} ctx={spotCtx} strong={touring} />
+      <aside className={`${styles.coach} ${styles[tone]}`} aria-live="polite" aria-label="Coach">
+        <div className={styles.head}>
+          <span className={styles.eyebrow}>
+            Mission {mission.number} · {mission.title}
+          </span>
+          {!view.isGameOver && (
+            <button
+              type="button"
+              className={styles.close}
+              onClick={() => setCollapsed(true)}
+              aria-label="Tuck the coach away"
+              title="Tuck the coach away — click the pill to bring it back"
+            >
+              –
             </button>
           )}
-          <button type="button" className={styles.link} onClick={() => leave(learnHref(mission.id))}>
-            Play this one again
-          </button>
         </div>
-      )}
-    </aside>,
+
+        {touring && step ? (
+          <div key={`tour-${tourStep}`} className={styles.body}>
+            <div className={styles.tourCount}>
+              A look around the table · {tourStep + 1} of {mission.tour.length}
+            </div>
+            <div className={styles.title}>{wordTip(step.title, view)}</div>
+            <p className={styles.text}>{wordTip(step.body, view)}</p>
+            <div className={styles.tourNav}>
+              {tourStep > 0 ? (
+                <button type="button" className={styles.link} onClick={() => setTourStep(tourStep - 1)}>
+                  ← Back
+                </button>
+              ) : (
+                <button type="button" className={styles.link} onClick={endTour}>
+                  Skip the tour
+                </button>
+              )}
+              {tourStep + 1 < mission.tour.length ? (
+                <button type="button" className={styles.primary} onClick={() => setTourStep(tourStep + 1)}>
+                  Next →
+                </button>
+              ) : (
+                <button type="button" className={styles.primary} onClick={endTour}>
+                  Let’s play
+                </button>
+              )}
+            </div>
+          </div>
+        ) : view.isGameOver ? (
+          <div key={tip.key} className={styles.body}>
+            <div className={styles.title}>{tip.title}</div>
+            <p className={styles.text}>{tip.body}</p>
+            <div className={styles.lessonsHead}>What you now know</div>
+            <ul className={styles.lessons}>
+              {mission.lessons.map((line) => (
+                <li key={line}>{wordTip(line, view)}</li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div key={tip.key} className={styles.body}>
+            <div className={styles.title}>{tip.title}</div>
+            <p className={styles.text}>{tip.body}</p>
+          </div>
+        )}
+
+        <ol className={styles.objectives} aria-label={`Objectives, ${doneCount} of ${objectives.length} done`}>
+          {objectives.map((o) => (
+            <li key={o.id} className={`${styles.objective} ${o.done ? styles.objectiveDone : ''}`}>
+              <span className={styles.tick} aria-hidden="true">
+                {o.done ? '✓' : ''}
+              </span>
+              <span>{o.label}</span>
+            </li>
+          ))}
+        </ol>
+
+        {view.isGameOver && (
+          <div className={styles.actions}>
+            {next ? (
+              <button type="button" className={styles.primary} onClick={() => leave(learnHref(next.id))}>
+                Next: {next.title} →
+              </button>
+            ) : (
+              <button type="button" className={styles.primary} onClick={() => leave(learnHref())}>
+                Course complete →
+              </button>
+            )}
+            <button type="button" className={styles.link} onClick={() => leave(learnHref(mission.id))}>
+              Play this one again
+            </button>
+          </div>
+        )}
+      </aside>
+    </>,
     document.body,
   )
 }

--- a/web-client/src/components/learn/LearnSpotlight.tsx
+++ b/web-client/src/components/learn/LearnSpotlight.tsx
@@ -1,0 +1,79 @@
+/**
+ * A ring around one part of the game board — the thing the coach is talking about.
+ *
+ * The board is not told about the coach. The ring is a fixed, pointer-transparent box portalled
+ * to `<body>`, positioned from the target's `getBoundingClientRect()` and re-measured on a short
+ * interval, so it follows the hand fanning out, the pass button changing width with its label,
+ * and the combat buttons appearing. A spot with no on-screen element draws nothing.
+ */
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { findSpot, type SpotContext, type SpotId } from '@/learn/spots'
+import styles from './LearnCoach.module.css'
+
+interface Box {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+const PAD = 6
+
+function measure(spot: SpotId, ctx: SpotContext): Box | null {
+  const el = findSpot(spot, ctx)
+  if (!el) return null
+  const r = el.getBoundingClientRect()
+  return { top: r.top - PAD, left: r.left - PAD, width: r.width + PAD * 2, height: r.height + PAD * 2 }
+}
+
+function same(a: Box | null, b: Box | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
+}
+
+export function LearnSpotlight({
+  spot,
+  ctx,
+  strong,
+}: {
+  spot: SpotId | undefined
+  ctx: SpotContext
+  /** The tour's ring is loud; a tip's ring is a quiet reminder. */
+  strong: boolean
+}) {
+  const [box, setBox] = useState<Box | null>(null)
+
+  useEffect(() => {
+    if (!spot) {
+      setBox(null)
+      return
+    }
+    let last: Box | null = null
+    const tick = () => {
+      const next = measure(spot, ctx)
+      if (!same(last, next)) {
+        last = next
+        setBox(next)
+      }
+    }
+    tick()
+    const id = window.setInterval(tick, 200)
+    window.addEventListener('resize', tick)
+    return () => {
+      window.clearInterval(id)
+      window.removeEventListener('resize', tick)
+    }
+  }, [spot, ctx])
+
+  if (!spot || !box) return null
+  return createPortal(
+    <div
+      key={spot}
+      className={`${styles.spotlight} ${strong ? styles.spotlightStrong : ''}`}
+      style={{ top: box.top, left: box.left, width: box.width, height: box.height }}
+      aria-hidden="true"
+    />,
+    document.body,
+  )
+}

--- a/web-client/src/components/learn/learn.module.css
+++ b/web-client/src/components/learn/learn.module.css
@@ -691,6 +691,107 @@
   text-align: center;
 }
 
+.cardTile {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.cardButton {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: zoom-in;
+  border-radius: 4.5% / 3.2%;
+  transition: transform 0.18s ease;
+}
+
+@media (hover: hover) {
+  .cardButton:hover {
+    transform: translateY(-4px) scale(1.04);
+  }
+}
+
+.cardNote {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ln-muted);
+  text-align: center;
+}
+
+/* Which sentence of a note applies is a property of the device, not the page. */
+.hoverOnly {
+  display: none;
+}
+
+.touchOnly {
+  display: inline;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .hoverOnly {
+    display: inline;
+  }
+
+  .touchOnly {
+    display: none;
+  }
+}
+
+/* Full-size card, on a dimmed page. Click anywhere (or Esc) to close. */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 24px;
+  background: rgba(6, 6, 10, 0.86);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  cursor: zoom-out;
+  animation: lightboxIn 0.18s ease-out both;
+}
+
+.lightboxImg {
+  width: min(360px, 80vw);
+  aspect-ratio: 488 / 680;
+  border-radius: 4.5% / 3.2%;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.7);
+}
+
+.lightboxNote {
+  margin: 0;
+  max-width: 360px;
+  text-align: center;
+  font-size: 15px;
+  line-height: 1.45;
+  color: var(--ln-paper);
+}
+
+.lightboxHint {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ln-muted);
+}
+
+@keyframes lightboxIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 /* Mini hand: the course's cards as a strip at the foot of each brief. */
 .miniHand {
   margin-top: 44px;

--- a/web-client/src/components/ui/StepStrip.tsx
+++ b/web-client/src/components/ui/StepStrip.tsx
@@ -187,6 +187,7 @@ export function StepStrip({
     >
       {renderTriangle(activeSide === 'top', 'top')}
       <div
+        data-learn="phase-strip"
         style={{
           backgroundColor: 'rgba(0, 0, 0, 0.85)',
           borderRadius: isMobile ? 6 : 8,

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -496,6 +496,18 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     related: ['priority-modes'],
   },
   {
+    id: 'card-preview',
+    section: 'playing',
+    title: 'Reading a card in full',
+    summary:
+      'Hover any card — hand, battlefield, stack, or the top of a graveyard or exile pile — and it opens full-size beside the pointer. On a touch screen, press and hold the card instead, or tap it and pick “View card”.',
+    body: [
+      { kind: 'p', text: 'The preview is read-only; nothing you do to it changes the game. Press F while a double-faced card is open to see its other face.' },
+    ],
+    shortcuts: ['flip-dfc'],
+    related: ['targeting-and-combat', 'zone-browsers'],
+  },
+  {
     id: 'targeting-and-combat',
     section: 'playing',
     title: 'Targeting, attacking and blocking',

--- a/web-client/src/learn/coach.test.ts
+++ b/web-client/src/learn/coach.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { coachTip, type CoachView } from './coach'
+import { coachTip, wordTip, type CoachView } from './coach'
+import { MISSIONS } from './missions'
 
 const base: CoachView = {
   turnNumber: 3,
@@ -11,8 +12,11 @@ const base: CoachView = {
   canAttack: false,
   canBlock: false,
   hasDecision: false,
+  isTargeting: false,
+  stackSize: 0,
   attackersIncoming: 0,
   passLabel: 'Pass to Attackers',
+  hasHover: true,
   isGameOver: false,
   won: null,
 }
@@ -35,6 +39,25 @@ describe('coachTip', () => {
     expect(coachTip({ ...base, step: 'POSTCOMBAT_MAIN' }).key).toBe('pass')
   })
 
+  it('names the flash window once attackers are declared', () => {
+    const idle = coachTip({ ...base, isMyTurn: false, attackersIncoming: 1 })
+    expect(idle.key).toBe('respond-attack')
+    expect(idle.tone).toBe('watch')
+    const flash = coachTip({ ...base, isMyTurn: false, attackersIncoming: 2, canCast: true })
+    expect(flash.title).toBe('They are attacking with 2 creatures.')
+    expect(flash.tone).toBe('act')
+    expect(flash.spot).toBe('hand')
+    // Once blocks are actually being asked for, the block prompt wins.
+    expect(coachTip({ ...base, isMyTurn: false, attackersIncoming: 1, canBlock: true }).key).toBe('block')
+  })
+
+  it('walks the player through picking a target mid-cast', () => {
+    const tip = coachTip({ ...base, isMyTurn: false, canCast: true, stackSize: 1, isTargeting: true })
+    expect(tip.key).toBe('target')
+    expect(tip.spot).toBe('battlefield')
+    expect(tip.body).toMatch(/highlighted — click one/)
+  })
+
   it('ranks the combat prompts above everything but a decision', () => {
     expect(coachTip({ ...base, canAttack: true, canPlayLand: true, canCast: true }).key).toBe('attack')
     expect(coachTip({ ...base, isMyTurn: false, canBlock: true, attackersIncoming: 2 }).title).toBe(
@@ -44,25 +67,78 @@ describe('coachTip', () => {
   })
 
   it('distinguishes responding on their turn from waiting', () => {
-    expect(coachTip({ ...base, isMyTurn: false }).key).toBe('respond')
-    expect(coachTip({ ...base, isMyTurn: false, canCast: true }).body).toMatch(/instant right now/)
+    expect(coachTip({ ...base, isMyTurn: false }).key).toBe('respond-idle')
+    const window = coachTip({ ...base, isMyTurn: false, canCast: true })
+    expect(window.key).toBe('respond-window')
+    expect(window.body).toMatch(/instant right now/)
     expect(coachTip({ ...base, isMyTurn: false, hasPriority: false }).key).toBe('waiting')
+  })
+
+  it('turns the response prompt into an instruction once their spell is on the stack', () => {
+    const tip = coachTip({ ...base, isMyTurn: false, canCast: true, stackSize: 1 })
+    expect(tip.key).toBe('respond')
+    expect(tip.tone).toBe('act')
+    expect(tip.body).toMatch(/resolves first/)
+    // With nothing to cast, a spell on the stack is only something to watch.
+    expect(coachTip({ ...base, isMyTurn: false, stackSize: 1 }).tone).toBe('watch')
   })
 
   it('has a first-turn tip while the game is still settling', () => {
     expect(coachTip({ ...base, turnNumber: 1, hasPriority: false }).key).toBe('first-turn')
   })
 
-  it('lets a mission re-word a tip by key without changing its tone', () => {
+  it('lets a mission re-word a tip by key without changing its tone or spot', () => {
     const tip = coachTip({ ...base, canPlayLand: true }, { land: { title: 'Play the Forest.', body: 'Click it.' } })
-    expect(tip).toEqual({ key: 'land', title: 'Play the Forest.', body: 'Click it.', tone: 'act' })
+    expect(tip).toEqual({ key: 'land', title: 'Play the Forest.', body: 'Click it.', tone: 'act', spot: 'hand' })
     expect(coachTip({ ...base, canCast: true }, { land: { title: 'x', body: 'y' } }).key).toBe('cast')
+    expect(coachTip({ ...base, canPlayLand: true }, { land: { spot: 'pass' } }).spot).toBe('pass')
   })
 
   it('names the real button wherever a tip says to press it', () => {
     expect(coachTip(base).body).toMatch(/Press Pass to Attackers,/)
     expect(coachTip({ ...base, step: 'POSTCOMBAT_MAIN', passLabel: 'End Turn' }).body).toMatch(/^Press End Turn\./)
     expect(coachTip({ ...base, passLabel: 'End Turn' }, { 'pass-to-combat': { title: 'Hit {pass}.', body: 'x' } }).title).toBe('Hit End Turn.')
+  })
+
+  it('names the gesture this device has', () => {
+    const mouse = coachTip({ ...base, canPlayLand: true })
+    const touch = coachTip({ ...base, canPlayLand: true, hasHover: false })
+    expect(mouse.body).toMatch(/click it and choose Play/)
+    expect(touch.body).toMatch(/tap it and choose Play/)
+    expect(wordTip('{read} to read it. {click} it. {pass}!', { passLabel: 'Resolve', hasHover: true })).toBe(
+      'Hover a card to read it. Click it. Resolve!',
+    )
+    expect(wordTip('{read} to read it. {click} it.', { passLabel: 'x', hasHover: false })).toBe(
+      'Press and hold a card to read it. Tap it.',
+    )
+  })
+
+  it('teaches both ways to play a card — dragging and clicking', () => {
+    for (const key of ['land', 'land-and-cast', 'cast'] as const) {
+      const view = { ...base, canPlayLand: key !== 'cast', canCast: key !== 'land' }
+      const tip = coachTip(view)
+      expect(tip.key).toBe(key)
+      expect(tip.body).toMatch(/[Dd]rag/)
+      expect(tip.body).toMatch(/click/)
+      expect(tip.spot).toBe('hand')
+    }
+  })
+
+  it('never leaves a placeholder in any mission’s wording', () => {
+    const views = [base, { ...base, hasHover: false }]
+    for (const m of MISSIONS) {
+      for (const view of views) {
+        for (const step of m.tour) {
+          expect(wordTip(step.title, view)).not.toMatch(/\{/)
+          expect(wordTip(step.body, view)).not.toMatch(/\{/)
+        }
+        for (const line of m.lessons) expect(wordTip(line, view)).not.toMatch(/\{/)
+        for (const [key, hint] of Object.entries(m.hints)) {
+          expect(wordTip(hint?.title ?? '', view), `${m.id}/${key}`).not.toMatch(/\{/)
+          expect(wordTip(hint?.body ?? '', view), `${m.id}/${key}`).not.toMatch(/\{/)
+        }
+      }
+    }
   })
 
   it('closes with the result, whatever it was', () => {

--- a/web-client/src/learn/coach.ts
+++ b/web-client/src/learn/coach.ts
@@ -1,10 +1,15 @@
 /**
  * The in-game coach for the course's missions: one tip at a time, chosen from what the board is
- * asking of the player right now.
+ * asking of the player right now, and a spot on the board to ring while saying it.
  *
  * Pure: {@link coachTip} takes a small projection of the game state and returns the tip to show,
  * so the rules are testable without a store. A mission can re-word any tip by its key
  * (`Mission.hints`); the React overlay (`LearnCoach.tsx`) does the projecting and the drawing.
+ *
+ * Every tip teaches the app as well as the game: the button it names is the button's real label
+ * (`{pass}` is substituted with the server-computed one), and the gesture it names is the one
+ * this device has — `{read}` is "Hover a card" with a mouse and "Press and hold a card" on a
+ * touch screen, `{click}` is "Click" or "Tap".
  *
  * The coach is armed with a mission id by the brief that starts the game and disarmed when that
  * game ends — it rides sessionStorage because the hand-off into a scenario game is a full
@@ -12,43 +17,44 @@
  */
 import type { MissionId } from './missions'
 import { missionById } from './missions'
+import type { SpotId } from './spots'
 
 const COACH_KEY = 'argentum.learn.coach'
-const INTRO_KEY = 'argentum.learn.coach.intro'
+const TOUR_KEY = 'argentum.learn.coach.tour'
 
 export function armCoach(mission: MissionId) {
   try {
     sessionStorage.setItem(COACH_KEY, mission)
-    sessionStorage.removeItem(INTRO_KEY)
+    sessionStorage.removeItem(TOUR_KEY)
   } catch {
     // Storage unavailable — the game still starts, just without a coach.
   }
 }
 
 /**
- * The intro card is shown once per game. It rides sessionStorage rather than component state
+ * The table tour runs once per game. It rides sessionStorage rather than component state
  * because the board unmounts and remounts across a reconnect or a resync, and the coach with it.
  */
-export function introSeen(): boolean {
+export function tourSeen(): boolean {
   try {
-    return sessionStorage.getItem(INTRO_KEY) === '1'
+    return sessionStorage.getItem(TOUR_KEY) === '1'
   } catch {
     return false
   }
 }
 
-export function markIntroSeen() {
+export function markTourSeen() {
   try {
-    sessionStorage.setItem(INTRO_KEY, '1')
+    sessionStorage.setItem(TOUR_KEY, '1')
   } catch {
-    // Then the intro shows again after a remount; nothing worse.
+    // Then the tour shows again after a remount; nothing worse.
   }
 }
 
 export function disarmCoach() {
   try {
     sessionStorage.removeItem(COACH_KEY)
-    sessionStorage.removeItem(INTRO_KEY)
+    sessionStorage.removeItem(TOUR_KEY)
   } catch {
     // Nothing to remove.
   }
@@ -77,8 +83,12 @@ export interface CoachView {
   canAttack: boolean
   /** The declare-blockers choice is open. */
   canBlock: boolean
-  /** Some other decision (a target, a "may", a discard) is waiting on the player. */
+  /** Some other decision (a "may", a discard, a server-side target choice) is waiting on the player. */
   hasDecision: boolean
+  /** The player is mid-cast, and the spell wants a target picked on the board. */
+  isTargeting: boolean
+  /** A spell or ability is waiting on the stack. */
+  stackSize: number
   attackersIncoming: number
   /**
    * What the big button at the bottom right says right now — "Pass", "Pass to Attackers",
@@ -86,6 +96,8 @@ export interface CoachView {
    * agree.
    */
   passLabel: string
+  /** Mouse or trackpad (hover works) rather than a touch screen. */
+  hasHover: boolean
   isGameOver: boolean
   won: boolean | null
 }
@@ -97,14 +109,38 @@ export interface CoachTip {
   body: string
   /** Tone drives the accent colour: what to do now, what is happening, or the end of the game. */
   tone: 'act' | 'watch' | 'done'
+  /** The board element to ring while this tip is up. */
+  spot?: SpotId
 }
 
-export function coachTip(view: CoachView, overrides: Partial<Record<string, { title: string; body: string }>> = {}): CoachTip {
+export interface TipOverride {
+  title?: string
+  body?: string
+  spot?: SpotId
+}
+
+/** The device-specific words a tip can use, with the mouse spelling first. */
+const GESTURES: Record<string, [hover: string, touch: string]> = {
+  '{read}': ['Hover a card', 'Press and hold a card'],
+  '{read-lower}': ['hover it', 'press and hold it'],
+  '{click}': ['Click', 'Tap'],
+  '{click-lower}': ['click', 'tap'],
+}
+
+/** Substitute `{pass}` and the gesture words so a tip always names this device's real controls. */
+export function wordTip(text: string, view: Pick<CoachView, 'passLabel' | 'hasHover'>): string {
+  let out = text.replaceAll('{pass}', view.passLabel)
+  for (const [token, [hover, touch]] of Object.entries(GESTURES)) {
+    out = out.replaceAll(token, view.hasHover ? hover : touch)
+  }
+  return out
+}
+
+export function coachTip(view: CoachView, overrides: Partial<Record<string, TipOverride>> = {}): CoachTip {
   const tip = baseTip(view)
   const override = overrides[tip.key]
-  const merged = override ? { ...tip, ...override } : tip
-  // `{pass}` in any tip is the button's current label, so "press {pass}" always names the real button.
-  return { ...merged, title: merged.title.replaceAll('{pass}', view.passLabel), body: merged.body.replaceAll('{pass}', view.passLabel) }
+  const merged: CoachTip = override ? { ...tip, ...override } : tip
+  return { ...merged, title: wordTip(merged.title, view), body: wordTip(merged.body, view) }
 }
 
 function baseTip(view: CoachView): CoachTip {
@@ -128,11 +164,21 @@ function baseTip(view: CoachView): CoachTip {
     return { key: 'draw', title: 'A draw.', body: 'Rare, but it happens. The mission counts.', tone: 'done' }
   }
 
+  if (view.isTargeting) {
+    return {
+      key: 'target',
+      title: 'Pick the target.',
+      body: 'The spell needs something to aim at. The cards it can legally target are highlighted — {click-lower} one, then Confirm. Cancel takes the spell back into your hand.',
+      tone: 'act',
+      spot: 'battlefield',
+    }
+  }
+
   if (view.hasDecision) {
     return {
       key: 'decision',
       title: 'The game is asking you something.',
-      body: 'Read the prompt — it might want a target, a choice, or a yes/no. Click a highlighted card to pick it.',
+      body: 'Read the prompt — it wants a target, a choice, or a yes/no. Highlighted cards are the legal picks; {click-lower} one. Back and Cancel are always there if you change your mind.',
       tone: 'act',
     }
   }
@@ -144,8 +190,9 @@ function baseTip(view: CoachView): CoachTip {
         view.attackersIncoming > 1
           ? `${view.attackersIncoming} creatures are attacking you.`
           : 'A creature is attacking you.',
-      body: 'Drag one of your untapped creatures onto the attacker it should block (or click the creature, then the attacker). A blocked attacker hits your creature instead of you. Then press Confirm Blocks — or No Blocks to take the hit.',
+      body: 'Drag one of your untapped creatures onto the attacker it should block; an arrow shows the block. A blocked attacker hits your creature instead of you. Then press Confirm Blocks — or No Blocks to take the hit.',
       tone: 'act',
+      spot: 'battlefield',
     }
   }
 
@@ -153,8 +200,9 @@ function baseTip(view: CoachView): CoachTip {
     return {
       key: 'attack',
       title: 'Combat — your creatures can attack.',
-      body: 'Click a creature to send it in, then Attack with N — or Attack All. Attackers tap, so think about what you leave back to block on their turn. Skip Attacking is always allowed.',
+      body: '{click} a creature to send it in, then Attack with N — or press Attack All. Attackers tap, so think about what you leave back to block on their turn. Skip Attacking is always allowed.',
       tone: 'act',
+      spot: 'combat-buttons',
     }
   }
 
@@ -163,24 +211,27 @@ function baseTip(view: CoachView): CoachTip {
       return {
         key: 'land-and-cast',
         title: 'Your main phase.',
-        body: 'Play a land first — click it in your hand, then Play. Then click a creature or spell you can afford and Cast it; your lands tap for you.',
+        body: 'Play a land first — drag it from your hand onto the battlefield, or {click-lower} it and choose Play. Then do the same with a creature or spell you can afford; your lands tap for you.',
         tone: 'act',
+        spot: 'hand',
       }
     }
     if (view.canPlayLand) {
       return {
         key: 'land',
         title: 'Play a land.',
-        body: 'One per turn, and it never costs anything. Click a land in your hand, then Play — more lands next turn means bigger spells next turn.',
+        body: 'One per turn, and it never costs anything. Drag a land from your hand onto the battlefield, or {click-lower} it and choose Play — more lands next turn means bigger spells next turn.',
         tone: 'act',
+        spot: 'hand',
       }
     }
     if (view.canCast) {
       return {
         key: 'cast',
         title: 'You can cast something.',
-        body: 'Cards you can afford light up in your hand. Click one, then Cast. Nothing worth casting? Press {pass} to move on.',
+        body: 'Cards you can afford glow in your hand. Drag one onto the battlefield, or {click-lower} it and choose Cast. Nothing worth casting? Press {pass} to move on.',
         tone: 'act',
+        spot: 'hand',
       }
     }
     if (view.step === 'PRECOMBAT_MAIN') {
@@ -189,6 +240,7 @@ function baseTip(view: CoachView): CoachTip {
         title: 'Nothing left to play.',
         body: 'Press {pass}, the blue button at the bottom right. If you have a creature that can attack, the game will stop at combat and ask.',
         tone: 'act',
+        spot: 'pass',
       }
     }
     return {
@@ -196,17 +248,46 @@ function baseTip(view: CoachView): CoachTip {
       title: 'Nothing to do here.',
       body: 'Press {pass}. The game moves on, and hands the turn over when yours is done.',
       tone: 'act',
+      spot: 'pass',
     }
   }
 
   if (!view.isMyTurn && view.hasPriority) {
+    if (view.attackersIncoming > 0 && view.stackSize === 0) {
+      return {
+        key: 'respond-attack',
+        title: view.attackersIncoming > 1 ? 'They are attacking with ' + view.attackersIncoming + ' creatures.' : 'They are attacking.',
+        body: view.canCast
+          ? 'Attackers are declared; blocks come next. A flash creature or an instant cast now still counts for this combat — or press {pass} to go straight to your blocks.'
+          : 'Attackers are declared; blocks come next. Press {pass} and the game will ask you to block.',
+        tone: view.canCast ? 'act' : 'watch',
+        spot: view.canCast ? 'hand' : 'pass',
+      }
+    }
+    if (view.stackSize > 0 && view.canCast) {
+      return {
+        key: 'respond',
+        title: 'Their spell is waiting — you can respond.',
+        body: 'It sits on the stack in the middle of the table and has not happened yet. Cast an instant now and yours resolves first, because it was cast last. Or press {pass} to let theirs happen.',
+        tone: 'act',
+        spot: 'hand',
+      }
+    }
+    if (view.canCast) {
+      return {
+        key: 'respond-window',
+        title: 'Their turn — you have a moment to respond.',
+        body: 'You can cast an instant right now — drag it out or {click-lower} it, then Cast. Otherwise, press {pass}.',
+        tone: 'watch',
+        spot: 'hand',
+      }
+    }
     return {
-      key: 'respond',
+      key: 'respond-idle',
       title: 'Their turn — you have a moment to respond.',
-      body: view.canCast
-        ? 'You can cast an instant right now, before their spell resolves — click it, then Cast. Otherwise, press {pass}.'
-        : 'Nothing you can cast at instant speed, so press {pass} and watch what they do.',
+      body: 'Nothing you can cast at instant speed, so press {pass} and watch what they do.',
       tone: 'watch',
+      spot: 'pass',
     }
   }
 
@@ -216,15 +297,17 @@ function baseTip(view: CoachView): CoachTip {
       title: 'This is your first turn.',
       body: 'The strip at the top shows where in the turn you are. You get the board back the moment there is something to decide.',
       tone: 'watch',
+      spot: 'phase-strip',
     }
   }
 
   return {
     key: 'waiting',
-    title: view.isMyTurn ? 'The game is working through your turn.' : 'The opponent is thinking.',
+    title: view.isMyTurn ? 'The game is working through your turn.' : 'The Tutor is thinking.',
     body: view.isMyTurn
       ? 'Steps with nothing to decide pass on their own. You get the board back the moment there is something to do.'
-      : 'When they attack you will be asked to block. When they cast a spell you may get a chance to respond.',
+      : 'Watch the strip at the top — the lit dot is where their turn is. If they attack you will be asked to block; if they cast a spell you may get a chance to respond.',
     tone: 'watch',
+    spot: 'phase-strip',
   }
 }

--- a/web-client/src/learn/missions.test.ts
+++ b/web-client/src/learn/missions.test.ts
@@ -15,6 +15,7 @@ import type { ClientCard, ClientGameState } from '@/types/gameState'
 import type { EntityId } from '@/types'
 import { COURSE_MINUTES, MISSIONS, missionById, missionCardNames, nextMission, type ObjectiveContext } from './missions'
 import { hasStarted, nextIncomplete } from './progressStore'
+import { ALL_SPOTS } from './spots'
 
 const SETS_ROOT = resolve(__dirname, '../../../mtg-sets')
 const BASICS = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest']
@@ -65,8 +66,26 @@ describe('the missions', () => {
       }
       // The opening cards the brief shows really are in the opening hand or on the board.
       const opening = new Set([...(spec.player1?.hand ?? []), ...(spec.player1?.battlefield ?? []).map((c) => c.name)])
-      expect(m.openingCards.filter((n) => !opening.has(n))).toEqual([])
+      expect(m.openingCards.map((c) => c.name).filter((n) => !opening.has(n))).toEqual([])
     }
+  })
+
+  it('walk the table before the game, and say what was learned after it', () => {
+    for (const m of MISSIONS) {
+      expect(m.tour.length, m.id).toBeGreaterThanOrEqual(2)
+      expect(m.tour.length, m.id).toBeLessThanOrEqual(4)
+      for (const step of m.tour) {
+        expect(ALL_SPOTS).toContain(step.spot)
+        expect(step.body.length).toBeLessThan(220)
+      }
+      expect(m.lessons.length, m.id).toBeGreaterThanOrEqual(2)
+      expect(m.lessons.length, m.id).toBeLessThanOrEqual(3)
+      for (const c of m.openingCards) expect(c.note.length, c.name).toBeGreaterThan(10)
+      for (const hint of Object.values(m.hints)) if (hint?.spot) expect(ALL_SPOTS).toContain(hint.spot)
+    }
+    // Every card the course teaches with is met on the table before it is named: the first
+    // mission's tour covers the hand, the battlefield, the turn strip and the pass button.
+    expect(missionById('first-steps')?.tour.map((s) => s.spot)).toEqual(['hand', 'battlefield', 'phase-strip', 'pass'])
   })
 
   it('keeps the promise on the home page honest', () => {

--- a/web-client/src/learn/missions.ts
+++ b/web-client/src/learn/missions.ts
@@ -18,6 +18,7 @@
 import type { ScenarioSpec } from '@/components/scenario/types'
 import type { ClientCard, ClientGameState } from '@/types/gameState'
 import type { EntityId } from '@/types'
+import type { SpotId } from './spots'
 
 export type MissionId = 'first-steps' | 'blocking' | 'instants' | 'real-game'
 
@@ -44,6 +45,25 @@ export interface Objective {
 
 /** Mission-specific wording for a coach tip key; the generic tip is used where none is given. */
 export interface HintOverride {
+  title?: string
+  body?: string
+  /** The board element to ring while the tip is up — see `learn/spots.ts`. */
+  spot?: SpotId
+}
+
+/** A card the brief shows before the game does, with one plain line on what it is for. */
+export interface OpeningCard {
+  name: string
+  note: string
+}
+
+/**
+ * One step of the table tour the coach walks through when the board first appears: a spot on the
+ * board to ring, and two sentences about it. Gesture words (`{read}`, `{click}`) and `{pass}` are
+ * substituted for this device and the real button — see `wordTip` in `learn/coach.ts`.
+ */
+export interface TourStep {
+  spot: SpotId
   title: string
   body: string
 }
@@ -61,10 +81,12 @@ export interface Mission {
   /** What the brief says you will do — three lines, no more. */
   brief: readonly string[]
   /** What the board shows first, so the brief can put the cards on the table before the game does. */
-  openingCards: readonly string[]
+  openingCards: readonly OpeningCard[]
   objectives: readonly Objective[]
-  /** Shown once, when the board first appears. */
-  intro: string
+  /** Walked through once, when the board first appears — each step rings one part of the table. */
+  tour: readonly TourStep[]
+  /** What the closing card says you now know — two or three lines, game and app together. */
+  lessons: readonly string[]
   hints: Partial<Record<string, HintOverride>>
   spec: (playerName: string) => ScenarioSpec
 }
@@ -213,34 +235,63 @@ export const MISSIONS: readonly Mission[] = [
     frame: 'G',
     minutes: 4,
     brief: [
-      'Play one land a turn and tap them for mana — your lands tap on their own when you cast.',
+      'Play one land a turn. Lands make mana, and your lands tap for you when you cast something.',
       'Cast creatures. A creature that just arrived has to wait a turn before it can attack.',
       'Attack with what can attack. Get the Tutor from 8 life to 0.',
     ],
-    openingCards: ['Forest', 'Grizzly Bears', 'Runeclaw Bear'],
+    openingCards: [
+      { name: 'Forest', note: 'A land. Free to play, one per turn; tap it for one green mana.' },
+      { name: 'Grizzly Bears', note: 'A creature. Costs two mana; hits for 2 and takes 2.' },
+      { name: 'Runeclaw Bear', note: 'The same bear in a different coat. Two of them is 4 damage a turn.' },
+    ],
     objectives: [playedLand, castCreature, attacked, won],
-    intro:
-      'This is the table. Your cards are at the bottom — the hand you can play from — and your lands and creatures go on the battlefield above them. Up top is the Tutor, on 8 life. Bring that to zero.',
+    tour: [
+      {
+        spot: 'hand',
+        title: 'Your hand.',
+        body: 'The cards you can play from. Cards you can afford glow. {read} to read it in full — that works anywhere on the table.',
+      },
+      {
+        spot: 'battlefield',
+        title: 'Your battlefield.',
+        body: 'Where your lands and creatures live once played. Two Forests are already down. The Tutor’s side is the mirror image above.',
+      },
+      {
+        spot: 'phase-strip',
+        title: 'The turn strip.',
+        body: 'A turn is a row of steps; the lit dot is where you are. Your turn, then theirs, then yours again.',
+      },
+      {
+        spot: 'pass',
+        title: 'The big button.',
+        body: 'When you are done, press it. It always says where it takes you next — right now, {pass}.',
+      },
+    ],
+    lessons: [
+      'Lands make mana; one a turn. Creatures cost mana and wait a turn before attacking.',
+      'Drag a card onto the battlefield to play it, or {click-lower} it and choose. {read} to read it.',
+      'The blue button moves the game on and names the next stop.',
+    ],
     hints: {
       land: {
         title: 'Play a land.',
-        body: 'Click the Forest in your hand, then Play Forest. Lands are free, one per turn, and every land you have is one more mana next turn.',
+        body: 'Drag the Forest from your hand up onto the battlefield — or {click-lower} it and choose Play Forest. Lands are free, one per turn, and every land is one more mana each turn.',
       },
       'land-and-cast': {
         title: 'Land first, then a creature.',
-        body: 'Click the Forest in your hand, then Play Forest. Then click Grizzly Bears and Cast it — it costs two mana, and your lands tap for you.',
+        body: 'Drag the Forest up onto the battlefield, or {click-lower} it and choose Play Forest. Then do the same with Grizzly Bears — it costs two mana, and your lands tap for you.',
       },
       cast: {
         title: 'Cast a creature.',
-        body: 'The cards you can afford light up. Click Grizzly Bears, then Cast. It lands on the battlefield, but it cannot attack until your next turn — that is summoning sickness.',
+        body: 'The cards you can afford glow. Drag Grizzly Bears onto the battlefield, or {click-lower} it and choose Cast. It lands but cannot attack until your next turn — that is summoning sickness.',
       },
       attack: {
         title: 'Attack!',
-        body: 'Press Attack All — or click a creature and then Attack with 1. The Tutor has nothing to block with, so every point of power goes straight to their life total.',
+        body: 'Press Attack All — or {click-lower} a creature and then Attack with 1. The Tutor has nothing to block with, so every point of power comes straight off their life.',
       },
       'pass-to-combat': {
         title: 'Nothing left to do — press {pass}.',
-        body: 'It is the blue button at the bottom right. The turn moves on; if a creature of yours can attack, the game stops at combat and asks you.',
+        body: 'The blue button at the bottom right. The turn moves on; if a creature of yours can attack, the game stops at combat and asks you.',
       },
       pass: {
         title: 'Nothing to do here — press {pass}.',
@@ -248,7 +299,7 @@ export const MISSIONS: readonly Mission[] = [
       },
       waiting: {
         title: 'The Tutor is taking a turn.',
-        body: 'They will play a land and pass. Watch the phase strip at the top — it comes back to you soon.',
+        body: 'They will play a land and pass. Watch the strip at the top — the lit dot walks through their turn and comes back to you.',
       },
     },
     spec: (name) => ({
@@ -285,26 +336,59 @@ export const MISSIONS: readonly Mission[] = [
       'A blocked attacker hits your creature instead of you. Compare power against toughness before you block.',
       'You start on 14 life with one creature. Their Bloodrock Cyclops must attack every turn — make it pay, then build up and win.',
     ],
-    openingCards: ['Giant Spider', 'Centaur Courser', 'Benalish Knight'],
+    openingCards: [
+      { name: 'Giant Spider', note: 'On the battlefield already. 2 power, 4 toughness: it blocks a 3/3 and lives.' },
+      { name: 'Centaur Courser', note: 'A 3/3 for three mana. Kills their Ogre in a fight and survives.' },
+      { name: 'Benalish Knight', note: 'Flash: an instant-speed creature. Cast it on their turn and surprise-block.' },
+    ],
     objectives: [blocked, killedInCombat, won],
-    intro:
-      'It is the Tutor’s turn, and they have two creatures to your one. Their Bloodrock Cyclops (3/3) is forced to attack every combat. Your Giant Spider is a 2/4 — four toughness means it survives three damage. When they attack, put it in front of the biggest thing coming.',
+    tour: [
+      {
+        spot: 'opponent-battlefield',
+        title: 'Their side.',
+        body: 'Two creatures to your one. The Bloodrock Cyclops (3/3) has to attack every combat — {read} to see it written on the card.',
+      },
+      {
+        spot: 'battlefield',
+        title: 'Your Giant Spider.',
+        body: 'The numbers in the corner are power / toughness: 2/4. Four toughness means it survives three damage, so the Cyclops cannot kill it.',
+      },
+      {
+        spot: 'log',
+        title: 'The log.',
+        body: 'Everything that happens is written down here. Combat goes by quickly; when you wonder what just hit you, open the log.',
+      },
+    ],
+    lessons: [
+      'Block by dragging your creature onto the attacker. An untapped creature can block one attacker.',
+      'Power is what a creature deals, toughness is what it survives. A blocker with more toughness than their power walks away.',
+      'Attacking taps a creature, so it cannot block on their turn. Keep a wall home when you need one.',
+    ],
     hints: {
       block: {
         title: 'Choose your blocks.',
-        body: 'Drag Giant Spider onto the Cyclops (or click the Spider, then the Cyclops). It survives 3 damage, so that block costs you nothing; whatever is unblocked hits you. Then press Confirm Blocks.',
+        body: 'Drag Giant Spider onto the Cyclops — an arrow appears. It survives 3 damage, so that block costs you nothing; whatever is unblocked hits you. Then press Confirm Blocks.',
+        spot: 'battlefield',
       },
       'land-and-cast': {
         title: 'Your turn — build up.',
-        body: 'Click a land in your hand and play it, then click a creature and cast it. Centaur Courser is a 3/3: it kills the Ogre and survives, and trades with the Cyclops.',
+        body: 'Play a land, then a creature — drag them up, or {click-lower} and choose. Centaur Courser is a 3/3: it kills the Ogre and survives, and trades with the Cyclops.',
       },
       attack: {
         title: 'Attack — but count first.',
-        body: 'Click the creatures to send in, then Attack with N. Anything that attacks is tapped on their turn and cannot block, so keep the Spider home if you still need a wall. Skip Attacking is fine too.',
+        body: '{click} the creatures to send in, then Attack with N. Anything that attacks is tapped on their turn and cannot block, so keep the Spider home if you still need a wall. Skip Attacking is fine too.',
       },
       respond: {
+        title: 'Their spell is on the stack.',
+        body: 'Benalish Knight has flash — it can be cast on their turn, like an instant. Cast it now and you have a second blocker before they attack; or press {pass} and keep it up your sleeve.',
+      },
+      'respond-window': {
         title: 'Their turn.',
-        body: 'You have nothing to cast at instant speed, so press {pass}. If they attack, you will be asked to block.',
+        body: 'Benalish Knight has flash, so you may cast it now — otherwise press {pass}. If they attack, you will be asked to block.',
+      },
+      'respond-attack': {
+        title: 'The Cyclops is coming.',
+        body: 'Attackers are declared; blocks come next. Benalish Knight cast now can block this very attack — first strike means it deals its damage before the creature it blocks. Or press {pass} and block with the Spider alone.',
       },
     },
     spec: (name) => ({
@@ -349,14 +433,43 @@ export const MISSIONS: readonly Mission[] = [
       'Spells go on the stack and resolve top-down: your response happens before the spell it answers.',
       'When Lightning Bolt targets your bear, save it with Giant Growth. Then win.',
     ],
-    openingCards: ['Grizzly Bears', 'Giant Growth', 'Centaur Courser'],
+    openingCards: [
+      { name: 'Grizzly Bears', note: 'Already on the battlefield, and about to be shot at.' },
+      { name: 'Giant Growth', note: 'An instant: +3/+3 until end of turn. Cast it in response and the bear survives the Bolt.' },
+      { name: 'Centaur Courser', note: 'Your next creature, once you have a third Forest and a quiet moment.' },
+    ],
     objectives: [castInstant, attacked, won],
-    intro:
-      'You have Grizzly Bears on the battlefield and Giant Growth in hand — an instant that gives +3/+3 until end of turn. It is the Tutor’s turn, and they have three Mountains. When a spell of theirs appears in the middle of the table, that is the stack, and the game will stop to ask if you want to respond.',
+    tour: [
+      {
+        spot: 'stack',
+        title: 'The stack.',
+        body: 'When anyone casts a spell it appears here first, and nothing happens until everybody passes. That gap is your window to respond.',
+      },
+      {
+        spot: 'priority-mode',
+        title: 'Auto.',
+        body: 'This switch decides how often the game stops to ask you. On Auto it stops whenever you hold an instant you can cast — so the Bolt will wait for you.',
+      },
+      {
+        spot: 'hand',
+        title: 'Giant Growth.',
+        body: 'An instant: +3/+3 until end of turn. When Lightning Bolt shows up on the stack aimed at your bear, cast this at the bear.',
+      },
+    ],
+    lessons: [
+      'A spell waits on the stack until everyone passes. The last spell cast resolves first.',
+      'An instant can be cast on anyone’s turn — you get a window whenever the game stops for you.',
+      'The Auto switch controls when the game stops to ask; it stops on its own when you hold an instant.',
+    ],
     hints: {
       respond: {
         title: 'Respond!',
-        body: 'Their spell is on the stack and has not happened yet. Click Giant Growth in your hand, Cast it, and pick Grizzly Bears as the target. Yours resolves first, because it was cast last.',
+        body: 'Their spell is on the stack and has not happened yet. Drag Giant Growth out — or {click-lower} it and choose Cast — and pick Grizzly Bears as the target. Yours resolves first, because it was cast last.',
+        spot: 'hand',
+      },
+      target: {
+        title: 'Aim it at the bear.',
+        body: 'Giant Growth needs a creature to grow. Grizzly Bears is highlighted — {click-lower} it, then Confirm. It becomes 5/5 until end of turn, and 3 damage no longer kills it.',
       },
       'land-and-cast': {
         title: 'Your turn.',
@@ -364,7 +477,7 @@ export const MISSIONS: readonly Mission[] = [
       },
       attack: {
         title: 'Attack.',
-        body: 'Click a creature, then Attack with N. Even when they have a blocker, an instant in hand turns a bad fight into a good one — cast it after blocks are declared.',
+        body: '{click} a creature, then Attack with N. Even when they have a blocker, an instant in hand turns a bad fight into a good one — cast it after blocks are declared.',
       },
     },
     spec: (name) => ({
@@ -379,8 +492,10 @@ export const MISSIONS: readonly Mission[] = [
       player2: {
         lifeTotal: 8,
         battlefield: [{ name: 'Mountain' }, { name: 'Mountain' }, { name: 'Mountain' }],
-        hand: ['Lightning Bolt', 'Shock', 'Mountain'],
-        library: curve(['Goblin Piker', 'Volcanic Hammer', 'Gray Ogre', 'Lightning Strike', 'Hill Giant', 'Raging Goblin', 'Bloodrock Cyclops'], ['Mountain']),
+        // Bolt is the only burn in hand: given Shock as well, the AI opens with the cheaper one
+        // and the brief's "when Lightning Bolt targets your bear" names a card that never shows.
+        hand: ['Lightning Bolt', 'Mountain'],
+        library: curve(['Shock', 'Goblin Piker', 'Volcanic Hammer', 'Gray Ogre', 'Lightning Strike', 'Hill Giant', 'Raging Goblin', 'Bloodrock Cyclops'], ['Mountain']),
       },
       phase: 'PRECOMBAT_MAIN',
       activePlayer: 2,
@@ -401,10 +516,34 @@ export const MISSIONS: readonly Mission[] = [
       'Play a land every turn, spend your mana, and count before you attack or block.',
       'Win or lose, finishing this game finishes the course.',
     ],
-    openingCards: ['Grizzly Bears', 'Benalish Knight', 'Runeclaw Bear'],
+    openingCards: [
+      { name: 'Grizzly Bears', note: 'On the battlefield from the start, ready to attack.' },
+      { name: 'Benalish Knight', note: 'A 2/2 with first strike and flash — it deals its damage before the other creature does.' },
+      { name: 'Runeclaw Bear', note: 'A second bear for the second turn.' },
+    ],
     objectives: [playedLand, castCreature, attacked, won],
-    intro:
-      'A real game: twenty life each, a creature apiece already on the board, and a full deck to draw from. The coach keeps saying what the board is waiting for; the decisions are yours.',
+    tour: [
+      {
+        spot: 'controls',
+        title: 'The controls.',
+        body: 'Undo takes back a tap or a cast the game can still rewind. The land icon switches to choosing your own lands to tap. ? Help explains everything else.',
+      },
+      {
+        spot: 'piles',
+        title: 'Your piles.',
+        body: 'Deck, graveyard and exile. {click} a pile to browse what is in it — your graveyard is where creatures go when they die.',
+      },
+      {
+        spot: 'opponent-life',
+        title: 'Twenty life.',
+        body: 'Life totals sit either side of the turn strip. Zero loses. The coach keeps saying what the board is waiting for; the decisions are yours.',
+      },
+    ],
+    lessons: [
+      'A full game: play a land every turn, spend your mana, count before you attack or block.',
+      'Undo, manual tapping and ? Help are in the bottom-right corner; the piles open when clicked.',
+      'You have played Magic. The PLAY menu has quick games against the AI, drafts and other people.',
+    ],
     hints: {},
     spec: (name) => ({
       player1Name: name,

--- a/web-client/src/learn/spots.test.ts
+++ b/web-client/src/learn/spots.test.ts
@@ -1,0 +1,42 @@
+/**
+ * A spot is only useful if the board actually carries its anchor. The selectors are DOM queries
+ * against attributes the board components render (`data-learn`, `data-zone`, `data-life-id`),
+ * so this reads the component sources and checks each attribute value is written somewhere —
+ * a renamed or dropped anchor fails here instead of silently drawing no ring.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ALL_SPOTS, spotSelector } from './spots'
+
+const COMPONENTS = resolve(__dirname, '../components')
+
+function sources(): string {
+  const chunks: string[] = []
+  for (const entry of readdirSync(COMPONENTS, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.tsx')) continue
+    chunks.push(readFileSync(resolve(entry.parentPath ?? '', entry.name), 'utf8'))
+  }
+  return chunks.join('\n')
+}
+
+describe('spots', () => {
+  const src = sources()
+  const ctx = { me: 'p1' as never, opponent: 'p2' as never }
+
+  it.each(ALL_SPOTS)('%s has an anchor the board renders', (spot) => {
+    const selector = spotSelector(spot, ctx)
+    const m = /\[(data-[a-z-]+)(?:="([^"]*)")?\]/.exec(selector)
+    expect(m, selector).not.toBeNull()
+    const [, attr, value] = m!
+    // A literal value must be written as that literal; an id-valued attribute (`data-life-id`)
+    // only needs the attribute itself to be rendered.
+    const needle = value === undefined || value === 'p2' || value === 'p1' ? `${attr}=` : `${attr}="${value}"`
+    if (needle === `${attr}=`) {
+      expect(src, needle).toContain(needle)
+    } else {
+      // `data-zone` values are chosen by a ternary in places, so accept the value as a quoted string too.
+      expect(src.includes(needle) || src.includes(`'${value}'`), needle).toBe(true)
+    }
+  })
+})

--- a/web-client/src/learn/spots.ts
+++ b/web-client/src/learn/spots.ts
@@ -1,0 +1,64 @@
+/**
+ * The places on the game board the coach can point at.
+ *
+ * A tip or a tour step names a spot; `LearnSpotlight` finds the element and draws a ring around
+ * it. The board marks its controls with `data-learn="…"` — an attribute, never a layout change —
+ * and the zones already carry `data-zone`. Everything here is a DOM query, so a spot that is not
+ * on screen (a phone layout without the log, a step with no combat buttons) simply draws nothing.
+ */
+import type { EntityId } from '@/types'
+
+export type SpotId =
+  | 'hand'
+  | 'battlefield'
+  | 'opponent-battlefield'
+  | 'phase-strip'
+  | 'pass'
+  | 'combat-buttons'
+  | 'controls'
+  | 'undo'
+  | 'priority-mode'
+  | 'stack'
+  | 'log'
+  | 'opponent-life'
+  | 'my-life'
+  | 'piles'
+
+export interface SpotContext {
+  me: EntityId
+  opponent: EntityId | undefined
+}
+
+const SELECTORS: Record<SpotId, string | ((ctx: SpotContext) => string)> = {
+  hand: '[data-zone="hand"]',
+  battlefield: '[data-zone="player-battlefield"]',
+  'opponent-battlefield': '[data-zone="opponent-battlefield"]',
+  'phase-strip': '[data-learn="phase-strip"]',
+  pass: '[data-learn="pass"]',
+  'combat-buttons': '[data-learn="combat-buttons"]',
+  controls: '[data-learn="controls"]',
+  undo: '[data-learn="undo"]',
+  'priority-mode': '[data-learn="priority-mode"]',
+  stack: '[data-learn="stack"]',
+  log: '[data-learn="log"]',
+  'opponent-life': (ctx) => (ctx.opponent ? `[data-life-id="${ctx.opponent}"]` : '[data-life-id]'),
+  'my-life': (ctx) => `[data-life-id="${ctx.me}"]`,
+  piles: '[data-zone="player-library"]',
+}
+
+export function spotSelector(spot: SpotId, ctx: SpotContext): string {
+  const s = SELECTORS[spot]
+  return typeof s === 'function' ? s(ctx) : s
+}
+
+/** The first on-screen match — a zone can be rendered twice for two layouts, one of them empty. */
+export function findSpot(spot: SpotId, ctx: SpotContext): Element | null {
+  const selector = spotSelector(spot, ctx)
+  for (const el of document.querySelectorAll(selector)) {
+    const r = el.getBoundingClientRect()
+    if (r.width > 0 && r.height > 0) return el
+  }
+  return null
+}
+
+export const ALL_SPOTS: readonly SpotId[] = Object.keys(SELECTORS) as SpotId[]

--- a/web-client/src/pages/LearnPage.tsx
+++ b/web-client/src/pages/LearnPage.tsx
@@ -98,8 +98,8 @@ function CourseHome() {
         </h1>
         <p className={styles.lede}>
           Four short games against the AI, each from a board set up to teach one thing, with a coach at your
-          elbow saying what to do next. About {COURSE_MINUTES} minutes all told. Nothing to read first,
-          nothing to sign up for.
+          elbow saying what to do next — and where on the table to do it. About {COURSE_MINUTES} minutes all
+          told. Nothing to read first, nothing to sign up for.
         </p>
         <div className={styles.heroActions}>
           {finished ? (
@@ -153,7 +153,7 @@ function Brief({ mission }: { mission: Mission }) {
   const completed = useLearnProgress((s) => s.completed)
   const plays = useLearnProgress((s) => s.plays)
   const done = completed.includes(mission.id)
-  const cards = useLessonCards(mission.openingCards)
+  const cards = useLessonCards(mission.openingCards.map((c) => c.name))
   const [name, setName] = useState(storedName)
   const [starting, setStarting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -262,11 +262,14 @@ function Brief({ mission }: { mission: Mission }) {
           <aside className={styles.briefColumn} aria-label="Your opening cards">
             <h2 className={styles.briefHeading}>Your opening cards</h2>
             <div className={styles.briefCards}>
-              {mission.openingCards.map((n) => (
-                <CardImage key={n} src={cards[n]?.imageUrl ?? ''} name={n} caption={n} />
+              {mission.openingCards.map((c) => (
+                <CardImage key={c.name} src={cards[c.name]?.imageUrl ?? ''} name={c.name} caption={c.name} note={c.note} />
               ))}
             </div>
-            <p className={styles.briefNote}>Hover any card at the table to read it in full.</p>
+            <p className={styles.briefNote}>
+              <span className={styles.hoverOnly}>Hover a card to lift it, click to read it in full. At the table, hovering any card does the same.</span>
+              <span className={styles.touchOnly}>Tap a card to read it in full. At the table, press and hold any card to do the same.</span>
+            </p>
           </aside>
         </div>
 


### PR DESCRIPTION
Polish pass on the Learn to Play course (#2075). The coach now teaches **Argentum's table** alongside the rules, and the things the course claimed but didn't do are fixed.

## What changed

**A spotlighted tour of the table.** Each mission opens with 2–4 steps, each ringing one part of the board while saying what it is for (`LearnSpotlight`, driven by a new `learn/spots.ts` map of DOM anchors). Mission 1: hand → battlefield → turn strip → the pass button. Mission 2: their side, your creature's P/T, the log. Mission 3: the stack, the Auto switch, the trick in hand. Mission 4: the undo / manual-tap / help row, the piles, the life totals. Skippable; Back/Next. While the game is on, an *act* tip keeps a quieter ring on the thing it names (hand, pass button, combat buttons, battlefield).

**Tips name both gestures and the device's words.** Every play tip says *drag the card onto the battlefield, or click it and choose*. New placeholders — `{read}` → "Hover a card" / "Press and hold a card", `{click}` → Click/Tap — are substituted per device (`(hover: hover) and (pointer: fine)`), and `{pass}` is still the server's real button label. New tips: picking a target mid-cast (with "then Confirm"), the flash window once attackers are declared, and the response prompt is now three keys (`respond` = their spell is on the stack and you can answer; `respond-window` = you could cast, nothing is on the stack; `respond-idle` = nothing to cast) so a mission's "Respond!" override no longer fires with an empty hand.

**Things that were wrong:**
- The brief said *"Hover any card at the table to read it in full"* under three static images. The opening cards now lift on hover and open full-size on click, each with a one-line note on what the card does; the note beside them names the real gesture and is device-aware. A `card-preview` help topic ("Reading a card in full") is added — nothing in `/help` covered hover / long-press / View card.
- Mission 2's block hint said *"or click the Spider, then the Cyclops"*. There is no click-to-block in the client (`GameCard.tsx` — a pure blocker's click is a no-op); every block tip now says drag.
- Mission 3's brief promises Lightning Bolt, but with Bolt *and* Shock in hand the AI opened with Shock. Shock moves to the top of the library; Bolt is the opening play.

**Coach panel:** the × that hid the coach for the rest of the game is now a "tuck away" that collapses it to a `Coach · n/m` pill; the closing card lists *What you now know* (game and app, 2–3 lines per mission).

**Board:** `data-learn="…"` attributes on the controls row, undo, priority-mode, pass and combat-button containers, the step strip, the stack and the log toggle. Attributes only — no layout or behaviour change. `spots.test.ts` reads the component sources and fails if an anchor disappears.

## Verified
- `npm run typecheck` clean; `vitest run` 52 files / 734 tests (learn: 42, including a placeholder-leak check over every mission's wording on both device profiles).
- Played in Chrome against the local server: mission 1 tour (all four rings land), tip + hand ring, collapse pill; mission 3 — Auto does stop with burn on the stack, the pass button reads *Resolve*, the stack ring, the Auto ring, the click → Cast → target → Confirm flow with the new targeting tip, the game-over card; mission 2 — the AI's precombat cast, the flash window at declare-attackers, the block prompt, and a real drag Spider → Cyclops drawing the block arrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173Xm5K5s6kieSoA9yk1afM
