### PR TITLE
Apply Devour as-enters to minted tokens (Momir Basic)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -506,6 +506,32 @@ data class DevourEntersContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the player selects permanents to sacrifice for Devour on a token minted from a
+ * bare card definition (CR 702.82) — the Momir Basic avatar's random-creature token.
+ *
+ * The sibling of [DevourEntersContinuation] for the path where nothing was ever cast. There is no
+ * entity to hang the pause on: the token does not exist yet, because devour is an as-enters
+ * replacement (CR 614) and a devour creature is typically a 0/0 that state-based actions would bin
+ * on arrival if it were placed first and counted afterwards. So the decision is raised *before*
+ * the mint, keyed by the chosen [cardDefinitionId], and the resumer re-enters
+ * [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition.mint] with the resulting
+ * counter count so the token enters already carrying it.
+ *
+ * @property cardDefinitionId Name of the definition the token will copy
+ * @property controllerId The player creating (and controlling) the token
+ * @property multiplier Counters placed per sacrificed permanent
+ * @property counterType Serialized counter type (string form of [com.wingedsheep.sdk.scripting.events.CounterTypeFilter])
+ */
+@Serializable
+data class DevourMintedTokenContinuation(
+    override val decisionId: String,
+    val cardDefinitionId: String,
+    val controllerId: EntityId,
+    val multiplier: Int,
+    val counterType: String
+) : ContinuationFrame
+
+/**
  * Resume after player chooses a budget modal combination (e.g., Season cycle pawprint modes).
  *
  * The executor pre-computes all valid combinations of modes that fit within the budget

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -272,6 +272,7 @@ val engineSerializersModule = SerializersModule {
         subclass(RevealCountersContinuation::class)
         subclass(ExileCountersContinuation::class)
         subclass(DevourEntersContinuation::class)
+        subclass(DevourMintedTokenContinuation::class)
         subclass(CastWithCreatureTypeContinuation::class)
         subclass(CastModalModeSelectionContinuation::class)
         subclass(CastModalTargetSelectionContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -41,6 +41,7 @@ class ModalAndCloneContinuationResumer(
         resumer(RevealCountersContinuation::class, ::resumeRevealCounters),
         resumer(ExileCountersContinuation::class, ::resumeExileCounters),
         resumer(DevourEntersContinuation::class, ::resumeDevourEnters),
+        resumer(DevourMintedTokenContinuation::class, ::resumeDevourMintedToken),
         resumer(CastWithCreatureTypeContinuation::class, ::resumeCastWithCreatureType),
         resumer(BudgetModalContinuation::class, ::resumeBudgetModal),
         resumer(CreateTokenCopyOfChosenContinuation::class, ::resumeCreateTokenCopyOfChosen),
@@ -1254,24 +1255,9 @@ class ModalAndCloneContinuationResumer(
         val events = mutableListOf<GameEvent>()
 
         // Sacrifice the chosen permanents.
-        if (sacrificed.isNotEmpty()) {
-            val names = sacrificed.map { id ->
-                newState.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
-            }
-            events.add(
-                com.wingedsheep.engine.core.PermanentsSacrificedEvent(
-                    controllerId, sacrificed, names
-                )
-            )
-            newState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                .trackPermanentSacrifice(newState, sacrificed, controllerId)
-            for (permanentId in sacrificed) {
-                val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .moveToZone(newState, permanentId, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
-                newState = result.state
-                events.addAll(result.events)
-            }
-        }
+        val (afterSacrifice, sacrificeEvents) = sacrificeForDevour(newState, controllerId, sacrificed)
+        newState = afterSacrifice
+        events.addAll(sacrificeEvents)
 
         // Place counters on the still-resolving spell entity.
         val counterCount = sacrificed.size * continuation.multiplier
@@ -1330,6 +1316,91 @@ class ModalAndCloneContinuationResumer(
         )
 
         return checkForMore(newState, events)
+    }
+
+    /**
+     * Sacrifice the permanents a player chose for a Devour as-enters replacement (CR 702.82,
+     * CR 701.21 — each goes to its owner's graveyard), emitting the sacrifice event and every
+     * zone-change event the moves produce.
+     *
+     * Shared by both devour entry paths — a permanent cast as a spell ([resumeDevourEnters]) and a
+     * token minted from a bare definition ([resumeDevourMintedToken]) — so the two cannot drift
+     * apart on what a devour sacrifice emits.
+     */
+    private fun sacrificeForDevour(
+        state: GameState,
+        controllerId: EntityId,
+        sacrificed: List<EntityId>,
+    ): Pair<GameState, List<GameEvent>> {
+        if (sacrificed.isEmpty()) return state to emptyList()
+        val events = mutableListOf<GameEvent>()
+        val names = sacrificed.map { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
+        }
+        events.add(
+            com.wingedsheep.engine.core.PermanentsSacrificedEvent(controllerId, sacrificed, names)
+        )
+        var newState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+            .trackPermanentSacrifice(state, sacrificed, controllerId)
+        for (permanentId in sacrificed) {
+            val result = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                .moveToZone(newState, permanentId, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
+            newState = result.state
+            events.addAll(result.events)
+        }
+        return newState to events
+    }
+
+    /**
+     * Resume after the player selects permanents to sacrifice for Devour on a token minted from a
+     * bare card definition — the Momir Basic avatar's random-creature token.
+     *
+     * The token does not exist yet: devour is an as-enters replacement (CR 614), and a devour
+     * creature is usually a 0/0, so the decision was raised *before* the mint rather than after.
+     * Sacrifices the picks, then re-enters
+     * [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition.mint] with the earned
+     * counter count so the token enters already carrying it — and its ETB triggers, fired by the
+     * caller off the mint's zone-change event, see the final power.
+     */
+    fun resumeDevourMintedToken(
+        state: GameState,
+        continuation: DevourMintedTokenContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card selection response for devour")
+        }
+        val cardDef = services.cardRegistry.getCard(continuation.cardDefinitionId)
+            ?: return ExecutionResult.error(
+                state, "Card definition not found: ${continuation.cardDefinitionId}"
+            )
+
+        val (afterSacrifice, sacrificeEvents) = sacrificeForDevour(
+            state, continuation.controllerId, response.selectedCards
+        )
+
+        val minted = com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition.mint(
+            state = afterSacrifice,
+            cardDef = cardDef,
+            controllerId = continuation.controllerId,
+            cardRegistry = services.cardRegistry,
+            staticAbilityHandler = com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler(
+                services.cardRegistry
+            ),
+            devourCounters = response.selectedCards.size * continuation.multiplier,
+        ).toExecutionResult()
+
+        // The mint can pause again (a devour creature that also has an as-enters choice); carry the
+        // sacrifice events across that pause so they are not lost.
+        if (minted.isPaused) {
+            return ExecutionResult.paused(
+                minted.state,
+                minted.pendingDecision!!,
+                sacrificeEvents + minted.events
+            )
+        }
+        return checkForMore(minted.state, sacrificeEvents + minted.events)
     }
 
     private fun resolveCounterTypeFromString(counterType: String): com.wingedsheep.sdk.core.CounterType? {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -31,6 +31,7 @@ import com.wingedsheep.sdk.scripting.CardNamePool
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersWithDevour
 import com.wingedsheep.sdk.scripting.OnEnterRunEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.references.Player
@@ -49,7 +50,7 @@ import com.wingedsheep.sdk.scripting.references.Player
  *    (sharing this object's [onEnterRunEffectFor] lookup).
  *  - [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition] — a token minted from a
  *    card definition (e.g. the Momir Basic avatar's random-creature token).
- *    [pauseForEntersWithChoice] only.
+ *    [pauseForEntersWithChoice] and [devourSacrificeCandidates].
  *  - [com.wingedsheep.engine.handlers.effects.zones.MoveToZoneEffectExecutor] — a card put onto
  *    the battlefield by an effect (reanimation, a blink or earthbend return from exile).
  *    [runOnEnterRunEffect] only.
@@ -120,6 +121,37 @@ object PermanentEntryReplacements {
      * [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] and [runOnEnterRunEffect]
      * cannot drift apart on it.
      */
+    /**
+     * The permanents [controllerId] may sacrifice for a Devour as-enters replacement (CR 702.82) —
+     * every battlefield permanent they *currently* control matching [devour]'s sacrifice filter,
+     * minus the entering object itself.
+     *
+     * Control is read off the projected state so an opponent's Act of Treason on one of your lands
+     * removes it from the pool (CR 701.21a: you can only sacrifice permanents you control). The
+     * filter match is likewise projected, per the project's battlefield-filter rule.
+     *
+     * Shared by the two entry paths that can meet a devour permanent: a spell resolving off the
+     * stack ([com.wingedsheep.engine.mechanics.stack.StackResolver], where [enteringId] is the
+     * spell entity) and a token minted from a bare definition
+     * ([com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition], where the token does
+     * not exist yet and [enteringId] is null).
+     */
+    fun devourSacrificeCandidates(
+        state: GameState,
+        controllerId: EntityId,
+        devour: EntersWithDevour,
+        enteringId: EntityId?,
+    ): List<EntityId> {
+        val predicateContext = PredicateContext(controllerId = controllerId, sourceId = enteringId)
+        return state.getBattlefield().filter { entityId ->
+            if (entityId == enteringId) return@filter false
+            if (state.projectedState.getController(entityId) != controllerId) return@filter false
+            predicateEvaluator.matches(
+                state, state.projectedState, entityId, devour.sacrificeFilter, predicateContext
+            )
+        }
+    }
+
     fun onEnterRunEffectFor(cardDef: CardDefinition?): OnEnterRunEffect? =
         cardDef?.script?.replacementEffects
             ?.filterIsInstance<OnEnterRunEffect>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -1,7 +1,11 @@
 package com.wingedsheep.engine.handlers.effects.token
 
 import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DevourMintedTokenContinuation
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
@@ -22,6 +26,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithDevour
 
 /**
  * Mints a token that is a copy of a bare [CardDefinition] — one not instantiated in any zone —
@@ -50,27 +55,81 @@ import com.wingedsheep.sdk.scripting.EntersTapped
  *  - **[EntersWithChoice]** (Alloy Golem, "as this enters, choose a color") pauses for a player
  *    decision via [PermanentEntryReplacements]; the chosen value is recorded in
  *    `CastChoicesComponent` and the token's ETB triggers fire from the resumer afterward.
+ *  - **[EntersWithDevour]** (Predator Dragon's devour, Famished Worldsire's devour land) pauses
+ *    for the controller to pick what to sacrifice — see [mint]'s `devourCounters` parameter for
+ *    why that pause happens *before* the token is placed.
  *
  * "When ~ enters" *triggered* abilities fire off the emitted [ZoneChangeEvent] (when there is no
  * choice) or from the [EntersWithChoiceOnBattlefieldContinuation] resumer (when a choice paused —
  * we deliberately omit the [ZoneChangeEvent] in that case so the triggers aren't detected twice).
  *
- * (Rarer as-enters replacements that pause for their own decision — Amplify reveal, Devour
- * sacrifice, EntersAsCopy — are not applied to minted tokens; a minted copy of such a creature
- * simply enters with zero amplify/devour counters. They are vanishingly rare in a random-creature
- * pool and would require generalizing their spell-keyed continuations.)
+ * (The remaining as-enters replacements that pause for their own decision — Amplify reveal,
+ * EntersAsCopy — are still not applied to minted tokens; a minted copy of such a creature simply
+ * enters with zero amplify counters. They would require generalizing their spell-keyed
+ * continuations the way devour's was.)
  */
 object TokenFromDefinition {
 
     private val conditionEvaluator = ConditionEvaluator()
 
+    /**
+     * @param devourCounters counters already earned by a Devour as-enters replacement (CR 702.82),
+     *   or `null` when devour has not been resolved yet. Devour asks its question *before* the
+     *   token exists rather than after: a devour creature is typically a 0/0 (Famished Worldsire),
+     *   so placing the token first and counting the sacrifices afterwards would leave a 0/0 on the
+     *   battlefield across a player decision for state-based actions to bin. The first call
+     *   therefore pauses on [DevourMintedTokenContinuation], and its resumer calls back in with
+     *   the multiplied count — placed alongside the token's printed enters-with counters, before
+     *   its ETB triggers can see it. A definition with no devour never pauses and this stays null.
+     */
     fun mint(
         state: GameState,
         cardDef: CardDefinition,
         controllerId: EntityId,
         cardRegistry: CardRegistry,
         staticAbilityHandler: StaticAbilityHandler? = null,
+        devourCounters: Int? = null,
     ): EffectResult {
+        // As-enters: Devour (CR 702.82) and its variants, raised before the token is minted — see
+        // [devourCounters]. Skipped when the controller has nothing to sacrifice; devour then just
+        // adds no counters, which is also what choosing zero permanents does (CR 702.82a).
+        val devour = cardDef.script.replacementEffects.filterIsInstance<EntersWithDevour>().firstOrNull()
+        if (devourCounters == null && devour != null) {
+            val candidates = PermanentEntryReplacements.devourSacrificeCandidates(
+                state, controllerId, devour, enteringId = null
+            )
+            if (candidates.isNotEmpty()) {
+                val decisionId = "devour-minted-token-${cardDef.name}-${controllerId.value}"
+                val decision = SelectCardsDecision(
+                    id = decisionId,
+                    playerId = controllerId,
+                    prompt = "${devour.description.substringBefore(" (")}: sacrifice any number of " +
+                        "${devour.sacrificeFilter.description}s for ${cardDef.name}",
+                    context = DecisionContext(
+                        sourceId = null,
+                        sourceName = cardDef.name,
+                        phase = DecisionPhase.RESOLUTION
+                    ),
+                    options = candidates,
+                    minSelections = 0,
+                    maxSelections = candidates.size,
+                    useTargetingUI = true
+                )
+                val paused = state
+                    .pushContinuation(
+                        DevourMintedTokenContinuation(
+                            decisionId = decisionId,
+                            cardDefinitionId = cardDef.name,
+                            controllerId = controllerId,
+                            multiplier = devour.multiplier,
+                            counterType = devour.counterType.description
+                        )
+                    )
+                    .withPendingDecision(decision)
+                return EffectResult.paused(paused, decision)
+            }
+        }
+
         val (tokenId, stateWithId) = state.newEntity()
 
         // Token is owned and controlled by the player creating it.
@@ -120,10 +179,22 @@ object TokenFromDefinition {
         )
 
         // As-enters: the token's own + global "enters with counters" (CR 614).
-        val (stateWithCounters, counterEvents) = EntersWithReplacements.applyOnEntry(
+        val (stateWithCounters, entersWithEvents) = EntersWithReplacements.applyOnEntry(
             newState, tokenId, controllerId, cardRegistry
         )
         newState = stateWithCounters
+        val counterEvents = entersWithEvents.toMutableList()
+
+        // As-enters: the Devour counters earned by the sacrifice made before the mint. Routed
+        // through the same helper as the printed enters-with counters so placement modifiers
+        // (Hardened Scales, Solemnity) and the "a counter was placed this turn" tracker apply.
+        if (devour != null && devourCounters != null && devourCounters > 0) {
+            val (devourState, devourEvents) = EntersWithReplacements.placeEntryCounters(
+                newState, tokenId, devour.counterType, devourCounters, controllerId, cardDef.name
+            )
+            newState = devourState
+            counterEvents.addAll(devourEvents)
+        }
 
         // As-enters: "choose X as this enters" (CR 614.12). Pauses for a player decision; the
         // resumer records the choice and fires the token's ETB triggers off a synthesized

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1271,15 +1271,8 @@ class StackResolver(
             val devourEffect = cardDef.script.replacementEffects
                 .filterIsInstance<com.wingedsheep.sdk.scripting.EntersWithDevour>().firstOrNull()
             if (devourEffect != null) {
-                val predicateContext = PredicateContext(controllerId = controllerId, sourceId = spellId)
-                val candidates = state.getBattlefield().filter { entityId ->
-                    if (entityId == spellId) return@filter false
-                    // Use projected controller — control-changing effects (e.g. an opponent's
-                    // Act of Treason on one of your lands) must be respected; you can only
-                    // sacrifice permanents you currently control (CR 701.21a).
-                    if (state.projectedState.getController(entityId) != controllerId) return@filter false
-                    predicateEvaluator.matches(state, state.projectedState, entityId, devourEffect.sacrificeFilter, predicateContext)
-                }
+                val candidates = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                    .devourSacrificeCandidates(state, controllerId, devourEffect, enteringId = spellId)
 
                 if (candidates.isNotEmpty()) {
                     val devourLabel = devourEffect.description.substringBefore(" (")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
@@ -269,6 +269,118 @@ class MomirBasicScenarioTest : ScenarioTestBase() {
             game.state.projectedState.getColors(token) shouldContain "RED"
         }
 
+        test("a minted devour token prompts for the sacrifice and enters with the counters") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Predator Dragon")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardsInHand(1, "Forest", 2)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Runeclaw Bear")
+                .build()
+
+            // Predator Dragon is mana value 6: a 4/4 with "Devour 2".
+            game.execute(game.momirAction(xValue = 6)).error shouldBe null
+            game.resolveStack()
+
+            // As-enters replacement (CR 702.82): "As this creature enters, you may sacrifice any
+            // number of creatures. It enters with twice that many +1/+1 counters on it." The
+            // minted token must surface the sacrifice prompt — the bug was that it never did, so
+            // the token entered with no devour counters at all.
+            val decision = game.getPendingDecision()
+            decision.shouldNotBeNull()
+
+            val bears = listOf(game.findPermanent("Grizzly Bears")!!, game.findPermanent("Runeclaw Bear")!!)
+            game.selectCards(bears)
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Grizzly Bears").shouldBeTrue()
+            game.isInGraveyard(1, "Runeclaw Bear").shouldBeTrue()
+
+            val token = game.findPermanents("Predator Dragon").single()
+            // 4/4 base + 2 creatures x devour 2 = four +1/+1 counters -> 8/8.
+            game.state.projectedState.getPower(token) shouldBe 8
+            game.state.projectedState.getToughness(token) shouldBe 8
+        }
+
+        test("a minted devour token sacrificing nothing enters with no counters") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Predator Dragon")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardsInHand(1, "Forest", 2)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .build()
+
+            game.execute(game.momirAction(xValue = 6)).error shouldBe null
+            game.resolveStack()
+
+            // CR 702.82a: devour lets you sacrifice *any number*, zero included.
+            game.getPendingDecision().shouldNotBeNull()
+            game.skipSelection()
+            game.resolveStack()
+
+            game.isOnBattlefield("Grizzly Bears").shouldBeTrue()
+            val token = game.findPermanents("Predator Dragon").single()
+            game.state.projectedState.getPower(token) shouldBe 4
+            game.state.projectedState.getToughness(token) shouldBe 4
+        }
+
+        test("a minted devour token with nothing to sacrifice never prompts") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Predator Dragon")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withCardsInHand(1, "Forest", 2)
+                .build()
+
+            game.execute(game.momirAction(xValue = 6)).error shouldBe null
+            game.resolveStack()
+
+            // No creatures to devour -> no decision, and the token still enters (with no counters).
+            game.getPendingDecision() shouldBe null
+            val token = game.findPermanents("Predator Dragon").single()
+            game.state.projectedState.getPower(token) shouldBe 4
+        }
+
+        test("devour land on a minted token sacrifices lands and feeds its own ETB (Famished Worldsire)") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Famished Worldsire")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Forest", 8)
+                .withCardsInHand(1, "Mountain", 2)
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            // Famished Worldsire is mana value 8: a 0/0 with "Devour land 3".
+            game.execute(game.momirAction(xValue = 8)).error shouldBe null
+            game.resolveStack()
+
+            // The devour *land* variant offers lands, not creatures.
+            val decision = game.getPendingDecision()
+            decision.shouldNotBeNull()
+
+            val forests = game.findPermanents("Forest").take(2)
+            forests shouldHaveSize 2
+            game.selectCards(forests)
+            game.resolveStack()
+
+            val token = game.findPermanents("Famished Worldsire").single()
+            // 0/0 base + 2 lands x devour land 3 = six +1/+1 counters -> 6/6. Without the counters
+            // the token would be a 0/0 that state-based actions bin the moment it arrives.
+            game.state.projectedState.getPower(token) shouldBe 6
+            game.state.projectedState.getToughness(token) shouldBe 6
+            game.state.getZone(game.player1Id, Zone.GRAVEYARD).size shouldBe 3 // 2 Forests + the discard
+
+            // Its own ETB reads that power: "look at the top X cards of your library, where X is
+            // this creature's power" — so the trigger only has cards to offer because devour ran.
+            game.getPendingDecision().shouldNotBeNull()
+        }
+
         test("the random copy is filtered to the chosen mana value") {
             // Pool has a mana-value-1 and a mana-value-4 creature; X=1 must only ever pick the 1.
             val game = scenario()


### PR DESCRIPTION
Fixes devour land doing nothing for **Famished Worldsire** in Momir Basic.

## The bug

Devour (CR 702.82) was wired into exactly one entry path: a permanent *cast as a spell*, in `StackResolver`. A token minted from a bare `CardDefinition` — the Momir Basic avatar’s random creature — went through `TokenFromDefinition.mint`, which never applied it. `TokenFromDefinition`’s own KDoc wrote this off as vanishingly rare in a random-creature pool; it is not, because it is silently *worse* than "no counters":

- **Famished Worldsire** is a **0/0** with `Devour land 3`. With no devour counters it entered as a 0/0 and state-based actions binned it on arrival — and its own ETB ("look at the top X cards of your library, where X is this creature’s power") had nothing to look at.
- **Predator Dragon**, **Thunder-Thrash Elder**, **Caldera Hellion**, **Thorn-Thrash Viashino** just entered with no counters at all.

## The fix

`TokenFromDefinition.mint` now raises the devour decision **before** the token is placed rather than after. That ordering is the point: a devour creature is typically a 0/0, so minting first and counting the sacrifices afterwards would leave a 0/0 on the battlefield across a player decision for SBAs to bin.

Because nothing was cast and the token does not exist yet, the new `DevourMintedTokenContinuation` is keyed by the chosen **card definition** rather than by an entity — the sibling of `DevourEntersContinuation`, which keys off the spell entity. Its resumer sacrifices the picks and re-enters `mint` with the multiplied counter count, so the token arrives already carrying it, before its ETB triggers can read its power.

Two smaller things fall out:

- The devour counters go through `EntersWithReplacements.placeEntryCounters`, the same helper as the printed enters-with counters, so placement modifiers (Hardened Scales, Solemnity) and the "a counter was placed this turn" tracker apply.
- The candidate query and the sacrifice itself are now shared with the spell path — `PermanentEntryReplacements.devourSacrificeCandidates` and `ModalAndCloneContinuationResumer.sacrificeForDevour` — so the two entry paths cannot drift on what devour offers or what it emits.

Still not applied to minted tokens, and still noted as such: Amplify’s reveal and `EntersAsCopy`. Both would need the same generalization of their spell-keyed continuations.

## Tests

Four new cases in `MomirBasicScenarioTest`, in the shape of the existing Alloy Golem test (which fixed the same class of bug one replacement over):

- Predator Dragon prompts for the sacrifice, eats two creatures, enters 8/8.
- Sacrificing nothing is legal (CR 702.82a) and yields a plain 4/4.
- Nothing to sacrifice → no prompt at all, token still enters.
- Famished Worldsire’s **devour land** offers lands, enters 6/6 off two Forests, and its own ETB then has a power to read.

## Verification

- `just test-class MomirBasicScenarioTest` — 21/21 pass (the 17 pre-existing plus the 4 new).
- `just test-rules` — BUILD SUCCESSFUL (engine tests + every card scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HzvUXqSbN2vMy1bRQpWyX