### PR TITLE
Fix Archenemy's Charm's "one or two target" mode returning nothing

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3815,6 +3815,13 @@ Every `TargetRequirement` carries count semantics (defaults shown):
 
 - `count = 1` — maximum number of targets.
 - `minCount = count` — minimum; set below `count` for "one or two target creatures".
+- **A requirement spanning more than one slot has no single bound handle.** Whenever `count > 1`,
+  `unlimited = true`, or a `dynamicMaxCount` is set, the chosen targets occupy that many slots of
+  the flat target list and are keyed per slot (`id[0]`, `id[1]`, …), so the bare `target(name, …)`
+  handle resolves to nothing and any effect handed it silently does nothing. Read such a
+  requirement with `ForEachTargetEffect(listOf(<effect>(EffectTarget.ContextTarget(0))))` — the
+  body runs once per chosen target. `CardLinter.MultiSlotTargetBinding` fails the build on the
+  bare-handle shape.
 - `optional = false` — when `true`, minimum becomes 0 ("up to N target ..."). An activated ability
   whose controller-chosen requirements are **all** optional (e.g. Boom Box's "Destroy up to one target
   artifact, up to one target creature, and up to one target land") is legal to activate with an *empty*

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -884,6 +884,13 @@ object CardLinter {
         val label: String,
         val targetCount: Int,
         val targetIds: Set<String>,
+        /**
+         * The subset of [targetIds] whose requirement spans more than one slot of the flat chosen-
+         * target list ("two target creatures", "one or two target …", `unlimited`, a
+         * `dynamicMaxCount`). Such a requirement has no single bound handle: its targets are keyed
+         * per slot, so a bare `BoundVariable` on the id resolves to nothing at resolution.
+         */
+        val multiSlotTargetIds: Set<String>,
         /** Non-null for Mode scopes: collections resolve against this enclosing scope. */
         val collectionParent: Scope?,
     ) {
@@ -903,8 +910,10 @@ object CardLinter {
             label: String,
             targetCount: Int = 0,
             targetIds: Set<String> = emptySet(),
+            multiSlotTargetIds: Set<String> = emptySet(),
             collectionParent: Scope? = null,
-        ): Scope = Scope(label, targetCount, targetIds, collectionParent).also { scopes.add(it) }
+        ): Scope = Scope(label, targetCount, targetIds, multiSlotTargetIds, collectionParent)
+            .also { scopes.add(it) }
     }
 
     // =========================================================================================
@@ -963,6 +972,8 @@ object CardLinter {
                 requirementSlotCount(cleaveReqs),
             ),
             targetIds = requirementIds(baseReqs) + requirementIds(kickerReqs) + requirementIds(cleaveReqs),
+            multiSlotTargetIds = multiSlotRequirementIds(baseReqs) +
+                multiSlotRequirementIds(kickerReqs) + multiSlotRequirementIds(cleaveReqs),
         )
 
         // Spell-resolution scope, in execution order: cast-time writers (captures, additional
@@ -1031,15 +1042,38 @@ object CardLinter {
         // requirements (the engine slices the flat target list per mode only when modes
         // declare their own).
         val scope = if (reqs.isEmpty() && collectionParent != null) {
-            state.newScope(label, collectionParent.targetCount, collectionParent.targetIds, collectionParent)
+            state.newScope(
+                label, collectionParent.targetCount, collectionParent.targetIds,
+                collectionParent.multiSlotTargetIds, collectionParent,
+            )
         } else {
-            state.newScope(label, requirementSlotCount(reqs), requirementIds(reqs), collectionParent)
+            state.newScope(
+                label, requirementSlotCount(reqs), requirementIds(reqs),
+                multiSlotRequirementIds(reqs), collectionParent,
+            )
         }
         walkInto(obj, scope, state)
     }
 
     private fun requirementIds(reqs: JsonArray): Set<String> =
         reqs.mapNotNull { ((it as? JsonObject)?.get("id") as? JsonPrimitive)?.contentOrNull }.toSet()
