### PR TITLE
Fix Balefire Dragon's board sweep never finding the damaged player's creatures

### DIFF
--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BalefireDragonScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BalefireDragonScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Balefire Dragon — "Whenever this creature deals combat damage to a player, it deals that much
+ * damage to each creature that player controls."
+ *
+ * The sweep is scoped by `ControllerPredicate.ControlledByReferencedPlayer(Player.TriggeringPlayer)`,
+ * and the damaged player rides on the trigger's `triggeringEntityId` (a self-bound damage trigger
+ * sets no distinct `triggeringPlayerId`) — so the filter has to resolve that reference the same way
+ * the effect-side resolver does, or the board sweep silently hits nothing.
+ */
+class BalefireDragonScenarioTest : FunSpec({
+
+    test("connecting with a player sweeps that player's creatures for the damage dealt") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+
+        val dragon = d.putCreatureOnBattlefield(attacker, "Balefire Dragon")
+        d.removeSummoningSickness(dragon)
+
+        // Two creatures for the defender (swept) and one for the attacker (untouched).
+        d.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        d.putCreatureOnBattlefield(defender, "Runeclaw Bear")
+        d.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(attacker, listOf(dragon), defender)
+        d.declareNoBlockers(defender)
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN) // combat damage, then the trigger resolves
+
+        d.getLifeTotal(defender) shouldBe 14
+        d.getGraveyardCardNames(defender).sorted() shouldBe listOf("Grizzly Bears", "Runeclaw Bear")
+        d.getCreatures(attacker).size shouldBe 2 // dragon + its own Bears survive
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1198,6 +1198,15 @@ class PredicateEvaluator {
         is EffectTarget.PlayerRef -> when (target.player) {
             Player.DefendingPlayer -> TargetResolutionUtils
                 .defendingPlayerOfAttacker(state, context.sourceId)
+            // "…deals combat damage to a player, [that player] …" (Balefire Dragon). A self-bound
+            // damage trigger carries the damaged player on `triggeringEntityId` and sets no
+            // distinct `triggeringPlayerId` (see DamageTriggerDetector), which is exactly the
+            // fallback TargetResolutionUtils.resolvePlayerTarget and the sibling
+            // ControlledByTriggeringPlayer / OwnedByTriggeringPlayer predicates already apply.
+            // PredicateContext can't do it alone — it has no state to tell a player id from a
+            // creature's — so the turn-order guard lives here.
+            Player.TriggeringPlayer ->
+                context.triggeringEntityId?.takeIf { it in state.turnOrder }
             else -> null
         }
         else -> null


### PR DESCRIPTION
## The bug

Balefire Dragon connects, the player loses 6 life, and then… nothing. Not one of that player's creatures takes damage.

## Root cause

The sweep is scoped by a controller predicate:

```kotlin
GameObjectFilter.Creature.targetPlayerControls(
    EffectTarget.PlayerRef(Player.TriggeringPlayer)
)   // -> ControllerPredicate.ControlledByReferencedPlayer
```

A **self-bound** damage trigger carries the damaged player on the trigger context's `triggeringEntityId` and leaves `triggeringPlayerId` null — `DamageTriggerDetector` says so in a comment, and only its `sourceFilter` branch (Fear of Burning Alive) copies the recipient into `triggeringPlayerId`.

Every other reader of `Player.TriggeringPlayer` already compensates for that:

- `TargetResolutionUtils.resolvePlayerTarget` → `context.triggeringPlayerId ?: context.triggeringEntityId`
- `PredicateEvaluator`'s `ControlledByTriggeringPlayer` branch → same fallback
- `PredicateEvaluator`'s `OwnedByTriggeringPlayer` branch → same fallback

The `ControlledByReferencedPlayer` branch was the one that didn't. `PredicateContext.resolvePlayerTarget` returned null for `PlayerRef(TriggeringPlayer)`, the predicate failed closed for every candidate, and the `ForEachInGroupEffect` iterated an empty set. A textbook dispatch fallthrough — the sibling cases were fixed, this one was missed.

## The fix

Resolved in `resolveReferencedPlayerFromState` — the state-aware fallback `ControlledByReferencedPlayer` already consults, and which already carries a `PlayerRef` branch for `Player.DefendingPlayer`. Putting it there rather than in `PredicateContext` matters: the fallback returns `triggeringEntityId`, which for other damage triggers is a *creature*, and only a state-aware site can guard it with `it in state.turnOrder`. `PredicateContext` has no `GameState` and could not make that check.

`PredicateContext.resolvePlayerTarget` has exactly one caller (this predicate), so the change is scoped to it.

## Blast radius

Two cards in the corpus put `PlayerRef(Player.TriggeringPlayer)` inside a controller predicate: Balefire Dragon (fixed here) and Fear of Burning Alive (already worked, via the `sourceFilter` detector branch that sets `triggeringPlayerId`). Every other `PlayerRef(Player.TriggeringPlayer)` in the corpus is an *effect target*, which travels the already-correct `TargetResolutionUtils` path.

## Test

New `BalefireDragonScenarioTest` — the dragon attacks unblocked, deals 6 to the defender, both of that player's creatures die, and the attacker's own Grizzly Bears survives (proving the sweep is scoped to the damaged player and not the board). It fails on `main` with an empty defender graveyard.

## Verification

`just test-rules` — green (engine tests plus the full card scenario suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UewknN7Kn4HHnkdqtB5Jxa