### PR TITLE
Add five Innistrad: Crimson Vow disturb cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 233 / 273
+**Implemented:** 238 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -20,7 +20,7 @@
 - [x] Avabruck Caretaker
 - [x] Ballista Watcher
 - [x] Belligerent Guest
-- [ ] Binding Geist
+- [x] Binding Geist
 - [x] Biolume Egg
 - [x] Bleed Dry
 - [x] Blood Fountain
@@ -71,7 +71,7 @@
 - [x] Desperate Farmer
 - [x] Dig Up
 - [x] Diregraf Scavenger
-- [ ] Distracting Geist
+- [x] Distracting Geist
 - [x] Diver Skaab
 - [ ] Dollhouse of Horrors
 - [x] Dominating Vampire
@@ -83,7 +83,7 @@
 - [x] Dreadlight Monstrosity
 - [x] Dreamroot Cascade
 - [x] Dreamshackle Geist
-- [ ] Drogskol Infantry
+- [x] Drogskol Infantry
 - [x] Dying to Serve
 - [x] Edgar's Awakening
 - [x] Edgar, Charmed Groom
@@ -145,7 +145,7 @@
 - [ ] Kaya, Geist Hunter
 - [x] Kessig Flamebreather
 - [x] Kessig Wolfrider
-- [ ] Kindly Ancestor
+- [x] Kindly Ancestor
 - [x] Lacerate Flesh
 - [x] Laid to Rest
 - [x] Lambholt Raconteur
@@ -163,7 +163,7 @@
 - [x] Militia Rallier
 - [x] Mindleech Ghoul
 - [ ] Mirrorhall Mimic
-- [ ] Mischievous Catgeist
+- [x] Mischievous Catgeist
 - [x] Moldgraf Millipede
 - [x] Mountain
 - [x] Mulch