+
+    /**
+     * Ids of the requirements that occupy more than one slot of the flat chosen-target list —
+     * `count > 1`, `unlimited`, or a `dynamicMaxCount`. [EffectContext.buildNamedTargets] keys
+     * those per slot (`id[0]`, `id[1]`, …) and leaves the bare `id` unmapped, so an effect handed
+     * the requirement's bound handle resolves to `null` and silently does nothing. Such a
+     * requirement is read with `ForEachTargetEffect` over `ContextTarget(0)` instead.
+     */
+    private fun multiSlotRequirementIds(reqs: JsonArray): Set<String> =
+        reqs.mapNotNull { req ->
+            val obj = req as? JsonObject ?: return@mapNotNull null
+            val id = (obj["id"] as? JsonPrimitive)?.contentOrNull ?: return@mapNotNull null
+            val unlimited = (obj["unlimited"] as? JsonPrimitive)?.contentOrNull == "true"
+            val dynamicMax = obj["dynamicMaxCount"]?.takeIf { it !is JsonNull } != null
+            val count = (obj["count"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull() ?: 1
+            id.takeIf { unlimited || dynamicMax || count > 1 }
+        }.toSet()
 
     /**
      * Number of `ContextTarget` indices a requirement list spans. `ContextTarget(i)` indexes the
@@ -1154,9 +1188,12 @@ object CardLinter {
             }
         )
         val child = if (reqs.isEmpty()) {
-            state.newScope(label, scope.targetCount, scope.targetIds, scope)
+            state.newScope(label, scope.targetCount, scope.targetIds, scope.multiSlotTargetIds, scope)
         } else {
-            state.newScope(label, requirementSlotCount(reqs), requirementIds(reqs), collectionParent = scope)
+            state.newScope(
+                label, requirementSlotCount(reqs), requirementIds(reqs),
+                multiSlotRequirementIds(reqs), collectionParent = scope,
+            )
         }
         obj[effectField]?.let { walk(it, child, state) }
     }
@@ -1380,6 +1417,19 @@ object CardLinter {
                 }
                 if (ref.boundName != null) {
                     val base = ref.boundName.substringBefore('[')
+                    if (base in scope.multiSlotTargetIds && base == ref.boundName) {
+                        state.findings.add(
+                            CardValidationError.MultiSlotTargetBinding(
+                                cardName = state.cardName,
+                                message = "'${state.cardName}' (${scope.label}): " +
+                                    "${ref.nodeType} reads BoundVariable('${ref.boundName}'), but that " +
+                                    "target requirement spans more than one slot of the chosen-target " +
+                                    "list, so the bare binding resolves to nothing and the effect " +
+                                    "silently does nothing. Read the targets one at a time with " +
+                                    "ForEachTargetEffect over EffectTarget.ContextTarget(0).",
+                            )
+                        )
+                    }
                     if (base !in scope.targetIds) {
                         state.findings.add(
                             CardValidationError.UnknownTargetBinding(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -268,6 +268,18 @@ sealed interface CardValidationError {
         override val message: String
     ) : CardValidationError
 
+    /**
+     * A bare `BoundVariable` read of a target requirement that spans more than one slot of the
+     * chosen-target list ("two target creatures", "one or two target …", `unlimited`, a
+     * `dynamicMaxCount`). Those targets are keyed per slot, so the bare binding resolves to nothing
+     * and the effect silently does nothing — read them with `ForEachTargetEffect` over
+     * `EffectTarget.ContextTarget(0)` instead.
+     */
+    data class MultiSlotTargetBinding(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
     /** A choice-slot read (`CastChoiceMade`, `HasChosenColor`, …) with no declaring ability. */
     data class UndeclaredChoiceSlotRead(
         override val cardName: String,

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardLinterTest.kt
@@ -260,6 +260,42 @@ class CardLinterTest : DescribeSpec({
             )
             CardLinter.lint(card).shouldBeEmpty()
         }
+
+        it("flags a bare BoundVariable on a multi-slot requirement") {
+            // "Return one or two target creature cards ... to your hand" handed straight to a
+            // single-target effect: the two chosen targets are keyed `cards[0]` / `cards[1]`, so
+            // the bare binding resolves to nothing and the spell silently does nothing.
+            val card = instant(
+                "Two At Once",
+                CardScript(
+                    spellEffect = DealDamageEffect(
+                        DynamicAmount.Fixed(2),
+                        EffectTarget.BoundVariable("cards"),
+                    ),
+                    targetRequirements = listOf(AnyTarget(id = "cards", count = 2, minCount = 1)),
+                ),
+            )
+            val findings = CardLinter.lint(card)
+            findings.shouldHaveSize(1)
+            findings[0].shouldBeInstanceOf<CardValidationError.MultiSlotTargetBinding>()
+                .message shouldContain "ForEachTargetEffect"
+        }
+
+        it("accepts a per-slot BoundVariable on a multi-slot requirement") {
+            val card = instant(
+                "Two At Once, Indexed",
+                CardScript(
+                    spellEffect = CompositeEffect(
+                        listOf(
+                            DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.BoundVariable("cards[0]")),
+                            DealDamageEffect(DynamicAmount.Fixed(1), EffectTarget.BoundVariable("cards[1]")),
+                        ),
+                    ),
+                    targetRequirements = listOf(AnyTarget(id = "cards", count = 2, minCount = 1)),
+                ),
+            )
+            CardLinter.lint(card).shouldBeEmpty()
+        }
     }
 
     describe("choice slots") {

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ArchenemysCharm.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ArchenemysCharm.kt
@@ -6,7 +6,9 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 
 /**
@@ -17,6 +19,12 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * • Exile target creature or planeswalker.
  * • Return one or two target creature and/or planeswalker cards from your graveyard to your hand.
  * • Put two +1/+1 counters on target creature you control. It gains lifelink until end of turn.
+ *
+ * Mode 2 is "one or two target" — a single requirement with min 1 / max 2 targets locked at cast
+ * (`TargetObject(count = 2, minCount = 1)`), then [ForEachTargetEffect] returns each chosen card.
+ * A multi-count requirement has no single bound handle to hand to a one-target effect: its chosen
+ * targets occupy `count` slots of the flat target list, and the per-target effect reads them one at
+ * a time through [EffectTarget.ContextTarget].
  */
 val ArchenemysCharm = card("Archenemy's Charm") {
     manaCost = "{B}{B}{B}"
@@ -31,8 +39,14 @@ val ArchenemysCharm = card("Archenemy's Charm") {
                 effect = Effects.Exile(target)
             }
             mode("Return one or two target creature and/or planeswalker cards from your graveyard to your hand") {
-                val targets = target("target creature and/or planeswalker cards", TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker, zone = Zone.GRAVEYARD), count = 2, minCount = 1))
-                effect = Effects.ReturnToHand(targets)
+                target = TargetObject(
+                    filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker, zone = Zone.GRAVEYARD),
+                    count = 2,
+                    minCount = 1
+                )
+                effect = ForEachTargetEffect(
+                    listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+                )
             }
             mode("Put two +1/+1 counters on target creature you control. It gains lifelink until end of turn") {
                 val target = target("target creature you control", Targets.CreatureYouControl)

--- a/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchenemysCharmScenarioTest.kt
+++ b/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchenemysCharmScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eoe.cards.ArchenemysCharm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Archenemy's Charm — {B}{B}{B} Instant, modal "Choose one —".
+ *
+ * Mode 1: exile target creature or planeswalker.
+ * Mode 2: return one or two target creature and/or planeswalker cards from your graveyard to hand.
+ * Mode 3: two +1/+1 counters on target creature you control; it gains lifelink until end of turn.
+ *
+ * Mode 2 is the regression: its "one or two target" requirement spans two slots of the flat target
+ * list, so the return has to run once per chosen slot ([ForEachTargetEffect] over
+ * `ContextTarget(0)`). Handing the requirement's bound handle to a single-target `ReturnToHand`
+ * resolved to nothing at all and the mode silently did nothing — with one card in the graveyard
+ * and with two.
+ */
+class ArchenemysCharmScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ArchenemysCharm)
+        return driver
+    }
+
+    test("Mode 2 — returns a single creature card from the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val dead = driver.putCardInGraveyard(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Archenemy's Charm")
+        driver.giveMana(me, Color.BLACK, 3)
+
+        val targets = listOf<ChosenTarget>(ChosenTarget.Card(dead, me, Zone.GRAVEYARD))
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHand(me).contains(dead) shouldBe true
+        driver.getGraveyard(me).contains(dead) shouldBe false
+    }
+
+    test("Mode 2 — returns two creature cards from the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val first = driver.putCardInGraveyard(me, "Centaur Courser")
+        val second = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(me, "Archenemy's Charm")
+        driver.giveMana(me, Color.BLACK, 3)
+
+        val targets = listOf<ChosenTarget>(
+            ChosenTarget.Card(first, me, Zone.GRAVEYARD),
+            ChosenTarget.Card(second, me, Zone.GRAVEYARD)
+        )
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHand(me).containsAll(listOf(first, second)) shouldBe true
+    }
+
+    test("Mode 2 — the mode is offered with a single legal target, min 1 / max 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val dead = driver.putCardInGraveyard(me, "Centaur Courser")
+        driver.putCardInHand(me, "Archenemy's Charm")
+        driver.giveMana(me, Color.BLACK, 3)
+
+        val action = driver.legalActions(me).single { it.description.startsWith("Return one or two") }
+        action.minTargets shouldBe 1
+        action.targetCount shouldBe 2
+        action.validTargets shouldBe listOf(dead)
+    }
+
+    test("Mode 1 — exiles target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Archenemy's Charm")
+        driver.giveMana(me, Color.BLACK, 3)
+
+        val targets = listOf<ChosenTarget>(ChosenTarget.Permanent(victim))
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getExile(opponent).contains(victim) shouldBe true
+    }
+
+    test("Mode 3 — two +1/+1 counters and lifelink until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val mine = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+
+        val spell = driver.putCardInHand(me, "Archenemy's Charm")
+        driver.giveMana(me, Color.BLACK, 3)
+
+        val targets = listOf<ChosenTarget>(ChosenTarget.Permanent(mine))
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, mine) shouldBe 5
+        projector.getProjectedToughness(driver.state, mine) shouldBe 5
+        driver.state.projectedState.hasKeyword(mine, com.wingedsheep.sdk.core.Keyword.LIFELINK) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -571,12 +571,16 @@
                 },
                 {
                     "effect": {
-                        "type": "MoveToZone",
-                        "target": {
-                            "type": "BoundVariable",
-                            "name": "target creature and/or planeswalker cards"
-                        },
-                        "destination": "Hand"
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        }
                     },
                     "targetRequirements": [
                         {
@@ -586,8 +590,7 @@
                             "filter": {
                                 "baseFilter": "creature|planeswalker",
                                 "zone": "Graveyard"
-                            },
-                            "id": "target creature and/or planeswalker cards"
+                            }
                         }
                     ],
                     "description": "Return one or two target creature and/or planeswalker cards from your graveyard to your hand"


