### PR TITLE
Add 63 Assay-ready cards to Portal Second Age

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornCavalier.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornCavalier.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Alaborn Cavalier
+ * {2}{W}{W}
+ * Creature — Human Knight
+ *
+ * The Portal "tapper on attack" shape — Seasoned Marshal in Portal, Flanking Troops in
+ * Portal Three Kingdoms. The optional clause is [MayEffect] around the tap, so the gate is the
+ * consent and the tap is the whole of the then-branch.
+ */
+val AlabornCavalier = card("Alaborn Cavalier") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Whenever this creature attacks, you may tap target creature."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("target", Targets.Creature)
+        effect = MayEffect(Effects.Tap(creature))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Kev Walker"
+        flavorText = "\"Course he ran! *I* wouldn't want to stare down that barrel, either!\"\n—Alaborn soldier"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornGrenadier.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornGrenadier.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alaborn Grenadier
+ * {W}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance
+ */
+val AlabornGrenadier = card("Alaborn Grenadier") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Vigilance"
+    power = 2
+    toughness = 2
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "David A. Cherry"
+        flavorText = "\"Ever proud, ever vigilant.\"\n—Grenadier motto"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornMusketeer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornMusketeer.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alaborn Musketeer
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/1
+ * Reach (This creature can block creatures with flying.)
+ */
+val AlabornMusketeer = card("Alaborn Musketeer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Reach (This creature can block creatures with flying.)"
+    power = 2
+    toughness = 1
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Heather Hudson"
+        flavorText = "Muskets gave the Alaborn army an advantage it had long lacked—air defense."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornVeteran.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornVeteran.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Alaborn Veteran
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/2
+ *
+ * {T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before
+ * attackers are declared.
+ */
+val AlabornVeteran = card("Alaborn Veteran") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "{T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Henry Van Der Linde"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AngelOfFury.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AngelOfFury.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angel of Fury
+ * {4}{W}{W}
+ * Creature — Angel
+ *
+ * The dies trigger reads the source itself, so the shuffle is aimed at [EffectTarget.Self];
+ * [Effects.ShuffleIntoLibrary] is the library-placement facade for that move.
+ */
+val AngelOfFury = card("Angel of Fury") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText =
+        "Flying\n" +
+        "When this creature dies, you may shuffle it into its owner's library."
+    power = 3
+    toughness = 5
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = MayEffect(Effects.ShuffleIntoLibrary(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "7"
+        artist = "Keith Parkinson"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ApprenticeSorcerer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ApprenticeSorcerer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Apprentice Sorcerer
+ * {2}{U}
+ * Creature — Human Wizard Sorcerer
+ * 1/1
+ *
+ * {T}: This creature deals 1 damage to any target. Activate only during your turn, before
+ * attackers are declared.
+ */
+val ApprenticeSorcerer = card("Apprentice Sorcerer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard Sorcerer"
+    oracleText = "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ArmoredGalleon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ArmoredGalleon.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+
+/**
+ * Armored Galleon
+ * {4}{U}
+ * Creature — Human Pirate
+ * 5/4
+ *
+ * This creature can't attack unless defending player controls an Island.
+ */
+val ArmoredGalleon = card("Armored Galleon") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "This creature can't attack unless defending player controls an Island."
+    power = 5
+    toughness = 4
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Doug Chaffee"
+        flavorText = "\"Information equals profits. Our merchants sell it, or our pirates use it.\"\n—Jefan, Talas ship captain"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ArmoredGriffin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ArmoredGriffin.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2/3
+ * Flying, vigilance
+ */
+val ArmoredGriffin = card("Armored Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    oracleText = "Flying, vigilance"
+    power = 2
+    toughness = 3
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Bradley Williams"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BasicLands.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Portal Second Age Basic Lands
+ *
+ * Portal Second Age contains 3 art variants of each basic land type.
+ * Cards 151-165 (Plains 151-153, Island 154-156, Swamp 157-159, Mountain 160-162, Forest 163-165)
+ */
+
+// =============================================================================
+// Plains (Cards 151-153)
+// =============================================================================
+
+val Plains151 = basicLand("Plains") {
+    collectorNumber = "151"
+    artist = "Fred Fields"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27ecf285-c48f-4ac3-9b75-0ee0ff052767.jpg"
+}
+
+val Plains152 = basicLand("Plains") {
+    collectorNumber = "152"
+    artist = "Fred Fields"
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a136975-e513-4c50-9d4a-855d03630470.jpg"
+}
+
+val Plains153 = basicLand("Plains") {
+    collectorNumber = "153"
+    artist = "Fred Fields"
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f67f2ecd-d5fb-406b-b14d-34eb087eb08b.jpg"
+}
+
+// =============================================================================
+// Island (Cards 154-156)
+// =============================================================================
+
+val Island154 = basicLand("Island") {
+    collectorNumber = "154"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0a83b1a-a734-4726-9d14-c75ef04798d1.jpg"
+}
+
+val Island155 = basicLand("Island") {
+    collectorNumber = "155"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b165ada0-7f52-4047-8596-c54247d13704.jpg"
+}
+
+val Island156 = basicLand("Island") {
+    collectorNumber = "156"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3cf8ecec-8925-470b-994d-79694d056834.jpg"
+}
+
+// =============================================================================
+// Swamp (Cards 157-159)
+// =============================================================================
+
+val Swamp157 = basicLand("Swamp") {
+    collectorNumber = "157"
+    artist = "Susan Van Camp"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80c0bd18-fdee-4cb2-8a7e-dd86bb8a6bbe.jpg"
+}
+
+val Swamp158 = basicLand("Swamp") {
+    collectorNumber = "158"
+    artist = "Susan Van Camp"
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adb62dd9-266b-4de9-8a11-3228b5f1e03a.jpg"
+}
+
+val Swamp159 = basicLand("Swamp") {
+    collectorNumber = "159"
+    artist = "Susan Van Camp"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c103ed69-b73b-4789-a28d-1fd071bc9029.jpg"
+}
+
+// =============================================================================
+// Mountain (Cards 160-162)
+// =============================================================================
+
+val Mountain160 = basicLand("Mountain") {
+    collectorNumber = "160"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bdfbb15a-d7f4-470a-9d36-78c710a6d397.jpg"
+}
+
+val Mountain161 = basicLand("Mountain") {
+    collectorNumber = "161"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/4453a5c0-76f2-422d-8cbc-4b21c17cdf1e.jpg"
+}
+
+val Mountain162 = basicLand("Mountain") {
+    collectorNumber = "162"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/9006aa97-884f-404a-9ead-af8437ea9596.jpg"
+}
+
+// =============================================================================
+// Forest (Cards 163-165)
+// =============================================================================
+
+val Forest163 = basicLand("Forest") {
+    collectorNumber = "163"
+    artist = "Quinton Hoover"
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89f4fcbb-86a8-475f-a547-d59014bb7a98.jpg"
+}
+
+val Forest164 = basicLand("Forest") {
+    collectorNumber = "164"
+    artist = "Quinton Hoover"
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa863815-1dcc-43d8-8076-a35037688b20.jpg"
+}
+
+val Forest165 = basicLand("Forest") {
+    collectorNumber = "165"
+    artist = "Quinton Hoover"
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/abebee47-5205-4855-ae72-475b58a02240.jpg"
+}
+
+/**
+ * All Portal Second Age basic land variants.
+ */
+val PortalSecondAgeBasicLands = listOf(
+    Plains151, Plains152, Plains153,
+    Island154, Island155, Island156,
+    Swamp157, Swamp158, Swamp159,
+    Mountain160, Mountain161, Mountain162,
+    Forest163, Forest164, Forest165
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BrimstoneDragon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BrimstoneDragon.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brimstone Dragon
+ * {6}{R}{R}
+ * Creature — Dragon
+ * 6/6
+ * Flying, haste
+ */
+val BrimstoneDragon = card("Brimstone Dragon") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    oracleText = "Flying, haste"
+    power = 6
+    toughness = 6
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "David A. Cherry"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BrutalNightstalker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BrutalNightstalker.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Brutal Nightstalker
+ * {3}{B}{B}
+ * Creature — Nightstalker
+ *
+ * "Have target opponent discard a card" is the published gather → select → move recipe
+ * [Patterns.Hand.discardCards] aimed at the bound target, so the discarding player both owns the
+ * gathered hand and makes the choice.
+ */
+val BrutalNightstalker = card("Brutal Nightstalker") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightstalker"
+    oracleText = "When this creature enters, you may have target opponent discard a card."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target", TargetOpponent())
+        effect = MayEffect(Patterns.Hand.discardCards(1, opponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Brom"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ChorusOfWoe.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ChorusOfWoe.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Chorus of Woe
+ * {B}
+ * Sorcery
+ * Creatures you control get +1/+0 until end of turn.
+ *
+ * A group pump over the creatures you control — the same shape as Festergloom, with the
+ * controller predicate on the group filter rather than the colour one.
+ */
+val ChorusOfWoe = card("Chorus of Woe") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +1/+0 until end of turn."
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            1, 0,
+            GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Randy Gallegos"
+        flavorText = "When nightstalkers sing, nothing in creation sleeps."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorBat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorBat.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dakmor Bat
+ * {1}{B}
+ * Creature — Bat
+ * 1/1
+ * Flying
+ */
+val DakmorBat = card("Dakmor Bat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    oracleText = "Flying"
+    power = 1
+    toughness = 1
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Una Fricker"
+        flavorText = "The bat thrives on what underestimates it."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorPlague.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorPlague.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dakmor Plague
+ * {3}{B}{B}
+ * Sorcery
+ * Dakmor Plague deals 3 damage to each creature and each player.
+ *
+ * The Steam Blast / Magma Giant sweeper shape: a group iteration over every creature (no
+ * controller predicate — both players') followed by a per-player iteration, whose body aims at
+ * [EffectTarget.Controller] because [Effects.ForEachPlayer] rebinds the controller each pass.
+ */
+val DakmorPlague = card("Dakmor Plague") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Dakmor Plague deals 3 damage to each creature and each player."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature),
+                Effects.DealDamage(3, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(3, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Jeff Miracola"
+        flavorText = "The tiniest cough can be deadlier than the fiercest dragon."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorSorceress.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorSorceress.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dakmor Sorceress
+ * {5}{B}
+ * Creature — Human Wizard Sorcerer
+ *
+ * Dakmor Sorceress's power is equal to the number of Swamps you control.
+ *
+ * A characteristic-defining ability (CR 604.3): the starred power is the P/T slot itself, not an
+ * entry in the ability list, so it lives in the card's dynamic power rather than inside a
+ * `CardScript`. Only power is dynamic — toughness stays a printed 4 — so this is the single-stat
+ * `dynamicPower(...)` helper (Enigma Drake's shape), not `dynamicStats(...)`.
+ */
+val DakmorSorceress = card("Dakmor Sorceress") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard Sorcerer"
+    oracleText = "Dakmor Sorceress's power is equal to the number of Swamps you control."
+    toughness = 4
+
+    dynamicPower(
+        DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land.withSubtype("Swamp")).count()
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Matthew D. Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DarkOffering.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DarkOffering.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dark Offering
+ * {4}{B}{B}
+ * Sorcery
+ * Destroy target nonblack creature. You gain 3 life.
+ *
+ * The Portal "nonblack removal plus lifegain" template — Soul Shred with a destroy instead of
+ * damage. The destroy is plain (regenerable), so no can't-be-regenerated marker.
+ */
+val DarkOffering = card("Dark Offering") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target nonblack creature. You gain 3 life."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"Our greatest hope has become our enemy's greatest triumph.\"\n—Restela, Alaborn marshal"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FalseSummoning.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FalseSummoning.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * False Summoning
+ * {1}{U}
+ * Instant
+ * Counter target creature spell.
+ *
+ * [Targets.CreatureSpell] is the stack-zoned creature filter; [Effects.CounterSpell] counters
+ * whatever the requirement bound, so the effect carries no target of its own.
+ */
+val FalseSummoning = card("False Summoning") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell."
+
+    spell {
+        target("target", Targets.CreatureSpell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "DiTerlizzi"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FestivalOfTrokin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FestivalOfTrokin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Festival of Trokin
+ * {W}
+ * Sorcery
+ * You gain 2 life for each creature you control.
+ *
+ * "2 life for each" is the battlefield count wrapped in [DynamicAmount.Multiply] — the count
+ * carries the player reference, so the filter itself takes no controller predicate.
+ */
+val FestivalOfTrokin = card("Festival of Trokin") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "You gain 2 life for each creature you control."
+
+    spell {
+        effect = Effects.GainLife(
+            DynamicAmount.Multiply(
+                DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).count(),
+                2
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Jeffrey R. Busch"
+        flavorText = "Everyone loves a good sale."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FoulSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/FoulSpirit.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Foul Spirit
+ * {2}{B}
+ * Creature — Spirit
+ *
+ * The bare imperative "sacrifice a land" names no player, so it is [Effects.SacrificeOwn] — the
+ * ability's controller sacrifices — not the `ForceSacrifice` shape that "target opponent
+ * sacrifices" needs.
+ */
+val FoulSpirit = card("Foul Spirit") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, sacrifice a land."
+    power = 3
+    toughness = 2
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.SacrificeOwn(GameObjectFilter.Land)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinFirestarter.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinFirestarter.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Goblin Firestarter
+ * {R}
+ * Creature — Goblin
+ * 1/1
+ *
+ * Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn,
+ * before attackers are declared.
+ */
+val GoblinFirestarter = card("Goblin Firestarter") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn, before attackers are declared."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "96"
+        artist = "Keith Parkinson"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinGeneral.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin General
+ * {1}{R}{R}
+ * Creature — Goblin Warrior
+ *
+ * "Goblin creatures you control" is the group iteration of [Effects.ForEachInGroup] — the pump is
+ * written once against [EffectTarget.Self], the current iteration entity, exactly as
+ * Rally the Troops writes its untap.
+ */
+val GoblinGeneral = card("Goblin General") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    oracleText = "Whenever this creature attacks, Goblin creatures you control get +1/+1 until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "97"
+        artist = "Keith Parkinson"
+        flavorText = "Lead, follow, or run around like crazy."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinWarStrikeReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinWarStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin War Strike reprint in P02. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinWarStrikeReprint = Printing(
+    oracleId = "5944d5c7-65ab-425f-a453-ed5871ca3d73",
+    name = "Goblin War Strike",
+    setCode = "P02",
+    collectorNumber = "105",
+    scryfallId = "738fecfd-1119-4dcb-acd6-ec9715d9c074",
+    artist = "Michael Weaver",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/738fecfd-1119-4dcb-acd6-ec9715d9c074.jpg",
+    releaseDate = "1998-06-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/HiddenHorrorReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/HiddenHorrorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hidden Horror reprint in P02. Canonical CardDefinition lives in its earliest set.
+ */
+val HiddenHorrorReprint = Printing(
+    oracleId = "db7c5a2f-9aea-4b14-86cf-7af79d6484af",
+    name = "Hidden Horror",
+    setCode = "P02",
+    collectorNumber = "75",
+    scryfallId = "64243f71-0941-47d5-816b-4548986726b4",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg",
+    releaseDate = "1998-06-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/IronhoofOx.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/IronhoofOx.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+
+/**
+ * Ironhoof Ox
+ * {3}{G}{G}
+ * Creature — Ox
+ * 4/4
+ *
+ * This creature can't be blocked by more than one creature.
+ */
+val IronhoofOx = card("Ironhoof Ox") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ox"
+    oracleText = "This creature can't be blocked by more than one creature."
+    power = 4
+    toughness = 4
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Una Fricker"
+        flavorText = "The good news is it's vegetarian. The bad news is it just doesn't like you."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/JustFate.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/JustFate.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+
+/**
+ * Just Fate
+ * {2}{W}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Destroy target attacking creature.
+ *
+ * The Portal "combat trick" timing pair: [com.wingedsheep.sdk.dsl.SpellBuilder.castOnlyDuring] plus
+ * `castOnlyIf(YouWereAttackedThisStep)` — same shape as Rally the Troops in this set.
+ */
+val JustFate = card("Just Fate") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Destroy target attacking creature."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        val victim = target("target", Targets.AttackingCreature)
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Bradley Williams"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/KissOfDeath.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/KissOfDeath.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kiss of Death
+ * {4}{B}{B}
+ * Sorcery
+ * Kiss of Death deals 4 damage to target opponent or planeswalker. You gain 4 life.
+ *
+ * "Target opponent or planeswalker" is the single [Targets.OpponentOrPlaneswalker] requirement, not a
+ * pair; the life gain is unconditional and defaults to the controller.
+ */
+val KissOfDeath = card("Kiss of Death") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Kiss of Death deals 4 damage to target opponent or planeswalker. You gain 4 life."
+
+    spell {
+        val victim = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.DealDamage(4, victim),
+            Effects.GainLife(4)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Melissa A. Benson"
+        flavorText = "\"I'd sooner lock lips with a viper. At least I might walk away from *that*.\"\n—Elvish scout"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/LurkingNightstalker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/LurkingNightstalker.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lurking Nightstalker
+ * {B}{B}
+ * Creature — Nightstalker
+ *
+ * "It gets +2/+0" is the source itself, so the pump is aimed at [EffectTarget.Self] rather than at
+ * a target slot the ability never announces.
+ */
+val LurkingNightstalker = card("Lurking Nightstalker") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightstalker"
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Kev Walker"
+        flavorText = "The shadows know."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Lynx.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Lynx.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lynx
+ * {1}{G}
+ * Creature — Cat
+ * 2/1
+ * Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)
+ */
+val Lynx = card("Lynx") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+    power = 2
+    toughness = 1
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Rebecca Guay"
+        flavorText = "Rarely seen, hardly heard, never caught."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/MoaningSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/MoaningSpirit.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moaning Spirit
+ * {2}{B}
+ * Creature — Spirit
+ * 2/1
+ * Flying
+ */
+val MoaningSpirit = card("Moaning Spirit") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying"
+    power = 2
+    toughness = 1
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Rebecca Guay"
+        flavorText = "The dead sing their own lullabies."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NightstalkerEngine.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NightstalkerEngine.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightstalker Engine
+ * {4}{B}
+ * Creature — Nightstalker
+ *
+ * Nightstalker Engine's power is equal to the number of creature cards in your graveyard.
+ *
+ * A characteristic-defining ability (CR 604.3): the starred power lives in the P/T slot, so it is a
+ * `dynamicPower(...)` over a graveyard count rather than an entry in a `CardScript`. Toughness stays
+ * a printed 3.
+ */
+val NightstalkerEngine = card("Nightstalker Engine") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightstalker"
+    oracleText = "Nightstalker Engine's power is equal to the number of creature cards in your graveyard."
+    toughness = 3
+
+    dynamicPower(DynamicAmounts.creatureCardsInYourGraveyard())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "81"
+        artist = "Mark Tedin"
+        flavorText = "Part metal, part bone, and all death."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodArchers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodArchers.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Norwood Archers
+ * {3}{G}
+ * Creature — Elf Archer
+ * 3/3
+ * Reach (This creature can block creatures with flying.)
+ */
+val NorwoodArchers = card("Norwood Archers") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Archer"
+    oracleText = "Reach (This creature can block creatures with flying.)"
+    power = 3
+    toughness = 3
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Rebecca Guay"
+        flavorText = "\"'Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodRiders.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodRiders.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+
+/**
+ * Norwood Riders
+ * {3}{G}
+ * Creature — Elf
+ * 3/3
+ *
+ * This creature can't be blocked by more than one creature.
+ */
+val NorwoodRiders = card("Norwood Riders") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf"
+    oracleText = "This creature can't be blocked by more than one creature."
+    power = 3
+    toughness = 3
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Rebecca Guay"
+        flavorText = "\"Trade my moose? Sure—when I find a *horse* that can spear ten goblins at a time!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/NorwoodWarrior.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Norwood Warrior
+ * {2}{G}
+ * Creature — Elf Warrior
+ * 2 / 2
+ *
+ * Whenever this creature becomes blocked, it gets +1/+1 until end of turn.
+ */
+val NorwoodWarrior = card("Norwood Warrior") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "Whenever this creature becomes blocked, it gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Rebecca Guay"
+        flavorText = "\"The woods hold peace for those who desire it, but those who seek battle will find me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreArsonist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreArsonist.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Arsonist
+ * {4}{R}
+ * Creature — Ogre
+ * 3 / 3
+ *
+ * When this creature enters, destroy target land.
+ */
+val OgreArsonist = card("Ogre Arsonist") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre"
+    oracleText = "When this creature enters, destroy target land."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target("target", Targets.Land)
+        effect = Effects.Destroy(land)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Jeffrey R. Busch"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreBerserker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreBerserker.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Berserker
+ * {4}{R}
+ * Creature — Ogre Berserker
+ * 4/2
+ * Haste
+ */
+val OgreBerserker = card("Ogre Berserker") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Berserker"
+    oracleText = "Haste"
+    power = 4
+    toughness = 2
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "David A. Cherry"
+        flavorText = "The machine does the growling, so the ogre's free to smile."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ProwlingNightstalker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ProwlingNightstalker.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Prowling Nightstalker
+ * {3}{B}
+ * Creature — Nightstalker
+ * 2/2
+ *
+ * This creature can't be blocked except by black creatures.
+ */
+val ProwlingNightstalker = card("Prowling Nightstalker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightstalker"
+    oracleText = "This creature can't be blocked except by black creatures."
+    power = 2
+    toughness = 2
+
+    staticAbility {
+        ability = CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Keith Parkinson"
+        flavorText = "Silent as a serpent, twisted as a lone bog tree, evil as Tojira's heart."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RaidingNightstalker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RaidingNightstalker.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raiding Nightstalker
+ * {2}{B}
+ * Creature — Nightstalker
+ * 2/2
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ */
+val RaidingNightstalker = card("Raiding Nightstalker") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightstalker"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+    power = 2
+    toughness = 2
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Pete Venters"
+        flavorText = "\"Our steeds need food, water, stabling. Theirs just need prey.\"\n—Restela, Alaborn marshal"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RazorclawBear.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RazorclawBear.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Razorclaw Bear
+ * {2}{G}{G}
+ * Creature — Bear
+ * 3 / 3
+ *
+ * Whenever this creature becomes blocked, it gets +2/+2 until end of turn.
+ */
+val RazorclawBear = card("Razorclaw Bear") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    oracleText = "Whenever this creature becomes blocked, it gets +2/+2 until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "142"
+        artist = "Heather Hudson"
+        flavorText = "One razorclaw is three bears too many.\n—Elvish saying"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Remove.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Remove.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+
+/**
+ * Remove
+ * {U}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Return target attacking creature to its owner's hand.
+ *
+ * The blue half of the Portal "combat trick" timing pair — [com.wingedsheep.sdk.dsl.SpellBuilder.castOnlyDuring]
+ * plus `castOnlyIf(YouWereAttackedThisStep)`, the same restriction pair Rally the Troops carries.
+ */
+val Remove = card("Remove") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Return target attacking creature to its owner's hand."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        val attacker = target("target", Targets.AttackingCreature)
+        effect = Effects.ReturnToHand(attacker)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "DiTerlizzi"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RighteousCharge.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RighteousCharge.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Righteous Charge
+ * {1}{W}{W}
+ * Sorcery
+ * Creatures you control get +2/+2 until end of turn.
+ *
+ * The untargeted mass pump: [Effects.ForEachInGroup] over the creatures you control, with the stat
+ * change aimed at [EffectTarget.Self] — the current iteration entity — the same shape Rally the
+ * Troops uses for its mass untap.
+ */
+val RighteousCharge = card("Righteous Charge") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +2/+2 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(2, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Jeffrey R. Busch"
+        flavorText = "\"Bravery shines brightest in a pure soul.\"\n—Restela, Alaborn marshal"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RiverBear.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RiverBear.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River Bear
+ * {3}{G}
+ * Creature — Bear
+ * 3/3
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ */
+val RiverBear = card("River Bear") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
+    power = 3
+    toughness = 3
+    keywords(Keyword.ISLANDWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "144"
+        artist = "Una Fricker"
+        flavorText = "The bears had been isolated on an island for hundreds of years, until the island sank and the bears didn't."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ScreechingDrake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ScreechingDrake.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Screeching Drake
+ * {3}{U}
+ * Creature — Drake
+ * 2 / 2
+ *
+ * Flying
+ * When this creature enters, draw a card, then discard a card.
+ *
+ * The discard half is the [Patterns.Hand] recipe — gather hand, select one, move it to
+ * the graveyard as a discard — so the prompt string stays the facade's own.
+ */
+val ScreechingDrake = card("Screeching Drake") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, draw a card, then discard a card."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1) then Patterns.Hand.discardCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Anson Maddocks"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SeaDrake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SeaDrake.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Sea Drake
+ * {2}{U}
+ * Creature — Drake
+ * 4 / 3
+ *
+ * Flying
+ * When this creature enters, return two target lands you control to their owner's hand.
+ *
+ * Two targets, one bounce each: [ForEachTargetEffect] fans the return out over the
+ * chosen lands, so the body aims at [EffectTarget.ContextTarget] 0 — the current
+ * iteration's target (the Rain of Salt shape).
+ */
+val SeaDrake = card("Sea Drake") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, return two target lands you control to their owner's hand."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target", TargetPermanent(count = 2, filter = TargetFilter.Land.youControl()))
+        effect = ForEachTargetEffect(
+            listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SteamCatapult.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SteamCatapult.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Steam Catapult
+ * {3}{W}{W}
+ * Creature — Human Soldier
+ * 2/3
+ *
+ * {T}: Destroy target tapped creature. Activate only during your turn, before attackers are
+ * declared.
+ */
+val SteamCatapult = card("Steam Catapult") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "{T}: Destroy target tapped creature. Activate only during your turn, before attackers are declared."
+    power = 2
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.TappedCreature)
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Mark Tedin"
+        flavorText = "\"You idiots! Turn it around! Turn it around!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SteamFrigate.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SteamFrigate.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+
+/**
+ * Steam Frigate
+ * {2}{U}
+ * Creature — Human Pirate
+ * 3/3
+ *
+ * This creature can't attack unless defending player controls an Island.
+ */
+val SteamFrigate = card("Steam Frigate") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "This creature can't attack unless defending player controls an Island."
+    power = 3
+    toughness = 3
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Mark Tedin"
+        flavorText = "\"Is it merchants or is it pirates?\"\n\"It's Talas—there's no difference.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SwarmOfRats.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SwarmOfRats.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Swarm of Rats
+ * {1}{B}
+ * Creature — Rat
+ *
+ * Swarm of Rats's power is equal to the number of Rats you control.
+ *
+ * A characteristic-defining ability (CR 604.3), so the starred power is `dynamicPower(...)` rather
+ * than an entry in a `CardScript`. The bare tribal noun "Rats you control" is *permanents* with the
+ * subtype, not creatures — a Rat artifact or enchantment would count — so the filter is
+ * [GameObjectFilter.Permanent] with the subtype, not [GameObjectFilter.Creature].
+ */
+val SwarmOfRats = card("Swarm of Rats") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "Swarm of Rats's power is equal to the number of Rats you control."
+    toughness = 1
+
+    dynamicPower(
+        DynamicAmounts.battlefield(Player.You, GameObjectFilter.Permanent.withSubtype("Rat")).count()
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SylvanYeti.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SylvanYeti.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Yeti
+ * {2}{G}{G}
+ * Creature — Yeti
+ *
+ * Sylvan Yeti's power is equal to the number of cards in your hand.
+ *
+ * A characteristic-defining ability (CR 604.3): the starred power is the P/T slot, so it is a
+ * `dynamicPower(...)` over the controller's hand size rather than an entry in a `CardScript`.
+ * Toughness stays a printed 4.
+ */
+val SylvanYeti = card("Sylvan Yeti") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Yeti"
+    oracleText = "Sylvan Yeti's power is equal to the number of cards in your hand."
+    toughness = 4
+
+    dynamicPower(DynamicAmounts.cardsInYourHand())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "147"
+        artist = "Brom"
+        flavorText = "The deeper the wood, the greater its strength."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasAirShip.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasAirShip.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talas Air Ship
+ * {3}{U}
+ * Creature — Human Pirate
+ * 3/2
+ * Flying
+ */
+val TalasAirShip = card("Talas Air Ship") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "Flying"
+    power = 3
+    toughness = 2
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Mark Tedin"
+        flavorText = "\"Their ships pollute our air as they themselves pollute our forest.\"\n—Arathel, elvish queen"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasExplorer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasExplorer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+
+/**
+ * Talas Explorer
+ * {1}{U}
+ * Creature — Human Pirate Scout
+ * 1 / 1
+ *
+ * Flying
+ * When this creature enters, look at target opponent's hand.
+ *
+ * "Look at target opponent's hand" targets a *player*, so the requirement is
+ * [Targets.Opponent]; [LookAtTargetHandEffect] has no `Effects.*` wrapper and is
+ * constructed directly (the Portal shape — see Ingenious Thief).
+ */
+val TalasExplorer = card("Talas Explorer") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate Scout"
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, look at target opponent's hand."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target", Targets.Opponent)
+        effect = LookAtTargetHandEffect(opponent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasResearcher.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasResearcher.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Talas Researcher
+ * {4}{U}
+ * Creature — Human Pirate Wizard
+ * 1/1
+ *
+ * {T}: Draw a card. Activate only during your turn, before attackers are declared.
+ */
+val TalasResearcher = card("Talas Researcher") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate Wizard"
+    oracleText = "{T}: Draw a card. Activate only during your turn, before attackers are declared."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Kaja Foglio"
+        flavorText = "From time, knowledge.\nFrom knowledge, power."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasScout.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasScout.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talas Scout
+ * {1}{U}
+ * Creature — Human Pirate Scout
+ * 1/2
+ * Flying
+ */
+val TalasScout = card("Talas Scout") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate Scout"
+    oracleText = "Flying"
+    power = 1
+    toughness = 2
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Heather Hudson"
+        flavorText = "\"Scouting a battle before you fight it is just good business.\"\n—Jefan, Talas ship captain"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasWarrior.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talas Warrior
+ * {1}{U}{U}
+ * Creature — Human Pirate Warrior
+ * 2/2
+ * This creature can't be blocked.
+ */
+val TalasWarrior = card("Talas Warrior") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate Warrior"
+    oracleText = "This creature can't be blocked."
+    power = 2
+    toughness = 2
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "53"
+        artist = "Douglas Shuler"
+        flavorText = "The sea is in their blood. Literally."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TempleAcolyte.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TempleAcolyte.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple Acolyte
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1 / 3
+ *
+ * When this creature enters, you gain 3 life.
+ */
+val TempleAcolyte = card("Temple Acolyte") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "When this creature enters, you gain 3 life."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Lubov"
+        flavorText = "Young, yes. Inexperienced, yes. Weak? Don't count on it."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TempleElder.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TempleElder.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Temple Elder
+ * {2}{W}
+ * Creature — Human Cleric
+ * 1/2
+ *
+ * {T}: You gain 1 life. Activate only during your turn, before attackers are declared.
+ */
+val TempleElder = card("Temple Elder") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "{T}: You gain 1 life. Activate only during your turn, before attackers are declared."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "David Horne"
+        flavorText = "\"Give us breath. Give us life. Prepare us for the day we make.\"\n—The Alaborn \"Rite of Battle\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TownSentry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TownSentry.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Town Sentry
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Whenever this creature blocks, it gets +0/+2 until end of turn.
+ *
+ * [Triggers.Blocks] is the SELF-bound "this creature blocks" event, so the pump aims at
+ * [EffectTarget.Self] — Shu Defender in white.
+ */
+val TownSentry = card("Town Sentry") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Whenever this creature blocks, it gets +0/+2 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(0, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Bradley Williams"
+        flavorText = "\"So he gots a sword. Big deal.\"\n\"Yeah, it's a big deal—it's a big sword!\"\n—Two goblins outside the gates of Trokin"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TreeMonkey.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TreeMonkey.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tree Monkey
+ * {G}
+ * Creature — Monkey
+ * 1/1
+ * Reach (This creature can block creatures with flying.)
+ */
+val TreeMonkey = card("Tree Monkey") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Monkey"
+    oracleText = "Reach (This creature can block creatures with flying.)"
+    power = 1
+    toughness = 1
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Una Fricker"
+        flavorText = "\"They serve the world best on a platter with shallots and onions.\"\n—Talas sailor"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/UndoReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/UndoReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undo reprint in P02. Canonical CardDefinition lives in its earliest set.
+ */
+val UndoReprint = Printing(
+    oracleId = "b446c3bd-3c7d-4d59-ba59-3dd80818465e",
+    name = "Undo",
+    setCode = "P02",
+    collectorNumber = "59",
+    scryfallId = "4ca55da2-33e1-44b5-88b2-ac159d842b1f",
+    artist = "Henry Van Der Linde",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4ca55da2-33e1-44b5-88b2-ac159d842b1f.jpg",
+    releaseDate = "1998-06-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/WildOx.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/WildOx.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Ox
+ * {3}{G}
+ * Creature — Ox
+ * 3/3
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ */
+val WildOx = card("Wild Ox") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ox"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+    power = 3
+    toughness = 3
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Jeffrey R. Busch"
+        flavorText = "It has the run of the swamps, and it knows it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Wildfire.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/Wildfire.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wildfire
+ * {4}{R}{R}
+ * Sorcery
+ * Each player sacrifices four lands of their choice. Wildfire deals 4 damage to each creature.
+ *
+ * "Each player sacrifices …" is [Effects.Sacrifice] naming [Player.Each] as the sacrificing player —
+ * each player chooses their own lands, in APNAP order. The sweep is [Effects.ForEachInGroup] over
+ * every creature with the damage aimed at [EffectTarget.Self], the current iteration entity.
+ */
+val Wildfire = card("Wildfire") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Each player sacrifices four lands of their choice. Wildfire deals 4 damage to each creature."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Sacrifice(
+                GameObjectFilter.Land,
+                4,
+                EffectTarget.PlayerRef(Player.Each)
+            ),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature),
+                Effects.DealDamage(4, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Rob Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/ChorusOfWoeReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/ChorusOfWoeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chorus of Woe reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val ChorusOfWoeReprint = Printing(
+    oracleId = "e175a3c1-df6c-4aa7-a4c9-893b466ad9e0",
+    name = "Chorus of Woe",
+    setCode = "S99",
+    collectorNumber = "68",
+    scryfallId = "ee70f692-35c4-4ea8-baad-c950725cfc30",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee70f692-35c4-4ea8-baad-c950725cfc30.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorPlagueReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorPlagueReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dakmor Plague reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val DakmorPlagueReprint = Printing(
+    oracleId = "a6cc516d-5a4b-455a-ab16-367d64215527",
+    name = "Dakmor Plague",
+    setCode = "S99",
+    collectorNumber = "72",
+    scryfallId = "bb2b809a-5bb7-4d7d-8ba1-c99051b83231",
+    artist = "Jeff Miracola",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb2b809a-5bb7-4d7d-8ba1-c99051b83231.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorSorceressReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorSorceressReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dakmor Sorceress reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val DakmorSorceressReprint = Printing(
+    oracleId = "be5d9522-40b4-4f45-978b-d78bd00f9491",
+    name = "Dakmor Sorceress",
+    setCode = "S99",
+    collectorNumber = "74",
+    scryfallId = "e8e355d8-a142-4504-9a27-721b6140dc8a",
+    artist = "Matthew D. Wilson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e8e355d8-a142-4504-9a27-721b6140dc8a.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DarkOfferingReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DarkOfferingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Offering reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val DarkOfferingReprint = Printing(
+    oracleId = "102356a9-0de5-4034-b121-034da5deb4f2",
+    name = "Dark Offering",
+    setCode = "S99",
+    collectorNumber = "75",
+    scryfallId = "2a39cf31-3cc2-4fe5-bb49-960c8d8b54fc",
+    artist = "Edward P. Beard, Jr.",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a39cf31-3cc2-4fe5-bb49-960c8d8b54fc.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinGeneralReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinGeneralReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin General reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinGeneralReprint = Printing(
+    oracleId = "5fab0d9c-ccf7-4c6a-94b4-959be139dad8",
+    name = "Goblin General",
+    setCode = "S99",
+    collectorNumber = "101",
+    scryfallId = "b02457a3-1a4a-4cf8-8b24-a4a2ea3584fd",
+    artist = "Keith Parkinson",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b02457a3-1a4a-4cf8-8b24-a4a2ea3584fd.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/LynxReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/LynxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lynx reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val LynxReprint = Printing(
+    oracleId = "61652a2d-dfe6-4d4f-8fad-9de1960208cb",
+    name = "Lynx",
+    setCode = "S99",
+    collectorNumber = "131",
+    scryfallId = "1c962a7a-8c3b-4343-a6ef-6be1d40ac940",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c962a7a-8c3b-4343-a6ef-6be1d40ac940.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/NorwoodArchersReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/NorwoodArchersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Norwood Archers reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val NorwoodArchersReprint = Printing(
+    oracleId = "4e4e96aa-2f05-4f1d-96f8-6c42cd3be589",
+    name = "Norwood Archers",
+    setCode = "S99",
+    collectorNumber = "137",
+    scryfallId = "4f5ed974-396a-4b93-8e15-90e180efd17e",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f5ed974-396a-4b93-8e15-90e180efd17e.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/RighteousChargeReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/RighteousChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Righteous Charge reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val RighteousChargeReprint = Printing(
+    oracleId = "252d9183-16eb-4345-8d15-56218b33abdd",
+    name = "Righteous Charge",
+    setCode = "S99",
+    collectorNumber = "22",
+    scryfallId = "f1bde9d5-953f-4e8d-9a24-6185cef0a304",
+    artist = "Jeffrey R. Busch",
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f1bde9d5-953f-4e8d-9a24-6185cef0a304.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SylvanYetiReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SylvanYetiReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Yeti reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanYetiReprint = Printing(
+    oracleId = "6493960b-4bbb-4ef0-8efb-abb122b1697d",
+    name = "Sylvan Yeti",
+    setCode = "S99",
+    collectorNumber = "146",
+    scryfallId = "096e7d5a-d998-4ef7-b34f-986aa69c526b",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/096e7d5a-d998-4ef7-b34f-986aa69c526b.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/UndoReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/UndoReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undo reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val UndoReprint = Printing(
+    oracleId = "b446c3bd-3c7d-4d59-ba59-3dd80818465e",
+    name = "Undo",
+    setCode = "S99",
+    collectorNumber = "58",
+    scryfallId = "12b944ea-add5-4806-a33e-264cc96a4a0e",
+    artist = "Terese Nielsen",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12b944ea-add5-4806-a33e-264cc96a4a0e.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/WildOxReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/WildOxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Ox reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val WildOxReprint = Printing(
+    oracleId = "a6aa245c-b620-486c-864b-0ea4e9bc4048",
+    name = "Wild Ox",
+    setCode = "S99",
+    collectorNumber = "151",
+    scryfallId = "f34823b8-fd6f-4e66-bfda-cc72181f4ca7",
+    artist = "Jeffrey R. Busch",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f34823b8-fd6f-4e66-bfda-cc72181f4ca7.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/WildfireReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/WildfireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildfire reprint in USG. Canonical CardDefinition lives in its earliest set.
+ */
+val WildfireReprint = Printing(
+    oracleId = "0da68ca2-07fd-4359-95a9-fb2f815e6ed0",
+    name = "Wildfire",
+    setCode = "USG",
+    collectorNumber = "228",
+    scryfallId = "72d50972-4549-40cd-9c33-4b341333803f",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72d50972-4549-40cd-9c33-4b341333803f.jpg",
+    releaseDate = "1998-10-12",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/Undo.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/Undo.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Undo
+ * {1}{U}{U}
+ * Sorcery
+ * Return two target creatures to their owners' hands.
+ *
+ * One requirement with `count = 2` rather than two requirements: the two creatures are chosen
+ * together and must be different objects. The bounce runs once per chosen target via
+ * [ForEachTargetEffect], whose body reads the current iteration's target as `ContextTarget(0)`.
+ */
+val Undo = card("Undo") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return two target creatures to their owners' hands."
+
+    spell {
+        target("target", TargetObject(count = 2, filter = TargetFilter.Creature))
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Terese Nielsen"
+        flavorText = "\"Oft have I wished to undo past deeds, but never did I imagine they would be undone for me.\"\n—Naimah, Femeref philosopher"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/SwarmOfRatsReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/SwarmOfRatsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swarm of Rats reprint in 8ED. Canonical CardDefinition lives in its earliest set.
+ */
+val SwarmOfRatsReprint = Printing(
+    oracleId = "7fe21ade-01f1-45ff-9b70-bc6302c3d284",
+    name = "Swarm of Rats",
+    setCode = "8ED",
+    collectorNumber = "167",
+    scryfallId = "2690a627-23c5-46a4-b508-a5bc6ecc08d7",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/2690a627-23c5-46a4-b508-a5bc6ecc08d7.jpg",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/TempleAcolyteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/TempleAcolyteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddf.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple Acolyte reprint in DDF. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleAcolyteReprint = Printing(
+    oracleId = "17e4085e-af44-4ba8-af05-ccfe4b35f96a",
+    name = "Temple Acolyte",
+    setCode = "DDF",
+    collectorNumber = "9",
+    scryfallId = "e32032f0-74a3-450e-8684-646ac2bda4fb",
+    artist = "Lubov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e32032f0-74a3-450e-8684-646ac2bda4fb.jpg",
+    releaseDate = "2010-09-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/RighteousChargeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/RighteousChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Righteous Charge reprint in GTC. Canonical CardDefinition lives in its earliest set.
+ */
+val RighteousChargeReprint = Printing(
+    oracleId = "252d9183-16eb-4345-8d15-56218b33abdd",
+    name = "Righteous Charge",
+    setCode = "GTC",
+    collectorNumber = "23",
+    scryfallId = "f52cb325-4f16-4cf3-9999-feafe0fde8c2",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f52cb325-4f16-4cf3-9999-feafe0fde8c2.jpg",
+    releaseDate = "2013-02-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ArmoredGriffinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ArmoredGriffinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Griffin reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val ArmoredGriffinReprint = Printing(
+    oracleId = "ad3d6003-66d3-486d-aa54-ddce1adb5ff1",
+    name = "Armored Griffin",
+    setCode = "PC2",
+    collectorNumber = "1",
+    scryfallId = "0f638ffc-20b3-4e8c-8f0a-0d034902bddd",
+    artist = "Brad Rigney",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f638ffc-20b3-4e8c-8f0a-0d034902bddd.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SeaDrakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SeaDrakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sea Drake reprint in MH2. Canonical CardDefinition lives in its earliest set.
+ */
+val SeaDrakeReprint = Printing(
+    oracleId = "44d1029f-604e-44d6-89f6-bd18344f5d79",
+    name = "Sea Drake",
+    setCode = "MH2",
+    collectorNumber = "268",
+    scryfallId = "5a8b69ff-22ef-451f-8322-b54eec79bacf",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a8b69ff-22ef-451f-8322-b54eec79bacf.jpg",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/P02.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/P02.json
@@ -1,3 +1,99 @@
+// Alaborn Cavalier
+{
+    "name": "Alaborn Cavalier",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever this creature attacks, you may tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"Course he ran! *I* wouldn't want to stare down that barrel, either!\"\n—Alaborn soldier",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e865658-67c8-43b2-8d3a-909fb1c17e8a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Alaborn Grenadier
+{
+    "name": "Alaborn Grenadier",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "David A. Cherry",
+        "flavorText": "\"Ever proud, ever vigilant.\"\n—Grenadier motto",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/153b7197-57a7-4e38-bd4a-4550b9d22dd8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Alaborn Musketeer
+{
+    "name": "Alaborn Musketeer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Reach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Heather Hudson",
+        "flavorText": "Muskets gave the Alaborn army an advantage it had long lacked—air defense.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/4776a9ed-dbc6-44d2-9761-b2d09ff34008.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Alaborn Trooper
 {
     "name": "Alaborn Trooper",
@@ -12,6 +108,112 @@
         "artist": "Lubov",
         "flavorText": "\"I dedicate my body to my country And my life to my King.\"\n—Alaborn Soldier's Oath",
         "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg?1783946495"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Alaborn Veteran
+{
+    "name": "Alaborn Veteran",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "{T}: Target creature gets +2/+2 until end of turn. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Henry Van Der Linde",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Angel of Fury
+{
+    "name": "Angel of Fury",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nWhen this creature dies, you may shuffle it into its owner's library.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Library",
+                        "placement": "Shuffled"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "RARE",
+        "artist": "Keith Parkinson",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2461bf0b-53e4-4103-8485-88a940ad66fd.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -85,6 +287,119 @@
     ]
 }
 
+// Apprentice Sorcerer
+{
+    "name": "Apprentice Sorcerer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard Sorcerer",
+    "oracleText": "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e1fd317-5500-40e8-ad79-323832815f81.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Armored Galleon
+{
+    "name": "Armored Galleon",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "This creature can't attack unless defending player controls an Island.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "DefendingPlayer",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "\"Information equals profits. Our merchants sell it, or our pirates use it.\"\n—Jefan, Talas ship captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/484b2978-2da5-41cf-85d4-128e9dae75c0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Armored Griffin
+{
+    "name": "Armored Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Bradley Williams",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54866603-c80c-4dc8-9655-eaf54ed2c5ab.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Barbtooth Wurm
 {
     "name": "Barbtooth Wurm",
@@ -125,6 +440,155 @@
     ]
 }
 
+// Brimstone Dragon
+{
+    "name": "Brimstone Dragon",
+    "manaCost": "{6}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, haste",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "RARE",
+        "artist": "David A. Cherry",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54c72f51-2e8c-4a2f-9b61-80f36f8af521.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Brutal Nightstalker
+{
+    "name": "Brutal Nightstalker",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Nightstalker",
+    "oracleText": "When this creature enters, you may have target opponent discard a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "UNCOMMON",
+        "artist": "Brom",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b471102b-a66e-4cdc-b20f-7ae1f9bd0e8a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Chorus of Woe
+{
+    "name": "Chorus of Woe",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +1/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Randy Gallegos",
+        "flavorText": "When nightstalkers sing, nothing in creation sleeps.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0289ddb3-b35c-4edf-92bb-06f84a3475d9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cruel Edict
 {
     "name": "Cruel Edict",
@@ -158,6 +622,87 @@
     ]
 }
 
+// Dakmor Bat
+{
+    "name": "Dakmor Bat",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Una Fricker",
+        "flavorText": "The bat thrives on what underestimates it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f45994db-776d-420e-9241-99bf3b71fa59.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dakmor Plague
+{
+    "name": "Dakmor Plague",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Dakmor Plague deals 3 damage to each creature and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Controller"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "The tiniest cough can be deadlier than the fiercest dragon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58b38ef1-5839-4292-91d6-e45698c69a75.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dakmor Scorpion
 {
     "name": "Dakmor Scorpion",
@@ -178,6 +723,191 @@
     ]
 }
 
+// Dakmor Sorceress
+{
+    "name": "Dakmor Sorceress",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Human Wizard Sorcerer",
+    "oracleText": "Dakmor Sorceress's power is equal to the number of Swamps you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land Swamp"
+            }
+        },
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Matthew D. Wilson",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/985ef9ad-b842-40b7-8d56-98143ecef0dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dark Offering
+{
+    "name": "Dark Offering",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target nonblack creature. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "\"Our greatest hope has become our enemy's greatest triumph.\"\n—Restela, Alaborn marshal",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3ce0cef9-6de4-4a71-b76a-eb0198387294.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// False Summoning
+{
+    "name": "False Summoning",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature",
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "DiTerlizzi",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd7d30a8-bc7a-42bc-8d1b-600cbf78ab98.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Festival of Trokin
+{
+    "name": "Festival of Trokin",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "You gain 2 life for each creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "creature"
+                },
+                "multiplier": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Jeffrey R. Busch",
+        "flavorText": "Everyone loves a good sale.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5bd783b-d4cd-4a53-8fec-a5ead7c14738.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Foul Spirit
+{
+    "name": "Foul Spirit",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhen this creature enters, sacrifice a land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "rk post",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64b63e5f-b2cf-42c2-8111-1ebb9ed5ca33.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Goblin Cavaliers
 {
     "name": "Goblin Cavaliers",
@@ -192,6 +922,110 @@
         "artist": "DiTerlizzi",
         "flavorText": "They get along so well with their goats because they're practically goats themselves.",
         "imageUri": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg?1783946467"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Goblin Firestarter
+{
+    "name": "Goblin Firestarter",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "UNCOMMON",
+        "artist": "Keith Parkinson",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84ee21ef-26c0-4def-9046-5d6fcfa3bfeb.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Goblin General
+{
+    "name": "Goblin General",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Whenever this creature attacks, Goblin creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Goblin ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "RARE",
+        "artist": "Keith Parkinson",
+        "flavorText": "Lead, follow, or run around like crazy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg"
     },
     "colorIdentityOverride": [
         "RED"
@@ -317,6 +1151,197 @@
     ]
 }
 
+// Ironhoof Ox
+{
+    "name": "Ironhoof Ox",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Ox",
+    "oracleText": "This creature can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Una Fricker",
+        "flavorText": "The good news is it's vegetarian. The bad news is it just doesn't like you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c2528c2-6405-4db9-9137-623946a4de2f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Just Fate
+{
+    "name": "Just Fate",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Bradley Williams",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kiss of Death
+{
+    "name": "Kiss of Death",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Kiss of Death deals 4 damage to target opponent or planeswalker. You gain 4 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponentOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"I'd sooner lock lips with a viper. At least I might walk away from *that*.\"\n—Elvish scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf6832c1-a0a9-49ec-a787-879e510aee08.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lurking Nightstalker
+{
+    "name": "Lurking Nightstalker",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Nightstalker",
+    "oracleText": "Whenever this creature attacks, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Kev Walker",
+        "flavorText": "The shadows know.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/002715a3-b84f-40ba-8fa9-6b2854626f4d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lynx
+{
+    "name": "Lynx",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Rebecca Guay",
+        "flavorText": "Rarely seen, hardly heard, never caught.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e8648e1-bc40-4eff-ad7b-ab0b62a47570.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Magma Giant
 {
     "name": "Magma Giant",
@@ -386,6 +1411,84 @@
     ]
 }
 
+// Moaning Spirit
+{
+    "name": "Moaning Spirit",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Rebecca Guay",
+        "flavorText": "The dead sing their own lullabies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdd99210-5201-4ecc-b86a-aee9dafe2657.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nightstalker Engine
+{
+    "name": "Nightstalker Engine",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Nightstalker",
+    "oracleText": "Nightstalker Engine's power is equal to the number of creature cards in your graveyard.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "creature"
+            }
+        },
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "RARE",
+        "artist": "Mark Tedin",
+        "flavorText": "Part metal, part bone, and all death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Norwood Archers
+{
+    "name": "Norwood Archers",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Reach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"'Air superiority?' Not while our archers scan the skies.\"\n—Elvish scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c545fa63-d0dd-422b-8d3b-88b444f13fce.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Norwood Ranger
 {
     "name": "Norwood Ranger",
@@ -400,6 +1503,76 @@
         "artist": "Ron Spencer",
         "flavorText": "Some trees bear deadly fruit.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/5/c557c0c2-eb0f-4a9d-9192-577a684b3426.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Norwood Riders
+{
+    "name": "Norwood Riders",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf",
+    "oracleText": "This creature can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"Trade my moose? Sure—when I find a *horse* that can spear ten goblins at a time!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/904ba8db-853e-4f51-acfe-83e472524380.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Norwood Warrior
+{
+    "name": "Norwood Warrior",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Whenever this creature becomes blocked, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"The woods hold peace for those who desire it, but those who seek battle will find me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f7ddf0a-1081-4ae0-ab91-b052153bab4c.jpg"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -421,6 +1594,78 @@
         "artist": "David A. Cherry",
         "flavorText": "After a while, ships stopped sailing within his reach.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg?1783946462"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ogre Arsonist
+{
+    "name": "Ogre Arsonist",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Ogre",
+    "oracleText": "When this creature enters, destroy target land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "Jeffrey R. Busch",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b67e28b2-9d25-4873-8db2-1f0853ab0c47.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ogre Berserker
+{
+    "name": "Ogre Berserker",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Ogre Berserker",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "David A. Cherry",
+        "flavorText": "The machine does the growling, so the ogre's free to smile.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6969d4d-c311-4663-bcd6-77a4d6458335.jpg"
     },
     "colorIdentityOverride": [
         "RED"
@@ -491,6 +1736,67 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Prowling Nightstalker
+{
+    "name": "Prowling Nightstalker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Nightstalker",
+    "oracleText": "This creature can't be blocked except by black creatures.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedExceptBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "BLACK"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Keith Parkinson",
+        "flavorText": "Silent as a serpent, twisted as a lone bog tree, evil as Tojira's heart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/749e3992-693b-4b4f-b410-b5f2faac0040.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Raiding Nightstalker
+{
+    "name": "Raiding Nightstalker",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Nightstalker",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Pete Venters",
+        "flavorText": "\"Our steeds need food, water, stabling. Theirs just need prey.\"\n—Restela, Alaborn marshal",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0df2887c-e70b-4ff3-a437-450c0037fb07.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -616,6 +1922,295 @@
     ]
 }
 
+// Razorclaw Bear
+{
+    "name": "Razorclaw Bear",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "Whenever this creature becomes blocked, it gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "RARE",
+        "artist": "Heather Hudson",
+        "flavorText": "One razorclaw is three bears too many.\n—Elvish saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Remove
+{
+    "name": "Remove",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "DiTerlizzi",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/adb08549-8ff8-410f-b817-0255abaf8b1e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Righteous Charge
+{
+    "name": "Righteous Charge",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +2/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Jeffrey R. Busch",
+        "flavorText": "\"Bravery shines brightest in a pure soul.\"\n—Restela, Alaborn marshal",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f7bd958-20c7-4394-8beb-06b32db90d32.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// River Bear
+{
+    "name": "River Bear",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "UNCOMMON",
+        "artist": "Una Fricker",
+        "flavorText": "The bears had been isolated on an island for hundreds of years, until the island sank and the bears didn't.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8508e3b-a934-4795-a2df-07e792f2685f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Screeching Drake
+{
+    "name": "Screeching Drake",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Anson Maddocks",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c16faac-b093-425b-b1e9-f71602d2f6dd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sea Drake
+{
+    "name": "Sea Drake",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, return two target lands you control to their owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "filter": {
+                        "baseFilter": "land ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d87a40cb-b30d-41ce-8e11-5fe3136fdadd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sleight of Hand
 {
     "name": "Sleight of Hand",
@@ -682,6 +2277,220 @@
     ]
 }
 
+// Steam Catapult
+{
+    "name": "Steam Catapult",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{T}: Destroy target tapped creature. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature tapped"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Mark Tedin",
+        "flavorText": "\"You idiots! Turn it around! Turn it around!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdbf23ff-e095-4c5c-afe6-76badfc422c5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Steam Frigate
+{
+    "name": "Steam Frigate",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "This creature can't attack unless defending player controls an Island.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "DefendingPlayer",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Mark Tedin",
+        "flavorText": "\"Is it merchants or is it pirates?\"\n\"It's Talas—there's no difference.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec3193cb-2c00-4ef8-bf2e-d3b1e3b875a3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Swarm of Rats
+{
+    "name": "Swarm of Rats",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "Swarm of Rats's power is equal to the number of Rats you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent Rat"
+            }
+        },
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f154e89e-bb64-4579-9ff5-f3fc1c480105.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sylvan Yeti
+{
+    "name": "Sylvan Yeti",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Yeti",
+    "oracleText": "Sylvan Yeti's power is equal to the number of cards in your hand.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Hand"
+            }
+        },
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "RARE",
+        "artist": "Brom",
+        "flavorText": "The deeper the wood, the greater its strength.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a8686e2-1e14-4b4a-b45b-cab4d5c57fce.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Talas Air Ship
+{
+    "name": "Talas Air Ship",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Mark Tedin",
+        "flavorText": "\"Their ships pollute our air as they themselves pollute our forest.\"\n—Arathel, elvish queen",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80bc3159-f585-45cd-8578-f3bf2fa9b2d1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Talas Explorer
+{
+    "name": "Talas Explorer",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Pirate Scout",
+    "oracleText": "Flying\nWhen this creature enters, look at target opponent's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LookAtTargetHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Douglas Shuler",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64f184c9-a716-4ba8-8efa-495358660de5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Talas Merchant
 {
     "name": "Talas Merchant",
@@ -699,6 +2508,247 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Talas Researcher
+{
+    "name": "Talas Researcher",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Pirate Wizard",
+    "oracleText": "{T}: Draw a card. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Kaja Foglio",
+        "flavorText": "From time, knowledge.\nFrom knowledge, power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Talas Scout
+{
+    "name": "Talas Scout",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Pirate Scout",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Heather Hudson",
+        "flavorText": "\"Scouting a battle before you fight it is just good business.\"\n—Jefan, Talas ship captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48e12f17-855e-47e0-b7e3-df5c388b01bb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Talas Warrior
+{
+    "name": "Talas Warrior",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Human Pirate Warrior",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "RARE",
+        "artist": "Douglas Shuler",
+        "flavorText": "The sea is in their blood. Literally.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Temple Acolyte
+{
+    "name": "Temple Acolyte",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature enters, you gain 3 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Lubov",
+        "flavorText": "Young, yes. Inexperienced, yes. Weak? Don't count on it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7be7cba2-5673-4bef-aa3d-cbfad8932610.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Temple Elder
+{
+    "name": "Temple Elder",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: You gain 1 life. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "David Horne",
+        "flavorText": "\"Give us breath. Give us life. Prepare us for the day we make.\"\n—The Alaborn \"Rite of Battle\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db4d4b14-d774-430c-a483-be04a238718d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Town Sentry
+{
+    "name": "Town Sentry",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature blocks, it gets +0/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Bradley Williams",
+        "flavorText": "\"So he gots a sword. Big deal.\"\n\"Yeah, it's a big deal—it's a big sword!\"\n—Two goblins outside the gates of Trokin",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5e9db36-0592-4e59-951a-d9d6c1522b99.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tree Monkey
+{
+    "name": "Tree Monkey",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Monkey",
+    "oracleText": "Reach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Una Fricker",
+        "flavorText": "\"They serve the world best on a platter with shallots and onions.\"\n—Talas sailor",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c60bbbf7-a005-4b4b-b8e4-e95bbb67f529.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -856,5 +2906,80 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Wild Ox
+{
+    "name": "Wild Ox",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Ox",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "UNCOMMON",
+        "artist": "Jeffrey R. Busch",
+        "flavorText": "It has the run of the swamps, and it knows it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c5a7890-86dc-4fb8-a47b-99331bbe7c29.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wildfire
+{
+    "name": "Wildfire",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player sacrifices four lands of their choice. Wildfire deals 4 damage to each creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "land",
+                    "count": 4,
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Rob Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b69cfcb0-db68-4494-a3e1-7c2ca279fcf5.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -1000,6 +1000,47 @@
     ]
 }
 
+// Undo
+{
+    "name": "Undo",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return two target creatures to their owners' hands.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Terese Nielsen",
+        "flavorText": "\"Oft have I wished to undo past deeds, but never did I imagine they would be undone for me.\"\n—Naimah, Femeref philosopher",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bef942e-9d17-4d40-a4c9-8be715e73a08.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vampiric Tutor
 {
     "name": "Vampiric Tutor",


### PR DESCRIPTION
Portal Second Age's ⚡ Assay-ready count goes **63 → 0**, measured on this branch with `just assay-ready P02` (never inferred). Every card was authored to `oracle-assay compile`'s JSON — the exact SDK model Argentum Assay's grammar builds — rather than to the printed oracle text.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 55 | canonical authored in P02 — this set is the earliest real printing |
| `elsewhere` | 1 | **Undo** — canonical authored in `vis/` (Visions, 1996), `Printing` row here |
| `row-only` | 2 | **Goblin War Strike** (canonical in SCG), **Hidden Horror** (canonical in WTH) |
| `basic` | 5 | Plains/Island/Swamp/Mountain/Forest — a `basicLand(...)` val each, 3 art variants (151–165), never a `Printing` row |

**Reprint tail:** 18 generated `Printing` rows across 8 sets — S99 ×11, and one each in 8ED, DDF, GTC, MH2, P02, PC2, USG. These only become visible once the canonical exists, so they belong in this PR. The P02 row is Undo's own, owed because its canonical went to VIS. `generate-reprints.py` was scoped with `--since main` (a bare run would have offered the whole corpus's backlog), and the printing caches were refreshed first — a cache past its 30-day TTL is skipped **silently**, and all 56 were refreshed to make the count trustworthy.

## Verification

| Gate | Result |
|---|---|
| `just build` | green |
| `just rebless-cards` | only P02 (+55 cards) and VIS (+1) moved; **0 pre-existing cards changed, 0 removed** (checked per-card, not by line count) |
| `CardDefinitionSnapshotTest` P02 + VIS | PASSED (tree match and JSON round-trip) |
| `FacadeBoundaryTest` | PASSED |
| `just assay-differential` | **5737 → 5793 compared, 5686 → 5742 confirmed, divergent unchanged at 51** — +56 cards, **zero new divergences**. None of the 51 is a P02 or VIS card; all are pre-existing. |
| `just check-card-printing` ×56 | **56/56 `ok`** — canonical in the earliest real printing, all scaffolded reprints rowed |
| `just assay-ready P02` on the branch | `0 Assay-ready` (30 declined remain — grammar work, not authoring work) |
| `:mtg-sets:1993-1999:tests` | 1037 passed |

## Capability pre-flight

Run *before* authoring, because a `Keyword.X` existing is not the engine reading it. All 15 SDK types this batch touches were traced to a live `rules-engine` consumer — **none is inert**:

`YouWereAttackedThisStep` → `ConditionEvaluator:1672` · `CastRestriction.OnlyIfCondition` / `OnlyDuringStep` → `CastSpellHandler` + `CastPermissionUtils` · `ActivationRestriction.BeforeStep` / `OnlyDuringYourTurn` → `ActivateAbilityHandler` · `CantAttackUnless` → `AttackRestrictionRules.CantAttackUnlessDefenderRule` · `CantBeBlockedByMoreThan` → `BlockPhaseManager` · `CantBeBlockedExceptBy` → `BlockEvasionRules` · `LookAtTargetHandEffect` → `LookAtTargetHandExecutor` · `ForceSacrifice`/`Sacrifice` → their executors · `Gated` → `GatedEffectExecutor` · `AggregateBattlefield`/`Count`/`Multiply` → `DynamicAmountEvaluator` · the `GatherCards`/`SelectFromCollection`/`MoveCollection` pipeline → its three executors.

No new SDK vocabulary was needed, so `docs/card-sdk-language-reference.md` is unchanged.

## Findings the sweep surfaced

- **`CantAttackUnless` is honoured only when *printed* and self-scoped.** `AttackRestrictionRules` reads `cardDef.staticAbilities` straight off the `CardRegistry` and filters to `Scope.Self` — it is the only `filterIsInstance<CantAttackUnless>()` site in the engine. A lord-shaped filter or a floating grant compiles and silently does nothing. The two cards here (Armored Galleon, Steam Frigate) are the supported printed self-scope shape. Contrast `CantBeBlockedByMoreThan`, which `BlockPhaseManager` checks in *both* the printed and granted forms. Not fixed here — it is `add-feature` territory and no shipped card depends on the broken shape.
- **`YouWereAttackedThisStep` is resolution-only and defender-scoped**, and had **zero** scenario tests despite four cards using it (Rally the Troops, and three PTK cards). It checks "creatures are attacking *you* right now", not a this-turn history flag, so it must be paired with `castOnlyDuring(DECLARE_ATTACKERS)` — which Just Fate and Remove both do. Reusing it in a `ConditionalStaticAbility` would read false under projection.
- **`CastOnlyIfCondition` and `ActivationOnlyIfCondition` are `@SerialName`s that differ from their Kotlin symbols** (`CastRestriction.OnlyIfCondition`, and its activation sibling). Pattern-matching Assay JSON against SDK class names silently misses these two.
- **`Count` over a zone and `AggregateBattlefield` are two different `DynamicAmount` shapes**, and `DynamicAmounts.zone(...).count()` builds a third (`AggregateZone`) that does not match what Assay reads. The four CDA cards here needed `DynamicAmounts.creatureCardsInYourGraveyard()` / `cardsInYourHand()` for the `Count` shape and `DynamicAmounts.battlefield(...).count()` for the aggregate.
- **Swarm of Rats confirms "a bare tribal noun is permanents"** — its compiled filter is `IsPermanent` + `HasSubtype(Rat)`, not `IsCreature`.

## Flaky tests, not regressions

Two failures appeared in a full-suite run under heavy machine load and **both pass in isolation on this branch**; `:ai:test` also passes on clean `main`:

- `ArenaHarnessTest` — first the hard-timeout watchdog halted the JVM (exit 13) after the test ran **305.5s against a 300s cap**; on a second loaded run a different test in the class failed a parallel-vs-sequential determinism assert. The arena's deck pool is `setCode = "POR"`, and this PR adds no POR card, so the decks are byte-identical to main's. Passes clean when run alone.
- `AbuJafarTest > blocking and dying destroys the attacker it blocked` — a `TimeoutCancellationException` (Arabian Nights, untouched here). Passes clean when run alone.

Neither is caused by this change, and neither is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011t4ACR3xEHhbxzLG1GopQj