### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DoranTheSiegeTower.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DoranTheSiegeTower.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Doran, the Siege Tower
+ * {W}{B}{G}
+ * Legendary Creature — Treefolk Shaman
+ * 0/5
+ * Each creature assigns combat damage equal to its toughness rather than its power.
+ *
+ * The static is unconditional and unrestricted — every creature on the battlefield, whoever
+ * controls it, Doran included. That is [GroupFilter.AllCreatures] with
+ * `onlyWhenToughnessGreaterThanPower = false`; the conditional form is
+ * [com.wingedsheep.mtg.sets.definitions.ecl.cards.BarkOfDoran]'s, not Doran's own.
+ */
+val DoranTheSiegeTower = card("Doran, the Siege Tower") {
+    manaCost = "{W}{B}{G}"
+    colorIdentity = "WBG"
+    typeLine = "Legendary Creature — Treefolk Shaman"
+    power = 0
+    toughness = 5
+    oracleText = "Each creature assigns combat damage equal to its toughness rather than its power."
+
+    staticAbility {
+        ability = AssignDamageEqualToToughness(
+            filter = GroupFilter.AllCreatures,
+            onlyWhenToughnessGreaterThanPower = false,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Mark Zug"
+        flavorText = "\"Each year that passes rings you inwardly with memory and might. " +
+            "Wield your heart, and the world will tremble.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg?1783942855"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/EyesOfTheWisent.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/EyesOfTheWisent.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Eyes of the Wisent
+ * {1}{G}
+ * Kindred Enchantment — Elemental
+ * Whenever an opponent casts a blue spell during your turn, you may create a 4/4 green
+ * Elemental creature token.
+ *
+ * "During your turn" is a CR 603.2 restriction on the trigger event, not an intervening "if" —
+ * it is checked only when the spell is cast, so a trigger that fires on your turn still resolves
+ * if the turn somehow changes underneath it. Hence [triggerRestriction], not `interveningIf`.
+ */
+val EyesOfTheWisent = card("Eyes of the Wisent") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Kindred Enchantment — Elemental"
+    oracleText = "Whenever an opponent casts a blue spell during your turn, you may create a " +
+        "4/4 green Elemental creature token."
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.Any.withColor(Color.BLUE))
+        triggerRestriction = Conditions.IsYourTurn
+        optional = true
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elemental"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg?1783942837",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "210"
+        artist = "Aleksi Briclot"
+        flavorText = "Calm as a wisent's watch\n—Elvish expression meaning \"safe\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg?1783942865"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Glarewielder.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Glarewielder.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Glarewielder
+ * {4}{R}
+ * Creature — Elemental Shaman
+ * 3/1
+ * Haste
+ * When this creature enters, up to two target creatures can't block this turn.
+ * Evoke {1}{R}
+ *
+ * "Up to two target creatures" is one requirement of `count = 2, optional = true`, and the
+ * restriction is applied per target — [ForEachTargetEffect] re-binds `ContextTarget(0)` to each
+ * chosen creature in turn, so choosing zero or one target is as legal as choosing two.
+ */
+val Glarewielder = card("Glarewielder") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Shaman"
+    power = 3
+    toughness = 1
+    oracleText = "Haste\nWhen this creature enters, up to two target creatures can't block this turn.\n" +
+        "Evoke {1}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when " +
+        "it enters.)"
+
+    keywords(Keyword.HASTE)
+
+    evoke = "{1}{R}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target", TargetCreature(optional = true, count = 2, filter = TargetFilter.Creature))
+        effect = ForEachTargetEffect(listOf(Effects.CantBlock(EffectTarget.ContextTarget(0))))
+        description = "up to two target creatures can't block this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg?1783942876"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MaskedAdmirers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MaskedAdmirers.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Masked Admirers
+ * {2}{G}{G}
+ * Creature — Elf Shaman
+ * 3/2
+ * When this creature enters, draw a card.
+ * Whenever you cast a creature spell, you may pay {G}{G}. If you do, return this card from your
+ * graveyard to your hand.
+ *
+ * The recursion ability functions only from the graveyard (CR 113.6b), so it is zone-scoped with
+ * `triggerZone = Zone.GRAVEYARD` the way Squee, Goblin Nabob is — without it the trigger would be
+ * indexed only while Masked Admirers is on the battlefield, where it can do nothing.
+ *
+ * "You may pay {G}{G}. If you do, …" is a [Gate.MayPay], not a plain `optional = true`: the return
+ * happens iff the mana is actually paid. [Effects.ReturnToHandFromGraveyard] carries the
+ * `fromZone` guard the *self*-return needs — nothing re-examines the card at resolution, so a
+ * Masked Admirers exiled from the graveyard in response would otherwise come back from exile.
+ */
+val MaskedAdmirers = card("Masked Admirers") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, draw a card.\n" +
+        "Whenever you cast a creature spell, you may pay {G}{G}. If you do, return this card " +
+        "from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Creature)
+        triggerZone = Zone.GRAVEYARD
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayManaCostEffect(ManaCost.parse("{G}{G}"))),
+            then = Effects.ReturnToHandFromGraveyard(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Eric Fortune"
+        flavorText = "\"Beauty determines value, and we determine beauty.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg?1783942860"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Smokebraider.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Smokebraider.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Smokebraider
+ * {1}{R}
+ * Creature — Elemental Shaman
+ * 1/1
+ * {T}: Add two mana in any combination of colors. Spend this mana only to cast Elemental
+ *      spells or activate abilities of Elementals.
+ *
+ * "In any combination of colors" colours each pip independently, so this is
+ * [Effects.AddManaInAnyCombination] (all five colours, the default) rather than
+ * `AddAnyColorMana`, which would force both pips to the same colour. The restriction admits both
+ * Elemental spells and activated abilities of Elemental sources, which is
+ * [ManaRestriction.SubtypeSpellsOrAbilitiesOnly]'s default (`creatureOnly = false`).
+ */
+val Smokebraider = card("Smokebraider") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add two mana in any combination of colors. Spend this mana only to cast " +
+        "Elemental spells or activate abilities of Elementals."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaInAnyCombination(
+            amount = 2,
+            restriction = ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Elemental"),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Anthony S. Waters"
+        flavorText = "\"Be silent and listen to your inner fire. Only then can you walk the Path of Flame.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg?1783942871"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DoranTheSiegeTowerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DoranTheSiegeTowerScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.DoranTheSiegeTower
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Doran, the Siege Tower (LRW #247) — {W}{B}{G} Legendary Creature — Treefolk Shaman 0/5
+ *
+ *   Each creature assigns combat damage equal to its toughness rather than its power.
+ *
+ * The static is unconditional and scoped to *every* creature, so the claims worth pinning are:
+ * it turns Doran's own 0 power into 5 damage, it *lowers* a 2/1's damage to 1 rather than only
+ * ever raising it, and it reaches creatures an opponent controls too.
+ */
+class DoranTheSiegeTowerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + DoranTheSiegeTower)
+        return driver
+    }
+
+    test("Doran itself assigns 5 combat damage despite 0 power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val doran = driver.putCreatureOnBattlefield(p1, "Doran, the Siege Tower")
+        driver.removeSummoningSickness(doran)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(doran), p2)
+        driver.declareNoBlockers(p2)
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        driver.getLifeTotal(p2) shouldBe 15
+    }
+
+    test("a 2/1 assigns 1 instead of 2 — the effect lowers damage as readily as it raises it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val guide = driver.putCreatureOnBattlefield(p1, "Goblin Guide")
+        driver.removeSummoningSickness(guide)
+        driver.putCreatureOnBattlefield(p1, "Doran, the Siege Tower")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(guide), p2)
+        driver.declareNoBlockers(p2)
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        withClue("Goblin Guide is 2/1, so with Doran out it deals its toughness: 1") {
+            driver.getLifeTotal(p2) shouldBe 19
+        }
+    }
+
+    test("without Doran the same 2/1 deals its printed power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val guide = driver.putCreatureOnBattlefield(p1, "Goblin Guide")
+        driver.removeSummoningSickness(guide)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(guide), p2)
+        driver.declareNoBlockers(p2)
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        driver.getLifeTotal(p2) shouldBe 18
+    }
+
+    test("the effect reaches creatures an opponent controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Doran belongs to the active player; the 2/1 blocker belongs to the opponent, and it is
+        // *its* damage that has to be re-read off its toughness. A 2/2 attacker survives 1 damage
+        // and dies to 2, so the blocker's controller is exactly what the assertion measures.
+        driver.putCreatureOnBattlefield(p1, "Doran, the Siege Tower")
+        val frogmite = driver.putCreatureOnBattlefield(p1, "Frogmite")
+        driver.removeSummoningSickness(frogmite)
+        val guide = driver.putCreatureOnBattlefield(p2, "Goblin Guide")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(frogmite), p2)
+        driver.bothPass()
+        driver.declareBlockers(p2, mapOf(guide to listOf(frogmite)))
+        driver.bothPass() // end of declare blockers
+        driver.bothPass() // first strike damage (nobody has it)
+        driver.bothPass() // combat damage
+
+        withClue("the opponent's 2/1 assigned its toughness — 1, not its printed 2") {
+            driver.state.getEntity(frogmite)?.get<DamageComponent>()?.amount shouldBe 1
+        }
+        withClue("the 2/2 attacker assigned its toughness (2), killing the 2/1 blocker") {
+            driver.getCreatures(p2).contains(guide) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EyesOfTheWisentScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EyesOfTheWisentScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.EyesOfTheWisent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Eyes of the Wisent (LRW #210) — {1}{G} Kindred Enchantment — Elemental
+ *
+ *   Whenever an opponent casts a blue spell during your turn, you may create a 4/4 green
+ *   Elemental creature token.
+ *
+ * Three axes have to hold at once and each can silently swallow the trigger: the *caster* must be
+ * an opponent, the *spell* must be blue, and the *turn* must be yours. The last is a CR 603.2
+ * trigger restriction rather than an intervening "if", so it is only ever read at cast time.
+ */
+class EyesOfTheWisentScenarioTest : FunSpec({
+
+    val blueBlink = CardDefinition.instant(
+        name = "Test Blue Instant",
+        manaCost = ManaCost.parse("{U}"),
+        oracleText = "Do nothing."
+    )
+    val redBlink = CardDefinition.instant(
+        name = "Test Red Instant",
+        manaCost = ManaCost.parse("{R}"),
+        oracleText = "Do nothing."
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + EyesOfTheWisent + blueBlink + redBlink)
+        return driver
+    }
+
+    test("an opponent's blue spell on your turn makes a 4/4 Elemental") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Eyes of the Wisent")
+
+        val spell = driver.putCardInHand(p2, "Test Blue Instant")
+        driver.giveMana(p2, Color.BLUE, 1)
+        driver.passPriority(p1)
+        driver.castSpell(p2, spell)
+
+        // The trigger is put on the stack above the spell, so it resolves first.
+        driver.bothPass()
+        driver.submitYesNo(p1, true)
+
+        val creatures = driver.getCreatures(p1)
+        creatures.size shouldBe 1
+        driver.getCardName(creatures.single()) shouldBe "Elemental Token"
+    }
+
+    test("declining the may makes no token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Eyes of the Wisent")
+
+        val spell = driver.putCardInHand(p2, "Test Blue Instant")
+        driver.giveMana(p2, Color.BLUE, 1)
+        driver.passPriority(p1)
+        driver.castSpell(p2, spell)
+
+        driver.bothPass()
+        driver.submitYesNo(p1, false)
+
+        driver.getCreatures(p1).size shouldBe 0
+    }
+
+    test("an opponent's non-blue spell does not trigger it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Eyes of the Wisent")
+
+        val spell = driver.putCardInHand(p2, "Test Red Instant")
+        driver.giveMana(p2, Color.RED, 1)
+        driver.passPriority(p1)
+        driver.castSpell(p2, spell)
+
+        withClue("only the red instant is on the stack — the colour filter held") {
+            driver.stackSize shouldBe 1
+        }
+    }
+
+    test("your own blue spell does not trigger it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Eyes of the Wisent")
+
+        val spell = driver.putCardInHand(p1, "Test Blue Instant")
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.castSpell(p1, spell)
+
+        withClue("the trigger reads 'an opponent casts', so the controller's own spell is inert") {
+            driver.stackSize shouldBe 1
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GlarewielderScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GlarewielderScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Glarewielder (LRW #171) — {4}{R} Creature — Elemental Shaman 3/1
+ *
+ *   Haste
+ *   When this creature enters, up to two target creatures can't block this turn.
+ *   Evoke {1}{R}
+ *
+ * "Up to two" is one requirement of `count = 2, optional = true`, and the restriction is applied
+ * once *per chosen target* — the effect is a `ForEachTargetEffect` over `CantBlock`, not a single
+ * `CantBlock` that would silently only reach the first creature. Evoke is what the card is played
+ * for: {1}{R}, the trigger still resolves, and the body is sacrificed on the way in.
+ */
+class GlarewielderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Glarewielder") {
+
+            test("both chosen creatures are barred from blocking — an untargeted one is not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Glarewielder")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Force of Nature", summoningSickness = false)
+                    // The control: never targeted, so it must still be able to block. Without it
+                    // a rejected block is indistinguishable from a rejected *step*.
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val force = game.findPermanent("Force of Nature")!!
+
+                game.castSpell(1, "Glarewielder").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger asks for its up-to-two targets") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(courser, force)).error shouldBe null
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Glarewielder" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("the first target can't be declared as a blocker") {
+                    game.declareBlockers(mapOf("Centaur Courser" to listOf("Glarewielder")))
+                        .error shouldNotBe null
+                }
+                withClue("nor can the second — the restriction reached both targets, not just one") {
+                    game.declareBlockers(mapOf("Force of Nature" to listOf("Glarewielder")))
+                        .error shouldNotBe null
+                }
+                withClue("the untargeted creature blocks normally, so the step is not what refused") {
+                    game.declareBlockers(mapOf("Llanowar Elves" to listOf("Glarewielder")))
+                        .error shouldBe null
+                }
+            }
+
+            test("evoked for {1}{R} it still fires its trigger and is then sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Glarewielder")
+                    // Exactly the evoke cost. {4}{R} is unpayable here, so a successful cast can
+                    // only have been the alternative cost.
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpellWithAlternativeCost(1, "Glarewielder").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger still happens on an evoked cast") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(courser)).error shouldBe null
+                game.resolveStack()
+
+                withClue("evoke sacrificed the body once it had entered") {
+                    game.isOnBattlefield("Glarewielder") shouldBe false
+                    game.isInGraveyard(1, "Glarewielder") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MaskedAdmirersScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MaskedAdmirersScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.MaskedAdmirers
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Masked Admirers (LRW #230) — {2}{G}{G} Creature — Elf Shaman 3/2
+ *
+ *   When this creature enters, draw a card.
+ *   Whenever you cast a creature spell, you may pay {G}{G}. If you do, return this card from your
+ *   graveyard to your hand.
+ *
+ * The recursion ability functions from the *graveyard* (CR 113.6b). That is the half a card like
+ * this silently loses: index the trigger on the battlefield only and it can never fire, because a
+ * Masked Admirers on the battlefield has nothing to return. So the tests here bracket the zone —
+ * it fires from the graveyard, and it does not fire from the battlefield.
+ */
+class MaskedAdmirersScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + MaskedAdmirers)
+        return driver
+    }
+
+    test("entering the battlefield draws a card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val admirers = driver.putCardInHand(p1, "Masked Admirers")
+        driver.giveMana(p1, Color.GREEN, 4)
+        val handBefore = driver.getHandSize(p1)
+
+        driver.castSpell(p1, admirers)
+        driver.bothPass() // resolve the creature
+        driver.bothPass() // resolve the ETB trigger
+
+        withClue("one card left the hand (the Admirers) and one was drawn") {
+            driver.getHandSize(p1) shouldBe handBefore
+        }
+    }
+
+    test("casting a creature spell and paying {G}{G} returns it from the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInGraveyard(p1, "Masked Admirers")
+
+        val bear = driver.putCardInHand(p1, "Centaur Courser")
+        driver.giveMana(p1, Color.GREEN, 5)
+        driver.castSpell(p1, bear)
+        driver.bothPass() // the trigger sits above the creature spell, so it resolves first
+
+        driver.submitYesNo(p1, true)
+        driver.bothPass()
+
+        withClue("the Admirers left the graveyard") {
+            driver.getGraveyardCardNames(p1).contains("Masked Admirers") shouldBe false
+        }
+        driver.getHand(p1).any { driver.getCardName(it) == "Masked Admirers" } shouldBe true
+    }
+
+    test("declining the payment leaves it in the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInGraveyard(p1, "Masked Admirers")
+
+        val bear = driver.putCardInHand(p1, "Centaur Courser")
+        driver.giveMana(p1, Color.GREEN, 5)
+        driver.castSpell(p1, bear)
+        driver.bothPass() // resolve the trigger
+
+        driver.submitYesNo(p1, false)
+        driver.bothPass()
+
+        driver.getGraveyardCardNames(p1).contains("Masked Admirers") shouldBe true
+    }
+
+    test("a noncreature spell does not offer the payment") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInGraveyard(p1, "Masked Admirers")
+
+        val bolt = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.castSpell(p1, bolt, listOf(driver.getOpponent(p1)))
+
+        withClue("only the Bolt is on the stack — 'a creature spell' held") {
+            driver.stackSize shouldBe 1
+        }
+    }
+
+    test("the trigger does not fire while the Admirers is on the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(p1, "Masked Admirers")
+
+        val bear = driver.putCardInHand(p1, "Centaur Courser")
+        driver.giveMana(p1, Color.GREEN, 5)
+        driver.castSpell(p1, bear)
+
+        withClue("`activeZones = [GRAVEYARD]` switches the ability off on the battlefield") {
+            driver.stackSize shouldBe 1
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SmokebraiderScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SmokebraiderScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.Smokebraider
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Smokebraider (LRW #189) — {1}{R} Creature — Elemental Shaman 1/1
+ *
+ *   {T}: Add two mana in any combination of colors. Spend this mana only to cast Elemental
+ *        spells or activate abilities of Elementals.
+ *
+ * Two mana, each pip coloured independently, both carrying
+ * `ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Elemental")`. The tests pin the *count* (two, not
+ * one), the restriction admitting an Elemental spell, and the restriction refusing everything else.
+ */
+class SmokebraiderScenarioTest : FunSpec({
+
+    val testElemental = CardDefinition.creature(
+        name = "Test Elemental",
+        manaCost = ManaCost.parse("{W}{U}"),
+        subtypes = setOf(Subtype("Elemental")),
+        power = 2,
+        toughness = 2
+    )
+    val testGoblin = CardDefinition.creature(
+        name = "Test Goblin",
+        manaCost = ManaCost.parse("{W}{U}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + Smokebraider + testElemental + testGoblin)
+        return driver
+    }
+
+    val manaAbilityId = Smokebraider.activatedAbilities[0].id
+
+    /**
+     * "In any combination of colors" prompts per pip, so the driver answers the colour decision
+     * until the ability stops asking — one white, then one blue, matching the two-colour test
+     * spells below.
+     */
+    fun GameTestDriver.tapForElementalMana(playerId: EntityId) {
+        val smokebraider = putCreatureOnBattlefield(playerId, "Smokebraider")
+        removeSummoningSickness(smokebraider)
+        submit(ActivateAbility(playerId, smokebraider, manaAbilityId))
+        val colors = listOf(Color.WHITE, Color.BLUE)
+        var next = 0
+        while (state.pendingDecision != null && next < colors.size) {
+            val decision = state.pendingDecision!!
+            submitDecision(playerId, ColorChosenResponse(decision.id, colors[next]))
+            next++
+        }
+    }
+
+    test("tapping adds two restricted mana, not one") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForElementalMana(p1)
+
+        val pool = driver.state.getEntity(p1)?.get<ManaPoolComponent>()
+        withClue("Smokebraider is the two-mana Springleaf Drum of Elementals, not a one-mana dork") {
+            pool!!.restrictedMana.size shouldBe 2
+        }
+    }
+
+    test("the restricted mana pays for an Elemental spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForElementalMana(p1)
+
+        val elemental = driver.putCardInHand(p1, "Test Elemental")
+        driver.submit(
+            CastSpell(playerId = p1, cardId = elemental, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+    }
+
+    test("the restricted mana cannot pay for a non-Elemental spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForElementalMana(p1)
+
+        val goblin = driver.putCardInHand(p1, "Test Goblin")
+        driver.submit(
+            CastSpell(playerId = p1, cardId = goblin, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe false
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/MaskedAdmirersReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/MaskedAdmirersReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Masked Admirers reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val MaskedAdmirersReprint = Printing(
+    oracleId = "ea97fc76-3a32-414c-aa12-87be1a0eb9f3",
+    name = "Masked Admirers",
+    setCode = "C14",
+    collectorNumber = "206",
+    scryfallId = "01f95490-3fb0-4f16-a64e-b6289d440a9a",
+    artist = "Eric Fortune",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01f95490-3fb0-4f16-a64e-b6289d440a9a.jpg?1783938829",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/SmokebraiderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/SmokebraiderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.hop.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Smokebraider reprint in Planechase. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val SmokebraiderReprint = Printing(
+    oracleId = "e970f2df-90cb-45b8-8ae5-71b762908925",
+    name = "Smokebraider",
+    setCode = "HOP",
+    collectorNumber = "66",
+    scryfallId = "d026cc47-9045-4f5b-b940-a6ea794d6fb9",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d026cc47-9045-4f5b-b940-a6ea794d6fb9.jpg?1783942320",
+    artist = "Anthony S. Waters",
+    releaseDate = "2009-09-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MaskedAdmirersKhcReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MaskedAdmirersKhcReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Masked Admirers reprint in Kaldheim Commander. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val MaskedAdmirersKhcReprint = Printing(
+    oracleId = "ea97fc76-3a32-414c-aa12-87be1a0eb9f3",
+    name = "Masked Admirers",
+    setCode = "KHC",
+    collectorNumber = "69",
+    scryfallId = "b8cc3361-046c-4908-8b8d-a0502bfc173a",
+    artist = "Eric Fortune",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8cc3361-046c-4908-8b8d-a0502bfc173a.jpg?1783928312",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -901,6 +901,41 @@
     ]
 }
 
+// Doran, the Siege Tower
+{
+    "name": "Doran, the Siege Tower",
+    "manaCost": "{W}{B}{G}",
+    "typeLine": "Legendary Creature — Treefolk Shaman",
+    "oracleText": "Each creature assigns combat damage equal to its toughness rather than its power.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "AssignDamageEqualToToughness",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "onlyWhenToughnessGreaterThanPower": false
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "\"Each year that passes rings you inwardly with memory and might. Wield your heart, and the world will tremble.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b006b169-295d-4ead-8e8e-29a9c3246025.jpg?1783942855"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Elvish Handservant
 {
     "name": "Elvish Handservant",
@@ -1228,6 +1263,61 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Eyes of the Wisent
+{
+    "name": "Eyes of the Wisent",
+    "manaCost": "{1}{G}",
+    "typeLine": "Kindred Enchantment — Elemental",
+    "oracleText": "Whenever an opponent casts a blue spell during your turn, you may create a 4/4 green Elemental creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 4,
+                        "toughness": 4,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Elemental"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b4ef48d-a328-4eb9-a2e3-925c1cd38b1a.jpg?1783942837"
+                    }
+                },
+                "triggerRestriction": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "flavorText": "Calm as a wisent's watch\n—Elvish expression meaning \"safe\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg?1783942865"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1957,6 +2047,69 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Glarewielder
+{
+    "name": "Glarewielder",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Elemental Shaman",
+    "oracleText": "Haste\nWhen this creature enters, up to two target creatures can't block this turn.\nEvoke {1}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE",
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "up to two target creatures can't block this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59fdc845-7165-40f3-a082-21a502b3f0f6.jpg?1783942876"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2945,6 +3098,78 @@
         "artist": "Quinton Hoover",
         "flavorText": "Eidren, perfect of Lys Alana, ordered hundreds of trees uprooted and rearranged into a pattern he deemed beautiful. Thus the Gilt-Leaf Wood was born.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1783942859"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Masked Admirers
+{
+    "name": "Masked Admirers",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "When this creature enters, draw a card.\nWhenever you cast a creature spell, you may pay {G}{G}. If you do, return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{G}{G}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "activeZones": [
+                    "Graveyard"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Eric Fortune",
+        "flavorText": "\"Beauty determines value, and we determine beauty.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9cf01d6-7d5d-4638-9884-733797c9f502.jpg?1783942860"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -4083,6 +4308,55 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Smokebraider
+{
+    "name": "Smokebraider",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Elemental Shaman",
+    "oracleText": "{T}: Add two mana in any combination of colors. Spend this mana only to cast Elemental spells or activate abilities of Elementals.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ],
+                    "restriction": {
+                        "type": "SubtypeSpellsOrAbilitiesOnly",
+                        "subtype": "Elemental"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Anthony S. Waters",
+        "flavorText": "\"Be silent and listen to your inner fire. Only then can you walk the Path of Flame.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3c6227b-bd43-47e8-927f-f8a78c532591.jpg?1783942871"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
The five cards Argentum Assay already reads whole for Lorwyn but the set hadn't authored — so each one lands inside the differential gate's compared set rather than outside it. All five compose existing `Effects.*` / `Patterns.*` vocabulary; nothing new was added to the SDK.

| Card | What it does | Built from |
|---|---|---|
| **Doran, the Siege Tower** {W}{B}{G} 0/5 | Each creature assigns combat damage equal to its toughness | `AssignDamageEqualToToughness(GroupFilter.AllCreatures, onlyWhenToughnessGreaterThanPower = false)` |
| **Eyes of the Wisent** {1}{G} | Opponent's blue spell on your turn → optional 4/4 green Elemental | `Triggers.opponentCasts` + `triggerRestriction = Conditions.IsYourTurn` + `Effects.CreateToken` |
| **Glarewielder** {4}{R} 3/1 | Haste, evoke {1}{R}, enters: up to two target creatures can't block | `evoke`, `TargetCreature(optional = true, count = 2)`, `ForEachTargetEffect(Effects.CantBlock(...))` |
| **Masked Admirers** {2}{G}{G} 3/2 | Enters: draw. Cast a creature spell, may pay {G}{G} to return it from the graveyard | `triggerZone = Zone.GRAVEYARD`, `Gate.MayPay`, `Effects.ReturnToHandFromGraveyard` |
| **Smokebraider** {1}{R} 1/1 | {T}: two mana in any combination, Elemental spells/abilities only | `Effects.AddManaInAnyCombination(2, restriction = SubtypeSpellsOrAbilitiesOnly("Elemental"))` |

Two cards from Assay's seven-card ready list were left out as the heaviest: **Austere Command** (four-mode "choose two") and **Drowner of Secrets**. Both remain Assay-ready for a later batch.

### The details worth reading

**Masked Admirers' recursion functions from the graveyard** (CR 113.6b) — `triggerZone = Zone.GRAVEYARD`, the same arrangement Squee, Goblin Nabob uses. Indexed on the battlefield instead, the ability can never do anything, because a Masked Admirers on the battlefield has nothing to return. Its test brackets the zone from both sides: it fires from the graveyard, and it stays silent from the battlefield. The return uses `Effects.ReturnToHandFromGraveyard` rather than plain `ReturnToHand` — the self-return facade carries the `fromZone` guard, and nothing re-examines an untargeted source at resolution.

**Doran's static is unconditional and unscoped.** `onlyWhenToughnessGreaterThanPower = false` and `GroupFilter.AllCreatures`, so it *lowers* a 2/1's damage as readily as it raises a 0/5's — and reaches creatures an opponent controls. All three are separate assertions in the test, the last measured off the blocker's damage rather than a survival check that would have passed either way.

**Glarewielder applies the restriction per target.** `ForEachTargetEffect` re-binds `ContextTarget(0)` to each chosen creature; a single `CantBlock` would have silently reached only the first. The blocking test carries an untargeted control creature that *can* block, so a rejected block can't be confused with a rejected step.

**Smokebraider is "in any combination", not "of any color"** — each pip is coloured independently, so `AddManaInAnyCombination`, not `AddAnyColorMana`.

### Printing rows

Canonical for all five is Lorwyn (each is an LRW original). Reprint rows added where the reprinting set is scaffolded: Masked Admirers in C14 and KHC, Smokebraider in HOP. `just check-card-printing` is green for all five.

### Verification

- Five scenario test files, one per card, 19 tests — all pass.
- `just build`: compiles; `CardDefinitionSnapshotTest` re-blessed and **only the five new cards moved** in `snapshots/cards/LRW.json`.
- `just assay-differential --set LRW`: 87 compared, 74 confirmed. The 13 `DIVERGENT` rows are all pre-existing cards (the Harbinger cycle, Boggart Birth Rite, Epic Proportions, Kithkin Greatheart, Scarred Vinebreeder, Wort). **None of the five new cards diverge** — Assay's independent reading of each oracle text agrees with the hand-written definition.
- `just check-card-printing` green for each card.

**Pre-existing failure, disclosed:** `ArenaHarnessTest > a v0 mirror is exactly 50%` and `> the same seed replays the same games, across threads` fail on this branch. They also fail on clean `main` when actually re-run (`--rerun`; an earlier "SUCCESSFUL" there was Gradle serving an UP-TO-DATE cached result, not a real run). Untouched by this change — no AI, arena, or engine code here. `BasicLandArtOrderTest`, `GymBeansConfigTest`, `AIPlayerTest` and `SealedDeckGeneratorTest` also timed out during the full-build run under machine contention; each passes when run on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn1WmDdvsiybTQd2VnBtWe