### PR DESCRIPTION
## The bug

Archenemy's Charm's second mode — *"Return one or two target creature and/or planeswalker cards from your graveyard to your hand"* — resolved without returning anything. Reported with one creature in the graveyard; it failed with two as well.

## Root cause

The mode handed the `target(...)` handle for a `count = 2, minCount = 1` requirement straight to a single-target `Effects.ReturnToHand`:

```kotlin
val targets = target("target creature and/or planeswalker cards", TargetObject(..., count = 2, minCount = 1))
effect = Effects.ReturnToHand(targets)
```

`EffectContext.buildNamedTargets` keys a multi-slot requirement's chosen targets **per slot** — `id[0]`, `id[1]`, … — and deliberately leaves the bare `id` unmapped. So `BoundVariable("target creature and/or planeswalker cards")` resolved to `null`, `MoveToZoneEffectExecutor` got no target, and the effect failed soft: the spell resolved, the mode reported nothing, the cards stayed put.

Nothing upstream was wrong — enumeration offered the mode correctly with `minTargets = 1 / maxTargets = 2` on a single legal target, and `TargetValidator` accepted the one-target cast. The whole failure was in the card's own effect wiring.

## The fix

The house shape for a multi-slot requirement is `ForEachTargetEffect` over `EffectTarget.ContextTarget(0)` — what Opera Love Song ("one or two target creatures each get +2/+0"), Rack and Ruin and Ulamog already do. The card now uses it.