--- a/backlog/sets/innistrad-crimson-vow/mechanics.md
+++ b/backlog/sets/innistrad-crimson-vow/mechanics.md
@@ -17,13 +17,13 @@ cards using *only* supported mechanics need **no backend change** — pure `add-
 | **Cleave** | 12 | 2 | ✅ `AlternativeCostType.CLEAVE` + `cleaveTarget`/`cleaveEffect` DSL | CR 702.148 — text-modifying alternative cost on instants/sorceries, modeled as a cast-mode branch (not string mutation). 10 authored (reference cards Alchemist's Gambit, Dig Up, Fierce Retribution, Path of Peril, Wash Away + this batch's Alchemist's Retrieval, Dread Fugue, Lunar Rejection, Parasitic Grasp, Winged Portent). 2 blocked on orthogonal sub-features — see [`engine-features-cleave-blocked.md`](engine-features-cleave-blocked.md): **Inspired Idea** (reduce max hand size by N) and **Lantern Flare** (`{X}` in the cleave cost). |
 | **Training** | 9 | 9 | ❌ **GAP → [#1261](https://github.com/wingedsheep/argentum-engine/issues/1261)** | CR 702.149 — attack trigger gated on a co-attacker with greater power → +1/+1 counter; plus a "when this creature trains" payoff hook (702.149c). Structural analog: Mentor + Decayed. |
 | **Exploit** | 9 | 9 | ❌ **GAP → [#1260](https://github.com/wingedsheep/argentum-engine/issues/1260)** | CR 702.110 — ETB "may sacrifice a creature" + a paired "when this creature exploits a creature" payoff (702.110b, the crux). Analog: Casualty's reflexive "when you do" trigger. Also surfaces as blocked trigger `WhenAPermanentExploitsAPermanent` (×9). |
-| **Disturb** | ~13 | ~13 | ⚠️ **GAP — no issue yet** | CR 702.146 — cast the back face from your graveyard, then exile. Transform machinery exists (`TransformEffects`), but there is no Disturb keyword or graveyard-cast-back-face DSL. All are DFCs (spirit front // enchantment or aura back). Not on the coverage leaderboard because these DFCs sit in the tool's "unmatched in mtgish" bucket. |
-| **Daybound / Nightbound** | ~14 | ~14 | ⚠️ **GAP — no issue yet** | CR 702.145 — day/night designation + werewolf-style DFC flips keyed on spells-cast-per-turn. **Zero** engine support: no day/night state tracker anywhere in main source, no keyword. All are DFCs. Also invisible to the coverage leaderboard (unmatched-in-mtgish bucket). |
+| **Disturb** | ~13 | ~7 | ✅ `disturb("{cost}")` DSL + `DisturbCasts` | CR 702.146 — cast the back face from your graveyard, then exile. Shipped since this file was written: the DSL sits on top of the existing transform machinery, and `DisturbCasts` owns the graveyard cast. Reference cards: Lantern Bearer, Twinblade Geist, Kindly Ancestor, Drogskol Infantry, Binding Geist, Mischievous Catgeist, Distracting Geist. |
+| **Daybound / Nightbound** | ~14 | ~14 | ✅ `DayNightService` + `DayNightDsl` | CR 702.145 — day/night designation + werewolf-style DFC flips keyed on spells-cast-per-turn. Shipped since this file was written: `DayNightService` holds the designation, `BeginningPhaseManager` advances it, and `DayNightMechanicScenarioTest` covers the flips. The remaining cards are authoring work, not engine work. |
 
 **Transform / DFC machinery** — ✅ present (`TransformEffect`, `ExileAndReturnTransformedEffect`,
 `ReturnSelfFromZoneTransformedEffect`). The *effect* layer that flips a permanent's face exists and is
-reused by other sets; what VOW is missing is the two *keyword layers* above (Disturb's graveyard-cast +
-Daybound/Nightbound's day/night trigger) that drive those flips.
+reused by other sets, and the two *keyword layers* above it — Disturb's graveyard-cast and
+Daybound/Nightbound's day/night trigger — have since shipped too.
 
 ## Evergreen / returning keywords present
 
@@ -53,15 +53,10 @@ the cleave-cost enumerator.
 Training and Exploit are the top remaining entries on `just coverage-gaps --set VOW`'s BLOCKED
 leaderboard (×9 each), so clearing them unlocks the most cards.
 
-**Two further gaps have no work item yet** — flagged here so they aren't mistaken for supported:
-
-- **Disturb** (CR 702.146, ~13 cards) — needs a graveyard-cast-back-face keyword layered on the
-  existing transform machinery.
-- **Daybound / Nightbound** (CR 702.145, ~14 cards) — needs a day/night game-state tracker plus the
-  werewolf-flip trigger; nothing exists today.
-
-Both are absent from the coverage leaderboard only because their DFCs land in the tool's
-"unmatched in mtgish" bucket (name-join misses), **not** because they're covered.
+**Disturb and Daybound / Nightbound are no longer gaps.** Both keyword layers shipped after this
+file was written — see the table above for the entry points. Their remaining cards are pure
+`add-card` authoring. They are absent from the coverage leaderboard because their DFCs land in the
+tool's "unmatched in mtgish" bucket (name-join misses), not because they're unsupported.
 
 **Smaller blocked capabilities** (from `coverage-gaps`, lower-volume — assess per card, may be pure
 `add-feature` one-offs): `SetPT` layer effect (×4), `RemoveCounters` cost/action (×3),
@@ -71,5 +66,5 @@ items.
 
 **Everything else is pure `add-card` authoring** — Blood-token cards, the returning/evergreen keyword
 cards, and standard effects. Suggested order: clear the Blood/evergreen single-faced cards first, then
-land the Cleave/Training/Exploit features (highest unlock), and defer the Disturb / Daybound DFCs until
-those two keyword layers are built.
+land the Training/Exploit features (highest unlock), and take the Disturb / Daybound DFCs as ordinary
+authoring work now that both keyword layers exist.

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BindingGeist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BindingGeist.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Binding Geist // Spectral Binding (Innistrad: Crimson Vow #48 — the card's earliest printing)
+ * {2}{U} · Creature — Spirit 3/1 // Enchantment — Aura
+ *
+ * Front — Binding Geist ({2}{U}, Creature — Spirit, 3/1)
+ *   Whenever this creature attacks, target creature an opponent controls gets -2/-0 until end of
+ *   turn.
+ *   Disturb {1}{U}
+ *
+ * Back — Spectral Binding (Enchantment — Aura, blue color indicator)
+ *   Enchant creature
+ *   Enchanted creature gets -2/-0.
+ *   If Spectral Binding would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: the two faces spell the same -2/-0 twice, once as a one-shot and once as a
+ * static, which is why they are two different SDK types rather than one shared value — the front is
+ * `Effects.ModifyStats` on an attack trigger (its duration defaults to end of turn) and the back is
+ * the [ModifyStats] *static* on the enchanted creature. Disturb (CR 702.146) puts the card on the
+ * stack back face up (CR 712.8c), so the disturb cast is an Aura spell that chooses what it
+ * enchants from `auraTarget`. The exile-instead clause is [RedirectZoneChange] with
+ * `selfOnly = true` so it functions in every zone (CR 614.12).
+ */
+private val BindingGeistFront = card("Binding Geist") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 1
+    oracleText = "Whenever this creature attacks, target creature an opponent controls gets " +
+        "-2/-0 until end of turn.\n" +
+        "Disturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val weakened = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-2, 0, weakened)
+    }
+
+    disturb("{1}{U}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1783924907"
+    }
+}
+
+private val SpectralBinding = card("Spectral Binding") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets -2/-0.\n" +
+        "If Spectral Binding would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-2, 0)
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1783924907"
+    }
+}
+
+val BindingGeist: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = BindingGeistFront,
+    backFace = SpectralBinding,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DistractingGeist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DistractingGeist.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Distracting Geist // Clever Distraction (Innistrad: Crimson Vow #9 — the card's earliest
+ * printing)
+ * {2}{W} · Creature — Spirit 2/1 // Enchantment — Aura
+ *
+ * Front — Distracting Geist ({2}{W}, Creature — Spirit, 2/1)
+ *   Whenever this creature attacks, tap target creature defending player controls.
+ *   Disturb {4}{W}
+ *
+ * Back — Clever Distraction (Enchantment — Aura, white color indicator)
+ *   Enchant creature
+ *   Enchanted creature has "Whenever this creature attacks, tap target creature defending player
+ *   controls."
+ *   If Clever Distraction would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: "defending player controls" is modelled as `Targets.CreatureOpponentControls`,
+ * the convention every attack-trigger card here uses for the defending player (Spring Splasher,
+ * Thunder Lasso, Web-Shooters). The back face prints the front face's ability in quotation marks,
+ * so it is a [GrantTriggeredAbility] rebuilding that same ability — the granted ability carries its
+ * own `targetRequirement`, and `Effects.Tap` reads it back as `ContextTarget(0)`. It keeps
+ * `Triggers.Attacks`' SELF binding: "this creature" inside the quotes is whatever creature has the
+ * ability, i.e. the enchanted creature, and `GrantTriggeredAbility` defaults its filter to the
+ * attached creature. Disturb is CR 702.146; the disturb cast puts the card on the stack back face
+ * up (CR 712.8c) as an Aura spell, and the exile-instead clause is [RedirectZoneChange] with
+ * `selfOnly = true` so it functions in every zone (CR 614.12).
+ */
+private val DistractingGeistFront = card("Distracting Geist") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever this creature attacks, tap target creature defending player controls.\n" +
+        "Disturb {4}{W} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val tapped = target("creature defending player controls", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(tapped)
+    }
+
+    disturb("{4}{W}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Andrew Mar"
+        flavorText = "\"I never did enjoy studying.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1783924930"
+        ruling(
+            "2021-11-19",
+            "Distracting Geist's triggered ability can only target a creature controlled by the " +
+                "player you are attacking with Distracting Geist, even if other creatures you " +
+                "control are also attacking other players. This is also true for the ability of " +
+                "the creature enchanted by Clever Distraction."
+        )
+    }
+}
+
+private val CleverDistraction = card("Clever Distraction") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"Whenever this creature attacks, tap target creature defending " +
+        "player controls.\"\n" +
+        "If Clever Distraction would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = Effects.Tap(EffectTarget.ContextTarget(0)),
+                targetRequirement = Targets.CreatureOpponentControls,
+            )
+        )
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Andrew Mar"
+        flavorText = "\"Me neither.\""
+        imageUri = "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1783924930"
+    }
+}
+
+val DistractingGeist: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = DistractingGeistFront,
+    backFace = CleverDistraction,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DrogskolInfantry.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DrogskolInfantry.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Drogskol Infantry // Drogskol Armaments (Innistrad: Crimson Vow #10 — the card's earliest
+ * printing)
+ * {1}{W} · Creature — Spirit Soldier 2/2 // Enchantment — Aura
+ *
+ * Front — Drogskol Infantry ({1}{W}, Creature — Spirit Soldier, 2/2)
+ *   Disturb {3}{W}
+ *
+ * Back — Drogskol Armaments (Enchantment — Aura, white color indicator)
+ *   Enchant creature
+ *   Enchanted creature gets +2/+2.
+ *   If Drogskol Armaments would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: the plainest member of the disturb-Aura cycle (CR 702.146) — a vanilla front face
+ * whose only ability is disturb, and a back face that is one [ModifyStats] static. The disturb cast
+ * puts the card on the stack back face up (CR 712.8c), so it is an Aura spell and what it enchants
+ * comes from the back face's `auraTarget`. The exile-instead clause is [RedirectZoneChange] with
+ * `selfOnly = true` so it functions in every zone (CR 614.12).
+ */
+private val DrogskolInfantryFront = card("Drogskol Infantry") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Soldier"
+    power = 2
+    toughness = 2
+    oracleText =
+        "Disturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    disturb("{3}{W}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Cristi Balanescu"
+        flavorText = "He swore to protect the Moorlands. A little thing like death was no excuse " +
+            "to break his oath."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1783924937"
+    }
+}
+
+private val DrogskolArmaments = card("Drogskol Armaments") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2.\n" +
+        "If Drogskol Armaments would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Cristi Balanescu"
+        flavorText = "When he could no longer carry on, he imparted his strength to the one who " +
+            "took up his duty."
+        imageUri = "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1783924937"
+    }
+}
+
+val DrogskolInfantry: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = DrogskolInfantryFront,
+    backFace = DrogskolArmaments,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KindlyAncestor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KindlyAncestor.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Kindly Ancestor // Ancestor's Embrace (Innistrad: Crimson Vow #22 — the card's earliest printing)
+ * {2}{W} · Creature — Spirit 2/3 // Enchantment — Aura
+ *
+ * Front — Kindly Ancestor ({2}{W}, Creature — Spirit, 2/3)
+ *   Lifelink
+ *   Disturb {1}{W}
+ *
+ * Back — Ancestor's Embrace (Enchantment — Aura, white color indicator)
+ *   Enchant creature
+ *   Enchanted creature has lifelink.
+ *   If Ancestor's Embrace would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: the same shape as [TwinbladeGeist] — a disturb card (CR 702.146) whose back face
+ * is an Aura, so the disturb cast is an Aura spell that picks what it enchants from the back face's
+ * `auraTarget` (CR 712.8c). The front keyword and the Aura's granted keyword are the same word, so
+ * the back face is one [GrantKeyword] static. The "would be put into a graveyard from anywhere,
+ * exile it instead" line is [RedirectZoneChange] with `selfOnly = true` so it functions in every
+ * zone (CR 614.12) — including from the stack, when the disturb spell is countered.
+ */
+private val KindlyAncestorFront = card("Kindly Ancestor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 3
+    oracleText = "Lifelink\n" +
+        "Disturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    keywords(Keyword.LIFELINK)
+    disturb("{1}{W}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Justyna Dura"
+        flavorText = "\"You look cold, dearie.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1783924921"
+    }
+}
+
+private val AncestorsEmbrace = card("Ancestor's Embrace") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has lifelink.\n" +
+        "If Ancestor's Embrace would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Justyna Dura"
+        flavorText = "\"Thank you, Grandmother. I love you too.\""
+        imageUri = "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1783924921"
+    }
+}
+
+val KindlyAncestor: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = KindlyAncestorFront,
+    backFace = AncestorsEmbrace,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MischievousCatgeist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MischievousCatgeist.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Mischievous Catgeist // Catlike Curiosity (Innistrad: Crimson Vow #69 — the card's earliest
+ * printing)
+ * {1}{U} · Creature — Cat Spirit 1/1 // Enchantment — Aura
+ *
+ * Front — Mischievous Catgeist ({1}{U}, Creature — Cat Spirit, 1/1)
+ *   Whenever this creature deals combat damage to a player, draw a card.
+ *   Disturb {2}{U}
+ *
+ * Back — Catlike Curiosity (Enchantment — Aura, blue color indicator)
+ *   Enchant creature
+ *   Enchanted creature has "Whenever this creature deals combat damage to a player, draw a card."
+ *   If Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: the back face prints the front face's ability in quotation marks, which is the
+ * SDK's [GrantTriggeredAbility] — the same ability the front face has as its own, rebuilt as a
+ * granted one. `GrantTriggeredAbility`'s filter defaults to the attached creature, so the Aura
+ * needs no explicit filter. The granted ability keeps `Triggers.DealsCombatDamageToPlayer`'s SELF
+ * binding: "this creature" inside the quotes is the creature that has the ability, i.e. the
+ * enchanted creature, not the Aura. Disturb is CR 702.146; the exile-instead clause is
+ * [RedirectZoneChange] with `selfOnly = true` so it functions in every zone (CR 614.12).
+ */
+private val MischievousCatgeistFront = card("Mischievous Catgeist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Cat Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature deals combat damage to a player, draw a card.\n" +
+        "Disturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(1)
+    }
+
+    disturb("{2}{U}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Denman Rooke"
+        flavorText = "\"I never get any knitting done, but I don't entirely mind.\"\n" +
+            "—Lorn, Lambholt innkeeper"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1783924899"
+    }
+}
+
+private val CatlikeCuriosity = card("Catlike Curiosity") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"Whenever this creature deals combat damage to a player, " +
+        "draw a card.\"\n" +
+        "If Catlike Curiosity would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.DrawCards(1),
+            )
+        )
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Denman Rooke"
+        imageUri = "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1783924899"
+    }
+}
+
+val MischievousCatgeist: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = MischievousCatgeistFront,
+    backFace = CatlikeCuriosity,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -1145,6 +1145,109 @@
     ]
 }
 
+// Binding Geist
+{
+    "name": "Binding Geist",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever this creature attacks, target creature an opponent controls gets -2/-0 until end of turn.\nDisturb {1}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Spectral Binding",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature gets -2/-0.\nIf Spectral Binding would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": -2,
+                    "toughnessBonus": 0
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "48",
+            "artist": "Campbell White",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1783924907"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/730e4629-dc54-415d-9493-88885788ca19.jpg?1783924907"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Biolume Egg
 {
     "name": "Biolume Egg",
@@ -4021,6 +4124,126 @@
     ]
 }
 
+// Distracting Geist
+{
+    "name": "Distracting Geist",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever this creature attacks, tap target creature defending player controls.\nDisturb {4}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{4}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature defending player controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature defending player controls"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Clever Distraction",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, tap target creature defending player controls.\"\nIf Clever Distraction would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantTriggeredAbility",
+                    "ability": {
+                        "id": "ability_2",
+                        "trigger": "AttackEvent",
+                        "effect": {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        }
+                    }
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "9",
+            "rarity": "UNCOMMON",
+            "artist": "Andrew Mar",
+            "flavorText": "\"Me neither.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1783924930"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "\"I never did enjoy studying.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7fc0939-6286-44de-a727-c83bfd3fa752.jpg?1783924930",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Distracting Geist's triggered ability can only target a creature controlled by the player you are attacking with Distracting Geist, even if other creatures you control are also attacking other players. This is also true for the ability of the creature enchanted by Clever Distraction."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Diver Skaab
 {
     "name": "Diver Skaab",
@@ -4590,6 +4813,81 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Drogskol Infantry
+{
+    "name": "Drogskol Infantry",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Soldier",
+    "oracleText": "Disturb {3}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{3}{W}"
+        }
+    ],
+    "backFace": {
+        "name": "Drogskol Armaments",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature gets +2/+2.\nIf Drogskol Armaments would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "10",
+            "artist": "Cristi Balanescu",
+            "flavorText": "When he could no longer carry on, he imparted his strength to the one who took up his duty.",
+            "imageUri": "https://cards.scryfall.io/normal/back/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1783924937"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Cristi Balanescu",
+        "flavorText": "He swore to protect the Moorlands. A little thing like death was no excuse to break his oath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f88e269e-ff3d-4775-8520-5b7a6dddf23d.jpg?1783924937"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -8501,6 +8799,81 @@
     ]
 }
 
+// Kindly Ancestor
+{
+    "name": "Kindly Ancestor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Lifelink\nDisturb {1}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK",
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{1}{W}"
+        }
+    ],
+    "backFace": {
+        "name": "Ancestor's Embrace",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature has lifelink.\nIf Ancestor's Embrace would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK"
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "22",
+            "artist": "Justyna Dura",
+            "flavorText": "\"Thank you, Grandmother. I love you too.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1783924921"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Justyna Dura",
+        "flavorText": "\"You look cold, dearie.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/25193485-7f41-4b05-9a69-4c112679f97c.jpg?1783924921"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lacerate Flesh
 {
     "name": "Lacerate Flesh",
@@ -9688,6 +10061,114 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Mischievous Catgeist
+{
+    "name": "Mischievous Catgeist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Cat Spirit",
+    "oracleText": "Whenever this creature deals combat damage to a player, draw a card.\nDisturb {2}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{2}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Catlike Curiosity",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nIf Catlike Curiosity would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantTriggeredAbility",
+                    "ability": {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "DealsDamageEvent",
+                            "damageType": "DamageCombat",
+                            "recipient": "AnyPlayer"
+                        },
+                        "effect": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "69",
+            "rarity": "UNCOMMON",
+            "artist": "Denman Rooke",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1783924899"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "UNCOMMON",
+        "artist": "Denman Rooke",
+        "flavorText": "\"I never get any knitting done, but I don't entirely mind.\"\n—Lorn, Lambholt innkeeper",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3ff628a-ef8e-45c4-84e7-a33ec28f025a.jpg?1783924899"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.constant
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.CardNamePool
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersTapped
@@ -16,6 +17,7 @@ import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.ReplacementEffect
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -540,6 +542,33 @@ object Replacements {
         listOf(plus, twice)
     }
 
+    /**
+     * "If ~ would be put into a graveyard from anywhere, exile it instead." — the second line every
+     * disturb back face prints (CR 702.146b), and the whole of this rule's corpus: 28 cards, every
+     * one of them a MID/VOW transforming card whose back is the disturbed face.
+     *
+     * A `constant` on the whole value, for [entersTapped]'s reason. `RedirectZoneChange` has six
+     * fields beyond the destination and this sentence spells none of them: `linkToSource`,
+     * `shuffleIntoLibrary`, `reveal` and a non-`Any` `requiredCause` all belong to other printed
+     * lines, and `appliesTo` is pinned by "from anywhere" (no `from`) plus "into a graveyard"
+     * (`to = GRAVEYARD`). A rule that let any of them vary would print this sentence for a value
+     * that means something else, which is the reversible-but-wrong class exactly.
+     *
+     * `selfOnly = true` is what "~" buys: the normalizer has already replaced the face's own name,
+     * so the subject *is* the source, and the sibling lines that name a filter instead — Rest in
+     * Peace's "a card or token", Dryad Militant's "an instant or sorcery card" — are a different
+     * value (`selfOnly = false`, a non-`Any` filter) and stay declined here rather than being
+     * folded into a slot this sentence would then mis-print.
+     */
+    private val exileInsteadOfGraveyard: Phrase<ReplacementEffect> = constant(
+        "if ${Normalizer.SELF} would be put into a graveyard from anywhere, exile it instead.",
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        ),
+    )
+
     val replacement: Phrase<ReplacementEffect> = oneOf(
         "a replacement effect",
         listOf(
@@ -548,6 +577,7 @@ object Replacements {
             shockLand,
             entersWithChosenNumber,
             entersWithLookedUpCardName,
+            exileInsteadOfGraveyard,
         ) + choiceNouns.map { (noun, value) -> entersWithChoice(noun, value) } +
             entersWithCounters + entersWithDynamicCounters + entersWithCountersPerCount +
             modifyLifeGain,

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/ReplacementsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/ReplacementsTest.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.assay.syntax.ParseOutcome
 import com.wingedsheep.assay.syntax.parseLine
 import com.wingedsheep.assay.syntax.printLine
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.CardNamePool
@@ -15,6 +16,7 @@ import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.ModifyLifeGain
 import com.wingedsheep.sdk.scripting.ModeOption
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.conditions.IsYourTurn
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -291,6 +293,32 @@ class ReplacementsTest : StringSpec({
             .script.replacementEffects.single().shouldBeInstanceOf<EntersWithDynamicCounters>()
         fragment("~ enters with a +1/+1 counter on it for each creature on the battlefield.")
             .script.replacementEffects.single().shouldBeInstanceOf<EntersWithDynamicCounters>()
+    }
+
+    // The second line every disturb back face prints (CR 702.146b) — 28 cards, all of them MID/VOW
+    // transforming cards. A `constant` on the whole value: the sentence spells no field beyond the
+    // destination, and the sibling lines that name a filter instead are a different value.
+    "the disturb back face's exile-instead line is a self-scoped redirect" {
+        fragment("If ~ would be put into a graveyard from anywhere, exile it instead.") shouldBe
+            CardFragment(
+                script = CardScript(
+                    replacementEffects = listOf(
+                        RedirectZoneChange(
+                            newDestination = Zone.EXILE,
+                            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+                            selfOnly = true,
+                        )
+                    )
+                )
+            )
+        roundTrips("If ~ would be put into a graveyard from anywhere, exile it instead.")
+        // Rest in Peace and Dryad Militant name a filter rather than the source, so they are a
+        // different value (`selfOnly = false`) and stay declined rather than folding into this rule.
+        declines("If a card or token would be put into a graveyard from anywhere, exile it instead.")
+        declines(
+            "If an instant or sorcery card would be put into a graveyard from anywhere, " +
+                "exile it instead."
+        )
     }
 
     "every as-it-enters choice rule prints what it parses" {


### PR DESCRIPTION
Five Innistrad: Crimson Vow disturb cards, plus the Assay grammar rule that lets Assay read four of
them whole. VOW goes 233 → 238 / 273.

## The cards

One cycle, five cards, every one built from existing primitives — a Spirit front face with
`disturb(...)`, and a back face that is the Aura the disturb cast puts on the stack (CR 712.8c).

| Card | Front face | Back face (Aura) |
|---|---|---|
| **Kindly Ancestor // Ancestor's Embrace** | Lifelink | `GrantKeyword(LIFELINK)` |
| **Drogskol Infantry // Drogskol Armaments** | vanilla 2/2 | `ModifyStats(2, 2)` |
| **Binding Geist // Spectral Binding** | attack trigger → `Effects.ModifyStats(-2, 0)` on a target an opponent controls | the same -2/-0 as a static |
| **Mischievous Catgeist // Catlike Curiosity** | `Triggers.DealsCombatDamageToPlayer` → draw | `GrantTriggeredAbility` rebuilding that ability |
| **Distracting Geist // Clever Distraction** | attack trigger → `Effects.Tap` on a defender | `GrantTriggeredAbility` rebuilding that ability |

Every back face carries the cycle's exile-instead clause as `RedirectZoneChange` with
`selfOnly = true`, so it functions in every zone (CR 614.12) — including from the stack, when the
disturb spell is countered.

Two notes on modelling choices:

- **"Defending player controls" is `Targets.CreatureOpponentControls`**, the convention every
  attack-trigger card here already uses (Spring Splasher, Thunder Lasso, Web-Shooters). See the
  caveat under *What is not covered* below.
- **The granted abilities keep their SELF binding.** "This creature" inside the quotes on an Aura is
  whatever creature has the ability — the enchanted creature, not the Aura — and
  `GrantTriggeredAbility` already defaults its filter to the attached creature.

No new SDK vocabulary, so no scenario tests: the cards are covered by the snapshot and lint nets, and
by the differential below.

## The Assay rule

`If ~ would be put into a graveyard from anywhere, exile it instead.` is the second line **every**
disturb back face prints (CR 702.146b), and the grammar had no rule for it — so all 28 MID/VOW
disturb cards declined on a line whose SDK value is written the same way in every golden.

It is a `constant` on the whole `RedirectZoneChange`, for the reason `entersTapped` is one: the
sentence spells nothing beyond the destination, and letting `linkToSource`, `shuffleIntoLibrary`,
`reveal` or `requiredCause` vary would print this text for a value that means something else.
`selfOnly = true` is what the normalizer's `~` buys, so the sibling lines that name a *filter*
instead — Rest in Peace's "a card or token", Dryad Militant's "an instant or sorcery card" — are a
different value and stay declined rather than folding into a slot this sentence would then
mis-print. The test asserts both directions and both declines.

## What is not covered, and why

**Distracting Geist still declines**, on `target creature defending player controls`. That is an
**SDK gap, not a grammar gap**, so per `oracle-assay/AGENTS.md` it is reported rather than routed
around.

There is no `ControllerPredicate.ControlledByDefendingPlayer`. Our cards spell it
`ControlledByOpponent`, which is correct in a duel and wrong in multiplayer — precisely the
distinction `Filters.byController` already draws in its KDoc between "an opponent controls" and "you
don't control" ("the two coincide in a duel and separate in multiplayer"). Teaching Assay to fold
the two printed forms onto one model would make it claim two different cards are the same card.

**109 corpus lines are waiting on that predicate.** It is `add-feature` work — a new predicate plus
a combat-aware resolution in the evaluator — not card work, so it is not in this PR.

Separately, `assay compile` declines every card here with `MULTI_FACE`: the compiler reads
single-faced cards. That is a pre-existing scope limit of the compiler, unrelated to this change.

## Verification

- `just build` — green. The expected `CardDefinitionSnapshotTest` diff was re-blessed with
  `just rebless-cards`; the VOW golden is **481 insertions, 0 deletions**, and the only names in it
  are this PR's ten faces.
- `just check` — green.
- `just check-card-printing` on all five — VOW is the earliest real printing for each; the only
  other printing is DBL, which is not scaffolded.
- `just assay-gate` — MISMATCH **0**, AMBIGUOUS **0**, redundant readings **0**. Round-trips
  27,785 → 27,810; cards fully covered 9,138 → 9,149.
- `just assay-differential` — **0 divergent in VOW** (65/65 compared cards confirmed). Corpus-wide
  the count is unchanged at 51, all pre-existing; none of them is a disturb card or prints this
  clause.
- `just assay-differential --set VOW`, `just check-backlog` — green. Backlog resynced to 238/273.
- Re-verified all ten faces field-by-field against Scryfall (mana cost, type line, P/T, rarity,
  collector number, artist, oracle text, image URI); every `image_uris.normal` returns HTTP 200.

The verdict ledger is **not** re-baked, deliberately: every disturb card's entry is `MULTI_FACE`,
which `CardCompiler` decides before it looks at any line, and the two filtered siblings still decline
on the same lines. Nothing in it moves.

`backlog/sets/innistrad-crimson-vow/mechanics.md` is also corrected — it still listed Disturb and
Daybound/Nightbound as engine gaps with no work item. Both shipped some time ago
(`disturb(...)` + `DisturbCasts`; `DayNightService` + `DayNightDsl`), which is what made this batch
pure authoring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpfLU76bNvSVwWdz6F8nz2
