### PR TITLE
Learn to Play: a fifth mission, card notes, warnings, phone layout, account progress

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -90,7 +90,7 @@ Flyway migration `V1__init.sql`:
 
 | Table | Purpose |
 |-------|---------|
-| `users` | account: email (unique), display name, created_at, `is_admin` (added in `V3__admin_role.sql`) |
+| `users` | account: email (unique), display name, created_at, `is_admin` (added in `V3__admin_role.sql`), `learn_progress` — the Learn to Play course document as the client's own JSON, opaque to the server (`V13__learn_progress.sql`) |
 | `login_tokens` | single-use magic-link tokens (SHA-256 hashed, short TTL) |
 | `decks` | saved decks: denormalized name/format + full `SharedDeck` JSON in `data` |
 | `match_results` | one row per finished game |

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/MagicLinkService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/MagicLinkService.kt
@@ -90,6 +90,15 @@ class MagicLinkService(
         return users.save(user.copy(displayName = displayName))
     }
 
+    /**
+     * Store the account's Learn to Play progress — the client's JSON, kept verbatim. Returns null if
+     * the account no longer exists. Caller validates the body (well-formed JSON, size cap).
+     */
+    fun updateLearnProgress(userId: UUID, progressJson: String): UserRow? {
+        val user = users.findById(userId).orElse(null) ?: return null
+        return users.save(user.copy(learnProgress = progressJson))
+    }
+
     private fun sha256Hex(value: String): String =
         MessageDigest.getInstance("SHA-256")
             .digest(value.toByteArray(Charsets.UTF_8))

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
@@ -6,7 +6,10 @@ import com.wingedsheep.gameserver.auth.InvalidLoginTokenException
 import com.wingedsheep.gameserver.auth.MagicLinkService
 import com.wingedsheep.gameserver.persistence.UserRow
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -56,6 +59,8 @@ class AuthController(
 
     companion object {
         const val MAX_DISPLAY_NAME_LENGTH = 40
+        /** A course of a handful of missions is a few hundred bytes; anything near this is not progress. */
+        const val MAX_LEARN_PROGRESS_BYTES = 4096
     }
 
     @PostMapping("/request-login")
@@ -101,6 +106,38 @@ class AuthController(
         val updated = magicLinkService.updateDisplayName(claims.userId, name)
             ?: return ResponseEntity.status(401).body(mapOf("error" to "Account no longer exists"))
         return ResponseEntity.ok(updated.toDto())
+    }
+
+    /**
+     * The account's Learn to Play progress — the client's own JSON, returned verbatim, or `{}` when
+     * the course was never started on this account. Guests keep the same document in localStorage;
+     * the client merges the two on sign-in.
+     */
+    @GetMapping("/me/learn-progress", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun learnProgress(@RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?): ResponseEntity<Any> {
+        val claims = authSupport.requireUser(authorization)
+        val user = magicLinkService.findUser(claims.userId)
+            ?: return ResponseEntity.status(401).body(mapOf("error" to "Account no longer exists"))
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(user.learnProgress ?: "{}")
+    }
+
+    /** Replace the account's Learn to Play progress. The body must be a JSON object, and small. */
+    @PutMapping("/me/learn-progress", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun updateLearnProgress(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestBody body: String,
+    ): ResponseEntity<Any> {
+        val claims = authSupport.requireUser(authorization)
+        if (body.length > MAX_LEARN_PROGRESS_BYTES) {
+            return ResponseEntity.badRequest().body(mapOf("error" to "Progress document too large"))
+        }
+        val parsed = runCatching { Json.parseToJsonElement(body) }.getOrNull()
+        if (parsed !is JsonObject) {
+            return ResponseEntity.badRequest().body(mapOf("error" to "Progress must be a JSON object"))
+        }
+        magicLinkService.updateLearnProgress(claims.userId, parsed.toString())
+            ?: return ResponseEntity.status(401).body(mapOf("error" to "Account no longer exists"))
+        return ResponseEntity.noContent().build()
     }
 
     private fun UserRow.toDto() =

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
@@ -28,6 +28,8 @@ data class UserRow(
     val isAdmin: Boolean = false,
     /** When true the account appears offline to its friends even while connected (presence opt-out). */
     val hidePresence: Boolean = false,
+    /** Learn to Play progress — the client's JSON, stored verbatim; null until the course is started. */
+    val learnProgress: String? = null,
     val createdAt: Instant = Instant.now(),
 )
 

--- a/game-server/src/main/resources/db/migration/V13__learn_progress.sql
+++ b/game-server/src/main/resources/db/migration/V13__learn_progress.sql
@@ -1,0 +1,5 @@
+-- Learn to Play course progress, per account. The client keeps the same JSON in localStorage for
+-- guests; a signed-in user's copy lives here so "2 of 5 missions" follows them across devices. The
+-- body is the client's `StoredProgress` JSON stored verbatim (a few hundred bytes at most): the
+-- server never interprets it, the way `decks.data` and `cubes.data` are opaque to it.
+ALTER TABLE users ADD COLUMN learn_progress TEXT;

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -120,6 +120,27 @@ export async function fetchMe(): Promise<AccountUser | null> {
 
 // ----- Saved decks -----
 
+/**
+ * Learn to Play progress on the account — the client's own document, stored verbatim by the
+ * server. `{}` when the course was never started there. See `learn/progressStore.ts` for the merge.
+ */
+export async function fetchLearnProgress(): Promise<unknown> {
+  const res = await fetch('/api/auth/me/learn-progress', { headers: authHeaders() })
+  if (res.status === 401) throw new UnauthorizedError()
+  if (!res.ok) throw new Error(`Failed to load course progress (${res.status})`)
+  return res.json()
+}
+
+export async function saveLearnProgress(progress: unknown): Promise<void> {
+  const res = await fetch('/api/auth/me/learn-progress', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(progress),
+  })
+  if (res.status === 401) throw new UnauthorizedError()
+  if (!res.ok) throw new Error(`Failed to save course progress (${res.status})`)
+}
+
 export interface DeckSummary {
   readonly id: number
   readonly name: string

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -30,6 +30,7 @@ import { RenderProfiler } from '@/utils/renderProfiler'
 import { CardPreview } from './card'
 import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, SpeedGauge, DayNightBadge, ConcedeButton, FullscreenButton, SpectatorCountBadge, TeamLifeBanner, EliminationNotice } from './overlay'
 import { HelpDrawer, HelpDrawerButton } from '../help/HelpDrawer'
+import { markLearnSignal } from '@/learn/signals'
 import { styles } from './board/styles'
 
 /**
@@ -1669,7 +1670,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             >
               <button
                 data-learn="undo"
-                onClick={requestUndo}
+                onClick={() => {
+                  markLearnSignal('undoUsed')
+                  requestUndo()
+                }}
                 disabled={!undoAvailable}
                 title="Undo"
                 style={{

--- a/web-client/src/components/game/GameLog.tsx
+++ b/web-client/src/components/game/GameLog.tsx
@@ -1,6 +1,7 @@
 import { useGameStore, type LogEntry } from '@/store/gameStore.ts'
 import { identitySeatColor, selectTeamMap } from '@/store/selectors.ts'
 import type { EntityId } from '@/types'
+import { markLearnSignal } from '@/learn/signals'
 import React, { useState, useRef, useEffect } from 'react'
 
 /**
@@ -35,7 +36,10 @@ export function GameLog() {
     return (
       <button
         data-learn="log"
-        onClick={() => setExpanded(true)}
+        onClick={() => {
+          setExpanded(true)
+          markLearnSignal('logOpened')
+        }}
         style={styles.toggleButton}
       >
         Log ({eventLog.length})

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -305,11 +305,14 @@ function GameCardImpl({
   // of the action menu that same tap had just opened — and since no mouseleave follows a tap, it
   // stayed there. Touch reaches the preview through the long-press below instead.
   const updateHoverPosition = useGameStore((s) => s.updateHoverPosition)
+  // While an action menu is open the pointer is still over the card that opened it, and the
+  // preview would land on top of the menu's buttons — the menu already shows the card full-size.
+  const menuOpen = useGameStore((s) => s.selectedCardId !== null)
 
   const handleHoverEnter = useCallback((e: React.PointerEvent) => {
-    if (e.pointerType === 'touch') return
+    if (e.pointerType === 'touch' || menuOpen) return
     hoverCard(card.id, { x: e.clientX, y: e.clientY })
-  }, [card.id, hoverCard])
+  }, [card.id, hoverCard, menuOpen])
 
   const handleHoverMove = useCallback((e: React.PointerEvent) => {
     if (e.pointerType === 'touch') return
@@ -1294,6 +1297,7 @@ function GameCardImpl({
     <div
       data-card-id={card.id}
       {...(isGhost ? { 'data-ghost': 'true' } : {})}
+      {...(isTapped ? { 'data-tapped': 'true' } : {})}
       onClick={handleClick}
       onDoubleClick={handleDoubleClickEvent}
       /* Mouse and touch both drive the drag handlers, so every mouse one has to ignore the

--- a/web-client/src/components/learn/CardImage.tsx
+++ b/web-client/src/components/learn/CardImage.tsx
@@ -37,7 +37,7 @@ export function CardImage({
         onClick={() => setOpen(true)}
         aria-label={`Read ${name} in full`}
       >
-        <img src={src} alt={name} className={styles.cardImg} loading="lazy" draggable={false} />
+        <img src={src} alt={name} className={styles.cardImg} draggable={false} />
       </button>
       {caption !== undefined && <div className={styles.cardName}>{caption}</div>}
       {note !== undefined && <p className={styles.cardNote}>{note}</p>}

--- a/web-client/src/components/learn/LearnCallout.tsx
+++ b/web-client/src/components/learn/LearnCallout.tsx
@@ -7,7 +7,7 @@
  * (the `/help` guide keeps a link for anyone who wants it back).
  */
 import { useNavigate } from 'react-router-dom'
-import { COURSE_MINUTES, MISSIONS } from '@/learn/missions'
+import { COURSE_COUNT_WORD, COURSE_MINUTES, MISSIONS } from '@/learn/missions'
 import { hasStarted, nextIncomplete, useLearnProgress } from '@/learn/progressStore'
 import styles from './LearnCallout.module.css'
 
@@ -35,7 +35,7 @@ export function LearnCallout({ variant }: { variant: 'arrival' | 'tier' }) {
           <span className={styles.arrivalBody}>
             {started
               ? `${completed.length} of ${MISSIONS.length} missions done — no name needed to continue.`
-              : `Learn by playing: four short guided games with a coach, about ${COURSE_MINUTES} minutes. No name needed.`}
+              : `Learn by playing: ${COURSE_COUNT_WORD} short guided games with a coach, about ${COURSE_MINUTES} minutes. No name needed.`}
           </span>
         </span>
         <span className={styles.arrivalArrow} aria-hidden="true">→</span>

--- a/web-client/src/components/learn/LearnCoach.module.css
+++ b/web-client/src/components/learn/LearnCoach.module.css
@@ -35,6 +35,43 @@
   --coach-accent: #4fc3f7;
 }
 
+/* A warning: something the player is about to do that a coach would stop them on. */
+.warn {
+  --coach-accent: #ff9d3c;
+}
+
+/* ---- Card note ------------------------------------------------------------ */
+/* One line about a card that just arrived on the table and carries a keyword the course has not
+   named yet — deathtouch, first strike, reach. Under the tip, above the objectives. */
+.note {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  align-items: start;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(239, 230, 207, 0.1);
+  font-size: 12.5px;
+  animation: coachIn 0.28s ease-out both;
+}
+
+.noteGlyph {
+  font-size: 14px;
+  color: var(--coach-accent);
+  line-height: 1.3;
+}
+
+.noteName {
+  color: #efe6cf;
+  font-weight: 600;
+}
+
+.noteKeyword {
+  color: var(--coach-accent);
+  font-weight: 600;
+}
+
 /* The game-over overlay (App.tsx) dims the board at z 1999–2000; the closing card sits above it
    so "Next mission" is the first thing a finished player can click. */
 .done {
@@ -258,6 +295,8 @@
   padding: 7px 14px 7px 10px;
   cursor: pointer;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .pill:hover {
@@ -345,22 +384,62 @@
   }
 }
 
+/* The tip's title, shown inside the pill on phones only — there the pill is the coach most of
+   the time, so it has to say something. */
+.pillTitle {
+  display: none;
+}
+
 @media (max-width: 640px) {
+  /* A phone has no room at the bottom: the hand, the pass button and the combat buttons are all
+     there. The coach lives as a pill (bottom-left, where the desktop's log toggle would be) and
+     opens as a sheet under the top bar, over the opponent's side, only while wanted. */
   .pill {
     left: 8px;
-    bottom: 44px;
+    top: 44px;
+    bottom: auto;
+    max-width: calc(100vw - 120px);
+    padding: 6px 12px 6px 9px;
+    font-size: 11.5px;
+  }
+
+  .pillTitle {
+    display: inline;
+    font-weight: 400;
+    color: #c9c3b4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
   }
 
   .coach {
     left: 8px;
-    bottom: 44px;
-    width: min(270px, calc(100vw - 16px));
+    right: 8px;
+    top: 44px;
+    bottom: auto;
+    width: auto;
+    max-height: min(46vh, 380px);
+    overflow-y: auto;
     font-size: 12px;
     padding: 8px 10px 10px;
+    gap: 8px;
+  }
+
+  .done {
+    /* The closing card is the one moment the sheet should sit over the middle of the table. */
+    top: 50%;
+    transform: translateY(-50%);
+    max-height: 80vh;
   }
 
   .title {
     font-size: 15px;
+  }
+
+  .objectives {
+    padding-top: 8px;
+    gap: 3px;
   }
 }
 

--- a/web-client/src/components/learn/LearnCoach.tsx
+++ b/web-client/src/components/learn/LearnCoach.tsx
@@ -5,9 +5,11 @@
  * - **Tour** — when the board first appears, a few steps that each ring one part of the table
  *   (hand, battlefield, turn strip, the pass button …) and say what it is for. Skippable.
  * - **Tip** — one line for what the board is waiting on, worded with the real button label and
- *   this device's gestures, with a quiet ring on the thing it names; the mission's objectives
- *   tick off underneath as the player does them.
- * - **Done** — the game ended: what you learned, and the next card in the hand.
+ *   this device's gestures, with a quiet ring on the thing it names; a card note under it when a
+ *   permanent with a keyword the course has not named yet is on the table; the mission's
+ *   objectives tick off underneath as the player does them.
+ * - **Done** — the game ended: what you learned, and the next card in the hand. A concede ends
+ *   the game but not the mission.
  *
  * Portalled to `<body>` like the help drawer: `#root` is overflow:hidden and the multiplayer
  * strip transforms its subtree, both of which break `position: fixed` for descendants.
@@ -18,10 +20,13 @@ import { useNavigate } from 'react-router-dom'
 import { useGameStore } from '@/store/gameStore'
 import { selectHasPriority, selectIsMyTurn, useStackCards } from '@/store/selectors'
 import { armedMission, coachTip, disarmCoach, markTourSeen, tourSeen, wordTip, type CoachView } from '@/learn/coach'
-import { learnHref, missionById, nextMission } from '@/learn/missions'
+import { latestNotedPermanent, learnHref, missionById, nextMission } from '@/learn/missions'
 import type { SpotContext } from '@/learn/spots'
+import { useLearnSignals } from '@/learn/signals'
+import { syncLearnProgress, useLearnProgress } from '@/learn/progressStore'
+import { GameOverReason, ZoneType } from '@/types/enums'
 import type { EntityId } from '@/types'
-import { useLearnProgress } from '@/learn/progressStore'
+import type { ClientCard } from '@/types/gameState'
 import { LearnSpotlight } from './LearnSpotlight'
 import styles from './LearnCoach.module.css'
 
@@ -34,11 +39,25 @@ function deviceHasHover(): boolean {
   }
 }
 
+/** A phone: the coach is a pill by default there, and a sheet only while the tour or the ending is up. */
+function smallScreen(): boolean {
+  try {
+    return window.matchMedia('(max-width: 640px)').matches
+  } catch {
+    return false
+  }
+}
+
+function isCreatureOnBattlefield(c: ClientCard): boolean {
+  return c.zone?.zoneType === ZoneType.BATTLEFIELD && c.cardTypes.some((t) => t.toUpperCase() === 'CREATURE')
+}
+
 export function LearnCoach() {
   const [missionId] = useState(armedMission)
   const mission = useMemo(() => missionById(missionId), [missionId])
-  const [collapsed, setCollapsed] = useState(false)
   const [tourStep, setTourStep] = useState<number | null>(() => (tourSeen() ? null : 0))
+  // On a phone the panel would cover the hand, so it starts tucked away unless the tour is up.
+  const [collapsed, setCollapsed] = useState(() => smallScreen() && tourSeen())
   const [hasHover] = useState(deviceHasHover)
   // Once the game is over the coach disarms itself, so a remount after that renders nothing —
   // which is also what stops the mission being finished twice.
@@ -51,17 +70,27 @@ export function LearnCoach() {
   const legalActions = useGameStore((s) => s.legalActions)
   const pendingDecision = useGameStore((s) => s.pendingDecision)
   const isTargeting = useGameStore((s) => s.targetingState !== null)
+  const combatState = useGameStore((s) => s.combatState)
   const gameOverState = useGameStore((s) => s.gameOverState)
   const nextStopPoint = useGameStore((s) => s.nextStopPoint)
   const isMyTurn = useGameStore(selectIsMyTurn)
   const hasPriority = useGameStore(selectHasPriority)
   const stackSize = useStackCards().length
+  const signals = useLearnSignals((s) => s.marked)
 
   const won = gameOverState ? (gameOverState.result === 'draw' ? null : gameOverState.result === 'win') : null
+  const conceded = gameOverState?.reason === GameOverReason.CONCESSION && gameOverState.result === 'lose'
+
+  const me = gameState?.viewingPlayerId
+  const players = gameState?.players
 
   const view = useMemo<CoachView | null>(() => {
     if (!gameState) return null
     const types = new Set(legalActions.map((a) => a.actionType))
+    const selected = combatState?.mode === 'declareAttackers' ? combatState.selectedAttackers : []
+    const cards = Object.values(gameState.cards)
+    const mine = cards.filter((c) => c.controllerId === gameState.viewingPlayerId && isCreatureOnBattlefield(c))
+    const theirs = cards.filter((c) => c.controllerId !== gameState.viewingPlayerId && isCreatureOnBattlefield(c))
     return {
       turnNumber: gameState.turnNumber,
       step: gameState.currentStep,
@@ -75,15 +104,31 @@ export function LearnCoach() {
       isTargeting,
       stackSize,
       attackersIncoming: gameState.combat?.attackers.length ?? 0,
+      attackersSelected: selected.length,
+      blockersLeft: mine.filter((c) => !c.isTapped && !selected.includes(c.id)).length,
+      theirCreatures: theirs.length,
+      conceded,
       passLabel: nextStopPoint ?? 'Pass',
       hasHover,
       isGameOver: gameState.isGameOver || gameOverState !== null,
       won,
     }
-  }, [gameState, legalActions, pendingDecision, isTargeting, gameOverState, nextStopPoint, isMyTurn, hasPriority, stackSize, hasHover, won])
+  }, [
+    gameState,
+    legalActions,
+    pendingDecision,
+    isTargeting,
+    combatState,
+    gameOverState,
+    nextStopPoint,
+    isMyTurn,
+    hasPriority,
+    stackSize,
+    conceded,
+    hasHover,
+    won,
+  ])
 
-  const me = gameState?.viewingPlayerId
-  const players = gameState?.players
   const spotCtx = useMemo<SpotContext>(
     () => ({
       me: me ?? ('' as EntityId),
@@ -94,19 +139,24 @@ export function LearnCoach() {
 
   const objectives = useMemo(() => {
     if (!mission || !gameState) return []
-    const ctx = { state: gameState, me: gameState.viewingPlayerId, won }
+    const ctx = { state: gameState, me: gameState.viewingPlayerId, won, signals }
     return mission.objectives.map((o) => ({ id: o.id, label: o.label, done: o.done(ctx) }))
-  }, [mission, gameState, won])
+  }, [mission, gameState, won, signals])
 
-  // The game ending is what finishes the mission, win or lose. Disarm so the next game — a
-  // rematch, or anything started from the menu — plays without a coach.
+  const cardNote = useMemo(() => (gameState ? latestNotedPermanent(gameState) : null), [gameState])
+
+  // A game played to its end finishes the mission, win or lose; a concede does not. Either way
+  // the coach disarms, so the next game — a rematch, or anything from the menu — has no coach.
   useEffect(() => {
     if (mission && view?.isGameOver && !finished) {
-      finish(mission.id)
+      if (!view.conceded) {
+        finish(mission.id)
+        void syncLearnProgress()
+      }
       disarmCoach()
       setFinished(true)
     }
-  }, [mission, view?.isGameOver, finished, finish])
+  }, [mission, view?.isGameOver, view?.conceded, finished, finish])
 
   if (!mission || !view) return null
 
@@ -119,6 +169,7 @@ export function LearnCoach() {
   const endTour = () => {
     markTourSeen()
     setTourStep(null)
+    if (smallScreen()) setCollapsed(true)
   }
 
   const leave = (to: string) => {
@@ -136,13 +187,14 @@ export function LearnCoach() {
       >
         <span className={styles.pillDot} aria-hidden="true" />
         Coach · {doneCount}/{objectives.length}
+        <span className={styles.pillTitle}>· {tip.title}</span>
       </button>,
       document.body,
     )
   }
 
   const tone = touring ? 'watch' : tip.tone
-  const spot = touring ? step?.spot : tip.tone === 'act' ? tip.spot : undefined
+  const spot = touring ? step?.spot : tip.tone === 'act' || tip.tone === 'warn' ? tip.spot : undefined
 
   return createPortal(
     <>
@@ -197,17 +249,33 @@ export function LearnCoach() {
           <div key={tip.key} className={styles.body}>
             <div className={styles.title}>{tip.title}</div>
             <p className={styles.text}>{tip.body}</p>
-            <div className={styles.lessonsHead}>What you now know</div>
-            <ul className={styles.lessons}>
-              {mission.lessons.map((line) => (
-                <li key={line}>{wordTip(line, view)}</li>
-              ))}
-            </ul>
+            {!view.conceded && (
+              <>
+                <div className={styles.lessonsHead}>What you now know</div>
+                <ul className={styles.lessons}>
+                  {mission.lessons.map((line) => (
+                    <li key={line}>{wordTip(line, view)}</li>
+                  ))}
+                </ul>
+              </>
+            )}
           </div>
         ) : (
           <div key={tip.key} className={styles.body}>
             <div className={styles.title}>{tip.title}</div>
             <p className={styles.text}>{tip.body}</p>
+          </div>
+        )}
+
+        {!touring && !view.isGameOver && cardNote && (
+          <div key={cardNote.name} className={styles.note} aria-label={`About ${cardNote.name}`}>
+            <span className={styles.noteGlyph} aria-hidden="true">
+              ✦
+            </span>
+            <span>
+              <span className={styles.noteName}>{cardNote.name}</span> — <span className={styles.noteKeyword}>{cardNote.note.keyword}.</span>{' '}
+              {cardNote.note.body}
+            </span>
           </div>
         )}
 
@@ -224,7 +292,11 @@ export function LearnCoach() {
 
         {view.isGameOver && (
           <div className={styles.actions}>
-            {next ? (
+            {view.conceded ? (
+              <button type="button" className={styles.primary} onClick={() => leave(learnHref(mission.id))}>
+                Play it again →
+              </button>
+            ) : next ? (
               <button type="button" className={styles.primary} onClick={() => leave(learnHref(next.id))}>
                 Next: {next.title} →
               </button>
@@ -233,8 +305,8 @@ export function LearnCoach() {
                 Course complete →
               </button>
             )}
-            <button type="button" className={styles.link} onClick={() => leave(learnHref(mission.id))}>
-              Play this one again
+            <button type="button" className={styles.link} onClick={() => leave(view.conceded ? learnHref() : learnHref(mission.id))}>
+              {view.conceded ? 'Back to the missions' : 'Play this one again'}
             </button>
           </div>
         )}

--- a/web-client/src/components/learn/LearnSpotlight.tsx
+++ b/web-client/src/components/learn/LearnSpotlight.tsx
@@ -8,7 +8,7 @@
  */
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { findSpot, spotRect, type SpotContext, type SpotId } from '@/learn/spots'
+import { spotBox, type SpotContext, type SpotId } from '@/learn/spots'
 import styles from './LearnCoach.module.css'
 
 interface Box {
@@ -21,9 +21,8 @@ interface Box {
 const PAD = 6
 
 function measure(spot: SpotId, ctx: SpotContext): Box | null {
-  const el = findSpot(spot, ctx)
-  if (!el) return null
-  const r = spotRect(el)
+  const r = spotBox(spot, ctx)
+  if (!r) return null
   return { top: r.top - PAD, left: r.left - PAD, width: r.width + PAD * 2, height: r.height + PAD * 2 }
 }
 

--- a/web-client/src/components/learn/LearnSpotlight.tsx
+++ b/web-client/src/components/learn/LearnSpotlight.tsx
@@ -8,7 +8,7 @@
  */
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { findSpot, type SpotContext, type SpotId } from '@/learn/spots'
+import { findSpot, spotRect, type SpotContext, type SpotId } from '@/learn/spots'
 import styles from './LearnCoach.module.css'
 
 interface Box {
@@ -23,7 +23,7 @@ const PAD = 6
 function measure(spot: SpotId, ctx: SpotContext): Box | null {
   const el = findSpot(spot, ctx)
   if (!el) return null
-  const r = el.getBoundingClientRect()
+  const r = spotRect(el)
   return { top: r.top - PAD, left: r.left - PAD, width: r.width + PAD * 2, height: r.height + PAD * 2 }
 }
 

--- a/web-client/src/components/learn/MissionHand.tsx
+++ b/web-client/src/components/learn/MissionHand.tsx
@@ -14,6 +14,7 @@ const ART_GLYPH: Record<MissionId, string> = {
   'first-steps': 'ms-land',
   blocking: 'ms-creature',
   instants: 'ms-instant',
+  removal: 'ms-enchantment',
   'real-game': 'ms-planeswalker',
 }
 
@@ -21,6 +22,7 @@ const TYPE_LINE: Record<MissionId, string> = {
   'first-steps': 'Mission — Lands & creatures',
   blocking: 'Mission — Combat',
   instants: 'Mission — The stack',
+  removal: 'Mission — Answers',
   'real-game': 'Game — Full rules',
 }
 

--- a/web-client/src/components/learn/useLessonCards.ts
+++ b/web-client/src/components/learn/useLessonCards.ts
@@ -66,3 +66,27 @@ function fallback(names: readonly string[]): Record<string, LessonCard> {
   for (const name of names) out[name] = { name, imageUrl: getCardImageUrl(name, undefined, 'normal'), summary: null }
   return out
 }
+
+/**
+ * Warm the browser's image cache for a list of cards — the course home calls this for every
+ * brief's opening cards, so a brief opens with its cards already painted instead of three grey
+ * boxes while Scryfall answers. Fire-and-forget; nothing is rendered.
+ */
+export function usePreloadLessonCards(names: readonly string[]) {
+  const key = names.join('|')
+  useEffect(() => {
+    const wanted = key.split('|').filter(Boolean)
+    if (wanted.length === 0) return
+    let cancelled = false
+    fetchSummaries(wanted).then((index) => {
+      if (cancelled) return
+      for (const name of wanted) {
+        const img = new Image()
+        img.src = getCardImageUrl(name, index.get(name)?.imageUri ?? undefined, 'normal')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [key])
+}

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -85,7 +85,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     section: 'getting-started',
     title: 'New to Magic itself?',
     summary:
-      'This guide assumes you know the game. If you do not, the Learn to Play course teaches it by playing: four short games against the AI, each from a board set up to teach one thing, with a coach saying what to do next.',
+      'This guide assumes you know the game. If you do not, the Learn to Play course teaches it by playing: a handful of short games against the AI, each from a board set up to teach one thing, with a coach saying what to do next and pointing at the part of the table to do it on.',
     body: [
       { kind: 'p', text: 'The course lives at /learn and needs no name or account. Progress is kept in this browser; the landing page points at it until you have finished.' },
     ],

--- a/web-client/src/learn/coach.test.ts
+++ b/web-client/src/learn/coach.test.ts
@@ -83,6 +83,24 @@ describe('coachTip', () => {
     expect(coachTip({ ...base, isMyTurn: false, stackSize: 1 }).tone).toBe('watch')
   })
 
+  it('keeps "the Tutor is taking a turn" to their turn, and reads the phase on both', () => {
+    const mineCombat = coachTip({ ...base, hasPriority: false, step: 'COMBAT_DAMAGE' })
+    expect(mineCombat.key).toBe('working')
+    expect(mineCombat.title).toBe('Combat is playing out.')
+    expect(coachTip({ ...base, hasPriority: false, step: 'END' }).title).toBe('Your turn is ending.')
+    expect(coachTip({ ...base, hasPriority: false }).title).toBe('The game is working through your turn.')
+
+    const theirs = (step: string) => coachTip({ ...base, isMyTurn: false, hasPriority: false, step })
+    expect(theirs('PRECOMBAT_MAIN').key).toBe('waiting')
+    expect(theirs('DECLARE_ATTACKERS').body).toMatch(/in combat/)
+    expect(theirs('UPKEEP').body).toMatch(/untap and draw/)
+    expect(theirs('CLEANUP').body).toMatch(/turn is ending/)
+    // A mission's "they will play a land and pass" override binds to their turn only.
+    const override = { waiting: { body: 'They will play a land and pass.' } }
+    expect(coachTip({ ...base, isMyTurn: false, hasPriority: false }, override).body).toBe('They will play a land and pass.')
+    expect(coachTip({ ...base, hasPriority: false, step: 'COMBAT_DAMAGE' }, override).body).not.toMatch(/play a land/)
+  })
+
   it('has a first-turn tip while the game is still settling', () => {
     expect(coachTip({ ...base, turnNumber: 1, hasPriority: false }).key).toBe('first-turn')
   })

--- a/web-client/src/learn/coach.test.ts
+++ b/web-client/src/learn/coach.test.ts
@@ -15,6 +15,10 @@ const base: CoachView = {
   isTargeting: false,
   stackSize: 0,
   attackersIncoming: 0,
+  attackersSelected: 0,
+  blockersLeft: 0,
+  theirCreatures: 0,
+  conceded: false,
   passLabel: 'Pass to Attackers',
   hasHover: true,
   isGameOver: false,
@@ -51,6 +55,24 @@ describe('coachTip', () => {
     expect(coachTip({ ...base, isMyTurn: false, attackersIncoming: 1, canBlock: true }).key).toBe('block')
   })
 
+  it('warns before an attack that leaves no blocker against a board that can hit back', () => {
+    const risky = coachTip({ ...base, canAttack: true, attackersSelected: 1, blockersLeft: 0, theirCreatures: 2 })
+    expect(risky.key).toBe('attack-warning')
+    expect(risky.tone).toBe('warn')
+    expect(risky.body).toMatch(/2 creatures/)
+    // Nothing selected yet, a blocker staying home, or an empty board on their side: no warning.
+    expect(coachTip({ ...base, canAttack: true, attackersSelected: 0, blockersLeft: 0, theirCreatures: 2 }).key).toBe('attack')
+    expect(coachTip({ ...base, canAttack: true, attackersSelected: 1, blockersLeft: 1, theirCreatures: 2 }).key).toBe('attack')
+    expect(coachTip({ ...base, canAttack: true, attackersSelected: 1, blockersLeft: 0, theirCreatures: 0 }).key).toBe('attack')
+  })
+
+  it('treats a concede as the end of the game, not the mission', () => {
+    const tip = coachTip({ ...base, isGameOver: true, won: false, conceded: true })
+    expect(tip.key).toBe('conceded')
+    expect(tip.tone).toBe('done')
+    expect(coachTip({ ...base, isGameOver: true, won: false }).key).toBe('lost')
+  })
+
   it('walks the player through picking a target mid-cast', () => {
     const tip = coachTip({ ...base, isMyTurn: false, canCast: true, stackSize: 1, isTargeting: true })
     expect(tip.key).toBe('target')
@@ -72,6 +94,16 @@ describe('coachTip', () => {
     expect(window.key).toBe('respond-window')
     expect(window.body).toMatch(/instant right now/)
     expect(coachTip({ ...base, isMyTurn: false, hasPriority: false }).key).toBe('waiting')
+  })
+
+  it('explains a spell waiting on the stack during your own turn', () => {
+    const idle = coachTip({ ...base, stackSize: 1 })
+    expect(idle.key).toBe('stack-mine')
+    expect(idle.tone).toBe('watch')
+    expect(idle.body).toMatch(/last spell cast happens first/)
+    expect(coachTip({ ...base, stackSize: 1, canCast: true }).tone).toBe('act')
+    // It outranks the land/cast prompts: a main phase with a stack is not a main phase to play in.
+    expect(coachTip({ ...base, stackSize: 1, canPlayLand: true, canCast: true }).key).toBe('stack-mine')
   })
 
   it('turns the response prompt into an instruction once their spell is on the stack', () => {

--- a/web-client/src/learn/coach.ts
+++ b/web-client/src/learn/coach.ts
@@ -301,13 +301,59 @@ function baseTip(view: CoachView): CoachTip {
     }
   }
 
+  // Nothing to decide right now. Two different keys, because they are two different situations —
+  // a mission's "the Tutor will play a land and pass" must never show in the player's own combat.
+  const phase = phaseOf(view.step)
+  if (view.isMyTurn) {
+    return {
+      key: 'working',
+      title: phase === 'combat' ? 'Combat is playing out.' : phase === 'end' ? 'Your turn is ending.' : 'The game is working through your turn.',
+      body:
+        phase === 'combat'
+          ? 'Attackers hit, blockers hit back, and the damage is dealt — the strip at the top walks through it. You get the board back the moment there is something to decide.'
+          : phase === 'end'
+            ? 'The Tutor gets a last chance to act, then it is their turn. Watch the strip at the top.'
+            : 'Steps with nothing to decide pass on their own. You get the board back the moment there is something to do.',
+      tone: 'watch',
+      spot: 'phase-strip',
+    }
+  }
   return {
     key: 'waiting',
-    title: view.isMyTurn ? 'The game is working through your turn.' : 'The Tutor is thinking.',
-    body: view.isMyTurn
-      ? 'Steps with nothing to decide pass on their own. You get the board back the moment there is something to do.'
-      : 'Watch the strip at the top — the lit dot is where their turn is. If they attack you will be asked to block; if they cast a spell you may get a chance to respond.',
+    title: 'The Tutor is taking a turn.',
+    body:
+      phase === 'combat'
+        ? 'They are in combat. If a creature of theirs attacks, the game will stop and ask you to block.'
+        : phase === 'end'
+          ? 'Their turn is ending. Yours is next — the strip at the top comes back to blue.'
+          : phase === 'beginning'
+            ? 'They untap and draw. Then their main phase: a land, and whatever they can afford.'
+            : 'They can play a land and cast spells. If they cast something you may get a chance to respond; if they attack you will be asked to block.',
     tone: 'watch',
     spot: 'phase-strip',
+  }
+}
+
+type Phase = 'beginning' | 'main' | 'combat' | 'end'
+
+/** The five phases behind the thirteen step names the server sends. */
+export function phaseOf(step: string): Phase {
+  switch (step) {
+    case 'UNTAP':
+    case 'UPKEEP':
+    case 'DRAW':
+      return 'beginning'
+    case 'BEGIN_COMBAT':
+    case 'DECLARE_ATTACKERS':
+    case 'DECLARE_BLOCKERS':
+    case 'FIRST_STRIKE_COMBAT_DAMAGE':
+    case 'COMBAT_DAMAGE':
+    case 'END_COMBAT':
+      return 'combat'
+    case 'END':
+    case 'CLEANUP':
+      return 'end'
+    default:
+      return 'main'
   }
 }

--- a/web-client/src/learn/coach.ts
+++ b/web-client/src/learn/coach.ts
@@ -90,6 +90,14 @@ export interface CoachView {
   /** A spell or ability is waiting on the stack. */
   stackSize: number
   attackersIncoming: number
+  /** While declaring attackers: how many creatures are selected to attack so far. */
+  attackersSelected: number
+  /** While declaring attackers: untapped creatures of mine that would stay home if the selected ones attack. */
+  blockersLeft: number
+  /** Creatures the opponent has on the battlefield. */
+  theirCreatures: number
+  /** The game ended because the player conceded — not a finished mission. */
+  conceded: boolean
   /**
    * What the big button at the bottom right says right now — "Pass", "Pass to Attackers",
    * "End Turn", "Resolve". The server computes it; the coach names it so the tip and the button
@@ -107,8 +115,8 @@ export interface CoachTip {
   key: string
   title: string
   body: string
-  /** Tone drives the accent colour: what to do now, what is happening, or the end of the game. */
-  tone: 'act' | 'watch' | 'done'
+  /** Tone drives the accent colour: what to do now, what is happening, a mistake in the making, or the end of the game. */
+  tone: 'act' | 'watch' | 'warn' | 'done'
   /** The board element to ring while this tip is up. */
   spot?: SpotId
 }
@@ -145,6 +153,14 @@ export function coachTip(view: CoachView, overrides: Partial<Record<string, TipO
 
 function baseTip(view: CoachView): CoachTip {
   if (view.isGameOver) {
+    if (view.conceded) {
+      return {
+        key: 'conceded',
+        title: 'You conceded.',
+        body: 'That ends the game but not the mission — it only counts when a game is played to the end, won or lost. Play it again whenever you like.',
+        tone: 'done',
+      }
+    }
     if (view.won === true) {
       return {
         key: 'won',
@@ -197,6 +213,20 @@ function baseTip(view: CoachView): CoachTip {
   }
 
   if (view.canAttack) {
+    // The classic first mistake: sending in the only creature that could block, into a board that
+    // can hit back. Said before the attack is confirmed, while it can still be undone with a click.
+    if (view.attackersSelected > 0 && view.blockersLeft === 0 && view.theirCreatures > 0) {
+      return {
+        key: 'attack-warning',
+        title: 'That leaves nobody home.',
+        body:
+          view.theirCreatures > 1
+            ? `Attackers tap, and they have ${view.theirCreatures} creatures that can hit back next turn with nothing of yours untapped to block. Sure? {click} a creature again to keep it back, or go ahead with Attack with N.`
+            : 'Attackers tap, and they have a creature that can hit back next turn with nothing of yours untapped to block. Sure? {click} a creature again to keep it back, or go ahead with Attack with N.',
+        tone: 'warn',
+        spot: 'combat-buttons',
+      }
+    }
     return {
       key: 'attack',
       title: 'Combat — your creatures can attack.',
@@ -207,6 +237,17 @@ function baseTip(view: CoachView): CoachTip {
   }
 
   if (view.isMyTurn && view.hasPriority) {
+    if (view.stackSize > 0) {
+      return {
+        key: 'stack-mine',
+        title: 'A spell is waiting on the stack.',
+        body: view.canCast
+          ? 'Nothing has happened yet. You can answer with an instant — drag it out or {click-lower} it — or press {pass} and let the stack resolve, last spell first.'
+          : 'Nothing to answer it with, so press {pass}. The stack resolves top-down: the last spell cast happens first, then the one under it.',
+        tone: view.canCast ? 'act' : 'watch',
+        spot: 'stack',
+      }
+    }
     if (view.canPlayLand && view.canCast) {
       return {
         key: 'land-and-cast',

--- a/web-client/src/learn/missions.test.ts
+++ b/web-client/src/learn/missions.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from 'vitest'
 import type { ClientEvent } from '@/types/events'
 import type { ClientCard, ClientGameState } from '@/types/gameState'
 import type { EntityId } from '@/types'
-import { COURSE_MINUTES, MISSIONS, missionById, missionCardNames, nextMission, type ObjectiveContext } from './missions'
+import { CARD_NOTES, COURSE_COUNT_WORD, COURSE_MINUTES, MISSIONS, latestNotedPermanent, missionById, missionCardNames, nextMission, type ObjectiveContext } from './missions'
 import { hasStarted, nextIncomplete } from './progressStore'
 import { ALL_SPOTS } from './spots'
 
@@ -64,8 +64,13 @@ describe('the missions', () => {
         expect(seat?.library?.length ?? 0).toBeLessThanOrEqual(100)
         expect(seat?.library?.length ?? 0).toBeGreaterThanOrEqual(8)
       }
-      // The opening cards the brief shows really are in the opening hand or on the board.
-      const opening = new Set([...(spec.player1?.hand ?? []), ...(spec.player1?.battlefield ?? []).map((c) => c.name)])
+      // The opening cards the brief shows really are in the opening hand, on the board, or among
+      // the first few draws.
+      const opening = new Set([
+        ...(spec.player1?.hand ?? []),
+        ...(spec.player1?.battlefield ?? []).map((c) => c.name),
+        ...(spec.player1?.library ?? []).slice(0, 4),
+      ])
       expect(m.openingCards.map((c) => c.name).filter((n) => !opening.has(n))).toEqual([])
     }
   })
@@ -76,7 +81,7 @@ describe('the missions', () => {
       expect(m.tour.length, m.id).toBeLessThanOrEqual(4)
       for (const step of m.tour) {
         expect(ALL_SPOTS).toContain(step.spot)
-        expect(step.body.length).toBeLessThan(220)
+        expect(step.body.length).toBeLessThan(400)
       }
       expect(m.lessons.length, m.id).toBeGreaterThanOrEqual(2)
       expect(m.lessons.length, m.id).toBeLessThanOrEqual(3)
@@ -93,8 +98,15 @@ describe('the missions', () => {
     expect(COURSE_MINUTES).toBeLessThanOrEqual(30)
   })
 
+  it('counts itself in words', () => {
+    expect(COURSE_COUNT_WORD).toBe('five')
+    expect(MISSIONS.length).toBe(5)
+  })
+
   it('walks forward', () => {
     expect(nextMission('first-steps')?.id).toBe('blocking')
+    expect(nextMission('instants')?.id).toBe('removal')
+    expect(nextMission('removal')?.id).toBe('real-game')
     expect(nextMission('real-game')).toBeUndefined()
     expect(missionById('nope')).toBeUndefined()
   })
@@ -119,7 +131,7 @@ function ctx(events: readonly object[], cards: ClientCard[], extra: Partial<Clie
     winnerId: null,
     ...extra,
   } as unknown as ClientGameState
-  return { state, me: ME, won: null }
+  return { state, me: ME, won: null, signals: new Set() }
 }
 
 const objective = (missionId: string, id: string) => {
@@ -162,6 +174,30 @@ describe('objectives', () => {
     expect(objective('blocking', 'kill').done(ctx([died], [cardOf('c1', ME, ['CREATURE'])]))).toBe(false)
   })
 
+  it('reads the app signals for the log and undo, and an Aura for the removal mission', () => {
+    const base = ctx([], [])
+    expect(objective('blocking', 'log').done(base)).toBe(false)
+    expect(objective('blocking', 'log').done({ ...base, signals: new Set(['logOpened']) })).toBe(true)
+    expect(objective('real-game', 'undo').done({ ...base, signals: new Set(['undoUsed']) })).toBe(true)
+    const cast = { type: 'spellCast', spellId: 's1', spellName: 'Pacifism', casterId: ME, description: '' } as const
+    expect(objective('removal', 'enchantment').done(ctx([cast], [cardOf('s1', ME, ['ENCHANTMENT'])]))).toBe(true)
+    expect(objective('removal', 'enchantment').done(ctx([cast], [cardOf('s1', ME, ['CREATURE'])]))).toBe(false)
+  })
+
+  it('names the keyword of the most recently arrived noted permanent', () => {
+    const entered = (id: string, name: string) =>
+      ({ type: 'permanentEntered', cardId: id, cardName: name, controllerId: THEM, enteredTapped: false, description: '' }) as const
+    const onTable = (id: string, name: string) =>
+      ({ ...cardOf(id, THEM, ['CREATURE']), name, zone: { zoneType: 'Battlefield' } }) as unknown as ClientCard
+    const rats = onTable('r1', 'Typhoid Rats')
+    const ogre = onTable('o1', 'Gray Ogre')
+    expect(latestNotedPermanent(ctx([entered('r1', 'Typhoid Rats'), entered('o1', 'Gray Ogre')], [rats, ogre]).state)?.note.keyword).toBe('Deathtouch')
+    // A noted card that has since left the battlefield is not explained.
+    const gone = { ...rats, zone: { zoneType: 'Graveyard' } } as unknown as ClientCard
+    expect(latestNotedPermanent(ctx([entered('r1', 'Typhoid Rats')], [gone]).state)).toBeNull()
+    expect(CARD_NOTES['Typhoid Rats']?.body).toMatch(/kills/)
+  })
+
   it('wins from the store result or the state', () => {
     const win = objective('real-game', 'win')
     expect(win.done(ctx([], []))).toBe(false)
@@ -175,6 +211,7 @@ describe('progress helpers', () => {
   it('continues at the first unfinished mission, in course order', () => {
     expect(nextIncomplete([])).toBe('first-steps')
     expect(nextIncomplete(['first-steps', 'instants'])).toBe('blocking')
+    expect(nextIncomplete(['first-steps', 'blocking', 'instants'])).toBe('removal')
     expect(nextIncomplete(MISSIONS.map((m) => m.id))).toBeUndefined()
     expect(hasStarted({ completed: [] })).toBe(false)
     expect(hasStarted({ completed: ['first-steps'] })).toBe(true)

--- a/web-client/src/learn/missions.ts
+++ b/web-client/src/learn/missions.ts
@@ -1,5 +1,5 @@
 /**
- * The Learn to Play course: four short games, each one a card in the hand on `/learn`.
+ * The Learn to Play course: a handful of short games, each one a card in the hand on `/learn`.
  *
  * Nothing here is read. Every mission is a scripted board sent to the production `/api/scenarios`
  * endpoint with the built-in AI in the other seat, and the teaching happens on the real game
@@ -19,8 +19,10 @@ import type { ScenarioSpec } from '@/components/scenario/types'
 import type { ClientCard, ClientGameState } from '@/types/gameState'
 import type { EntityId } from '@/types'
 import type { SpotId } from './spots'
+import type { LearnSignal } from './signals'
+import { ZoneType } from '@/types/enums'
 
-export type MissionId = 'first-steps' | 'blocking' | 'instants' | 'real-game'
+export type MissionId = 'first-steps' | 'blocking' | 'instants' | 'removal' | 'real-game'
 
 /**
  * The frame colour each mission card wears — one of Magic's colours, gold for multicolour,
@@ -34,6 +36,8 @@ export interface ObjectiveContext {
   me: EntityId
   /** Set once the game is over, from the store's game-over state. */
   won: boolean | null
+  /** Things done to the app rather than the game — the log opened, Undo pressed. See `learn/signals.ts`. */
+  signals: ReadonlySet<LearnSignal>
 }
 
 export interface Objective {
@@ -173,6 +177,112 @@ const won: Objective = {
   done: (ctx) => ctx.won === true || (ctx.state.isGameOver && ctx.state.winnerId === ctx.me),
 }
 
+const castEnchantment: Objective = {
+  id: 'enchantment',
+  label: 'Cast an Aura on a creature',
+  done: (ctx) =>
+    log(ctx).some((e) => {
+      if (e.type !== 'spellCast' || e.casterId !== ctx.me) return false
+      return hasType(card(ctx, e.spellId), 'ENCHANTMENT')
+    }),
+}
+
+const readLog: Objective = {
+  id: 'log',
+  label: 'Open the log',
+  done: (ctx) => ctx.signals.has('logOpened'),
+}
+
+const usedUndo: Objective = {
+  id: 'undo',
+  label: 'Take a move back with Undo',
+  done: (ctx) => ctx.signals.has('undoUsed'),
+}
+
+// ── Card notes ──────────────────────────────────────────────────────────────
+
+/** One line about a keyword, shown when a card carrying it lands on the table. */
+export interface CardNote {
+  keyword: string
+  body: string
+}
+
+/**
+ * The keywords the course's decks carry, explained the first time they matter — when the card
+ * arrives on the battlefield, on either side. Keyed by card name; a card with no entry is vanilla.
+ */
+export const CARD_NOTES: Readonly<Record<string, CardNote>> = {
+  'Typhoid Rats': {
+    keyword: 'Deathtouch',
+    body: 'Any amount of damage it deals to a creature kills that creature — a 1/1 with deathtouch trades with anything it touches. Block it with something you can spare, or take the 1.',
+  },
+  'Benalish Knight': {
+    keyword: 'First strike · Flash',
+    body: 'First strike: it deals its combat damage before creatures without it — if that kills the other creature, it never hits back. Flash: it can be cast at instant speed, on anyone’s turn.',
+  },
+  'Youthful Knight': {
+    keyword: 'First strike',
+    body: 'It deals its combat damage first. If that kills the creature it is fighting, the fight is over before it hits back.',
+  },
+  'Giant Spider': {
+    keyword: 'Reach',
+    body: 'It can block creatures with flying. Without reach, a flier sails over your ground creatures.',
+  },
+  'Serra Angel': {
+    keyword: 'Flying · Vigilance',
+    body: 'Flying: only creatures with flying or reach can block it. Vigilance: attacking does not tap it, so it can attack and still block.',
+  },
+  'Bog Imp': {
+    keyword: 'Flying',
+    body: 'Only your creatures with flying or reach can block it. Giant Spider can; the bears cannot.',
+  },
+  'Raging Goblin': {
+    keyword: 'Haste',
+    body: 'No summoning sickness — it can attack the turn it arrives.',
+  },
+  'Thundering Giant': {
+    keyword: 'Haste',
+    body: 'No summoning sickness — it can attack the turn it arrives. Four power, the turn it lands.',
+  },
+  'Bloodrock Cyclops': {
+    keyword: 'Attacks each combat if able',
+    body: 'It has no choice: every combat it can attack, it must. Put a blocker it cannot kill in front of it and it just keeps running into the wall.',
+  },
+  'Drudge Skeletons': {
+    keyword: 'Regenerate',
+    body: 'For one black mana, the next time it would die this turn it taps and stays instead. Damage will not keep it down while they have a Swamp untapped.',
+  },
+  'Child of Night': {
+    keyword: 'Lifelink',
+    body: 'Damage it deals also gains its controller that much life — every hit is a two-point swing.',
+  },
+  Pacifism: {
+    keyword: 'Aura',
+    body: 'An enchantment that attaches to a creature and stays there. That creature cannot attack or block for as long as Pacifism is on it.',
+  },
+  Oakenform: {
+    keyword: 'Aura',
+    body: 'Attaches to a creature and stays: +3/+3 for as long as it is there. If the creature dies, the Aura goes to the graveyard with it.',
+  },
+}
+
+/**
+ * The most recently arrived permanent on the battlefield that carries a note — what the coach
+ * should explain right now. Null when nothing noted is on the table.
+ */
+export function latestNotedPermanent(state: ClientGameState): { name: string; note: CardNote } | null {
+  const events = state.gameLog ?? []
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]
+    if (e?.type !== 'permanentEntered') continue
+    const c = state.cards[e.cardId]
+    if (!c || c.zone?.zoneType !== ZoneType.BATTLEFIELD) continue
+    const note = CARD_NOTES[c.name]
+    if (note) return { name: c.name, note }
+  }
+  return null
+}
+
 // ── Decks ────────────────────────────────────────────────────────────────────
 
 /** Repeat lands between spells so a list reads as a curve, top-first. */
@@ -268,7 +378,7 @@ export const MISSIONS: readonly Mission[] = [
       },
     ],
     lessons: [
-      'Lands make mana; one a turn. Creatures cost mana and wait a turn before attacking.',
+      'Lands make mana; one a turn. Casting taps your lands; they untap at the start of your next turn.',
       'Drag a card onto the battlefield to play it, or {click-lower} it and choose. {read} to read it.',
       'The blue button moves the game on and names the next stop.',
     ],
@@ -290,12 +400,13 @@ export const MISSIONS: readonly Mission[] = [
         body: 'Press Attack All — or {click-lower} a creature and then Attack with 1. The Tutor has nothing to block with, so every point of power comes straight off their life.',
       },
       'pass-to-combat': {
-        title: 'Nothing left to do — press {pass}.',
-        body: 'The blue button at the bottom right. The turn moves on; if a creature of yours can attack, the game stops at combat and asks you.',
+        title: 'That is what mana is.',
+        body: 'The Forests turned sideways are tapped: they paid for what you cast, and untap at the start of your next turn. Nothing left to play — press {pass}. If a creature of yours can attack, the game stops at combat and asks.',
+        spot: 'tapped-lands',
       },
       pass: {
         title: 'Nothing to do here — press {pass}.',
-        body: 'The Tutor takes a turn, then it is back to you with a fresh card drawn. A creature you cast this turn can attack on the next one.',
+        body: 'The Tutor takes a turn, then it is back to you with a fresh card drawn and your lands untapped. A creature you cast this turn can attack on the next one.',
       },
       waiting: {
         title: 'The Tutor is taking a turn.',
@@ -339,9 +450,9 @@ export const MISSIONS: readonly Mission[] = [
     openingCards: [
       { name: 'Giant Spider', note: 'On the battlefield already. 2 power, 4 toughness: it blocks a 3/3 and lives.' },
       { name: 'Centaur Courser', note: 'A 3/3 for three mana. Kills their Ogre in a fight and survives.' },
-      { name: 'Benalish Knight', note: 'Flash: an instant-speed creature. Cast it on their turn and surprise-block.' },
+      { name: 'Benalish Knight', note: 'Your second draw. Flash: cast it on their turn, like an instant, for a surprise blocker.' },
     ],
-    objectives: [blocked, killedInCombat, won],
+    objectives: [blocked, killedInCombat, readLog, won],
     tour: [
       {
         spot: 'opponent-battlefield',
@@ -356,7 +467,7 @@ export const MISSIONS: readonly Mission[] = [
       {
         spot: 'log',
         title: 'The log.',
-        body: 'Everything that happens is written down here. Combat goes by quickly; when you wonder what just hit you, open the log.',
+        body: 'Everything that happens is written down here. Combat goes by quickly — after the first one, open the log and read what hit what.',
       },
     ],
     lessons: [
@@ -398,8 +509,11 @@ export const MISSIONS: readonly Mission[] = [
         // Two unblocked swings (5 a turn) must not end the mission on the spot: 14 leaves room for one mistake.
         lifeTotal: 14,
         battlefield: [{ name: 'Forest' }, { name: 'Forest' }, { name: 'Plains' }, { name: 'Giant Spider', summoningSickness: false }],
-        hand: ['Plains', 'Centaur Courser', 'Benalish Knight'],
-        library: curve(['Trained Armodon', 'Silvercoat Lion', 'Rumbling Baloth', 'Pacifism', 'Serra Angel', 'Craw Wurm', 'Pillarfield Ox'], GW_LANDS),
+        // No flash creature in the opening hand: holding one makes Auto stop at every step of the
+        // Tutor's first turn, and the first thing a new player learns is pressing Pass five times.
+        // Benalish Knight is the second draw, once the pass button is old news.
+        hand: ['Plains', 'Centaur Courser'],
+        library: curve(['Benalish Knight', 'Trained Armodon', 'Silvercoat Lion', 'Rumbling Baloth', 'Pacifism', 'Serra Angel', 'Craw Wurm', 'Pillarfield Ox'], GW_LANDS),
       },
       player2: {
         lifeTotal: 10,
@@ -434,8 +548,11 @@ export const MISSIONS: readonly Mission[] = [
       'When Lightning Bolt targets your bear, save it with Giant Growth. Then win.',
     ],
     openingCards: [
-      { name: 'Grizzly Bears', note: 'Already on the battlefield, and about to be shot at.' },
-      { name: 'Giant Growth', note: 'An instant: +3/+3 until end of turn. Cast it in response and the bear survives the Bolt.' },
+      { name: 'Grizzly Bears', note: 'A 2/2, already on the battlefield — and about to be shot at.' },
+      {
+        name: 'Giant Growth',
+        note: 'An instant: +3/+3 until end of turn. Lightning Bolt deals 3; a 2/2 dies to it, a 5/5 does not.',
+      },
       { name: 'Centaur Courser', note: 'Your next creature, once you have a third Forest and a quiet moment.' },
     ],
     objectives: [castInstant, attacked, won],
@@ -453,13 +570,13 @@ export const MISSIONS: readonly Mission[] = [
       {
         spot: 'hand',
         title: 'Giant Growth.',
-        body: 'An instant: +3/+3 until end of turn. When Lightning Bolt shows up on the stack aimed at your bear, cast this at the bear.',
+        body: 'An instant, so you may cast it on their turn — even while their spell is waiting on the stack. It makes one creature +3/+3 until the turn ends: your 2/2 bear becomes a 5/5. Lightning Bolt deals 3 damage; 3 kills a 2/2, but not a 5/5. So when the Bolt appears, aimed at the bear, cast Giant Growth on the bear — yours resolves first, and the Bolt hits a 5/5.',
       },
     ],
     lessons: [
       'A spell waits on the stack until everyone passes. The last spell cast resolves first.',
       'An instant can be cast on anyone’s turn — you get a window whenever the game stops for you.',
-      'The Auto switch controls when the game stops to ask; it stops on its own when you hold an instant.',
+      'Damage kills a creature when it reaches its toughness. Raising toughness in response is how a trick saves a creature.',
     ],
     hints: {
       respond: {
@@ -505,8 +622,98 @@ export const MISSIONS: readonly Mission[] = [
     }),
   },
   {
-    id: 'real-game',
+    id: 'removal',
     number: 4,
+    title: 'Answers',
+    blurb: 'Their Hill Giant is bigger than anything you have. Do not fight it — Pacifism takes it out of the game.',
+    frame: 'B',
+    minutes: 5,
+    brief: [
+      'Not every problem is solved in combat. Removal deals with a creature directly.',
+      'Pacifism is an Aura: an enchantment that attaches to a creature. That creature can no longer attack or block.',
+      'They have Doom Blade, the other kind of answer. Expect to lose a creature — then win anyway.',
+    ],
+    openingCards: [
+      { name: 'Pacifism', note: 'An Aura. Cast it on their Hill Giant and the Giant sits out the rest of the game.' },
+      { name: 'Grizzly Bears', note: 'On the battlefield already. A 2/2 — the Giant would eat it.' },
+      { name: 'Centaur Courser', note: 'A 3/3: bigger than their Ogre, and the Giant will be out of the way.' },
+    ],
+    objectives: [castEnchantment, attacked, won],
+    tour: [
+      {
+        spot: 'opponent-battlefield',
+        title: 'The problem.',
+        body: 'Their Hill Giant is a 3/3 and your bear is a 2/2. Attack into it and the bear dies for nothing; block with it and the same. So answer it instead of fighting it.',
+      },
+      {
+        spot: 'hand',
+        title: 'Pacifism.',
+        body: 'An enchantment — a card that stays on the battlefield and keeps doing something. This one is an Aura: it is cast at a creature and attaches to it, and that creature can neither attack nor block.',
+      },
+      {
+        spot: 'piles',
+        title: 'The graveyard.',
+        body: 'Where a creature goes when it dies — and where Doom Blade will send one of yours. Face up; {click-lower} a pile to browse it.',
+      },
+    ],
+    lessons: [
+      'Removal answers a creature without fighting it: an Aura like Pacifism stays attached, an instant like Doom Blade kills outright.',
+      'A dead creature goes to its owner’s graveyard, face up. Click a pile to read what is in it.',
+      'After an answer, count again: their Giant is out, and your 3/3 outsizes what is left.',
+    ],
+    hints: {
+      'land-and-cast': {
+        title: 'Answer the Giant.',
+        body: 'Play the Plains, then Pacifism: drag it out or {click-lower} it and choose Cast, and pick the Hill Giant as its target. It costs one white mana and one of any colour — the Plains and a Forest tap for it.',
+      },
+      cast: {
+        title: 'Pacifism is the play.',
+        body: 'Drag it out or {click-lower} it and choose Cast, then pick the Hill Giant. An Aura is cast at a creature and stays on it.',
+      },
+      target: {
+        title: 'Aim it at the Hill Giant.',
+        body: 'The biggest thing they have. {click} it, then Confirm. Pacifism stays attached, and the Giant can neither attack nor block while it does.',
+      },
+      attack: {
+        title: 'Now attack.',
+        body: 'The Giant cannot block. Count what can: {click-lower} the creatures to send in, then Attack with N. Skip Attacking if the trade is bad.',
+      },
+      'stack-mine': {
+        title: 'They answered back.',
+        body: 'Doom Blade — the other kind of removal — is on the stack aimed at a creature of yours; that creature will die and go to your graveyard. Press {pass}: the stack resolves top-down, so Doom Blade happens first, then Pacifism still lands on the Giant.',
+      },
+    },
+    spec: (name) => ({
+      player1Name: name,
+      player2Name: TUTOR_NAME,
+      player1: {
+        lifeTotal: 12,
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }, { name: 'Plains' }, { name: 'Grizzly Bears', summoningSickness: false }],
+        hand: ['Pacifism', 'Plains', 'Centaur Courser'],
+        library: curve(['Trained Armodon', 'Giant Growth', 'Youthful Knight', 'Rumbling Baloth', 'Serra Angel', 'Craw Wurm', 'Pillarfield Ox'], GW_LANDS),
+      },
+      player2: {
+        lifeTotal: 10,
+        battlefield: [
+          { name: 'Mountain' },
+          { name: 'Swamp' },
+          { name: 'Mountain' },
+          { name: 'Hill Giant', summoningSickness: false },
+          { name: 'Gray Ogre', summoningSickness: false },
+        ],
+        hand: ['Doom Blade', 'Swamp'],
+        library: curve(['Goblin Piker', 'Walking Corpse', 'Volcanic Hammer', 'Hill Giant', 'Scathe Zombies', 'Raging Goblin', 'Child of Night'], RB_LANDS),
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+      priorityPlayer: 1,
+      mode: 'AI',
+      aiPlayer: 2,
+    }),
+  },
+  {
+    id: 'real-game',
+    number: 5,
     title: 'A real game',
     blurb: 'Twenty life each, full decks, everything at once. The coach stays — but the game is yours.',
     frame: 'artifact',
@@ -521,12 +728,12 @@ export const MISSIONS: readonly Mission[] = [
       { name: 'Benalish Knight', note: 'A 2/2 with first strike and flash — it deals its damage before the other creature does.' },
       { name: 'Runeclaw Bear', note: 'A second bear for the second turn.' },
     ],
-    objectives: [playedLand, castCreature, attacked, won],
+    objectives: [playedLand, castCreature, usedUndo, won],
     tour: [
       {
         spot: 'controls',
         title: 'The controls.',
-        body: 'Undo takes back a tap or a cast the game can still rewind. The land icon switches to choosing your own lands to tap. ? Help explains everything else.',
+        body: 'Undo takes back a tap or a cast the game can still rewind — try it once this game. The land icon switches to choosing your own lands to tap. ? Help explains everything else.',
       },
       {
         spot: 'piles',
@@ -536,7 +743,7 @@ export const MISSIONS: readonly Mission[] = [
       {
         spot: 'opponent-life',
         title: 'Twenty life.',
-        body: 'Life totals sit either side of the turn strip. Zero loses. The coach keeps saying what the board is waiting for; the decisions are yours.',
+        body: 'Life totals sit either side of the turn strip. Zero loses. When a card with a keyword lands — deathtouch, first strike, flying — the coach explains it under the tip. The decisions are yours.',
       },
     ],
     lessons: [
@@ -586,6 +793,10 @@ export function learnHref(id?: MissionId): string {
 
 /** Playing time for the whole course — what the home page promises. */
 export const COURSE_MINUTES = MISSIONS.reduce((sum, m) => sum + m.minutes, 0)
+
+/** "five", for the sentences that count the missions — derived, so adding one cannot leave a stale "four". */
+export const COURSE_COUNT_WORD =
+  ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'][MISSIONS.length] ?? String(MISSIONS.length)
 
 /** Every card name any mission can put in play — what the catalog test checks. */
 export function missionCardNames(): readonly string[] {

--- a/web-client/src/learn/progressStore.ts
+++ b/web-client/src/learn/progressStore.ts
@@ -1,11 +1,15 @@
 /**
- * Course progress, kept in this browser. A mission is complete once its game reached its end —
- * won or lost; playing it through is the point, not the result.
+ * Course progress. A mission is complete once its game reached a real end — won or lost; playing
+ * it through is the point, not the result. A concede is not an end.
  *
- * localStorage rather than the account: the course is aimed at someone who has not picked a name
- * yet, let alone signed in, and losing "2 of 4" on a new device is no real loss.
+ * Lives in localStorage for everyone (the course is aimed at someone who has not picked a name
+ * yet), and on the account too once signed in: {@link syncLearnProgress} merges the two — a
+ * mission finished anywhere counts, the play count is the larger — then writes the merge to both,
+ * so "2 of 5" follows the player across devices without a guest ever losing anything.
  */
 import { create } from 'zustand'
+import { fetchLearnProgress, saveLearnProgress } from '@/api/account'
+import { useAuthStore } from '@/store/authStore'
 import { MISSIONS, type MissionId } from './missions'
 
 const STORAGE_KEY = 'argentum.learn.progress'
@@ -16,16 +20,40 @@ export interface StoredProgress {
   plays: Record<string, number>
 }
 
+const KNOWN = new Set<string>(MISSIONS.map((m) => m.id))
+
+/** Read any JSON as progress, dropping mission ids this build does not know. */
+export function parseProgress(raw: unknown): StoredProgress {
+  if (!raw || typeof raw !== 'object') return { completed: [], plays: {} }
+  const parsed = raw as Partial<StoredProgress>
+  const plays: Record<string, number> = {}
+  for (const [id, n] of Object.entries(parsed.plays ?? {})) {
+    if (KNOWN.has(id) && typeof n === 'number' && n > 0) plays[id] = Math.floor(n)
+  }
+  return {
+    completed: (Array.isArray(parsed.completed) ? parsed.completed : []).filter((id): id is MissionId => KNOWN.has(id)),
+    plays,
+  }
+}
+
+/** Union of finished missions (in course order), the larger play count per mission. */
+export function mergeProgress(a: StoredProgress, b: StoredProgress): StoredProgress {
+  const done = new Set<MissionId>([...a.completed, ...b.completed])
+  const plays: Record<string, number> = {}
+  for (const id of new Set([...Object.keys(a.plays), ...Object.keys(b.plays)])) {
+    plays[id] = Math.max(a.plays[id] ?? 0, b.plays[id] ?? 0)
+  }
+  return { completed: MISSIONS.map((m) => m.id).filter((id) => done.has(id)), plays }
+}
+
+export function sameProgress(a: StoredProgress, b: StoredProgress): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
 function load(): StoredProgress {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { completed: [], plays: {} }
-    const parsed = JSON.parse(raw) as Partial<StoredProgress>
-    const known = new Set<string>(MISSIONS.map((m) => m.id))
-    return {
-      completed: (parsed.completed ?? []).filter((id): id is MissionId => known.has(id)),
-      plays: parsed.plays ?? {},
-    }
+    return raw ? parseProgress(JSON.parse(raw)) : { completed: [], plays: {} }
   } catch {
     return { completed: [], plays: {} }
   }
@@ -39,10 +67,18 @@ function save(progress: StoredProgress) {
   }
 }
 
+/** Push to the account when signed in; a failure is silent — localStorage already has it. */
+function pushToAccount(progress: StoredProgress) {
+  if (useAuthStore.getState().status !== 'authenticated') return
+  void saveLearnProgress(progress).catch(() => undefined)
+}
+
 interface LearnProgressState extends StoredProgress {
-  /** A mission's game ended. Marks it complete and counts the play. */
+  /** A mission's game ended for real. Marks it complete and counts the play. */
   finish: (id: MissionId) => void
   reset: () => void
+  /** Replace the whole document — what a sync does after merging. */
+  replace: (progress: StoredProgress) => void
 }
 
 export const useLearnProgress = create<LearnProgressState>((set, get) => ({
@@ -54,14 +90,46 @@ export const useLearnProgress = create<LearnProgressState>((set, get) => ({
       plays: { ...plays, [id]: (plays[id] ?? 0) + 1 },
     }
     save(next)
+    pushToAccount(next)
     set(next)
   },
   reset: () => {
     const next: StoredProgress = { completed: [], plays: {} }
     save(next)
+    pushToAccount(next)
     set(next)
   },
+  replace: (progress) => {
+    save(progress)
+    set(progress)
+  },
 }))
+
+let syncing: Promise<void> | null = null
+
+/**
+ * Merge this browser's progress with the signed-in account's and store the result in both places.
+ * No-op for guests. Safe to call often (the course home, the end of a mission): one sync runs at a
+ * time and a network failure leaves the local copy untouched.
+ */
+export function syncLearnProgress(): Promise<void> {
+  if (useAuthStore.getState().status !== 'authenticated') return Promise.resolve()
+  if (syncing) return syncing
+  syncing = (async () => {
+    try {
+      const remote = parseProgress(await fetchLearnProgress())
+      const local = { completed: useLearnProgress.getState().completed, plays: useLearnProgress.getState().plays }
+      const merged = mergeProgress(local, remote)
+      if (!sameProgress(merged, local)) useLearnProgress.getState().replace(merged)
+      if (!sameProgress(merged, remote)) await saveLearnProgress(merged)
+    } catch {
+      // Offline, or the server has no accounts: the local copy stands.
+    } finally {
+      syncing = null
+    }
+  })()
+  return syncing
+}
 
 /** The first mission not yet completed — where "Continue" goes. Undefined once the course is done. */
 export function nextIncomplete(completed: readonly MissionId[]): MissionId | undefined {

--- a/web-client/src/learn/signals.ts
+++ b/web-client/src/learn/signals.ts
@@ -1,0 +1,27 @@
+/**
+ * Things the player does *to the app* that leave no trace in the game state — opening the log,
+ * pressing Undo. The board components mark them with one call each, and course objectives read
+ * them like any other fact. In-memory only: a new game is a full page navigation, so a fresh
+ * document starts with nothing marked, and a board remount mid-game keeps what was marked.
+ */
+import { create } from 'zustand'
+
+export type LearnSignal = 'logOpened' | 'undoUsed'
+
+interface LearnSignalsState {
+  marked: ReadonlySet<LearnSignal>
+  mark: (signal: LearnSignal) => void
+}
+
+export const useLearnSignals = create<LearnSignalsState>((set, get) => ({
+  marked: new Set(),
+  mark: (signal) => {
+    if (get().marked.has(signal)) return
+    set({ marked: new Set([...get().marked, signal]) })
+  },
+}))
+
+/** For components that just want to say "this happened" without subscribing. */
+export function markLearnSignal(signal: LearnSignal) {
+  useLearnSignals.getState().mark(signal)
+}

--- a/web-client/src/learn/spots.ts
+++ b/web-client/src/learn/spots.ts
@@ -61,4 +61,30 @@ export function findSpot(spot: SpotId, ctx: SpotContext): Element | null {
   return null
 }
 
+export interface SpotRect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+/**
+ * The box to ring: the element's own rect, grown to cover every card inside it. A hand fans its
+ * cards with rotations and overlaps that spill past the zone's layout box, and a bounding rect
+ * reads the box, not the transformed children — so the ring would cut the outer cards in half.
+ * `getBoundingClientRect` on each card does include its transform.
+ */
+export function spotRect(el: Element): SpotRect {
+  let { top, left, right, bottom } = el.getBoundingClientRect()
+  for (const card of el.querySelectorAll('[data-card-id]')) {
+    const r = card.getBoundingClientRect()
+    if (r.width === 0 || r.height === 0) continue
+    top = Math.min(top, r.top)
+    left = Math.min(left, r.left)
+    right = Math.max(right, r.right)
+    bottom = Math.max(bottom, r.bottom)
+  }
+  return { top, left, width: right - left, height: bottom - top }
+}
+
 export const ALL_SPOTS: readonly SpotId[] = Object.keys(SELECTORS) as SpotId[]

--- a/web-client/src/learn/spots.ts
+++ b/web-client/src/learn/spots.ts
@@ -23,6 +23,7 @@ export type SpotId =
   | 'opponent-life'
   | 'my-life'
   | 'piles'
+  | 'tapped-lands'
 
 export interface SpotContext {
   me: EntityId
@@ -44,6 +45,7 @@ const SELECTORS: Record<SpotId, string | ((ctx: SpotContext) => string)> = {
   'opponent-life': (ctx) => (ctx.opponent ? `[data-life-id="${ctx.opponent}"]` : '[data-life-id]'),
   'my-life': (ctx) => `[data-life-id="${ctx.me}"]`,
   piles: '[data-zone="player-library"]',
+  'tapped-lands': '[data-zone="player-battlefield"] [data-card-id][data-tapped="true"]',
 }
 
 export function spotSelector(spot: SpotId, ctx: SpotContext): string {
@@ -69,13 +71,17 @@ export interface SpotRect {
 }
 
 /**
- * The box to ring: the element's own rect, grown to cover every card inside it. A hand fans its
- * cards with rotations and overlaps that spill past the zone's layout box, and a bounding rect
- * reads the box, not the transformed children — so the ring would cut the outer cards in half.
- * `getBoundingClientRect` on each card does include its transform.
+ * The box to ring for one element: the union of the cards inside it, or its own rect when it holds
+ * none. A hand fans its cards with rotations and overlaps that spill past the zone's layout box,
+ * and a battlefield's box is mostly empty table — the cards are what the eye is meant to find.
+ * `getBoundingClientRect` on each card includes its transform.
  */
 export function spotRect(el: Element): SpotRect {
-  let { top, left, right, bottom } = el.getBoundingClientRect()
+  const own = el.getBoundingClientRect()
+  let top = Infinity
+  let left = Infinity
+  let right = -Infinity
+  let bottom = -Infinity
   for (const card of el.querySelectorAll('[data-card-id]')) {
     const r = card.getBoundingClientRect()
     if (r.width === 0 || r.height === 0) continue
@@ -84,6 +90,29 @@ export function spotRect(el: Element): SpotRect {
     right = Math.max(right, r.right)
     bottom = Math.max(bottom, r.bottom)
   }
+  if (top === Infinity) return { top: own.top, left: own.left, width: own.width, height: own.height }
+  return { top, left, width: right - left, height: bottom - top }
+}
+
+/**
+ * The box to ring for a spot: every on-screen match, unioned — one element for most spots, several
+ * for the ones that name a set of cards (`tapped-lands`). Null when nothing is on screen.
+ */
+export function spotBox(spot: SpotId, ctx: SpotContext): SpotRect | null {
+  let top = Infinity
+  let left = Infinity
+  let right = -Infinity
+  let bottom = -Infinity
+  for (const el of document.querySelectorAll(spotSelector(spot, ctx))) {
+    const own = el.getBoundingClientRect()
+    if (own.width === 0 || own.height === 0) continue
+    const r = spotRect(el)
+    top = Math.min(top, r.top)
+    left = Math.min(left, r.left)
+    right = Math.max(right, r.left + r.width)
+    bottom = Math.max(bottom, r.top + r.height)
+  }
+  if (top === Infinity) return null
   return { top, left, width: right - left, height: bottom - top }
 }
 

--- a/web-client/src/pages/LearnPage.tsx
+++ b/web-client/src/pages/LearnPage.tsx
@@ -1,5 +1,5 @@
 /**
- * `/learn` — the course home, a hand of four mission cards — and `/learn/:missionId`, the brief
+ * `/learn` — the course home, a hand of mission cards — and `/learn/:missionId`, the brief
  * for one mission: three lines on what you will do, the cards you start with, and the button
  * that puts you at the table.
  *
@@ -10,14 +10,14 @@
  */
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { COURSE_MINUTES, MISSIONS, TUTOR_NAME, learnHref, missionById, type Mission, type MissionId } from '@/learn/missions'
+import { COURSE_COUNT_WORD, COURSE_MINUTES, MISSIONS, TUTOR_NAME, learnHref, missionById, type Mission, type MissionId } from '@/learn/missions'
 import { armCoach } from '@/learn/coach'
-import { hasStarted, nextIncomplete, useLearnProgress } from '@/learn/progressStore'
+import { hasStarted, nextIncomplete, syncLearnProgress, useLearnProgress } from '@/learn/progressStore'
 import { useAuthStore } from '@/store/authStore'
 import type { ScenarioCreateResponse } from '@/components/scenario/types'
 import { MissionHand, MiniHand, frameVar } from '@/components/learn/MissionHand'
 import { CardImage } from '@/components/learn/CardImage'
-import { useLessonCards } from '@/components/learn/useLessonCards'
+import { useLessonCards, usePreloadLessonCards } from '@/components/learn/useLessonCards'
 import styles from '@/components/learn/learn.module.css'
 
 const NAME_KEY = 'argentum-player-name'
@@ -81,10 +81,15 @@ function CourseHome() {
 
   useEffect(() => {
     document.title = 'Learn to play — Argentum'
+    // Signed in? Fold the account's progress into this browser's, and vice versa.
+    void syncLearnProgress()
     return () => {
       document.title = 'Argentum Engine'
     }
   }, [])
+
+  // Every brief's opening cards, fetched now so the brief opens with its cards already painted.
+  usePreloadLessonCards(MISSIONS.flatMap((m) => m.openingCards.map((c) => c.name)))
 
   return (
     <>
@@ -97,9 +102,10 @@ function CourseHome() {
           <em>by playing it.</em>
         </h1>
         <p className={styles.lede}>
-          Four short games against the AI, each from a board set up to teach one thing, with a coach at your
-          elbow saying what to do next — and where on the table to do it. About {COURSE_MINUTES} minutes all
-          told. Nothing to read first, nothing to sign up for.
+          {COURSE_COUNT_WORD[0]!.toUpperCase() + COURSE_COUNT_WORD.slice(1)} short games against the AI, each
+          from a board set up to teach one thing, with a coach at your elbow saying what to do next — and where
+          on the table to do it. About {COURSE_MINUTES} minutes all told. Nothing to read first, nothing to sign
+          up for.
         </p>
         <div className={styles.heroActions}>
           {finished ? (

--- a/web-client/src/store/slices/ui/animationSlice.ts
+++ b/web-client/src/store/slices/ui/animationSlice.ts
@@ -109,7 +109,9 @@ export const createAnimationSlice: SliceCreator<AnimationSlice> = (set, get) => 
 
   // Card selection actions
   selectCard: (cardId) => {
-    set({ selectedCardId: cardId })
+    // Opening a card's action menu drops any hover preview: the pointer is still over the card
+    // that was clicked, and the preview would sit on top of the menu's buttons.
+    set(cardId ? { selectedCardId: cardId, hoveredCardId: null, autoTapPreview: null } : { selectedCardId: cardId })
   },
 
   hoverCard: (cardId, position) => {


### PR DESCRIPTION
Follow-ups to #2076, in three commits: the hand ring, the phase-aware waiting tip, and then the full improvement pass.

## New teaching
- **Mission 4 — "Answers".** Pacifism on a Hill Giant while the Tutor holds Doom Blade: removal, Auras, the graveyard — and when the AI responds to Pacifism with Doom Blade (it does), a second look at the stack with a mission-specific "They answered back" tip. "A real game" is mission 5; the count word on the home page / callout / help topic is derived from `MISSIONS`.
- **Card notes.** When a permanent with a keyword the course has not named lands on the table — deathtouch (Typhoid Rats), first strike + flash (Benalish Knight), reach, flying, vigilance, haste, "attacks each combat if able", regenerate, lifelink, Aura — the coach explains it under the tip for as long as the card is there (`CARD_NOTES` + `latestNotedPermanent`, read off `permanentEntered` in the log).
- **Mana, shown.** Mission 1's after-cast tip rings the tapped Forests (`tapped-lands` spot via a `data-tapped` attribute on `GameCard`) and says what tapped means.
- **Giant Growth explained with numbers**: 2/2 → 5/5, Bolt deals 3, 3 < 5, so cast it when the Bolt appears aimed at the bear.
- **Attack warning.** Selecting attackers that leave no untapped blocker against a board that can hit back gets an orange "That leaves nobody home" while it can still be undone (new `warn` tone).
- **A spell on the stack during your own turn** (the AI responding) has its own tip instead of "nothing left to play, press the blue button".
- **Two app objectives**: open the log (mission 2), use Undo (mission 5) — a tiny `learn/signals` store the log toggle and undo button mark.

## Rough edges
- A **concede no longer counts** as finishing the mission (own closing card, no "what you now know").
- **Mission 2** no longer opens with a flash creature in hand — Auto stopped at every step of the Tutor's first turn and the first lesson was pressing Pass five times; verified the AI's first turn now runs straight to the block prompt. Benalish Knight is the second draw.
- **Opening an action menu drops the hover preview** that sat on top of its buttons (`selectCard` clears `hoveredCardId`; hover is suppressed while a menu is open).
- **Spotlight rings measure the cards inside a zone** rather than its layout box: the hand ring wraps the fanned cards, the battlefield ring the cards rather than the empty table.
- The brief's card images are **preloaded** from the course home.
- **Phones**: the coach starts as a pill (top-left, carrying the tip's title) and opens as a sheet over the opponent's side; it no longer covers the hand and the combat buttons. Checked in a 390×844 frame.

## Progress on the account
`users.learn_progress` (`V13__learn_progress.sql`) holds the client's progress JSON verbatim; `GET`/`PUT /api/auth/me/learn-progress` (4 KB cap, must be a JSON object). The client merges the local and account copies (union of finished missions, max plays) on the course home and after each finished mission; guests are unchanged.

## Verified
- `npm run typecheck` clean; `vitest run` 52 files / 742 tests (learn: 50 — warning, concede, stack-on-my-turn, signals objectives, card notes, count word).
- `:game-server:compileKotlin` clean.
- Played in Chrome: mission 4 end to end (targeting override, Doom Blade response tip, Pacifism note), mission 2 (no stops on the AI's first turn, block drag, the attack warning), the five-card hand, the opponent-battlefield ring on cards, the phone frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173Xm5K5s6kieSoA9yk1afM