## Regression guard

The failure mode here is that a wrong binding is *silent*, so the card fix alone would let the next author repeat it. `CardLinter` gains `MultiSlotTargetBinding`: a bare `BoundVariable` read of a requirement spanning more than one target slot (`count > 1`, `unlimited`, or a `dynamicMaxCount`) is an ERROR naming the card, the scope, and the `ForEachTargetEffect` fix. The rest of the corpus is clean under it — the ~20 other multi-slot cards declare the requirement and never reference its handle.

`docs/card-sdk-language-reference.md`'s "Target count" section documents the rule alongside `minCount`.

## Verification

- `just test-class ArchenemysCharmScenarioTest` — 5 tests, all green. Mode 2 with one target, mode 2 with two targets, mode 2's enumeration shape (`minTargets = 1`, `targetCount = 2`, the single legal target offered), plus mode 1 and mode 3.
  - The one-target test fails on `main` at the "card is in hand" assertion, which is the reported bug.
- `just test-class CardLinterTest` — 43 tests green, including the two new ones (flags the bare handle, accepts the per-slot `id[0]`/`id[1]` form).
- `:mtg-sdk:test` + `:mtg-sets:test` — green, so `CardLintTest`'s corpus-wide gate passes with the new check armed and `FacadeBoundaryTest` is satisfied.
- `just rebless-cards` — the EOE snapshot moves for this card only (`MoveToZone` + `BoundVariable` → `ForEach` + `ContextTarget(0)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aAPMQGNGpqDucqVHTtRvW