### PR TITLE
Add 29 Assay-ready cards to Ravnica: City of Guilds

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BenevolentAncestor.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BenevolentAncestor.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Benevolent Ancestor
+ * {2}{W}
+ * Creature — Spirit
+ * 0/4
+ * Defender (This creature can't attack.)
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ *
+ * "Prevent the next N damage ... this turn" is the damage *shield*
+ * ([Effects.PreventNextDamage]), not the static replacement effect Fog Bank uses: a shield is
+ * created on resolution, absorbs one damage event up to its amount, and expires at end of turn.
+ */
+val BenevolentAncestor = card("Benevolent Ancestor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("any target", Targets.Any)
+        effect = Effects.PreventNextDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Nick Percival"
+        flavorText = "Although the door is flimsy and the lock pathetically small, Josuri's family never fears the night outside."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Caregiver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Caregiver.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Caregiver
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * {W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to any target this turn.
+ *
+ * The sacrifice is an unrestricted "a creature" — Caregiver itself is a legal choice, so the cost
+ * takes [GameObjectFilter.Creature] with no `excludeSelf`.
+ */
+val Caregiver = card("Caregiver") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "{W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to any target this turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{W}"),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        val t = target("any target", Targets.Any)
+        effect = Effects.PreventNextDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "William Simpson"
+        flavorText = "\"The guilds each believe its way is right, but their ways only bring blood to Ravnica's streets and tears to Ravnica's families.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ConsultTheNecrosages.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ConsultTheNecrosages.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Consult the Necrosages
+ * {1}{U}{B}
+ * Sorcery
+ * Choose one —
+ * • Target player draws two cards.
+ * • Target player discards two cards.
+ *
+ * Each mode carries its own target requirement: the modes are separately targeted, so the chosen
+ * player is bound per mode rather than once for the spell.
+ */
+val ConsultTheNecrosages = card("Consult the Necrosages") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Target player draws two cards.\n" +
+        "• Target player discards two cards."
+
+    spell {
+        modal {
+            mode("Target player draws two cards.") {
+                val p = target("target player", Targets.Player)
+                effect = Effects.DrawCards(2, p)
+            }
+            mode("Target player discards two cards.") {
+                val p = target("target player", Targets.Player)
+                effect = Patterns.Hand.discardCards(2, p)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Paolo Parente"
+        flavorText = "Dimir rank and file never see nor hear their guildmaster. All orders are given through mysterious necrosages who appear from the shadows, tersely toss out a command, and then melt into the darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DimirGuildmage.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DimirGuildmage.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Dimir Guildmage
+ * {U/B}{U/B}
+ * Creature — Human Wizard
+ * 2/2
+ * ({U/B} can be paid with either {U} or {B}.)
+ * {3}{U}: Target player draws a card. Activate only as a sorcery.
+ * {3}{B}: Target player discards a card. Activate only as a sorcery.
+ */
+val DimirGuildmage = card("Dimir Guildmage") {
+    manaCost = "{U/B}{U/B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "({U/B} can be paid with either {U} or {B}.)\n" +
+        "{3}{U}: Target player draws a card. Activate only as a sorcery.\n" +
+        "{3}{B}: Target player discards a card. Activate only as a sorcery."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        val p = target("target player", Targets.Player)
+        effect = Effects.DrawCards(1, p)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}")
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Hand.discardCards(1, p)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "245"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DromadPurebred.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DromadPurebred.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dromad Purebred
+ * {4}{W}
+ * Creature — Camel Beast
+ * 1/5
+ * Whenever this creature is dealt damage, you gain 1 life.
+ *
+ * A flat 1 life however much damage arrived — [Triggers.TakesDamage] with a fixed amount, not the
+ * `TRIGGER_DAMAGE_AMOUNT` context property Sunhome Enforcer reads.
+ */
+val DromadPurebred = card("Dromad Purebred") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Camel Beast"
+    oracleText = "Whenever this creature is dealt damage, you gain 1 life."
+    power = 1
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Carl Critchlow"
+        flavorText = "\"I have seen much from the back of my dromad, most of it terribly wrong. The more I see, the more I am convinced of the rightness of my path.\"\n—Heruj, Selesnya initiate"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DuskmantleHouseOfShadow.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DuskmantleHouseOfShadow.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Duskmantle, House of Shadow
+ * Land
+ * {T}: Add {C}.
+ * {U}{B}, {T}: Target player mills a card.
+ */
+val DuskmantleHouseOfShadow = card("Duskmantle, House of Shadow") {
+    manaCost = ""
+    colorIdentity = "UB"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{U}{B}, {T}: Target player mills a card."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{B}"), Costs.Tap)
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(1, p)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "277"
+        artist = "Martina Pilcerova"
+        flavorText = "In a space where there is no room, in a structure that was never built, meets the guild that doesn't exist."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FistsOfIronwood.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FistsOfIronwood.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Fists of Ironwood
+ * {1}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, create two 1/1 green Saproling creature tokens.
+ * Enchanted creature has trample.
+ *
+ * [GrantKeyword]'s filter defaults to the attached creature, which is exactly what an Aura's
+ * "Enchanted creature has ..." line means — no explicit [com.wingedsheep.sdk.dsl.Filters] needed.
+ */
+val FistsOfIronwood = card("Fists of Ironwood") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, create two 1/1 green Saproling creature tokens.\n" +
+        "Enchanted creature has trample."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Glen Angus"
+        flavorText = "Saprolings add the three and the four to the \"one-two punch.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlightOfFancy.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlightOfFancy.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Flight of Fancy
+ * {3}{U}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, draw two cards.
+ * Enchanted creature has flying.
+ */
+val FlightOfFancy = card("Flight of Fancy") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, draw two cards.\n" +
+        "Enchanted creature has flying."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Glen Angus"
+        flavorText = "The view from above is an inspiration to the newly winged."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GalvanicArc.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GalvanicArc.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Galvanic Arc
+ * {2}{R}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, it deals 3 damage to any target.
+ * Enchanted creature has first strike.
+ *
+ * The enters trigger targets independently of the Aura's own enchant target — the damage can be
+ * pointed anywhere, including at the enchanted creature.
+ */
+val GalvanicArc = card("Galvanic Arc") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, it deals 3 damage to any target.\n" +
+        "Enchanted creature has first strike."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GlimpseTheUnthinkable.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GlimpseTheUnthinkable.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glimpse the Unthinkable
+ * {U}{B}
+ * Sorcery
+ * Target player mills ten cards.
+ *
+ * [Patterns.Library.mill] publishes the whole recipe — a `GatherCards(TopOfLibrary, isMill = true)`
+ * and one `MoveCollection` to the graveyard. The `isMill` flag is load-bearing: CR 701.13 applies
+ * "mill that many plus N instead" at the count site, so a same-shaped plain move is a different
+ * thing.
+ */
+val GlimpseTheUnthinkable = card("Glimpse the Unthinkable") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Target player mills ten cards."
+
+    spell {
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(10, p)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "208"
+        artist = "Brandon Kitkouski"
+        flavorText = "\"I am confident that if anyone actually penetrates our facades, even the most perceptive would still be fundamentally unprepared for the truth of House Dimir.\"\n—Szadek"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GoblinSpelunkersReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GoblinSpelunkersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Spelunkers reprint in RAV. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinSpelunkersReprint = Printing(
+    oracleId = "0534a514-2847-4dbc-8178-6a2886c75bf6",
+    name = "Goblin Spelunkers",
+    setCode = "RAV",
+    collectorNumber = "128",
+    scryfallId = "6c3889c5-3321-486c-b03c-8607f2393a75",
+    artist = "Glenn Fabry",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6c3889c5-3321-486c-b03c-8607f2393a75.jpg",
+    releaseDate = "2005-10-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Moroii.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Moroii.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Moroii
+ * {2}{U}{B}
+ * Creature — Vampire
+ * 4/4
+ * Flying
+ * At the beginning of your upkeep, you lose 1 life.
+ */
+val Moroii = card("Moroii") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Vampire"
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, you lose 1 life."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.LoseLife(1, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Touched by moroii\"\n—Undercity slang meaning \"to grow old\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NullmageShepherd.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NullmageShepherd.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Nullmage Shepherd
+ * {3}{G}
+ * Creature — Elf Shaman
+ * 2/4
+ * Tap four untapped creatures you control: Destroy target artifact or enchantment.
+ *
+ * [Costs.TapPermanents] already carries "untapped ... you control"; the Shepherd itself is one of
+ * the four it may tap, so `excludeSelf` stays at its default.
+ */
+val NullmageShepherd = card("Nullmage Shepherd") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "Tap four untapped creatures you control: Destroy target artifact or enchantment."
+    power = 2
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 4, filter = GameObjectFilter.Creature)
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Stephen Tappin"
+        flavorText = "The shepherds work in secret, seeking out abominations against nature and returning them to earth and dust."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/OrdruunCommando.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/OrdruunCommando.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ordruun Commando
+ * {3}{R}
+ * Creature — Minotaur Soldier
+ * 4/1
+ * {W}: Prevent the next 1 damage that would be dealt to this creature this turn.
+ *
+ * The shield names its own source, so the ability takes no target — [EffectTarget.Self] rather
+ * than a `target(...)` handle.
+ */
+val OrdruunCommando = card("Ordruun Commando") {
+    manaCost = "{3}{R}"
+    colorIdentity = "WR"
+    typeLine = "Creature — Minotaur Soldier"
+    oracleText = "{W}: Prevent the next 1 damage that would be dealt to this creature this turn."
+    power = 4
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = Effects.PreventNextDamage(1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Stephen Tappin"
+        flavorText = "Thick of muscle, stout of heart, and possessing a burning love of justice and the battlefield, the Ordruun minotaurs are the foundation of the Boros Legion."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PeregrineMask.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PeregrineMask.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Peregrine Mask
+ * {1}
+ * Artifact — Equipment
+ * Equipped creature has defender, flying, and first strike.
+ * Equip {2}
+ *
+ * Three separate [GrantKeyword] statics rather than one multi-keyword ability: the SDK keeps one
+ * keyword per grant, and each defaults to the equipped creature. `equipAbility` sets `equipCost`
+ * and lowers the sorcery-speed attach ability in one place.
+ */
+val PeregrineMask = card("Peregrine Mask") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has defender, flying, and first strike.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEFENDER)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "268"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "The mask confers both the prowess of a falcon and its loyalty."
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RootKinAlly.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RootKinAlly.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Root-Kin Ally
+ * {4}{G}{G}
+ * Creature — Elemental Warrior
+ * 3/3
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Tap two untapped creatures you control: This creature gets +2/+2 until end of turn.
+ *
+ * [Costs.TapPermanents] already means "untapped ... you control", so the filter is the bare
+ * [GameObjectFilter.Creature]. Root-Kin Ally is a legal choice for its own cost — nothing in the
+ * printed line excludes it — so `excludeSelf` stays at its default.
+ */
+val RootKinAlly = card("Root-Kin Ally") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Warrior"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Tap two untapped creatures you control: This creature gets +2/+2 until end of turn."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.CONVOKE)
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 2, filter = GameObjectFilter.Creature)
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sandsower.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sandsower.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sandsower
+ * {3}{W}
+ * Creature — Spirit
+ * 1/3
+ * Tap three untapped creatures you control: Tap target creature.
+ */
+val Sandsower = card("Sandsower") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Tap three untapped creatures you control: Tap target creature."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 3, filter = GameObjectFilter.Creature)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Kev Walker"
+        flavorText = "It drifts through the streets as a breeze of collective sighs, wilting the bustle with dreams and heavy eyelids."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ScatterTheSeeds.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ScatterTheSeeds.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scatter the Seeds
+ * {3}{G}{G}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Create three 1/1 green Saproling creature tokens.
+ */
+val ScatterTheSeeds = card("Scatter the Seeds") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Create three 1/1 green Saproling creature tokens."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        effect = Effects.CreateToken(
+            count = 3,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "181"
+        artist = "Rob Alexander"
+        flavorText = "From the seeds of faith, great forests grow."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SearingMeditation.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SearingMeditation.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Searing Meditation
+ * {1}{R}{W}
+ * Enchantment
+ * Whenever you gain life, you may pay {2}. If you do, this enchantment deals 2 damage to any target.
+ *
+ * [MayPayManaEffect] lowers to the `Gate.MayPay` gate — the printed "you may pay ... If you do"
+ * is one gated effect, not an `optional` flag beside a separate one. The target is chosen when
+ * the trigger goes on the stack, before the payment is offered.
+ */
+val SearingMeditation = card("Searing Meditation") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you gain life, you may pay {2}. If you do, this enchantment deals 2 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        val t = target("any target", Targets.Any)
+        effect = MayPayManaEffect(ManaCost.parse("{2}"), Effects.DealDamage(2, t))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Dave Dorman"
+        flavorText = "\"When I meditate I see the world as it should be. All that does not fit, I remove.\"\n—Alovnek, Boros guildmage"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SelesnyaEvangel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SelesnyaEvangel.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Selesnya Evangel
+ * {G}{W}
+ * Creature — Elf Shaman
+ * 1/2
+ * {1}, {T}, Tap an untapped creature you control: Create a 1/1 green Saproling creature token.
+ *
+ * The {T} in the same cost already taps the Evangel, and an already-tapped permanent can't be
+ * tapped again to pay a cost (CR 107.5) — so the tap-a-creature atom needs no `excludeSelf`.
+ */
+val SelesnyaEvangel = card("Selesnya Evangel") {
+    manaCost = "{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "{1}, {T}, Tap an untapped creature you control: Create a 1/1 green Saproling creature token."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature)
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "228"
+        artist = "Rob Alexander"
+        flavorText = "\"The clamor of the city drowns all voices. But together we can sing a harmony that will resonate from Ravnica's tallest spires to her deepest wells.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sewerdreg.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Sewerdreg.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sewerdreg
+ * {3}{B}{B}
+ * Creature — Spirit
+ * 3/3
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ * Sacrifice this creature: Exile target card from a graveyard.
+ *
+ * "A graveyard" is any player's — [Targets.CardInGraveyard] is zone-scoped, not owner-scoped.
+ */
+val Sewerdreg = card("Sewerdreg") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n" +
+        "Sacrifice this creature: Exile target card from a graveyard."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.SWAMPWALK)
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target card from a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Joel Thomas"
+        flavorText = "They hardly have form, dripping through pipe and grate with the slip and stench of flowing sewage."
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SunderingVitae.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SunderingVitae.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sundering Vitae
+ * {2}{G}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Destroy target artifact or enchantment.
+ */
+val SunderingVitae = card("Sundering Vitae") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Destroy target artifact or enchantment."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Shishizaru"
+        flavorText = "Centuries of wind, rain, and roots compressed into an instant of destruction: such is the power of Selesnya."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SunhomeEnforcer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SunhomeEnforcer.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sunhome Enforcer
+ * {2}{R}{W}
+ * Creature — Giant Soldier
+ * 2/4
+ * Whenever this creature deals combat damage, you gain that much life.
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ *
+ * "That much" is the damage the trigger fired on, read live off the event as
+ * [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT]. The trigger names no recipient — combat damage to a
+ * player *or* to a blocking creature both count — so it takes the bare [Triggers.dealsDamage]
+ * factory rather than one of the recipient-scoped constants.
+ */
+val SunhomeEnforcer = card("Sunhome Enforcer") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Creature — Giant Soldier"
+    oracleText = "Whenever this creature deals combat damage, you gain that much life.\n" +
+        "{1}{R}: This creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(DamageType.Combat)
+        effect = Effects.GainLife(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT))
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Greg Staples"
+        flavorText = "\"Law soothed his savage heart. Where fury once burned, the enduring flame of order now shines.\"\n—Razia"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThundersongTrumpeter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThundersongTrumpeter.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thundersong Trumpeter
+ * {R}{W}
+ * Creature — Human Soldier
+ * 2/1
+ * {T}: Target creature can't attack or block this turn.
+ *
+ * "Can't attack or block" is two restrictions, not one: [Effects.CantAttack] is read by the
+ * combat-tax rules and [Effects.CantBlock] by the block-legality rules, so both must be applied
+ * to the same target.
+ */
+val ThundersongTrumpeter = card("Thundersong Trumpeter") {
+    manaCost = "{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "{T}: Target creature can't attack or block this turn."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.CantAttack(t),
+            Effects.CantBlock(t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "235"
+        artist = "Michael Sutfin"
+        flavorText = "\"Hear that? Those notes mean we've arrived at Sunhome! Let our allies' hearts soar and our enemies' hearts shatter at the sound!\"\n—Klattic, Boros legionnaire"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TidewaterMinion.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TidewaterMinion.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tidewater Minion
+ * {3}{U}{U}
+ * Creature — Elemental Minion
+ * 4/4
+ * Defender (This creature can't attack.)
+ * {4}: This creature loses defender until end of turn.
+ * {T}: Untap target permanent.
+ */
+val TidewaterMinion = card("Tidewater Minion") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Minion"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{4}: This creature loses defender until end of turn.\n" +
+        "{T}: Untap target permanent."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        effect = Effects.RemoveKeyword(Keyword.DEFENDER, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target permanent", Targets.Permanent)
+        effect = Effects.Untap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Tomas Giorello"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TorpidMoloch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TorpidMoloch.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Torpid Moloch
+ * {R}
+ * Creature — Lizard
+ * 3/2
+ * Defender (This creature can't attack.)
+ * Sacrifice three lands: This creature loses defender until end of turn.
+ *
+ * "Loses defender" is [Effects.RemoveKeyword], a layer-6 removal lasting until end of turn —
+ * activating twice in a turn is redundant, not cumulative.
+ */
+val TorpidMoloch = card("Torpid Moloch") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "Sacrifice three lands: This creature loses defender until end of turn."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.SacrificeMultiple(3, GameObjectFilter.Land)
+        effect = Effects.RemoveKeyword(Keyword.DEFENDER, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Paolo Parente"
+        flavorText = "Market hucksters sell molochs for use as watchdogs. Of course, that's all molochs do. Sit around . . . and watch."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VedalkenEntrancer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VedalkenEntrancer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vedalken Entrancer
+ * {3}{U}
+ * Creature — Vedalken Wizard
+ * 1/4
+ * {U}, {T}: Target player mills two cards.
+ */
+val VedalkenEntrancer = card("Vedalken Entrancer") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Wizard"
+    oracleText = "{U}, {T}: Target player mills two cards."
+    power = 1
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(2, p)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Dan Murayama Scott"
+        flavorText = "Their denial reaches far into your future."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VindictiveMob.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VindictiveMob.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Vindictive Mob
+ * {4}{B}{B}
+ * Creature — Human Berserker
+ * 5/5
+ * When this creature enters, sacrifice a creature.
+ * This creature can't be blocked by Saprolings.
+ *
+ * The bare imperative "sacrifice a creature" is [Effects.SacrificeOwn] — the ability's controller
+ * sacrifices, with no player named. `Effects.Sacrifice` is the other sentence ("target opponent
+ * sacrifices ..."). The Mob itself is a legal choice, which is what makes it a real drawback when
+ * it is the only creature you control.
+ *
+ * The blocker noun is the bare tribal "Saprolings", i.e. Saproling *permanents* —
+ * [GameObjectFilter.Permanent] with the subtype, not `.Creature`.
+ */
+val VindictiveMob = card("Vindictive Mob") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Berserker"
+    oracleText = "When this creature enters, sacrifice a creature.\n" +
+        "This creature can't be blocked by Saprolings."
+    power = 5
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+    }
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Permanent.withSubtype(Subtype.SAPROLING))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Wayne Reynolds"
+        flavorText = "Many minds, a single madness."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoodwraithStrangler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoodwraithStrangler.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Woodwraith Strangler
+ * {2}{B}{G}
+ * Creature — Plant Zombie
+ * 2/2
+ * Exile a creature card from your graveyard: Regenerate this creature.
+ *
+ * There is no `Effects.Regenerate` facade — [RegenerateEffect] on [EffectTarget.Self] is the
+ * shipped spelling (Cudgel Troll, Asphodel Wanderer).
+ */
+val WoodwraithStrangler = card("Woodwraith Strangler") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Plant Zombie"
+    oracleText = "Exile a creature card from your graveyard: Regenerate this creature."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.ExileFromGraveyard(1, GameObjectFilter.Creature)
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Pat Lee"
+        flavorText = "\"Nothing could be more natural than roots sucking nourishment from the dead.\"\n—Savra"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FistsOfIronwoodReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FistsOfIronwoodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fists of Ironwood reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val FistsOfIronwoodReprint = Printing(
+    oracleId = "2f6a5278-23bf-47b2-a2b9-dfff7d96f3dd",
+    name = "Fists of Ironwood",
+    setCode = "CMD",
+    collectorNumber = "156",
+    scryfallId = "7e61a67a-6298-48e0-b0e6-fa70330353f6",
+    artist = "Glen Angus",
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e61a67a-6298-48e0-b0e6-fa70330353f6.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SelesnyaEvangelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SelesnyaEvangelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selesnya Evangel reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val SelesnyaEvangelReprint = Printing(
+    oracleId = "4a2fea39-99d6-4766-9f2c-0a63925349cb",
+    name = "Selesnya Evangel",
+    setCode = "CMD",
+    collectorNumber = "223",
+    scryfallId = "32a20292-8b19-4386-95b4-85efc903146b",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32a20292-8b19-4386-95b4-85efc903146b.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/VedalkenEntrancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/VedalkenEntrancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vedalken Entrancer reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val VedalkenEntrancerReprint = Printing(
+    oracleId = "04cc5292-a485-4bb8-a143-9364229d480f",
+    name = "Vedalken Entrancer",
+    setCode = "M13",
+    collectorNumber = "76",
+    scryfallId = "dc4bbd25-5ddd-4502-b582-b7d89c9f97a5",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc4bbd25-5ddd-4502-b582-b7d89c9f97a5.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VedalkenEntrancerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VedalkenEntrancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vedalken Entrancer reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val VedalkenEntrancerReprint = Printing(
+    oracleId = "04cc5292-a485-4bb8-a143-9364229d480f",
+    name = "Vedalken Entrancer",
+    setCode = "JMP",
+    collectorNumber = "188",
+    scryfallId = "559bdfd6-8baf-430d-a4c4-5acf81e58b62",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/559bdfd6-8baf-430d-a4c4-5acf81e58b62.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/NullmageShepherdReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/NullmageShepherdReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nullmage Shepherd reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val NullmageShepherdReprint = Printing(
+    oracleId = "4dcfd397-9d29-420c-8fd8-c7c2a99de122",
+    name = "Nullmage Shepherd",
+    setCode = "KHC",
+    collectorNumber = "70",
+    scryfallId = "c4a15a09-cf68-411a-a18d-aaad00d308c9",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4a15a09-cf68-411a-a18d-aaad00d308c9.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -162,6 +162,55 @@
     ]
 }
 
+// Benevolent Ancestor
+{
+    "name": "Benevolent Ancestor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Defender (This creature can't attack.)\n{T}: Prevent the next 1 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Nick Percival",
+        "flavorText": "Although the door is flimsy and the lock pathetically small, Josuri's family never fears the night outside.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f23110b5-0dd4-49a2-8991-bc673aed53c9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Blockbuster
 {
     "name": "Blockbuster",
@@ -491,6 +540,70 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Caregiver
+{
+    "name": "Caregiver",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "William Simpson",
+        "flavorText": "\"The guilds each believe its way is right, but their ways only bring blood to Ravnica's streets and tears to Ravnica's families.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c33d3fe-cdd3-4829-8f10-6611f063983b.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -925,6 +1038,104 @@
     ]
 }
 
+// Consult the Necrosages
+{
+    "name": "Consult the Necrosages",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Target player draws two cards.\n• Target player discards two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Target player draws two cards."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 2 cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Target player discards two cards."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Paolo Parente",
+        "flavorText": "Dimir rank and file never see nor hear their guildmaster. All orders are given through mysterious necrosages who appear from the shadows, tersely toss out a command, and then melt into the darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f51484b-3bad-4332-87f8-61924e153799.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Courier Hawk
 {
     "name": "Courier Hawk",
@@ -1320,6 +1531,121 @@
     ]
 }
 
+// Dimir Guildmage
+{
+    "name": "Dimir Guildmage",
+    "manaCost": "{U/B}{U/B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "({U/B} can be paid with either {U} or {B}.)\n{3}{U}: Target player draws a card. Activate only as a sorcery.\n{3}{B}: Target player discards a card. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69b822aa-4144-400a-b993-f146cbeed54f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Dimir Signet
 {
     "name": "Dimir Signet",
@@ -1613,6 +1939,133 @@
     ]
 }
 
+// Dromad Purebred
+{
+    "name": "Dromad Purebred",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Camel Beast",
+    "oracleText": "Whenever this creature is dealt damage, you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"I have seen much from the back of my dromad, most of it terribly wrong. The more I see, the more I am convinced of the rightness of my path.\"\n—Heruj, Selesnya initiate",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/0106caf1-2201-4661-96a5-56af02963fa6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Duskmantle, House of Shadow
+{
+    "name": "Duskmantle, House of Shadow",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{U}{B}, {T}: Target player mills a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "277",
+        "rarity": "UNCOMMON",
+        "artist": "Martina Pilcerova",
+        "flavorText": "In a space where there is no room, in a structure that was never built, meets the guild that doesn't exist.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d3c85e2-58a5-4469-85ea-7e89268f310c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Elvish Skysweeper
 {
     "name": "Elvish Skysweeper",
@@ -1782,6 +2235,61 @@
     ]
 }
 
+// Fists of Ironwood
+{
+    "name": "Fists of Ironwood",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, create two 1/1 green Saproling creature tokens.\nEnchanted creature has trample.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Glen Angus",
+        "flavorText": "Saprolings add the three and the four to the \"one-two punch.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/7193c00f-0398-485c-974d-346ee59cd4c7.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Flame-Kin Zealot
 {
     "name": "Flame-Kin Zealot",
@@ -1844,6 +2352,53 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Flight of Fancy
+{
+    "name": "Flight of Fancy",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw two cards.\nEnchanted creature has flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Glen Angus",
+        "flavorText": "The view from above is an inspiration to the newly winged.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c8ad201-ce70-45bf-9ac3-51f5ccfa8df9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1929,6 +2484,60 @@
     ]
 }
 
+// Galvanic Arc
+{
+    "name": "Galvanic Arc",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, it deals 3 damage to any target.\nEnchanted creature has first strike.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64d816df-51e5-46f8-ad9a-68f3f656dbcd.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Gather Courage
 {
     "name": "Gather Courage",
@@ -1991,6 +2600,66 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b87dc27-3cea-4101-aec5-ca0b96978476.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Glimpse the Unthinkable
+{
+    "name": "Glimpse the Unthinkable",
+    "manaCost": "{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player mills ten cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 10
+                        },
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        },
+                        "isMill": true
+                    },
+                    "storeAs": "milled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "milled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "RARE",
+        "artist": "Brandon Kitkouski",
+        "flavorText": "\"I am confident that if anyone actually penetrates our facades, even the most perceptive would still be fundamentally unprepared for the truth of House Dimir.\"\n—Szadek",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48058253-54b8-403b-8d95-94d8da986e69.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
 }
 
 // Golgari Guildmage
@@ -2836,6 +3505,52 @@
     ]
 }
 
+// Moroii
+{
+    "name": "Moroii",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Flying\nAt the beginning of your upkeep, you lose 1 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Controller"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Touched by moroii\"\n—Undercity slang meaning \"to grow old\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3de9ce70-67d1-4007-94ed-4545867e90c8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Mortipede
 {
     "name": "Mortipede",
@@ -2901,6 +3616,61 @@
     ]
 }
 
+// Nullmage Shepherd
+{
+    "name": "Nullmage Shepherd",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "Tap four untapped creatures you control: Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 4,
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target artifact or enchantment"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Tappin",
+        "flavorText": "The shepherds work in secret, seeking out abominations against nature and returning them to earth and dust.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11f2a6de-1598-4dd9-81a0-9a4f3dd4de0b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Oathsworn Giant
 {
     "name": "Oathsworn Giant",
@@ -2944,6 +3714,50 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Ordruun Commando
+{
+    "name": "Ordruun Commando",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Minotaur Soldier",
+    "oracleText": "{W}: Prevent the next 1 damage that would be dealt to this creature this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": "Self",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Stephen Tappin",
+        "flavorText": "Thick of muscle, stout of heart, and possessing a burning love of justice and the battlefield, the Ordruun minotaurs are the foundation of the Boros Legion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa726c0e-3a7e-4299-8842-4ce1f9f26567.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
     ]
 }
 
@@ -3025,6 +3839,69 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Peregrine Mask
+{
+    "name": "Peregrine Mask",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has defender, flying, and first strike.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEFENDER"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "The mask confers both the prowess of a falcon and its loyalty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/9196f43e-f905-4e83-8e47-9d8fd53a4c9f.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Perilous Forays
@@ -3375,6 +4252,57 @@
     ]
 }
 
+// Root-Kin Ally
+{
+    "name": "Root-Kin Ally",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTap two untapped creatures you control: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e469162b-c8c9-4746-80f3-d2c2acd89e0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sacred Foundry
 {
     "name": "Sacred Foundry",
@@ -3411,6 +4339,96 @@
     ]
 }
 
+// Sandsower
+{
+    "name": "Sandsower",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Tap three untapped creatures you control: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "It drifts through the streets as a breeze of collective sighs, wilting the bustle with dreams and heavy eyelids.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43472fbe-d4f6-41b5-9928-965336d44a8f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Scatter the Seeds
+{
+    "name": "Scatter the Seeds",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 green Saproling creature tokens.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Saproling"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "artist": "Rob Alexander",
+        "flavorText": "From the seeds of faith, great forests grow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4415070-4304-482b-b8e5-2bf689af0843.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Scion of the Wild
 {
     "name": "Scion of the Wild",
@@ -3444,6 +4462,59 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Searing Meditation
+{
+    "name": "Searing Meditation",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you gain life, you may pay {2}. If you do, this enchantment deals 2 damage to any target.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "RARE",
+        "artist": "Dave Dorman",
+        "flavorText": "\"When I meditate I see the world as it should be. All that does not fit, I remove.\"\n—Alovnek, Boros guildmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33c1fbdd-884d-467a-956e-7c28881002ab.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
     ]
 }
 
@@ -3494,6 +4565,66 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Selesnya Evangel
+{
+    "name": "Selesnya Evangel",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{1}, {T}, Tap an untapped creature you control: Create a 1/1 green Saproling creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "artist": "Rob Alexander",
+        "flavorText": "\"The clamor of the city drowns all voices. But together we can sing a harmony that will resonate from Ravnica's tallest spires to her deepest wells.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18bc93c1-f236-4d1b-bb54-5041b3cae5a6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
     ]
 }
 
@@ -3701,6 +4832,56 @@
     ]
 }
 
+// Sewerdreg
+{
+    "name": "Sewerdreg",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nSacrifice this creature: Exile target card from a graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card from a graveyard"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card from a graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "artist": "Joel Thomas",
+        "flavorText": "They hardly have form, dripping through pipe and grate with the slip and stench of flowing sewage.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b216ad4e-29b4-4e03-8c16-5796277bd05f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Siege Wurm
 {
     "name": "Siege Wurm",
@@ -3858,6 +5039,111 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sundering Vitae
+{
+    "name": "Sundering Vitae",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target artifact or enchantment.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target artifact or enchantment"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target artifact or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Shishizaru",
+        "flavorText": "Centuries of wind, rain, and roots compressed into an instant of destruction: such is the power of Selesnya.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1ab15b40-c5c8-4d77-a4c0-982b6bf94267.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sunhome Enforcer
+{
+    "name": "Sunhome Enforcer",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Creature — Giant Soldier",
+    "oracleText": "Whenever this creature deals combat damage, you gain that much life.\n{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "\"Law soothed his savage heart. Where fury once burned, the enduring flame of order now shines.\"\n—Razia",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4d5a88e-fc8f-4dd6-a1db-8e44b74ee0a1.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
     ]
 }
 
@@ -4056,6 +5342,171 @@
     ]
 }
 
+// Thundersong Trumpeter
+{
+    "name": "Thundersong Trumpeter",
+    "manaCost": "{R}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{T}: Target creature can't attack or block this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CantAttack",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "artist": "Michael Sutfin",
+        "flavorText": "\"Hear that? Those notes mean we've arrived at Sunhome! Let our allies' hearts soar and our enemies' hearts shatter at the sound!\"\n—Klattic, Boros legionnaire",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/7410c546-745c-469f-b3b8-eafb69391600.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
+// Tidewater Minion
+{
+    "name": "Tidewater Minion",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Elemental Minion",
+    "oracleText": "Defender (This creature can't attack.)\n{4}: This creature loses defender until end of turn.\n{T}: Untap target permanent.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "RemoveKeyword",
+                    "keyword": "DEFENDER",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        },
+                        "id": "target permanent"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Tomas Giorello",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67ffa68f-cc21-41c8-ad3d-d6b60a4ccd36.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Torpid Moloch
+{
+    "name": "Torpid Moloch",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "Defender (This creature can't attack.)\nSacrifice three lands: This creature loses defender until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land",
+                        "count": 3
+                    }
+                },
+                "effect": {
+                    "type": "RemoveKeyword",
+                    "keyword": "DEFENDER",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Paolo Parente",
+        "flavorText": "Market hucksters sell molochs for use as watchdogs. Of course, that's all molochs do. Sit around . . . and watch.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/7900ff91-0e47-4903-a680-9031f4a23cb4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Undercity Shade
 {
     "name": "Undercity Shade",
@@ -4215,6 +5666,86 @@
     ]
 }
 
+// Vedalken Entrancer
+{
+    "name": "Vedalken Entrancer",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Vedalken Wizard",
+    "oracleText": "{U}, {T}: Target player mills two cards.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Their denial reaches far into your future.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/faf5e4b8-3bb9-4a4c-b8fa-2cae5372ba24.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Veteran Armorer
 {
     "name": "Veteran Armorer",
@@ -4339,6 +5870,57 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Vindictive Mob
+{
+    "name": "Vindictive Mob",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "When this creature enters, sacrifice a creature.\nThis creature can't be blocked by Saprolings.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsPermanent",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Saproling"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "flavorText": "Many minds, a single madness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23c5c72c-982c-4cfd-b576-089200b4cc04.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4602,5 +6184,46 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Woodwraith Strangler
+{
+    "name": "Woodwraith Strangler",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Creature — Plant Zombie",
+    "oracleText": "Exile a creature card from your graveyard: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomExileFrom",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "artist": "Pat Lee",
+        "flavorText": "\"Nothing could be more natural than roots sucking nourishment from the dead.\"\n—Savra",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be72ff91-f810-46c3-884f-6e65827824bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }


### PR DESCRIPTION
Sweeps RAV's ⚡ Assay-ready count from **29 → 0**.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 28 | canonical authored here — RAV is the earliest real printing |
| `row-only` | 1 | Goblin Spelunkers → `Printing` row (canonical in USG) |
| `elsewhere` | 0 | — |
| `basic` | 0 | RAV's basics already ship via `RavnicaBasicLands.kt` |
| `unscaffolded` | 0 | — |

**Reprint tail** — 5 rows in 4 other sets, invisible to `check-card-printing` until these canonicals existed, so they land here: CMD (Fists of Ironwood, Selesnya Evangel), JMP + M13 (Vedalken Entrancer), KHC (Nullmage Shepherd).

## Verification

| Gate | Before | After |
|---|---|---|
| `assay differential` | 5817 compared / 5766 confirmed / **51 divergent** | 5845 / 5794 / **51 divergent** |
| `just assay-ready RAV` | 29 Assay-ready | **0** Assay-ready |

**+28 compared, +28 confirmed, zero new divergences.** Every card was authored to `assay compile`'s JSON rather than to the oracle text, which is why the differential is a formality rather than a bug hunt.

- `just build` — green (compile + `:mtg-sets:test`, incl. `FacadeBoundaryTest`).
- `just rebless-cards` — only `snapshots/cards/RAV.json` moved; diff is 28 additions, zero cards lost (the 58 "removed" lines are Elvish Skysweeper's block relocating in alphabetical order).
- `just check-card-printing` — all 28 canonicals report *canonical is in the card's earliest real printing and all scaffolded reprints have rows*.

## Capability pre-flight

Every SDK type the batch touches was traced to a live `rules-engine` consumer before any authoring; none is display-only, so no engine work was needed and nothing here ships a card that lies.

| SDK type | engine consumer | precedent |
|---|---|---|
| `PreventDamageEffect` (`Effects.PreventNextDamage`) | `PreventDamageExecutor` | — |
| `CostAtom.TapPermanents` | `CostPaymentService` | Hand of Justice |
| `CONVOKE` | `AlternativePaymentHandler`, `CastSpellEnumerator` | Devouring Light (same set) |
| `SWAMPWALK` | `BlockEvasionRules` | — |
| `RemoveKeywordEffect` | `EffectApplicator`, `StaticAbilityHandler` | Shoal Serpent |
| `RegenerateEffect` | `LethalDamageCheck` | Asphodel Wanderer |
| `CantBeBlockedBy` | `BlockPhaseManager` | Rampart Crawler |
| `CantAttackEffect` / `CantBlockEffect` | `CombatTaxes` / `CantBlockExecutor` | — |
| `GatedEffect` via `MayPayManaEffect` | — | Urza's Chalice |
| `TRIGGER_DAMAGE_AMOUNT` | `DynamicAmountEvaluator` | El-Hajjâj |
| `DamageReceivedEvent`, `LifeGainEvent` | `TriggerIndex` | — |
| equip (`equipAbility`) | — | Aeronaut's Wings |

Nothing in the batch is a first-in-corpus mechanic, so no scenario test is owed under the sweep's rule; the differential is the correctness net for all 29.

## Notes worth keeping

- **`Effects.SacrificeOwn`, not `Effects.Sacrifice`** — Vindictive Mob's bare imperative "sacrifice a creature" means *the ability's controller* sacrifices with no player named. `Effects.Sacrifice` is `ForceSacrificeEffect`, which is the other sentence ("target opponent sacrifices…").
- **A damage *shield* is not a prevention replacement effect.** "Prevent the next 1 damage … this turn" (Benevolent Ancestor, Caregiver, Ordruun Commando) is `Effects.PreventNextDamage` — created on resolution, absorbs one event, expires at end of turn. Fog Bank's static `PreventDamage` replacement is a different model.
- **`Costs.TapPermanents` already means "untapped … you control."** The filter is the bare `GameObjectFilter.Creature`; adding `.untapped().youControl()` would be the same fact written twice and would diverge from Assay's reading.
- **"Can't attack or block" is two effects**, read by two different rule sites (`CombatTaxes` and `CantBlockExecutor`) — Thundersong Trumpeter needs both.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5S1ZTRdMqMzKb9ACy2kSv