### PR TITLE
Learn to Play: the coach answers your moves, and the tour steps aside when you go ahead

### DIFF
--- a/web-client/src/components/learn/LearnCoach.module.css
+++ b/web-client/src/components/learn/LearnCoach.module.css
@@ -40,6 +40,34 @@
   --coach-accent: #ff9d3c;
 }
 
+/* ---- The answer to a move ------------------------------------------------- */
+/* One line above the tip saying back what the player just did — the Forest is down, the bear
+   attacks, no blocks. Up for a few seconds; the tip is what stays. */
+.notice {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  align-items: start;
+  margin-bottom: 8px;
+  font-size: 12.5px;
+  color: #efe6cf;
+  animation: coachIn 0.28s ease-out both;
+}
+
+.noticeTick {
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: var(--coach-accent);
+  color: #1a1408;
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  animation: tickIn 0.35s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
 /* ---- Card note ------------------------------------------------------------ */
 /* One line about a card that just arrived on the table and carries a keyword the course has not
    named yet — deathtouch, first strike, reach. Under the tip, above the objectives. */

--- a/web-client/src/components/learn/LearnCoach.tsx
+++ b/web-client/src/components/learn/LearnCoach.tsx
@@ -3,23 +3,39 @@
  * course armed it (see `learn/coach.ts`). Three states:
  *
  * - **Tour** — when the board first appears, a few steps that each ring one part of the table
- *   (hand, battlefield, turn strip, the pass button …) and say what it is for. Skippable.
+ *   (hand, battlefield, turn strip, the pass button …) and say what it is for. Skippable — and
+ *   the board stays live under it, so a player who plays the Forest while the tour is still
+ *   introducing the hand has simply started; the tour steps aside the moment they do.
  * - **Tip** — one line for what the board is waiting on, worded with the real button label and
- *   this device's gestures, with a quiet ring on the thing it names; a card note under it when a
- *   permanent with a keyword the course has not named yet is on the table; the mission's
- *   objectives tick off underneath as the player does them.
+ *   this device's gestures, with a quiet ring on the thing it names; above it, for a few
+ *   seconds, one line answering the thing the player just did (the Forest is down, the bear
+ *   attacks, no blocks); a card note under it when a permanent with a keyword the course has not
+ *   named yet is on the table; the mission's objectives tick off underneath as the player does
+ *   them.
  * - **Done** — the game ended: what you learned, and the next card in the hand. A concede ends
  *   the game but not the mission.
  *
  * Portalled to `<body>` like the help drawer: `#root` is overflow:hidden and the multiplayer
  * strip transforms its subtree, both of which break `position: fixed` for descendants.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { useGameStore } from '@/store/gameStore'
 import { selectHasPriority, selectIsMyTurn, useStackCards } from '@/store/selectors'
-import { armedMission, coachTip, disarmCoach, markTourSeen, tourSeen, wordTip, type CoachView } from '@/learn/coach'
+import {
+  armedMission,
+  coachTip,
+  disarmCoach,
+  markTourSeen,
+  noticeFromLog,
+  noticeFromMove,
+  playerIsActing,
+  tourSeen,
+  wordTip,
+  type ActionNotice,
+  type CoachView,
+} from '@/learn/coach'
 import { latestNotedPermanent, learnHref, missionById, nextMission } from '@/learn/missions'
 import type { SpotContext } from '@/learn/spots'
 import { useLearnSignals } from '@/learn/signals'
@@ -52,6 +68,14 @@ function isCreatureOnBattlefield(c: ClientCard): boolean {
   return c.zone?.zoneType === ZoneType.BATTLEFIELD && c.cardTypes.some((t) => t.toUpperCase() === 'CREATURE')
 }
 
+/** How long the line answering the player's last move stays up before the tip stands alone again. */
+const NOTICE_MS = 9000
+
+/** The line answering a move, and whether that move was the one that cut the tour short. */
+interface ShownNotice extends ActionNotice {
+  endedTour: boolean
+}
+
 export function LearnCoach() {
   const [missionId] = useState(armedMission)
   const mission = useMemo(() => missionById(missionId), [missionId])
@@ -62,6 +86,10 @@ export function LearnCoach() {
   // Once the game is over the coach disarms itself, so a remount after that renders nothing —
   // which is also what stops the mission being finished twice.
   const [finished, setFinished] = useState(false)
+  const [notice, setNotice] = useState<ShownNotice | null>(null)
+  // What the coach has already answered: the log entries read so far, and the view it last saw.
+  const seenLog = useRef<number | null>(null)
+  const lastView = useRef<CoachView | null>(null)
   const navigate = useNavigate()
   const finish = useLearnProgress((s) => s.finish)
   const returnToMenu = useGameStore((s) => s.returnToMenu)
@@ -88,6 +116,7 @@ export function LearnCoach() {
     if (!gameState) return null
     const types = new Set(legalActions.map((a) => a.actionType))
     const selected = combatState?.mode === 'declareAttackers' ? combatState.selectedAttackers : []
+    const mandatory = combatState?.mode === 'declareAttackers' ? combatState.mandatoryAttackers : []
     const cards = Object.values(gameState.cards)
     const mine = cards.filter((c) => c.controllerId === gameState.viewingPlayerId && isCreatureOnBattlefield(c))
     const theirs = cards.filter((c) => c.controllerId !== gameState.viewingPlayerId && isCreatureOnBattlefield(c))
@@ -105,6 +134,7 @@ export function LearnCoach() {
       stackSize,
       attackersIncoming: gameState.combat?.attackers.length ?? 0,
       attackersSelected: selected.length,
+      attackersChosen: selected.filter((id) => !mandatory.includes(id)).length,
       blockersLeft: mine.filter((c) => !c.isTapped && !selected.includes(c.id)).length,
       theirCreatures: theirs.length,
       conceded,
@@ -145,6 +175,48 @@ export function LearnCoach() {
 
   const cardNote = useMemo(() => (gameState ? latestNotedPermanent(gameState) : null), [gameState])
 
+  const endTour = () => {
+    markTourSeen()
+    setTourStep(null)
+    if (smallScreen()) setCollapsed(true)
+  }
+
+  // Answer the player's own moves. The log is the server's full per-player list, so the entries
+  // past the ones already read are what happened since the last look — the first look reads
+  // nothing, so a remount mid-game does not replay the whole game back. Passes, answered prompts
+  // and combat choices leave no entry; the previous view tells those apart. A move during the
+  // tour ends the tour: the player is ahead of it, and a tip about the live board beats a step
+  // about the opening one.
+  useEffect(() => {
+    if (!view || !gameState) return
+    const log = gameState.gameLog ?? []
+    const seen = seenLog.current
+    const prev = lastView.current
+    seenLog.current = log.length
+    lastView.current = view
+    if (view.isGameOver) return
+    // A shorter log is an undo: the game rewound, and the board moving back is not a move.
+    const rewound = seen !== null && log.length < seen
+    const found = rewound
+      ? { key: `undo-${log.length}`, text: 'Undone — the game is back where it was.' }
+      : (noticeFromLog(log.slice(seen ?? log.length), gameState.viewingPlayerId, gameState.cards, seen ?? log.length) ??
+        (prev ? noticeFromMove(prev, view) : null))
+    const touring = tourStep !== null
+    if (found) setNotice({ ...found, endedTour: touring })
+    if (touring && (found || playerIsActing(view))) {
+      if (!found) setNotice({ key: `ahead-${view.turnNumber}-${view.step}`, text: 'You went ahead.', endedTour: true })
+      endTour()
+    }
+    // `tourStep` is read, not reacted to: a tour click has nothing new to answer.
+  }, [view, gameState])
+
+  // The notice is a moment, not a fixture: the tip is what stays.
+  useEffect(() => {
+    if (!notice) return
+    const id = window.setTimeout(() => setNotice((n) => (n?.key === notice.key ? null : n)), NOTICE_MS)
+    return () => window.clearTimeout(id)
+  }, [notice])
+
   // A game played to its end finishes the mission, win or lose; a concede does not. Either way
   // the coach disarms, so the next game — a rematch, or anything from the menu — has no coach.
   useEffect(() => {
@@ -166,11 +238,6 @@ export function LearnCoach() {
   const touring = tourStep !== null && !view.isGameOver && tourStep < mission.tour.length
   const step = touring ? mission.tour[tourStep] : undefined
 
-  const endTour = () => {
-    markTourSeen()
-    setTourStep(null)
-    if (smallScreen()) setCollapsed(true)
-  }
 
   const leave = (to: string) => {
     returnToMenu()
@@ -262,6 +329,17 @@ export function LearnCoach() {
           </div>
         ) : (
           <div key={tip.key} className={styles.body}>
+            {notice && (
+              <div key={notice.key} className={styles.notice} role="status">
+                <span className={styles.noticeTick} aria-hidden="true">
+                  ✓
+                </span>
+                <span>
+                  {notice.text}
+                  {notice.endedTour && ' You are ahead of the tour, so it steps aside — the coach follows your moves from here.'}
+                </span>
+              </div>
+            )}
             <div className={styles.title}>{tip.title}</div>
             <p className={styles.text}>{tip.body}</p>
           </div>

--- a/web-client/src/learn/coach.test.ts
+++ b/web-client/src/learn/coach.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { coachTip, wordTip, type CoachView } from './coach'
+import { coachTip, noticeFromLog, noticeFromMove, playerIsActing, wordTip, type CoachView } from './coach'
+import type { ClientCard } from '@/types/gameState'
+import type { ClientEvent } from '@/types/events'
+import type { EntityId } from '@/types'
 import { MISSIONS } from './missions'
 
 const base: CoachView = {
@@ -16,6 +19,7 @@ const base: CoachView = {
   stackSize: 0,
   attackersIncoming: 0,
   attackersSelected: 0,
+  attackersChosen: 0,
   blockersLeft: 0,
   theirCreatures: 0,
   conceded: false,
@@ -197,5 +201,103 @@ describe('coachTip', () => {
     expect(coachTip({ ...base, isGameOver: true, won: null }).key).toBe('draw')
     // Game over beats every live prompt.
     expect(coachTip({ ...base, isGameOver: true, won: true, canAttack: true, hasDecision: true }).key).toBe('won')
+  })
+})
+
+const id = (s: string) => s as EntityId
+const me = id('p1')
+const them = id('p2')
+
+function cardOf(id: string, types: string[], controllerId: EntityId = me): ClientCard {
+  return { id, cardTypes: types, controllerId, ownerId: controllerId } as unknown as ClientCard
+}
+
+const cards = Object.fromEntries(
+  [cardOf('forest', ['LAND']), cardOf('bear', ['CREATURE']), cardOf('spider', ['CREATURE']), cardOf('cyclops', ['CREATURE'], them)].map(
+    (c) => [c.id, c],
+  ),
+) as Record<EntityId, ClientCard>
+
+describe('noticeFromLog', () => {
+  it('says the land is down, with what that buys', () => {
+    const log: ClientEvent[] = [
+      { type: 'permanentEntered', cardId: id('forest'), cardName: 'Forest', controllerId: me, enteredTapped: false, description: '' },
+    ]
+    const n = noticeFromLog(log, me, cards, 4)
+    expect(n?.key).toBe('permanentEntered-4')
+    expect(n?.text).toMatch(/^Forest is on the battlefield/)
+  })
+
+  it('answers a creature cast with its arrival, not the cast', () => {
+    const log: ClientEvent[] = [
+      { type: 'spellCast', spellId: id('bear'), spellName: 'Grizzly Bears', casterId: me, description: '' },
+      { type: 'spellResolved', spellId: id('bear'), spellName: 'Grizzly Bears', description: '' },
+      { type: 'permanentEntered', cardId: id('bear'), cardName: 'Grizzly Bears', controllerId: me, enteredTapped: false, description: '' },
+    ]
+    expect(noticeFromLog(log, me, cards, 0)?.text).toMatch(/Grizzly Bears is on the battlefield.*next turn/)
+    // The cast alone — an instant, or the first update of two — is the stack line.
+    expect(noticeFromLog(log.slice(0, 1), me, cards, 0)?.text).toMatch(/^You cast Grizzly Bears/)
+  })
+
+  it('ignores what the other seat did', () => {
+    const log: ClientEvent[] = [
+      { type: 'permanentEntered', cardId: id('cyclops'), cardName: 'Bloodrock Cyclops', controllerId: them, enteredTapped: false, description: '' },
+      { type: 'spellCast', spellId: id('x'), spellName: 'Lightning Bolt', casterId: them, description: '' },
+      { type: 'creatureAttacked', creatureId: id('cyclops'), creatureName: 'Bloodrock Cyclops', attackingPlayerId: them, defendingPlayerId: me, description: '' },
+      { type: 'creatureBlocked', blockerId: id('cyclops'), blockerName: 'Bloodrock Cyclops', attackerId: id('bear'), attackerName: 'Grizzly Bears', description: '' },
+    ]
+    expect(noticeFromLog(log, me, cards, 0)).toBeNull()
+    expect(noticeFromLog([], me, cards, 0)).toBeNull()
+  })
+
+  it('lists the attackers as one line and keys it once', () => {
+    const log: ClientEvent[] = [
+      { type: 'creatureAttacked', creatureId: id('bear'), creatureName: 'Grizzly Bears', attackingPlayerId: me, defendingPlayerId: them, description: '' },
+      { type: 'creatureAttacked', creatureId: id('spider'), creatureName: 'Giant Spider', attackingPlayerId: me, defendingPlayerId: them, description: '' },
+    ]
+    const n = noticeFromLog(log, me, cards, 7)
+    expect(n?.text).toBe('Grizzly Bears and Giant Spider attack.')
+    expect(n?.key).toBe('attack-7')
+    expect(noticeFromLog(log.slice(0, 1), me, cards, 7)?.text).toBe('Grizzly Bears attacks.')
+  })
+
+  it('answers a block by whose creature blocked', () => {
+    const log: ClientEvent[] = [
+      { type: 'creatureBlocked', blockerId: id('spider'), blockerName: 'Giant Spider', attackerId: id('cyclops'), attackerName: 'Bloodrock Cyclops', description: '' },
+    ]
+    expect(noticeFromLog(log, me, cards, 0)?.text).toMatch(/^Giant Spider blocks Bloodrock Cyclops/)
+  })
+})
+
+describe('noticeFromMove', () => {
+  it('reads a pass off the step moving while the player held priority', () => {
+    expect(noticeFromMove(base, { ...base, step: 'BEGIN_COMBAT' })?.text).toBe('You passed.')
+    expect(noticeFromMove(base, { ...base, turnNumber: 4, isMyTurn: false, hasPriority: false })?.text).toBe('You passed.')
+    // Without priority the game moves on its own — the Tutor's turn is not the player's doing.
+    const theirs = { ...base, isMyTurn: false, hasPriority: false, step: 'UPKEEP' }
+    expect(noticeFromMove(theirs, { ...theirs, step: 'PRECOMBAT_MAIN' })).toBeNull()
+    expect(noticeFromMove(base, base)).toBeNull()
+  })
+
+  it('reads the stack resolving as a pass', () => {
+    expect(noticeFromMove({ ...base, stackSize: 1 }, base)?.key).toMatch(/^resolved-/)
+    // The stack growing is the other seat responding, not a pass.
+    expect(noticeFromMove({ ...base, stackSize: 1 }, { ...base, stackSize: 2, hasPriority: true })).toBeNull()
+  })
+
+  it('names a skipped attack and no blocks, and an answered prompt', () => {
+    expect(noticeFromMove({ ...base, canAttack: true }, base)?.text).toMatch(/^No attack this turn/)
+    expect(noticeFromMove({ ...base, canBlock: true, isMyTurn: false }, { ...base, isMyTurn: false })?.text).toMatch(/^No blocks/)
+    expect(noticeFromMove({ ...base, hasDecision: true }, base)?.text).toBe('Answered.')
+  })
+})
+
+describe('playerIsActing', () => {
+  it('is true mid-cast and mid-attack, false at rest', () => {
+    expect(playerIsActing(base)).toBe(false)
+    expect(playerIsActing({ ...base, isTargeting: true })).toBe(true)
+    expect(playerIsActing({ ...base, canAttack: true, attackersSelected: 1, attackersChosen: 1 })).toBe(true)
+    // A creature that must attack is selected before the player has done anything.
+    expect(playerIsActing({ ...base, canAttack: true, attackersSelected: 1, attackersChosen: 0 })).toBe(false)
   })
 })

--- a/web-client/src/learn/coach.ts
+++ b/web-client/src/learn/coach.ts
@@ -15,6 +15,9 @@
  * game ends — it rides sessionStorage because the hand-off into a scenario game is a full
  * navigation (`/?token=…`), which drops React state but not the tab.
  */
+import type { EntityId } from '@/types'
+import type { ClientEvent } from '@/types/events'
+import type { ClientCard } from '@/types/gameState'
 import type { MissionId } from './missions'
 import { missionById } from './missions'
 import type { SpotId } from './spots'
@@ -92,6 +95,11 @@ export interface CoachView {
   attackersIncoming: number
   /** While declaring attackers: how many creatures are selected to attack so far. */
   attackersSelected: number
+  /**
+   * Of those, how many the player picked themselves — a creature that must attack is selected
+   * by the board before the player touches anything.
+   */
+  attackersChosen: number
   /** While declaring attackers: untapped creatures of mine that would stay home if the selected ones attack. */
   blockersLeft: number
   /** Creatures the opponent has on the battlefield. */
@@ -373,6 +381,117 @@ function baseTip(view: CoachView): CoachTip {
     tone: 'watch',
     spot: 'phase-strip',
   }
+}
+
+// ── Answering the player's own moves ────────────────────────────────────────
+//
+// A tip says what the board is waiting for; a notice says what the player just did. Without the
+// second, a player who plays the Forest while the tour is still introducing the hand is left
+// with a coach describing a table that no longer exists. Every notice is read off the same
+// facts the objectives use — the log for plays, casts, attacks and blocks — plus two consecutive
+// views for the moves that leave no log entry (a pass, an answered prompt, a skipped attack).
+
+/** One line said back to the player about the thing they just did. */
+export interface ActionNotice {
+  /** Stable per action, so the line animates once and a re-render does not replay it. */
+  key: string
+  text: string
+}
+
+function hasType(card: ClientCard | undefined, type: string): boolean {
+  return card !== undefined && card.cardTypes.some((t) => t.toUpperCase() === type)
+}
+
+function listNames(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? ''
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+}
+
+/**
+ * What the player did in the log entries that arrived since the coach last looked, worded back
+ * to them — or null when none of those entries were theirs. `offset` is where `fresh` starts in
+ * the full log, so the key stays stable across renders. The last thing they did wins: a creature
+ * cast is logged as a cast and then as an arrival, and the arrival is the one worth saying.
+ */
+export function noticeFromLog(
+  fresh: readonly ClientEvent[],
+  me: EntityId,
+  cards: Readonly<Record<EntityId, ClientCard>>,
+  offset: number,
+): ActionNotice | null {
+  let notice: ActionNotice | null = null
+  const attackers: string[] = []
+  for (const [i, e] of fresh.entries()) {
+    const key = `${e.type}-${offset + i}`
+    switch (e.type) {
+      case 'permanentEntered': {
+        if (e.controllerId !== me) continue
+        const card = cards[e.cardId]
+        if (hasType(card, 'LAND')) {
+          notice = { key, text: `${e.cardName} is on the battlefield — one more mana every turn from now on.` }
+        } else if (hasType(card, 'CREATURE')) {
+          notice = { key, text: `${e.cardName} is on the battlefield. It can attack from your next turn.` }
+        } else {
+          notice = { key, text: `${e.cardName} is on the battlefield.` }
+        }
+        continue
+      }
+      case 'spellCast':
+        if (e.casterId !== me) continue
+        notice = { key, text: `You cast ${e.spellName}. It sits on the stack until everyone passes.` }
+        continue
+      case 'creatureAttacked':
+        if (e.attackingPlayerId !== me) continue
+        attackers.push(e.creatureName)
+        notice = {
+          key: `attack-${offset + i - attackers.length + 1}`,
+          text: `${listNames(attackers)} ${attackers.length > 1 ? 'attack' : 'attacks'}.`,
+        }
+        continue
+      case 'creatureBlocked':
+        if (cards[e.blockerId]?.controllerId !== me) continue
+        notice = { key, text: `${e.blockerName} blocks ${e.attackerName} — the damage goes to your creature, not to you.` }
+        continue
+      default:
+        continue
+    }
+  }
+  return notice
+}
+
+/**
+ * The moves that leave no log entry, read off two consecutive views. The game cannot take
+ * priority, a prompt or a combat choice away from the player — only their own action does — so
+ * the transition is the proof. Null when nothing between the two views was the player's doing.
+ * Call it after {@link noticeFromLog}: a declared attack or block is logged, and the log's line
+ * is the better one.
+ */
+export function noticeFromMove(prev: CoachView, next: CoachView): ActionNotice | null {
+  const at = `${next.turnNumber}-${next.step}`
+  if (prev.canBlock && !next.canBlock) {
+    return { key: `no-blocks-${at}`, text: 'No blocks — the attack comes through to you.' }
+  }
+  if (prev.canAttack && !next.canAttack) {
+    return { key: `no-attack-${at}`, text: 'No attack this turn — your creatures stay home to block.' }
+  }
+  if (prev.hasDecision && !next.hasDecision) {
+    return { key: `answered-${at}`, text: 'Answered.' }
+  }
+  if (prev.hasPriority && next.stackSize < prev.stackSize) {
+    return { key: `resolved-${at}`, text: 'You passed, and the stack resolved — the last spell cast happened first.' }
+  }
+  if (prev.hasPriority && (next.step !== prev.step || next.turnNumber !== prev.turnNumber)) {
+    return { key: `passed-${at}`, text: 'You passed.' }
+  }
+  return null
+}
+
+/**
+ * The player is in the middle of something — a spell waiting on its target, creatures picked to
+ * attack. Not yet a move, but the tour has no business talking over it.
+ */
+export function playerIsActing(view: CoachView): boolean {
+  return view.isTargeting || view.attackersChosen > 0
 }
 
 type Phase = 'beginning' | 'main' | 'combat' | 'end'


### PR DESCRIPTION
## The problem

The table tour at the start of a mission is four static steps over a **live** board. A player who plays the Forest while the tour is still introducing the hand gets three more steps about a table that no longer exists ("Two Forests are already down…"), and nothing in the coach acknowledges that they did anything.

## What changes

The coach now reads the player's own moves and answers them.

- **`noticeFromLog`** — words back what the log says the player just did: *"Forest is on the battlefield — one more mana every turn from now on."*, *"Grizzly Bears is on the battlefield. It can attack from your next turn."*, *"You cast X. It sits on the stack until everyone passes."*, *"X attacks."* / *"X and Y attack."*, *"X blocks Y — the damage goes to your creature, not to you."* Keyed by log index so a re-render never replays it. The last thing they did wins, so a creature cast is answered by its arrival, not the cast.
- **`noticeFromMove`** — the moves that leave no log entry, read off two consecutive views: *"You passed."*, the stack resolving, an answered prompt, *"No attack this turn — your creatures stay home to block."*, *"No blocks — the attack comes through to you."* The game cannot take priority, a prompt or a combat choice away from the player, so the transition is the proof; the Tutor's turn moving on its own is never read as a pass.
- **`playerIsActing`** — mid-cast targeting, or attackers the player picked themselves (mandatory attackers are pre-selected by the board and don't count).

In the panel: the notice sits above the tip for nine seconds with a tick in the accent colour. **A move during the tour ends the tour**, with the same line plus *"You are ahead of the tour, so it steps aside — the coach follows your moves from here."* A shorter log is an undo and is said as one, not read as a pass.

All three readers are pure functions in `learn/coach.ts` with unit tests; the component only diffs the log length and the previous view.

## Screenshots

Played the Forest at tour step 1 — the tour steps aside and the coach answers the move:

![tour steps aside](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-coach-answers-moves-screenshots/tour-steps-aside.jpg)

The bear's arrival, then the attack:

![creature notice](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-coach-answers-moves-screenshots/creature-notice.png)

![attack notice](https://raw.githubusercontent.com/wingedsheep/argentum-engine/learn-coach-answers-moves-screenshots/attack-notice.png)

(`learn-coach-answers-moves-screenshots` is a throwaway branch holding only these images.)

## Verification

- `npm run typecheck` and `vitest run src/learn` (59 tests, 12 new) green.
- Live on mission 1: the tour did **not** end on its own at game start (no spurious pass from the opening priority hand-off); playing the Forest at step 1 ended it with the land notice; the bear's arrival, "You passed." and "Grizzly Bears attacks." followed; the Tutor's turn produced no false notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173Xm5K5s6kieSoA9yk1afM
