### PR TITLE
Add 62 Assay-ready cards to Theros Beyond Death

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/IdyllicTutor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/IdyllicTutor.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Idyllic Tutor
+ * {2}{W}
+ * Sorcery
+ *
+ * Search your library for an enchantment card, reveal it, put it into your hand, then shuffle.
+ *
+ * The whole sentence is one [Patterns.Library.searchLibrary] recipe: its defaults already gather
+ * from the library, select up to one card, move the found card to hand, shuffle, and emit the
+ * `LibrarySearchedEvent` (CR 701.23). Only `reveal = true` is spelled out — restating the pipeline
+ * by hand is how a corpus card once silently lost `revealed`.
+ */
+val IdyllicTutor = card("Idyllic Tutor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for an enchantment card, reveal it, put it into your hand, then shuffle."
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Enchantment,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Howard Lyon"
+        flavorText = "\"If one's life is blessed, solutions to all life's problems will appear at the right " +
+            "moment.\"\n—*The Book of Kith and Kin*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ReturnToNatureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ReturnToNatureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to Nature reprint in ELD. Canonical CardDefinition lives in its earliest set.
+ */
+val ReturnToNatureReprint = Printing(
+    oracleId = "777b8ec4-a783-4297-96b7-4f200d0eb734",
+    name = "Return to Nature",
+    setCode = "ELD",
+    collectorNumber = "173",
+    scryfallId = "c3d5088e-21d0-4255-a14c-ad950133a90e",
+    artist = "Mark Poole",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3d5088e-21d0-4255-a14c-ad950133a90e.jpg",
+    releaseDate = "2019-10-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodAspirantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodAspirantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Aspirant reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodAspirantReprint = Printing(
+    oracleId = "6db51087-6995-4ed4-978a-3d17d60019af",
+    name = "Blood Aspirant",
+    setCode = "J22",
+    collectorNumber = "501",
+    scryfallId = "b4fa2529-e00e-457b-928f-b1c378f31cb5",
+    artist = "Tyler Walpole",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4fa2529-e00e-457b-928f-b1c378f31cb5.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MireTritonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MireTritonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mire Triton reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val MireTritonReprint = Printing(
+    oracleId = "4fe6f784-0290-4d4a-85ae-0b66522d31e9",
+    name = "Mire Triton",
+    setCode = "J22",
+    collectorNumber = "443",
+    scryfallId = "56246461-67f3-46cb-a2df-ef90ea89ceb3",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/56246461-67f3-46cb-a2df-ef90ea89ceb3.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MireTritonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MireTritonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mire Triton reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MireTritonReprint = Printing(
+    oracleId = "4fe6f784-0290-4d4a-85ae-0b66522d31e9",
+    name = "Mire Triton",
+    setCode = "JMP",
+    collectorNumber = "257",
+    scryfallId = "d9dc87b3-60b2-4cf8-b620-334700db1aa9",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d9dc87b3-60b2-4cf8-b620-334700db1aa9.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Infuriate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Infuriate.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infuriate
+ * {R}
+ * Instant
+ *
+ * Target creature gets +3/+2 until end of turn.
+ *
+ * Canonical printing lives in Core Set 2020 (the card's earliest real printing); later sets —
+ * including Theros Beyond Death — contribute only a [com.wingedsheep.sdk.model.Printing] row.
+ * "Until end of turn" is [Effects.ModifyStats]' default duration, so it is left unwritten.
+ */
+val Infuriate = card("Infuriate") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+2 until end of turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(3, 2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Caio Monteiro"
+        flavorText = "\"No shirt, no shoes, no service.\"\n" +
+            "—Marketplace sign"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ReturnToNatureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ReturnToNatureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to Nature reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val ReturnToNatureReprint = Printing(
+    oracleId = "777b8ec4-a783-4297-96b7-4f200d0eb734",
+    name = "Return to Nature",
+    setCode = "M21",
+    collectorNumber = "200",
+    scryfallId = "3f1b4490-d96d-4448-835b-6cc453c1f344",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3f1b4490-d96d-4448-835b-6cc453c1f344.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SetessanTrainingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SetessanTrainingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Setessan Training reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val SetessanTrainingReprint = Printing(
+    oracleId = "3ff3b9c4-80ec-44d9-99ec-6fea3a86468b",
+    name = "Setessan Training",
+    setCode = "M21",
+    collectorNumber = "205",
+    scryfallId = "1947f64a-5ca0-4dda-8bbd-8472e72ecf18",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/1947f64a-5ca0-4dda-8bbd-8472e72ecf18.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ReturnToNatureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ReturnToNatureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to Nature reprint in MID. Canonical CardDefinition lives in its earliest set.
+ */
+val ReturnToNatureReprint = Printing(
+    oracleId = "777b8ec4-a783-4297-96b7-4f200d0eb734",
+    name = "Return to Nature",
+    setCode = "MID",
+    collectorNumber = "195",
+    scryfallId = "6e25c252-4177-4193-914c-b6933d9c0d7d",
+    artist = "Kim Sokol",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e25c252-4177-4193-914c-b6933d9c0d7d.jpg",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/TherosBeyondDeathSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/TherosBeyondDeathSet.kt
@@ -21,6 +21,10 @@ object TherosBeyondDeathSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArchonOfFallingStars.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArchonOfFallingStars.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Archon of Falling Stars
+ * {4}{W}{W}
+ * Creature — Archon
+ * 4/4
+ *
+ * Flying
+ * When this creature dies, you may return target enchantment card from your graveyard to the battlefield.
+ *
+ * A plain [Triggers.Dies] — battlefield → graveyard, SELF binding, and *no* `triggerZone`: setting
+ * one replaces the default `{BATTLEFIELD}` and the dies trigger would never be indexed.
+ *
+ * The target is an object in the graveyard, so its controller predicate reads **owner**
+ * (`ownedByYou()`): a card in a graveyard has no controller. `optional = true` is the DSL's
+ * shorthand for the printed "you may" and lowers to exactly `MayEffect(effect)`.
+ *
+ * [Effects.PutOntoBattlefieldFromGraveyard] keeps its `fromZone = GRAVEYARD` guard even though the
+ * target requirement already scopes the graveyard: the requirement decides legality at
+ * announcement, the guard skips the move if the card has left the graveyard by resolution.
+ */
+val ArchonOfFallingStars = card("Archon of Falling Stars") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Archon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature dies, you may return target enchantment card from your graveyard to the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val enchantment = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Enchantment.ownedByYou(), zone = Zone.GRAVEYARD)),
+        )
+        optional = true
+        effect = Effects.PutOntoBattlefieldFromGraveyard(enchantment)
+        description = "When this creature dies, you may return target enchantment card from your " +
+            "graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Victor Adame Minguez"
+        flavorText = "\"The archon fell like a star from the sky, meeting the rising sun at the horizon's edge.\"\n—*The Cosmogony*"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BloodAspirant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BloodAspirant.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blood Aspirant
+ * {1}{R}
+ * Creature — Satyr Berserker
+ * 1/1
+ *
+ * Whenever you sacrifice a permanent, put a +1/+1 counter on this creature.
+ * {1}{R}, {T}, Sacrifice a creature or enchantment: This creature deals 1 damage to target creature.
+ * That creature can't block this turn.
+ *
+ * The trigger is [Triggers.YouSacrificeA] — the *per-permanent* template (CR 603.2c), which fires
+ * once for each matching permanent rather than once per batch, and whose `ANY` binding lets the
+ * Satyr count itself. The two abilities interact by design: the activated ability's sacrifice is
+ * paid as a **cost**, and the cost-payment paths emit `PermanentsSacrificedEvent` just like an
+ * effect-driven sacrifice does, so activating the second ability grows the Satyr via the first.
+ *
+ * The activated ability's two clauses are one `Composite` over a single shared target — the damage
+ * and the block restriction both read the same bound `target`, so this is a `then` chain and not
+ * two requirements.
+ */
+val BloodAspirant = card("Blood Aspirant") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Satyr Berserker"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever you sacrifice a permanent, put a +1/+1 counter on this creature.\n" +
+        "{1}{R}, {T}, Sacrifice a creature or enchantment: This creature deals 1 damage to target creature. " +
+        "That creature can't block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Permanent)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.CreatureOrEnchantment)
+        )
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(1, creature) then Effects.CantBlock(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "128"
+        artist = "Tyler Walpole"
+        flavorText = "It's a small step from revel to bloodbath."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BrineGiant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BrineGiant.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Brine Giant
+ * {6}{U}
+ * Creature — Giant
+ * 5/6
+ *
+ * Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)
+ *
+ * The stock [KeywordAbility.Affinity] cost reduction, here over [CardType.ENCHANTMENT] rather than
+ * the Mirrodin-era artifacts: `CostCalculator` counts permanents of the *declared* `forType`, so no
+ * new vocabulary is needed for Theros' enchantment-matters spin on the keyword.
+ *
+ * Affinity is a cost reduction, not an alternative cost — Brine Giant's mana value stays 7 in every
+ * zone however cheaply it was cast, and only its generic {6} can be shaved.
+ */
+val BrineGiant = card("Brine Giant") {
+    manaCost = "{6}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Giant"
+    power = 5
+    toughness = 6
+    oracleText = "Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)"
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ENCHANTMENT))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Yongjae Choi"
+        flavorText = "The oracles of Meletis foresaw neither its rise from the depths nor the destruction " +
+            "it would leave in its wake."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BronzeSword.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/BronzeSword.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Bronze Sword
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+0.
+ * Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * The plain Equipment shape, identical to Torch Gauntlet: one [ModifyStats] static scoped to
+ * [Filters.EquippedCreature] — the type's own default, the attached-to group — plus `equipAbility`,
+ * which sets `equipCost` *and* lowers the sorcery-speed, equip-flagged attach ability in one call.
+ * Never hand-roll that activated ability: an unflagged equip ability is invisible to every engine
+ * rule keyed off `ActivatedAbility.isEquipAbility` (equip discounts, instant-speed-equip grants).
+ */
+val BronzeSword = card("Bronze Sword") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(2, 0, Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "232"
+        artist = "Kev Walker"
+        flavorText = "Every strike of the smith's hammer infuses a sword with the determination of its creator."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/CarelessCelebrant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/CarelessCelebrant.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Careless Celebrant
+ * {1}{R}
+ * Creature — Satyr Shaman
+ * 2/1
+ *
+ * When this creature dies, it deals 2 damage to target creature or planeswalker an opponent controls.
+ *
+ * A plain [Triggers.Dies] — no `triggerZone`, which would replace the default `{BATTLEFIELD}` and
+ * leave the trigger unindexed.
+ *
+ * "Creature or planeswalker **an opponent controls**" carries a controller predicate, so it is a
+ * filtered [TargetObject] rather than the SDK's bare `TargetCreatureOrPlaneswalker` (which holds no
+ * filter at all and only spells the unqualified phrase).
+ *
+ * No `damageSource`: "it deals" is the source dealing the damage, which is what the effect already
+ * means with the field left null.
+ */
+val CarelessCelebrant = card("Careless Celebrant") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Satyr Shaman"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, it deals 2 damage to target creature or planeswalker an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val victim = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls())),
+        )
+        effect = Effects.DealDamage(2, victim)
+        description = "When this creature dies, it deals 2 damage to target creature or " +
+            "planeswalker an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Mathias Kollros"
+        flavorText = "\"Renata was mesmerized by the satyr's dance of gleeful indifference, of reckless grace and bright disaster.\"\n—Luphea of Setessa, *Histories*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ChainToMemory.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ChainToMemory.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chain to Memory
+ * {U}
+ * Instant
+ *
+ * Target creature gets -4/-0 until end of turn. Scry 2.
+ *
+ * Two printed sentences, so the spell effect is a two-element [Effects.Composite] in printed order:
+ * the [Effects.ModifyStats] pump on the bound target, then the compact [Effects.Scry] macro. The
+ * toughness modifier is an explicit `0` rather than omitted — "-4/-0" spells both halves.
+ */
+val ChainToMemory = card("Chain to Memory") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-0 until end of turn. Scry 2."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(-4, 0, t),
+            Effects.Scry(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Paul Scott Canavan"
+        flavorText = "Those who do not learn from their mistakes are bound to relive them."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/DiscordantPiper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/DiscordantPiper.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Discordant Piper
+ * {1}{B}
+ * Creature — Zombie Satyr
+ * 2/1
+ *
+ * When this creature dies, create a 0/1 white Goat creature token.
+ *
+ * A plain [Triggers.Dies] over a single [Effects.CreateToken]. No `triggerZone` — setting one
+ * replaces the default `{BATTLEFIELD}` and the trigger is then never indexed. THB ships the Goat
+ * token art, so the token resolves its image from the set's own printing.
+ */
+val DiscordantPiper = card("Discordant Piper") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Satyr"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, create a 0/1 white Goat creature token."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Goat"),
+        )
+        description = "When this creature dies, create a 0/1 white Goat creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "John Stanko"
+        flavorText = "The death of the party."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EatToExtinction.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EatToExtinction.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eat to Extinction
+ * {3}{B}
+ * Instant
+ *
+ * Exile target creature or planeswalker. Surveil 1. (Look at the top card of your library. You may
+ * put that card into your graveyard.)
+ *
+ * [Effects.Exile] is the exile-flavoured `MoveToZone`; no `fromZone` guard, because the target is a
+ * battlefield permanent chosen at cast time rather than a card fished out of another zone. The
+ * surveil rider is the compact [Effects.Surveil] macro, which the engine expands to the shared
+ * surveil pipeline at resolution so "whenever you surveil" triggers still see it.
+ */
+val EatToExtinction = card("Eat to Extinction") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature or planeswalker. Surveil 1. (Look at the top card of your " +
+        "library. You may put that card into your graveyard.)"
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.Exile(t),
+            Effects.Surveil(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "90"
+        artist = "Vincent Proce"
+        flavorText = "\"Kroxa devours what he may—not for sustenance or pleasure, but because it is " +
+            "his nature. He is unending hunger given form.\"\n—Klothys, god of destiny"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EidolonOfInspiration.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EidolonOfInspiration.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eidolon of Inspiration
+ * {1}{W}{W}
+ * Enchantment Creature — Spirit
+ * 2/2
+ *
+ * At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.
+ *
+ * "on your turn" is the `StepEvent`'s player scope, not a condition: [Triggers.BeginCombat] is
+ * `StepEvent(BEGIN_COMBAT, Player.You)`. Its each-combat sibling ([Triggers.EachCombat], which
+ * Stampede Rider in this same set uses) differs only in that field.
+ */
+val EidolonOfInspiration = card("Eidolon of Inspiration") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Spirit"
+    power = 2
+    toughness = 2
+    oracleText = "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "271"
+        artist = "Bram Sels"
+        flavorText = "\"Agios was felled by a minotaur's blade, but I swear I have seen him since—in the midst of " +
+            "battle, wherever help is needed most.\"\n—Phrokos, soldier of Akros"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg"
+        inBooster = false
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EidolonOfPhilosophy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EidolonOfPhilosophy.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eidolon of Philosophy
+ * {U}
+ * Enchantment Creature — Spirit
+ * 1/2
+ *
+ * {6}{U}, Sacrifice this creature: Draw three cards.
+ *
+ * A one-drop blocker that turns into a late-game card-draw spell. The sacrifice is part of the
+ * activation cost, not the effect, so it is [Costs.SacrificeSelf] inside the cost composite rather
+ * than a sacrifice effect: the creature is gone the moment the ability is activated, whether or not
+ * the ability goes on to resolve.
+ */
+val EidolonOfPhilosophy = card("Eidolon of Philosophy") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Spirit"
+    power = 1
+    toughness = 2
+    oracleText = "{6}{U}, Sacrifice this creature: Draw three cards."
+
+    // {6}{U}, Sacrifice this creature: Draw three cards.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{6}{U}"),
+            Costs.SacrificeSelf
+        )
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Adam Paquette"
+        flavorText = "\"And what did Erekastos teach us is the nature of the soul?\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FatefulEnd.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FatefulEnd.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fateful End
+ * {2}{R}
+ * Instant
+ *
+ * Fateful End deals 3 damage to any target. Scry 1.
+ *
+ * A burn spell plus a rider: [Effects.Composite] of [Effects.DealDamage] at the [Targets.Any]
+ * binding and the compact [Effects.Scry] macro, in printed order. The scry happens even if the
+ * damage is prevented, because it is a separate effect in the same resolution.
+ */
+val FatefulEnd = card("Fateful End") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Fateful End deals 3 damage to any target. Scry 1."
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(3, t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Chris Rallis"
+        flavorText = "\"Everything will be put back in its proper place.\"\n—Klothys, god of destiny"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FinalDeath.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FinalDeath.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Final Death
+ * {4}{B}
+ * Instant
+ *
+ * Exile target creature.
+ *
+ * One sentence, so the spell effect is the bare [Effects.Exile] move rather than a single-element
+ * composite. No `fromZone` guard: the target is a battlefield permanent bound at cast time.
+ */
+val FinalDeath = card("Final Death") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Johann Bodin"
+        flavorText = "The Underworld erodes memory, identity, and eventually the physical form, " +
+            "leaving only crumbling statues called misera—hollow monuments to mortal futility."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FinalFlare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FinalFlare.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Final Flare
+ * {2}{R}
+ * Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a creature or enchantment.
+ * Final Flare deals 5 damage to target creature.
+ *
+ * The sacrifice is an [Costs.additional] atom, not a target: it is chosen and paid while the spell
+ * is being cast, so nothing can respond between the sacrifice and the spell going on the stack, and
+ * the sacrificed permanent is never a legal object for the damage. [GameObjectFilter.CreatureOrEnchantment]
+ * is the printed noun phrase — a creature *or* an enchantment, so an enchantment creature qualifies
+ * on either half.
+ */
+val FinalFlare = card("Final Flare") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature or enchantment.\n" +
+        "Final Flare deals 5 damage to target creature."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.CreatureOrEnchantment))
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Kev Walker"
+        flavorText = "Those who fought without honor in life are taken to Agonas and doomed to " +
+            "fight forever in its arenas."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/GrimPhysician.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/GrimPhysician.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grim Physician
+ * {B}
+ * Creature — Zombie
+ * 1/1
+ *
+ * When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.
+ *
+ * A plain [Triggers.Dies] — no `triggerZone`, which would replace the default `{BATTLEFIELD}` and
+ * leave the trigger unindexed. [Effects.ModifyStats] already ends at end of turn, so the printed
+ * duration needs no argument.
+ */
+val GrimPhysician = card("Grim Physician") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val victim = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-1, -1, victim)
+        description = "When this creature dies, target creature an opponent controls gets -1/-1 " +
+            "until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Mark Zug"
+        flavorText = "The Returned retain no memory of their identities, but sometimes they mindlessly attempt familiar tasks."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/HyraxTowerScout.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/HyraxTowerScout.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hyrax Tower Scout
+ * {2}{G}
+ * Creature — Human Scout
+ * 3/3
+ *
+ * When this creature enters, untap target creature.
+ *
+ * A plain self-ETB into [Effects.Untap] — the untap half of `TapUntapEffect`. The slot is the
+ * unrestricted [Targets.Creature]: the printed line says "target creature", with no controller
+ * clause, so the requirement carries only the `IsCreature` predicate.
+ */
+val HyraxTowerScout = card("Hyrax Tower Scout") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, untap target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Untap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Micah Epstein"
+        flavorText = "The scouts of Hyrax Tower keep watch at the edge of Setessan territory, protecting the polis from inhuman monsters and enemy armies."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IdyllicTutorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IdyllicTutorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Idyllic Tutor reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val IdyllicTutorReprint = Printing(
+    oracleId = "57c9ff89-dd30-467b-bb3e-499eeea8cb94",
+    name = "Idyllic Tutor",
+    setCode = "THB",
+    collectorNumber = "24",
+    scryfallId = "f06edd53-f3ac-44b0-a087-5670ba8f0fa5",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IndomitableWillReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IndomitableWillReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Indomitable Will reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val IndomitableWillReprint = Printing(
+    oracleId = "cca60afe-b044-4401-8322-170aa015873c",
+    name = "Indomitable Will",
+    setCode = "THB",
+    collectorNumber = "25",
+    scryfallId = "47772a34-c72f-44e8-b272-4ef2d2af5c82",
+    artist = "Micah Epstein",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47772a34-c72f-44e8-b272-4ef2d2af5c82.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/InevitableEnd.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/InevitableEnd.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Inevitable End
+ * {2}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "At the beginning of your upkeep, sacrifice a creature."
+ *
+ * The quoted ability is *granted to the enchanted creature* ([GrantTriggeredAbility] over the default
+ * attached-creature filter) rather than printed on the Aura, which is what makes the quoted "your"
+ * mean the enchanted creature's controller: the engine indexes a granted trigger on the permanent it
+ * was granted to, so [Triggers.YourUpkeep]'s `Player.You` reads that permanent's controller. Printing
+ * an ordinary triggered ability on the Aura instead would make the Aura's controller sacrifice —
+ * wrong for a card whose whole point is enchanting someone else's creature. Relic Bane is the same
+ * shape, and its scenario test pins the attribution.
+ *
+ * The granted ability keeps [Triggers.YourUpkeep]'s own `ANY` binding; an `ATTACHED` binding would
+ * drop it out of the trigger index entirely.
+ *
+ * The sacrifice is [Effects.SacrificeOwn], not `Effects.Sacrifice`: the printed clause is the bare
+ * imperative, so the ability's controller chooses and sacrifices one of their own creatures. There is
+ * no named player and no target.
+ */
+val InevitableEnd = card("Inevitable End") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"At the beginning of your upkeep, sacrifice a creature.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YourUpkeep.event,
+                binding = Triggers.YourUpkeep.binding,
+                effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "Josh Hass"
+        flavorText = "\"How many more will die before you accept your fate?\"\n—Erebos, god of the dead"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/InfuriateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/InfuriateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infuriate reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val InfuriateReprint = Printing(
+    oracleId = "d23119ca-73d1-4a48-a8d0-dab8919d891f",
+    name = "Infuriate",
+    setCode = "THB",
+    collectorNumber = "141",
+    scryfallId = "85a74392-4056-428c-a807-b062957e838e",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/85a74392-4056-428c-a807-b062957e838e.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IroassBlessing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IroassBlessing.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Iroas's Blessing
+ * {3}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature you control
+ * When this Aura enters, it deals 4 damage to target creature or planeswalker an opponent controls.
+ * Enchanted creature gets +1/+1.
+ *
+ * Two independent target restrictions: the aura's own is "creature you control", while the
+ * enters-the-battlefield trigger reaches across the table for a creature *or planeswalker* an opponent
+ * controls — a combined-type object filter rather than a plain creature requirement.
+ */
+val IroassBlessing = card("Iroas's Blessing") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, it deals 4 damage to target creature or planeswalker an opponent controls.\n" +
+        "Enchanted creature gets +1/+1."
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls()))
+        )
+        effect = Effects.DealDamage(4, t)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Victor Adame Minguez"
+        flavorText = "The blessing is not the strength itself, but the knowledge of how to use it."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/LampadOfDeathsVigil.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/LampadOfDeathsVigil.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lampad of Death's Vigil
+ * {1}{B}
+ * Enchantment Creature — Nymph
+ * 1/3
+ *
+ * {1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life.
+ *
+ * Two separate life effects, not [Effects.DrainLife]: the printed life gain is a flat 1, not "life
+ * equal to the life lost this way", so in multiplayer the Lampad drains every opponent for 1 but
+ * still gains only 1. The sacrifice filter is unrestricted creatures, so the Lampad may eat itself.
+ */
+val LampadOfDeathsVigil = card("Lampad of Death's Vigil") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Nymph"
+    power = 1
+    toughness = 3
+    oracleText = "{1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Jason Felix"
+        flavorText = "\"Grief-struck, she weeps for each mortal's final death.\"\n—Psemilla, Meletian poet"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MemoryDrain.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MemoryDrain.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Memory Drain
+ * {2}{U}{U}
+ * Instant
+ *
+ * Counter target spell. Scry 2.
+ *
+ * Two sentences in one effect, so the scry is not gated on the counter: [Effects.Composite] runs
+ * [Effects.CounterSpell] then [Effects.Scry], and a spell that has already left the stack does not
+ * stop the second half. The same shape as Theros' own Dissolve, one scry deeper.
+ */
+val MemoryDrain = card("Memory Drain") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Scry 2."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.Scry(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "PINDURSKI"
+        flavorText = "Alythos sat and stared blankly out over the glassy oceans of Nerono, trying in vain to " +
+            "remember what he knew he had forgotten."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MireTriton.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MireTriton.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mire Triton
+ * {1}{B}
+ * Creature — Zombie Merfolk
+ * 2/1
+ *
+ * Deathtouch
+ * When this creature enters, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)
+ *
+ * Two printed clauses, so two members of the trigger's [Effects.Composite]: the mill recipe
+ * ([Patterns.Library.mill], a Gather → MoveCollection pair that stays nested as its own composite)
+ * and the life gain. Written with `Effects.Composite` rather than `then` because `then` flattens a
+ * composite receiver, which would splice the mill's two pipeline steps into the outer list.
+ */
+val MireTriton = card("Mire Triton") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Merfolk"
+    power = 2
+    toughness = 1
+    oracleText = "Deathtouch\n" +
+        "When this creature enters, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.mill(2),
+            Effects.GainLife(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Seb McKinnon"
+        flavorText = "Caught between life and death, between land and sea, between thought and oblivion."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MiresGrasp.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MiresGrasp.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Mire's Grasp
+ * {1}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets -3/-3.
+ *
+ * "Enchant creature" is a bare creature restriction — any creature, either side of the table — so the
+ * aura target is [Targets.Creature] with no controller predicate. [ModifyStats] defaults its filter to
+ * the attached creature, which is exactly the "enchanted creature" the printed line names.
+ */
+val MiresGrasp = card("Mire's Grasp") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets -3/-3."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-3, -3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Chris Rallis"
+        flavorText = "Those caught attempting to escape the Underworld spend the rest of their " +
+            "existence trapped in the Mire of Punishment."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MossViper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/MossViper.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moss Viper
+ * {G}
+ * Creature — Snake
+ * 1/1
+ *
+ * Deathtouch
+ *
+ * A single printed keyword — [Keyword.DEATHTOUCH] on the keyword set, nothing else to model.
+ */
+val MossViper = card("Moss Viper") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Mike Bierek"
+        flavorText = "Nylea watches over all the creatures of the forest except for the snakes. " +
+            "Blessed by Pharika, they can take care of themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NaiadOfHiddenCoves.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NaiadOfHiddenCoves.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Naiad of Hidden Coves
+ * {2}{U}
+ * Enchantment Creature — Nymph
+ * 2/3
+ *
+ * During turns other than yours, spells you cast cost {1} less to cast.
+ *
+ * The "during turns other than yours" clause folds into [ModifySpellCost]'s own `gating` slot rather
+ * than wrapping the ability in a `ConditionalStaticAbility`: cost calculation scans the battlefield
+ * for bare `is ModifySpellCost` statics and never consults the layer system, so a conditional
+ * wrapper would hide the ability and the reduction would silently never apply.
+ */
+val NaiadOfHiddenCoves = card("Naiad of Hidden Coves") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Nymph"
+    power = 2
+    toughness = 3
+    oracleText = "During turns other than yours, spells you cast cost {1} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.IsNotYourTurn),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Kieran Yanner"
+        flavorText = "\"Wave-borne, he watches over secrets of the shore.\"\n—Psemilla, Meletian poet"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NexusWardens.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NexusWardens.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Nexus Wardens
+ * {2}{G}
+ * Creature — Satyr Archer
+ * 1/4
+ *
+ * Reach
+ * Constellation — Whenever an enchantment you control enters, you gain 2 life.
+ *
+ * Constellation is an ability word with no rules meaning of its own, so this is a plain
+ * enters-the-battlefield watcher over enchantments you control with [TriggerBinding.ANY] — the
+ * Wardens themselves are not an enchantment, so the trigger must not be bound to the source.
+ */
+val NexusWardens = card("Nexus Wardens") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Satyr Archer"
+    power = 1
+    toughness = 4
+    oracleText = "Reach\n" +
+        "Constellation — Whenever an enchantment you control enters, you gain 2 life."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GainLife(2)
+        description = "Constellation — Whenever an enchantment you control enters, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Dan Murayama Scott"
+        flavorText = "The Summer Nexus is a holy grove in Setessa where the starfields of Nyx glitter in the shadows."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyleasForerunner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyleasForerunner.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Nylea's Forerunner
+ * {4}{G}
+ * Enchantment Creature — Beast
+ * 5/3
+ *
+ * Trample
+ * Other creatures you control have trample.
+ *
+ * The printed "Other" is the [GroupFilter] `excludeSelf` flag, not a predicate on the base filter —
+ * the Forerunner already has trample from its own keyword, and the lord grant must not double up on
+ * it. Same shape as Khenra Charioteer.
+ */
+val NyleasForerunner = card("Nylea's Forerunner") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Beast"
+    power = 5
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Other creatures you control have trample."
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.TRAMPLE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Christopher Burdett"
+        flavorText = "Where its feet tread, the thunder of many others will follow."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheDead.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheDead.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omen of the Dead
+ * {B}
+ * Enchantment
+ *
+ * Flash
+ * When this enchantment enters, return target creature card from your graveyard to your hand.
+ * {2}{B}, Sacrifice this enchantment: Scry 2.
+ *
+ * The black member of the Omen cycle: a flash enchantment that cashes in for its spell effect on
+ * entry and later sacrifices itself to smooth the next draw.
+ *
+ * The recursion is [Effects.ReturnToHand] rather than the `fromZone`-guarded
+ * [Effects.ReturnToHandFromGraveyard] twin, because the target requirement
+ * ([Targets.CreatureCardInYourGraveyard]) already pins the card to your graveyard — a second guard
+ * would be redundant on a targeted return.
+ */
+val OmenOfTheDead = card("Omen of the Dead") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Flash\n" +
+        "When this enchantment enters, return target creature card from your graveyard to your hand.\n" +
+        "{2}{B}, Sacrifice this enchantment: Scry 2."
+
+    keywords(Keyword.FLASH)
+
+    // When this enchantment enters, return target creature card from your graveyard to your hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creatureCard = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.ReturnToHand(creatureCard)
+    }
+
+    // {2}{B}, Sacrifice this enchantment: Scry 2.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}"),
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Piotr Dura"
+        flavorText = "\"My time will come, when life's frantic striving will fade into the boundless quiet of death.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheForge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheForge.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omen of the Forge
+ * {1}{R}
+ * Enchantment
+ *
+ * Flash
+ * When this enchantment enters, it deals 2 damage to any target.
+ * {2}{R}, Sacrifice this enchantment: Scry 2.
+ *
+ * The red member of the Omen cycle — a flash Shock that later sacrifices itself to smooth the next
+ * draw. "Any target" is [Targets.Any]; the damage is sourced from the enchantment itself, which is
+ * the facade's default, so no explicit `damageSource` is written.
+ */
+val OmenOfTheForge = card("Omen of the Forge") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Flash\n" +
+        "When this enchantment enters, it deals 2 damage to any target.\n" +
+        "{2}{R}, Sacrifice this enchantment: Scry 2."
+
+    keywords(Keyword.FLASH)
+
+    // When this enchantment enters, it deals 2 damage to any target.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, victim)
+    }
+
+    // {2}{R}, Sacrifice this enchantment: Scry 2.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{R}"),
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Piotr Dura"
+        flavorText = "\"My time will come, when all the world will be reforged in the fires of my invention.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheSea.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OmenOfTheSea.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omen of the Sea
+ * {1}{U}
+ * Enchantment
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this enchantment enters, scry 2, then draw a card.
+ * {2}{U}, Sacrifice this enchantment: Scry 2. (Look at the top two cards of your library, then put
+ * any number of them on the bottom and the rest on top in any order.)
+ *
+ * The blue member of the Omen cycle. The entry trigger's printed "scry 2, then draw a card" is a
+ * single ordered sequence, so it is one `then`-composed pair rather than two abilities — the scry
+ * must finish before the draw sees the top of the library.
+ */
+val OmenOfTheSea = card("Omen of the Sea") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "When this enchantment enters, scry 2, then draw a card.\n" +
+        "{2}{U}, Sacrifice this enchantment: Scry 2. (Look at the top two cards of your library, " +
+        "then put any number of them on the bottom and the rest on top in any order.)"
+
+    keywords(Keyword.FLASH)
+
+    // When this enchantment enters, scry 2, then draw a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(2).then(Effects.DrawCards(1))
+    }
+
+    // {2}{U}, Sacrifice this enchantment: Scry 2.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{U}"),
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Piotr Dura"
+        flavorText = "\"My time will come, when the rising tide will surge above the tallest mountain.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OreadOfMountainsBlaze.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/OreadOfMountainsBlaze.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oread of Mountain's Blaze
+ * {1}{R}
+ * Enchantment Creature — Nymph
+ * 1/3
+ *
+ * {2}{R}, Discard a card: Draw a card.
+ *
+ * A plain looter on a stick: the discard is an unfiltered [Costs.DiscardCard] cost atom, so the card
+ * leaves the hand as the ability is activated, before the replacement draw ever happens.
+ */
+val OreadOfMountainsBlaze = card("Oread of Mountain's Blaze") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Nymph"
+    power = 1
+    toughness = 3
+    oracleText = "{2}{R}, Discard a card: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.DiscardCard)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Yigit Koroglu"
+        flavorText = "\"Flame-wrapped, she dances a burning swath amid the clouds.\"\n—Psemilla, Meletian poet"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PharikasLibation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PharikasLibation.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Pharika's Libation
+ * {2}{B}
+ * Instant
+ *
+ * Choose one —
+ * • Target opponent sacrifices a creature of their choice.
+ * • Target opponent sacrifices an enchantment of their choice.
+ *
+ * Each mode names its *own* target opponent, so the requirement is declared inside the mode rather
+ * than lifted to the spell: only the chosen mode's target is announced, and the two modes are
+ * independent edicts. "Of their choice" is [Effects.Sacrifice]'s default — the named player picks
+ * what to sacrifice, not the spell's controller.
+ */
+val PharikasLibation = card("Pharika's Libation") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target opponent sacrifices a creature of their choice.\n" +
+        "• Target opponent sacrifices an enchantment of their choice."
+
+    spell {
+        modal {
+            mode("Target opponent sacrifices a creature of their choice") {
+                val opponent = target("target", Targets.Opponent)
+                effect = Effects.Sacrifice(filter = GameObjectFilter.Creature, target = opponent)
+            }
+            mode("Target opponent sacrifices an enchantment of their choice") {
+                val opponent = target("target", Targets.Opponent)
+                effect = Effects.Sacrifice(filter = GameObjectFilter.Enchantment, target = opponent)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Jason Felix"
+        flavorText = "\"If you will not pour your drink out for me, I shall pour mine out for you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RageScarredBerserker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RageScarredBerserker.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rage-Scarred Berserker
+ * {4}{B}
+ * Creature — Minotaur Berserker
+ * 5/4
+ *
+ * When this creature enters, target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+ *
+ * One target, two riders on it: [Effects.ModifyStats] then [Effects.GrantKeyword], in the printed
+ * order. Both facades default to `Duration.EndOfTurn`, which is exactly the printed "until end of
+ * turn", so neither writes a duration explicitly.
+ */
+val RageScarredBerserker = card("Rage-Scarred Berserker") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Minotaur Berserker"
+    power = 5
+    toughness = 4
+    oracleText = "When this creature enters, target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, creature),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Antonio José Manzanedo"
+        flavorText = "The fury of the slaughter god Mogis burns within him."
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ReturnToNatureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ReturnToNatureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to Nature reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val ReturnToNatureReprint = Printing(
+    oracleId = "777b8ec4-a783-4297-96b7-4f200d0eb734",
+    name = "Return to Nature",
+    setCode = "THB",
+    collectorNumber = "197",
+    scryfallId = "a4515a76-53f0-40a2-8b88-70b73447d1e6",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4515a76-53f0-40a2-8b88-70b73447d1e6.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RiptideTurtle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RiptideTurtle.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riptide Turtle
+ * {1}{U}
+ * Creature — Turtle
+ * 0/5
+ *
+ * Flash
+ * Defender
+ *
+ * Two printed keywords on the keyword set — flash is a casting permission the engine reads off the
+ * card, defender a combat restriction; neither needs a parameterized [com.wingedsheep.sdk.scripting.KeywordAbility].
+ */
+val RiptideTurtle = card("Riptide Turtle") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Turtle"
+    power = 0
+    toughness = 5
+    oracleText = "Flash\n" +
+        "Defender"
+
+    keywords(Keyword.FLASH, Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Brian Valeza"
+        flavorText = "\"As the storm waves crushed my sailors, I cried out to Thassa. The next time I saw them, " +
+            "hard shells encased them, and they swam away to safety.\"\n—Siona, captain of the *Pyleas*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RumblingSentry.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RumblingSentry.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rumbling Sentry
+ * {3}{W}{W}
+ * Creature — Giant
+ * 3/6
+ *
+ * When this creature enters, scry 1.
+ *
+ * The same shape as this set's Thaumaturge's Familiar: a self-ETB into [Patterns.Library.scry],
+ * whose no-target overload is the bare `ScryEffect` the controller performs.
+ */
+val RumblingSentry = card("Rumbling Sentry") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant"
+    power = 3
+    toughness = 6
+    oracleText = "When this creature enters, scry 1."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Yongjae Choi"
+        flavorText = "\"To provoke the mountain is to invite the avalanche.\"\n—Perisophia the philosopher"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SageOfMysteries.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SageOfMysteries.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Sage of Mysteries
+ * {U}
+ * Creature — Human Wizard
+ * 0/2
+ *
+ * Constellation — Whenever an enchantment you control enters, target player mills two cards.
+ *
+ * Constellation is an ability word with no rules meaning of its own — a plain enters-the-battlefield
+ * watcher over enchantments you control, bound with [TriggerBinding.ANY] so the Sage (not itself an
+ * enchantment) isn't the thing being watched. The mill is [Patterns.Library.mill]'s gather-then-move
+ * pipeline aimed at the chosen player rather than the controller.
+ */
+val SageOfMysteries = card("Sage of Mysteries") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 0
+    toughness = 2
+    oracleText = "Constellation — Whenever an enchantment you control enters, target player mills two cards."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val t = target("target", Targets.Player)
+        effect = Patterns.Library.mill(2, t)
+        description = "Constellation — Whenever an enchantment you control enters, target player mills two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "John Stanko"
+        flavorText = "\"I see destruction, suffering, and one tormented glimmer of hope.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanChampion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanChampion.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Setessan Champion
+ * {2}{G}
+ * Creature — Human Warrior
+ * 1/3
+ *
+ * Constellation — Whenever an enchantment you control enters, put a +1/+1 counter on this creature
+ * and draw a card.
+ *
+ * Constellation is an ability word with no rules meaning of its own, so this is a plain
+ * enters-the-battlefield watcher over enchantments you control with [TriggerBinding.ANY] — the
+ * Champion is not an enchantment, so the trigger must not be bound to its own source. The printed
+ * "and" is the two-member composite `then` builds: counter first, then the draw.
+ */
+val SetessanChampion = card("Setessan Champion") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior"
+    power = 1
+    toughness = 3
+    oracleText = "Constellation — Whenever an enchantment you control enters, put a +1/+1 counter on this creature and draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+            .then(Effects.DrawCards(1))
+        description = "Constellation — Whenever an enchantment you control enters, put a +1/+1 counter on this creature and draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "198"
+        artist = "Emrah Elmasli"
+        flavorText = "\"A blessing is not a gift. It is a duty.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanSkirmisher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanSkirmisher.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Setessan Skirmisher
+ * {1}{G}
+ * Creature — Human Warrior
+ * 2/1
+ *
+ * Constellation — Whenever an enchantment you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * Constellation is an ability word with no rules meaning of its own — a plain enters-the-battlefield
+ * watcher over enchantments you control, bound with [TriggerBinding.ANY] because the Skirmisher is
+ * not the permanent being watched. The pump is untargeted: it always hits the source itself, so it
+ * is [EffectTarget.Self] rather than a target slot.
+ */
+val SetessanSkirmisher = card("Setessan Skirmisher") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Constellation — Whenever an enchantment you control enters, this creature gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Constellation — Whenever an enchantment you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Greg Staples"
+        flavorText = "Bassara, the tower of the fox, houses the elite skirmishers who guard the Nessian Wood against trespassers."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanTraining.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SetessanTraining.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Setessan Training
+ * {1}{G}
+ * Enchantment — Aura
+ *
+ * Enchant creature you control
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +1/+0 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ *
+ * "Enchant creature you control" narrows the aura target to [Targets.CreatureYouControl]. The last
+ * printed line joins a stat modification and a keyword grant with "and", which the SDK spells as two
+ * separate static abilities — both default their filter to the attached creature.
+ */
+val SetessanTraining = card("Setessan Training") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature gets +1/+0 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "201"
+        artist = "Scott Murphy"
+        flavorText = "In the heart of Setessa, the warriors of Leina Tower defend the polis and train its daughters."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SoulreaperOfMogis.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SoulreaperOfMogis.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Soulreaper of Mogis
+ * {2}{B}
+ * Enchantment Creature — Minotaur Shaman
+ * 2/3
+ *
+ * {2}{B}, Sacrifice a creature: Draw a card.
+ *
+ * Two cost atoms in the order the card prints them, joined by [Costs.Composite]. "A creature" is
+ * the unscoped creature filter — a sacrifice cost can only ever be paid with a permanent you
+ * control, so no controller predicate is written.
+ */
+val SoulreaperOfMogis = card("Soulreaper of Mogis") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Minotaur Shaman"
+    power = 2
+    toughness = 3
+    oracleText = "{2}{B}, Sacrifice a creature: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Dmitry Burmak"
+        flavorText = "\"We offer to Mogis the blood of the weak, and in return he makes us strong.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SphinxMindbreaker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SphinxMindbreaker.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sphinx Mindbreaker
+ * {5}{U}{U}
+ * Creature — Sphinx
+ * 6/6
+ *
+ * Flying
+ * When this creature enters, each opponent mills ten cards.
+ *
+ * The miller is a parameter of the mill recipe, not a wrapper around it: passing
+ * `EffectTarget.PlayerRef(Player.EachOpponent)` puts `EachOpponent` on both the gather's
+ * `TopOfLibrary` and the move's `ToZone`, so one pipeline fans out over every opponent's library.
+ * A `ForEachPlayerEffect` around a controller-scoped mill would be a different model.
+ */
+val SphinxMindbreaker = card("Sphinx Mindbreaker") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\n" +
+        "When this creature enters, each opponent mills ten cards."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(10, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "290"
+        artist = "PINDURSKI"
+        flavorText = "Riddles draw you in, paradoxes hold you fast, and answers shatter your perceptions."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg"
+        inBooster = false
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/StampedeRider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/StampedeRider.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stampede Rider
+ * {2}{R}
+ * Creature — Satyr
+ * 2/3
+ *
+ * Trample
+ * At the beginning of each combat, if you control a creature with power 4 or greater, this creature
+ * gets +1/+1 until end of turn.
+ *
+ * "each combat" is [Triggers.EachCombat] — `StepEvent(BEGIN_COMBAT, Player.Each)`, the each-turn
+ * sibling of Eidolon of Inspiration's `BeginCombat`. The "if …" clause is a true intervening-if
+ * (CR 603.4), so it goes in the ability's `interveningIf` field rather than gating the effect;
+ * `Conditions.YouControl` is `Exists(You, Battlefield, filter)`, which is the spelling Nessian
+ * Hornbeetle in this same set already uses for the identical clause.
+ */
+val StampedeRider = card("Stampede Rider") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Satyr"
+    power = 2
+    toughness = 3
+    oracleText = "Trample\n" +
+        "At the beginning of each combat, if you control a creature with power 4 or greater, " +
+        "this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EachCombat
+        interveningIf = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Aaron Miller"
+        flavorText = "To a satyr, a stampede is just another kind of revelry."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SternDismissal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SternDismissal.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stern Dismissal
+ * {U}
+ * Instant
+ *
+ * Return target creature or enchantment an opponent controls to its owner's hand.
+ *
+ * One target, not two: the "creature or enchantment" is a single `Or` predicate on the target
+ * filter, and "an opponent controls" is the filter's controller predicate rather than a separate
+ * clause. Type and controller are both read off projected state when target legality is checked,
+ * so a creature that became an enchantment — or changed hands — this turn is judged as it stands.
+ */
+val SternDismissal = card("Stern Dismissal") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature or enchantment an opponent controls to its owner's hand."
+
+    spell {
+        val victim = target(
+            "target",
+            TargetPermanent(filter = TargetFilter.CreatureOrEnchantment.opponentControls()),
+        )
+        effect = Effects.ReturnToHand(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Lie Setiawan"
+        flavorText = "Cities offer tribute to Ephara and carve her image into their walls, imploring her to " +
+            "protect them from the dangers of the wild."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SunmanePegasus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SunmanePegasus.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sunmane Pegasus
+ * {3}{W}
+ * Creature — Pegasus
+ * 2/3
+ *
+ * Flying
+ * {1}{W}: This creature gains vigilance and lifelink until end of turn. (Attacking doesn't cause it
+ * to tap. Damage dealt by it also causes you to gain that much life.)
+ *
+ * "Gains vigilance and lifelink" is two independent [Effects.GrantKeyword] grants on
+ * [EffectTarget.Self] composed in order, not a single multi-keyword grant — each keyword is its own
+ * until-end-of-turn floating effect, so one can be stripped without the other.
+ */
+val SunmanePegasus = card("Sunmane Pegasus") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Pegasus"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{1}{W}: This creature gains vigilance and lifelink until end of turn. " +
+        "(Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "John Severin Brassell"
+        flavorText = "Chosen by Heliod, Daxos approached the pegasus without fear, and rode it without " +
+            "saddle or reins."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfAbandonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfAbandonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Abandon reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfAbandonReprint = Printing(
+    oracleId = "3baa8e38-ef93-435d-b63e-f781d5bfcc68",
+    name = "Temple of Abandon",
+    setCode = "THB",
+    collectorNumber = "244",
+    scryfallId = "7d5f8481-47f7-4531-9dad-686cdfb5d2ad",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d5f8481-47f7-4531-9dad-686cdfb5d2ad.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfDeceitReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfDeceitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Deceit reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfDeceitReprint = Printing(
+    oracleId = "33b9b3bd-33ca-46f3-b8bb-a978bc3d1085",
+    name = "Temple of Deceit",
+    setCode = "THB",
+    collectorNumber = "245",
+    scryfallId = "e3d4fd29-dab5-481f-94c9-eeb70f3c29dd",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3d4fd29-dab5-481f-94c9-eeb70f3c29dd.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfEnlightenmentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfEnlightenmentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Enlightenment reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfEnlightenmentReprint = Printing(
+    oracleId = "89f43e27-790b-4ca1-8ba7-0882b31e0783",
+    name = "Temple of Enlightenment",
+    setCode = "THB",
+    collectorNumber = "246",
+    scryfallId = "adad8390-66d8-4022-a059-c68e44e718fe",
+    artist = "Piotr Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adad8390-66d8-4022-a059-c68e44e718fe.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfMaliceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfMaliceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Malice reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfMaliceReprint = Printing(
+    oracleId = "7c439c18-31dc-41fe-b03d-3fca06e6fc0b",
+    name = "Temple of Malice",
+    setCode = "THB",
+    collectorNumber = "247",
+    scryfallId = "9490a495-9f17-45a8-b10c-7de4fcbd2778",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/9490a495-9f17-45a8-b10c-7de4fcbd2778.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfPlentyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TempleOfPlentyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Plenty reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfPlentyReprint = Printing(
+    oracleId = "e521322b-0e83-458c-8936-7021a80ee279",
+    name = "Temple of Plenty",
+    setCode = "THB",
+    collectorNumber = "248",
+    scryfallId = "6e6256ea-ccb5-4595-8278-44266f922e31",
+    artist = "Chris Ostrowski",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e6256ea-ccb5-4595-8278-44266f922e31.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TherosBeyondDeathBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TherosBeyondDeathBasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Theros Beyond Death Basic Lands
+ *
+ * Theros Beyond Death prints three art variants of each basic land type:
+ * the booster basics (250-254) and two further variants each (278-287).
+ */
+
+// =============================================================================
+// Plains (Cards 250, 278, 279)
+// =============================================================================
+
+val TherosBeyondDeathPlains250 = basicLand("Plains") {
+    collectorNumber = "250"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg"
+}
+
+val TherosBeyondDeathPlains278 = basicLand("Plains") {
+    collectorNumber = "278"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg"
+}
+
+val TherosBeyondDeathPlains279 = basicLand("Plains") {
+    collectorNumber = "279"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db68b6a3-10e5-42d1-9325-94a4a821782a.jpg"
+}
+
+// =============================================================================
+// Island (Cards 251, 280, 281)
+// =============================================================================
+
+val TherosBeyondDeathIsland251 = basicLand("Island") {
+    collectorNumber = "251"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg"
+}
+
+val TherosBeyondDeathIsland280 = basicLand("Island") {
+    collectorNumber = "280"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg"
+}
+
+val TherosBeyondDeathIsland281 = basicLand("Island") {
+    collectorNumber = "281"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b82c12c2-2ebf-470b-b0d2-92ccc5faa056.jpg"
+}
+
+// =============================================================================
+// Swamp (Cards 252, 282, 283)
+// =============================================================================
+
+val TherosBeyondDeathSwamp252 = basicLand("Swamp") {
+    collectorNumber = "252"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg"
+}
+
+val TherosBeyondDeathSwamp282 = basicLand("Swamp") {
+    collectorNumber = "282"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg"
+}
+
+val TherosBeyondDeathSwamp283 = basicLand("Swamp") {
+    collectorNumber = "283"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e54a44f2-70bf-4782-bd13-9d03e109d60d.jpg"
+}
+
+// =============================================================================
+// Mountain (Cards 253, 284, 285)
+// =============================================================================
+
+val TherosBeyondDeathMountain253 = basicLand("Mountain") {
+    collectorNumber = "253"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg"
+}
+
+val TherosBeyondDeathMountain284 = basicLand("Mountain") {
+    collectorNumber = "284"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg"
+}
+
+val TherosBeyondDeathMountain285 = basicLand("Mountain") {
+    collectorNumber = "285"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d10d759b-db5b-4a59-840c-05bcbf2381f3.jpg"
+}
+
+// =============================================================================
+// Forest (Cards 254, 286, 287)
+// =============================================================================
+
+val TherosBeyondDeathForest254 = basicLand("Forest") {
+    collectorNumber = "254"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg"
+}
+
+val TherosBeyondDeathForest286 = basicLand("Forest") {
+    collectorNumber = "286"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg"
+}
+
+val TherosBeyondDeathForest287 = basicLand("Forest") {
+    collectorNumber = "287"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6af0c659-f182-4ad4-bca7-e6c3377f808d.jpg"
+}
+
+/**
+ * All Theros Beyond Death basic land variants.
+ */
+val TherosBeyondDeathBasicLands = listOf(
+    TherosBeyondDeathPlains250, TherosBeyondDeathPlains278, TherosBeyondDeathPlains279,
+    TherosBeyondDeathIsland251, TherosBeyondDeathIsland280, TherosBeyondDeathIsland281,
+    TherosBeyondDeathSwamp252, TherosBeyondDeathSwamp282, TherosBeyondDeathSwamp283,
+    TherosBeyondDeathMountain253, TherosBeyondDeathMountain284, TherosBeyondDeathMountain285,
+    TherosBeyondDeathForest254, TherosBeyondDeathForest286, TherosBeyondDeathForest287
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThunderingChariot.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThunderingChariot.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thundering Chariot
+ * {4}
+ * Artifact — Vehicle
+ * 3/3
+ *
+ * First strike, trample, haste
+ * Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes
+ * an artifact creature until end of turn.)
+ *
+ * The Sky Skiff shape: the three simple keywords on the keyword set, and crew as a parameterized
+ * [KeywordAbility.crew] — the engine's `CrewEnumerator` and `CrewVehicleHandler` both resolve the
+ * requirement by finding `KeywordAbility.Numeric(Keyword.CREW, n)` on the card definition, so the
+ * bare `Keyword.CREW` marker alone would render the line and do nothing.
+ *
+ * A Vehicle's printed P/T sits on a non-creature type line; `power`/`toughness` still model it, and
+ * the crew effect is what turns those numbers on. Haste is not redundant here: the Vehicle has been
+ * under your control only since this turn, so crewing it the turn it enters would otherwise leave it
+ * summoning-sick (CR 302.6).
+ */
+val ThunderingChariot = card("Thundering Chariot") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 3
+    oracleText = "First strike, trample, haste\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: " +
+        "This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.TRAMPLE, Keyword.HASTE)
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Aaron Miller"
+        flavorText = "In times of conflict, the philosophers of Meletis trade their podiums for conveyances of war."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TritonWaverider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TritonWaverider.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Triton Waverider
+ * {3}{U}
+ * Creature — Merfolk Wizard
+ * 3/3
+ *
+ * Constellation — Whenever an enchantment you control enters, this creature gains flying until end of turn.
+ *
+ * Constellation is an ability word with no rules meaning of its own — a plain enters-the-battlefield
+ * watcher over enchantments you control, bound with [TriggerBinding.ANY] because the Waverider is
+ * not the permanent being watched. Same shape as Favored of Iroas, with flying in place of double
+ * strike.
+ */
+val TritonWaverider = card("Triton Waverider") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Constellation — Whenever an enchantment you control enters, this creature gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        description = "Constellation — Whenever an enchantment you control enters, this creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Lie Setiawan"
+        flavorText = "\"You can no more stop me than you can halt the tide.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TriumphantSurge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/TriumphantSurge.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Triumphant Surge
+ * {3}{W}
+ * Instant
+ *
+ * Destroy target creature with power 4 or greater. You gain 3 life.
+ *
+ * "Power 4 or greater" is a predicate on the target filter (`powerAtLeast(4)`), which the legality
+ * check evaluates against projected state — a creature pumped to 4 power this turn is a legal
+ * target, and one shrunk below 4 in response stops being one. The life gain is a second sentence
+ * in the same effect, so it happens whether or not the destroy still has a target.
+ */
+val TriumphantSurge = card("Triumphant Surge") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with power 4 or greater. You gain 3 life."
+
+    spell {
+        val victim = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(4)))
+        effect = Effects.Composite(
+            Effects.Destroy(victim),
+            Effects.GainLife(3),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Daarken"
+        flavorText = "Not even death can quench a hero's inner fire."
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/VenomousHierophant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/VenomousHierophant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Venomous Hierophant
+ * {3}{B}
+ * Creature — Gorgon Cleric
+ * 3/3
+ *
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ * When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)
+ *
+ * A self-mill: [Patterns.Library.mill] with its default controller scope, so the gather and the
+ * move both read `Player.You`. The single printed clause means the recipe's own composite is the
+ * trigger's whole effect — no outer wrapper.
+ */
+val VenomousHierophant = card("Venomous Hierophant") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Gorgon Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n" +
+        "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Johannes Voss"
+        flavorText = "\"Many have sought snake-twined Pharika's panacea. Do you wish to share their fate?\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/VexingGull.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/VexingGull.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vexing Gull
+ * {2}{U}
+ * Creature — Bird
+ * 2/2
+ *
+ * Flash
+ * Flying
+ *
+ * Two printed keywords, nothing else — a flash flier that ambushes an attacker for three mana.
+ */
+val VexingGull = card("Vexing Gull") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\n" +
+        "Flying"
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Volkan Baǵa"
+        flavorText = "\"May the skies be clear of gales and gulls.\"\n—Meletian prayer"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/WitnessOfTomorrows.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/WitnessOfTomorrows.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Witness of Tomorrows
+ * {4}{U}
+ * Enchantment Creature — Sphinx
+ * 3/4
+ *
+ * Flying
+ * {3}{U}: Scry 1.
+ *
+ * A repeatable mana sink with no tap symbol and no sacrifice, so the activation cost is the bare
+ * mana atom ([Costs.Mana]) rather than a composite — the ability can be activated any number of
+ * times as long as you can pay.
+ */
+val WitnessOfTomorrows = card("Witness of Tomorrows") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Sphinx"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "{3}{U}: Scry 1."
+
+    keywords(Keyword.FLYING)
+
+    // {3}{U}: Scry 1.
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        effect = Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Svetlin Velinov"
+        flavorText = "\"As the future slips its way into the present, it ceases to be my concern.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/TempleOfEnlightenmentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/TempleOfEnlightenmentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Enlightenment reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfEnlightenmentReprint = Printing(
+    oracleId = "89f43e27-790b-4ca1-8ba7-0882b31e0783",
+    name = "Temple of Enlightenment",
+    setCode = "VOC",
+    collectorNumber = "185",
+    scryfallId = "f68f08ae-f560-4310-89f9-d38986903bd6",
+    artist = "Piotr Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f68f08ae-f560-4310-89f9-d38986903bd6.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/TempleOfMaliceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/TempleOfMaliceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Malice reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfMaliceReprint = Printing(
+    oracleId = "7c439c18-31dc-41fe-b03d-3fca06e6fc0b",
+    name = "Temple of Malice",
+    setCode = "VOC",
+    collectorNumber = "186",
+    scryfallId = "6a5b300c-155d-49d2-a929-08d2bf37ae30",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a5b300c-155d-49d2-a929-08d2bf37ae30.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ReturnToNature.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ReturnToNature.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.withId
+
+/**
+ * Return to Nature
+ * {1}{G}
+ * Instant
+ *
+ * Choose one —
+ * • Destroy target artifact.
+ * • Destroy target enchantment.
+ * • Exile target card from a graveyard.
+ *
+ * Three modes, each with its own single target. Every mode binds its requirement under the same
+ * name, so each mode's effect reads its own chosen object; the modes are deliberately left without
+ * hand-written descriptions so each one's text derives from its effect.
+ */
+val ReturnToNature = card("Return to Nature") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target enchantment.\n" +
+        "• Exile target card from a graveyard."
+
+    spell {
+        val chosen = EffectTarget.BoundVariable("target")
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                effect = Effects.Destroy(chosen),
+                target = Targets.Artifact.withId("target")
+            ),
+            Mode.withTarget(
+                effect = Effects.Destroy(chosen),
+                target = Targets.Enchantment.withId("target")
+            ),
+            Mode.withTarget(
+                effect = Effects.Exile(chosen),
+                target = Targets.CardInGraveyard.withId("target")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "Alayna Danner"
+        flavorText = "\"Yes, nature is stronger. You don't see little buildings sprouting on trees.\"\n—Emmara"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -748,6 +748,49 @@
     ]
 }
 
+// Infuriate
+{
+    "name": "Infuriate",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Caio Monteiro",
+        "flavorText": "\"No shirt, no shoes, no service.\"\n—Marketplace sign",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7ac778f6-8997-47ee-a676-3eb9f8d1592f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ironroot Warlord
 {
     "name": "Ironroot Warlord",

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -70,6 +70,63 @@
     ]
 }
 
+// Idyllic Tutor
+{
+    "name": "Idyllic Tutor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for an enchantment card, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "enchantment"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "\"If one's life is blessed, solutions to all life's problems will appear at the right moment.\"\n—*The Book of Kith and Kin*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a5e7a59-7322-46eb-9903-00131234b310.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Indomitable Ancients
 {
     "name": "Indomitable Ancients",

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -60,6 +60,66 @@
     ]
 }
 
+// Archon of Falling Stars
+{
+    "name": "Archon of Falling Stars",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nWhen this creature dies, you may return target enchantment card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    },
+                    "descriptionOverride": "When this creature dies, you may return target enchantment card from your graveyard to the battlefield."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "enchantment own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature dies, you may return target enchantment card from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "\"The archon fell like a star from the sky, meeting the rising sun at the horizon's edge.\"\n—*The Cosmogony*",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0dd1e40-a514-42df-8cc1-364998c7700c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Archon of Sun's Grace
 {
     "name": "Archon of Sun's Grace",
@@ -136,6 +196,189 @@
     ]
 }
 
+// Blood Aspirant
+{
+    "name": "Blood Aspirant",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Satyr Berserker",
+    "oracleText": "Whenever you sacrifice a permanent, put a +1/+1 counter on this creature.\n{1}{R}, {T}, Sacrifice a creature or enchantment: This creature deals 1 damage to target creature. That creature can't block this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "permanent",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|enchantment"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Walpole",
+        "flavorText": "It's a small step from revel to bloodbath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d4f3fa3-ba1f-48dc-a56b-738936f1bf86.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Brine Giant
+{
+    "name": "Brine Giant",
+    "manaCost": "{6}{U}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Affinity for enchantments (This spell costs {1} less to cast for each enchantment you control.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ENCHANTMENT"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Yongjae Choi",
+        "flavorText": "The oracles of Meletis foresaw neither its rise from the depths nor the destruction it would leave in its wake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6811a9dc-e521-4c9e-accb-1efb8346c1db.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Bronze Sword
+{
+    "name": "Bronze Sword",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "232",
+        "artist": "Kev Walker",
+        "flavorText": "Every strike of the smith's hammer infuses a sword with the determination of its creator.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b33162d-8d8f-4312-b31e-04ce86e3b914.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Captivating Unicorn
 {
     "name": "Captivating Unicorn",
@@ -192,6 +435,304 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Careless Celebrant
+{
+    "name": "Careless Celebrant",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Satyr Shaman",
+    "oracleText": "When this creature dies, it deals 2 damage to target creature or planeswalker an opponent controls.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|planeswalker ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature dies, it deals 2 damage to target creature or planeswalker an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Renata was mesmerized by the satyr's dance of gleeful indifference, of reckless grace and bright disaster.\"\n—Luphea of Setessa, *Histories*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bac6bdd4-b25b-41f6-835d-7d1570cdb951.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Chain to Memory
+{
+    "name": "Chain to Memory",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-0 until end of turn. Scry 2.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Paul Scott Canavan",
+        "flavorText": "Those who do not learn from their mistakes are bound to relive them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa0e1a22-8f27-4c5b-a65c-c35abd2ff05b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Discordant Piper
+{
+    "name": "Discordant Piper",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Satyr",
+    "oracleText": "When this creature dies, create a 0/1 white Goat creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Goat"
+                    ]
+                },
+                "descriptionOverride": "When this creature dies, create a 0/1 white Goat creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "John Stanko",
+        "flavorText": "The death of the party.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8cce294-f6ee-4b18-8b65-7d01d0317b00.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Eat to Extinction
+{
+    "name": "Eat to Extinction",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature or planeswalker. Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "RARE",
+        "artist": "Vincent Proce",
+        "flavorText": "\"Kroxa devours what he may—not for sustenance or pleasure, but because it is his nature. He is unending hunger given form.\"\n—Klothys, god of destiny",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Eidolon of Inspiration
+{
+    "name": "Eidolon of Inspiration",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Enchantment Creature — Spirit",
+    "oracleText": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "\"Agios was felled by a minotaur's blade, but I swear I have seen him since—in the midst of battle, wherever help is needed most.\"\n—Phrokos, soldier of Akros",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53343a0c-d97c-4d6f-b696-5343a962e3dd.jpg",
+        "inBooster": false
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Eidolon of Philosophy
+{
+    "name": "Eidolon of Philosophy",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment Creature — Spirit",
+    "oracleText": "{6}{U}, Sacrifice this creature: Draw three cards.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Adam Paquette",
+        "flavorText": "\"And what did Erekastos teach us is the nature of the soul?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2897635-b387-485d-932f-5655244a381f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -275,6 +816,52 @@
     ]
 }
 
+// Fateful End
+{
+    "name": "Fateful End",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Fateful End deals 3 damage to any target. Scry 1.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rallis",
+        "flavorText": "\"Everything will be put back in its proper place.\"\n—Klothys, god of destiny",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56455067-92c0-45b5-ac2e-525c35b41215.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Favored of Iroas
 {
     "name": "Favored of Iroas",
@@ -327,6 +914,295 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Final Death
+{
+    "name": "Final Death",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Johann Bodin",
+        "flavorText": "The Underworld erodes memory, identity, and eventually the physical form, leaving only crumbling statues called misera—hollow monuments to mortal futility.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e5b8580-9198-4735-83c1-289400c1d814.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Final Flare
+{
+    "name": "Final Flare",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature or enchantment.\nFinal Flare deals 5 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature|enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Kev Walker",
+        "flavorText": "Those who fought without honor in life are taken to Agonas and doomed to fight forever in its arenas.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0c95dee-a480-4878-a967-9e46be9ee372.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Grim Physician
+{
+    "name": "Grim Physician",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Mark Zug",
+        "flavorText": "The Returned retain no memory of their identities, but sometimes they mindlessly attempt familiar tasks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7e92c82-840f-4c75-b617-7b58a07be5b4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hyrax Tower Scout
+{
+    "name": "Hyrax Tower Scout",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "When this creature enters, untap target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Micah Epstein",
+        "flavorText": "The scouts of Hyrax Tower keep watch at the edge of Setessan territory, protecting the polis from inhuman monsters and enemy armies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb7f2638-d757-4df6-90b0-b616534dd3a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Inevitable End
+{
+    "name": "Inevitable End",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, sacrifice a creature.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Sacrifice",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "flavorText": "\"How many more will die before you accept your fate?\"\n—Erebos, god of the dead",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6522f01-ae7a-467e-9a05-530a5ccd304d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Iroas's Blessing
+{
+    "name": "Iroas's Blessing",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, it deals 4 damage to target creature or planeswalker an opponent controls.\nEnchanted creature gets +1/+1.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|planeswalker ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "The blessing is not the strength itself, but the knowledge of how to use it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab6e99a5-b105-489e-aff6-7d2ca50d8ba9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -396,6 +1272,283 @@
     ]
 }
 
+// Lampad of Death's Vigil
+{
+    "name": "Lampad of Death's Vigil",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment Creature — Nymph",
+    "oracleText": "{1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Jason Felix",
+        "flavorText": "\"Grief-struck, she weeps for each mortal's final death.\"\n—Psemilla, Meletian poet",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8c9ada9-ea25-4a96-a4be-e4cf8f7a014f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Memory Drain
+{
+    "name": "Memory Drain",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. Scry 2.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "Scry",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "PINDURSKI",
+        "flavorText": "Alythos sat and stared blankly out over the glassy oceans of Nerono, trying in vain to remember what he knew he had forgotten.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aadc1809-d6bb-455c-b6ce-dd11521808b6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Mire Triton
+{
+    "name": "Mire Triton",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Merfolk",
+    "oracleText": "Deathtouch\nWhen this creature enters, mill two cards and you gain 2 life. (To mill a card, put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Seb McKinnon",
+        "flavorText": "Caught between life and death, between land and sea, between thought and oblivion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f8427d3-4d9e-48c9-838b-239fd1357d95.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Mire's Grasp
+{
+    "name": "Mire's Grasp",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets -3/-3.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -3,
+                "toughnessBonus": -3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Chris Rallis",
+        "flavorText": "Those caught attempting to escape the Underworld spend the rest of their existence trapped in the Mire of Punishment.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ae0c536-612d-4916-a8da-5aaaf14218b1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Moss Viper
+{
+    "name": "Moss Viper",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Deathtouch",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Mike Bierek",
+        "flavorText": "Nylea watches over all the creatures of the forest except for the snakes. Blessed by Pharika, they can take care of themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Naiad of Hidden Coves
+{
+    "name": "Naiad of Hidden Coves",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment Creature — Nymph",
+    "oracleText": "During turns other than yours, spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {}
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": "IsNotYourTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"Wave-borne, he watches over secrets of the shore.\"\n—Psemilla, Meletian poet",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc6ae489-658b-4c12-b204-f7b58ce84375.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Nessian Hornbeetle
 {
     "name": "Nessian Hornbeetle",
@@ -436,6 +1589,87 @@
         "artist": "Jason Felix",
         "flavorText": "\"The first rule of politics can be learned from a lowly hornbeetle: it is wise to cultivate powerful friends.\"\n—Pythamon, sage of Meletis",
         "imageUri": "https://cards.scryfall.io/normal/front/8/2/8200fcda-e30c-460f-9964-47e657b7c758.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Nexus Wardens
+{
+    "name": "Nexus Wardens",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Satyr Archer",
+    "oracleText": "Reach\nConstellation — Whenever an enchantment you control enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "The Summer Nexus is a holy grove in Setessa where the starfields of Nyx glitter in the shadows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68cb4e56-bcad-43a3-8600-a3594047205a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Nylea's Forerunner
+{
+    "name": "Nylea's Forerunner",
+    "manaCost": "{4}{G}",
+    "typeLine": "Enchantment Creature — Beast",
+    "oracleText": "Trample\nOther creatures you control have trample.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Christopher Burdett",
+        "flavorText": "Where its feet tread, the thunder of many others will follow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cf2b6be-80a8-4464-a909-8cc658196a14.jpg"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -542,6 +1776,321 @@
     ]
 }
 
+// Omen of the Dead
+{
+    "name": "Omen of the Dead",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash\nWhen this enchantment enters, return target creature card from your graveyard to your hand.\n{2}{B}, Sacrifice this enchantment: Scry 2.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Piotr Dura",
+        "flavorText": "\"My time will come, when life's frantic striving will fade into the boundless quiet of death.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/8023fc44-fb8e-420d-a68c-b45912c4e5bd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Omen of the Forge
+{
+    "name": "Omen of the Forge",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash\nWhen this enchantment enters, it deals 2 damage to any target.\n{2}{R}, Sacrifice this enchantment: Scry 2.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Piotr Dura",
+        "flavorText": "\"My time will come, when all the world will be reforged in the fires of my invention.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70388773-709b-4cd8-a8b7-56093fd77a1d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Omen of the Sea
+{
+    "name": "Omen of the Sea",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this enchantment enters, scry 2, then draw a card.\n{2}{U}, Sacrifice this enchantment: Scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Scry",
+                            "count": 2
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Piotr Dura",
+        "flavorText": "\"My time will come, when the rising tide will surge above the tallest mountain.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5f30ecd-d009-4d44-aef4-c926ed55a521.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Oread of Mountain's Blaze
+{
+    "name": "Oread of Mountain's Blaze",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment Creature — Nymph",
+    "oracleText": "{2}{R}, Discard a card: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Yigit Koroglu",
+        "flavorText": "\"Flame-wrapped, she dances a burning swath amid the clouds.\"\n—Psemilla, Meletian poet",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f9bb73a-5b4e-4c9b-b0a6-8e531dc27394.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Pharika's Libation
+{
+    "name": "Pharika's Libation",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Target opponent sacrifices a creature of their choice.\n• Target opponent sacrifices an enchantment of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target opponent sacrifices a creature of their choice"
+                },
+                {
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "enchantment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target opponent sacrifices an enchantment of their choice"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Jason Felix",
+        "flavorText": "\"If you will not pour your drink out for me, I shall pour mine out for you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0307bb5c-0a46-4f6b-b6d5-58cf31987bb5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pious Wayfarer
 {
     "name": "Pious Wayfarer",
@@ -610,6 +2159,360 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Rage-Scarred Berserker
+{
+    "name": "Rage-Scarred Berserker",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Minotaur Berserker",
+    "oracleText": "When this creature enters, target creature you control gets +1/+0 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "Antonio José Manzanedo",
+        "flavorText": "The fury of the slaughter god Mogis burns within him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f76d7c4-a5d6-4144-b5f3-e43b96b695b7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Riptide Turtle
+{
+    "name": "Riptide Turtle",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Turtle",
+    "oracleText": "Flash\nDefender",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLASH",
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Brian Valeza",
+        "flavorText": "\"As the storm waves crushed my sailors, I cried out to Thassa. The next time I saw them, hard shells encased them, and they swam away to safety.\"\n—Siona, captain of the *Pyleas*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc4ba296-950c-4e39-ab5e-06be07e4a190.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Rumbling Sentry
+{
+    "name": "Rumbling Sentry",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "When this creature enters, scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"To provoke the mountain is to invite the avalanche.\"\n—Perisophia the philosopher",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f93f3c9-b317-40c1-87f5-0038c09b646d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sage of Mysteries
+{
+    "name": "Sage of Mysteries",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, target player mills two cards.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, target player mills two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "John Stanko",
+        "flavorText": "\"I see destruction, suffering, and one tormented glimmer of hope.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/4138fd65-e0c3-42a1-9c0d-4d5f20228b55.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Setessan Champion
+{
+    "name": "Setessan Champion",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, put a +1/+1 counter on this creature and draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, put a +1/+1 counter on this creature and draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "RARE",
+        "artist": "Emrah Elmasli",
+        "flavorText": "\"A blessing is not a gift. It is a duty.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8ce9858-747e-441c-95a8-6af44aa2098d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Setessan Skirmisher
+{
+    "name": "Setessan Skirmisher",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Greg Staples",
+        "flavorText": "Bassara, the tower of the fox, houses the elite skirmishers who guard the Nessian Wood against trespassers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46739993-6afe-428d-bf63-b57649e38a65.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Setessan Training
+{
+    "name": "Setessan Training",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, draw a card.\nEnchanted creature gets +1/+0 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "artist": "Scott Murphy",
+        "flavorText": "In the heart of Setessa, the warriors of Leina Tower defend the polis and train its daughters.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8322d31-6194-4fda-99a3-b6426c57488a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -689,6 +2592,268 @@
         "artist": "Cliff Childs",
         "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg?1782707504"
     }
+}
+
+// Soulreaper of Mogis
+{
+    "name": "Soulreaper of Mogis",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment Creature — Minotaur Shaman",
+    "oracleText": "{2}{B}, Sacrifice a creature: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"We offer to Mogis the blood of the weak, and in return he makes us strong.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55e2f383-d2a0-4424-bf7a-79e82d6f691f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sphinx Mindbreaker
+{
+    "name": "Sphinx Mindbreaker",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying\nWhen this creature enters, each opponent mills ten cards.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 10
+                                },
+                                "player": "EachOpponent",
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "290",
+        "rarity": "RARE",
+        "artist": "PINDURSKI",
+        "flavorText": "Riddles draw you in, paradoxes hold you fast, and answers shatter your perceptions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg",
+        "inBooster": false
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stampede Rider
+{
+    "name": "Stampede Rider",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Satyr",
+    "oracleText": "Trample\nAt the beginning of each combat, if you control a creature with power 4 or greater, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Aaron Miller",
+        "flavorText": "To a satyr, a stampede is just another kind of revelry.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c32c6192-2f8d-4656-af8b-c488e27a75e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Stern Dismissal
+{
+    "name": "Stern Dismissal",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature or enchantment an opponent controls to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|enchantment ctrl:opponent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Lie Setiawan",
+        "flavorText": "Cities offer tribute to Ephara and carve her image into their walls, imploring her to protect them from the dangers of the wild.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0aec4d0f-ba1e-45f8-9764-9bcc3fa50e51.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sunmane Pegasus
+{
+    "name": "Sunmane Pegasus",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying\n{1}{W}: This creature gains vigilance and lifelink until end of turn. (Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "John Severin Brassell",
+        "flavorText": "Chosen by Heliod, Daxos approached the pegasus without fear, and rode it without saddle or reins.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Terror of Mount Velus
@@ -777,4 +2942,253 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg?1783931515"
     },
     "colorIdentityOverride": []
+}
+
+// Thundering Chariot
+{
+    "name": "Thundering Chariot",
+    "manaCost": "{4}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "First strike, trample, haste\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "TRAMPLE",
+        "HASTE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Aaron Miller",
+        "flavorText": "In times of conflict, the philosophers of Meletis trade their podiums for conveyances of war.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd2fa92d-5521-421c-b3f8-7c14bbef3080.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Triton Waverider
+{
+    "name": "Triton Waverider",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, this creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, this creature gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"You can no more stop me than you can halt the tide.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8cb11d7-feae-4511-9a03-bda23119b6a5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Triumphant Surge
+{
+    "name": "Triumphant Surge",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with power 4 or greater. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow>=4"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Daarken",
+        "flavorText": "Not even death can quench a hero's inner fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75d6eb18-a49d-4fa5-a333-78aafbc4abcb.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Venomous Hierophant
+{
+    "name": "Venomous Hierophant",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Gorgon Cleric",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhen this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Johannes Voss",
+        "flavorText": "\"Many have sought snake-twined Pharika's panacea. Do you wish to share their fate?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dc2b661-2f42-419d-837f-bbf097c1153c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vexing Gull
+{
+    "name": "Vexing Gull",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flash\nFlying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"May the skies be clear of gales and gulls.\"\n—Meletian prayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/869fee23-df75-448d-9fca-6ba6713d459f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Witness of Tomorrows
+{
+    "name": "Witness of Tomorrows",
+    "manaCost": "{4}{U}",
+    "typeLine": "Enchantment Creature — Sphinx",
+    "oracleText": "Flying\n{3}{U}: Scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"As the future slips its way into the present, it ceases to be my concern.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64cd9d60-826c-4b35-9684-dccb0880399e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -1036,6 +1036,90 @@
     ]
 }
 
+// Return to Nature
+{
+    "name": "Return to Nature",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Exile target card from a graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Graveyard"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "artist": "Alayna Danner",
+        "flavorText": "\"Yes, nature is stronger. You don't see little buildings sprouting on trees.\"\n—Emmara",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/085e3129-591b-46ec-ac8b-cff428927c01.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Spark Reaper
 {
     "name": "Spark Reaper",


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Theros Beyond Death had not authored yet.

**`just assay-ready THB`: 62 → 0**, re-measured on this branch (not inferred).

## The four-way split

| bucket | count | work |
|---|---|---|
| `original` | 48 | canonical authored in THB |
| `elsewhere` | 3 | canonical authored in the earlier set + a THB `Printing` row |
| `row-only` | 6 | `Printing` row only — canonical already in the corpus |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override |

The three `elsewhere` canonicals: **Idyllic Tutor** → MOR (2008-02-01), **Infuriate** → M20
(2019-07-12), **Return to Nature** → WAR (2019-05-03). Earliest-printing dates verified against the
Scryfall printings cache; `check-card-printing` agrees on all three.

The 5 basics ship as 15 `basicLand(...)` vals — THB prints three art variants of each type (250–254
plus 278–287) — and `TherosBeyondDeathSet` gained the `basicLands` override it was missing. No
`Printing` rows for basics.

## The reprint tail

`generate-reprints.py --since main` (scoped, not a bare run) wrote **10** rows across 6 sets: 3 into
THB for the `elsewhere` canonicals, and **7 into other sets** that only became visible once the
canonicals existed — J22 ×2, M21 ×2, ELD, JMP, MID. Printing caches were refreshed first, so nothing
was silently dropped to the 30-day TTL (`0 stale cache`). A further 2 VOC rows came with the Temple
`row-only` batch.

## Verification

| gate | result |
|---|---|
| `just build` | green |
| `just rebless-cards` | 4 goldens moved — THB, M20, MOR, WAR. Diffed by card name: **48 added to THB, nothing removed**; M20/MOR/WAR are pure insertions |
| `just assay-differential` | **compared 5817 → 5868 (+51), confirmed 5766 → 5817 (+51), divergent 51 → 51 (+0)** |
| `just check-card-printing` | all 51 authored canonicals report `ok` |
| `just assay-ready THB` | 62 → 0 |

**Every one of the 51 new cards is confirmed by the differential and none appears among the
divergences.** The 51 divergences that remain are all pre-existing on `main` — the baseline was taken
with this same freshly-built binary before any card was written.

## Capability pre-flight

Traced every construct the list touches to its `rules-engine` consumer before authoring, because a
`Keyword.X` existing is not the engine reading it. **All 15 came back live** — no card here needs new
SDK vocabulary, and no new `Effect` type or executor was added.

The four that were genuinely in doubt:

- **Affinity for enchantments** (Brine Giant) — `CostCalculator.kt:107-114` reads the declared
  `forType` through a fully generic, projection-correct `countPermanentsOfType`. No artifact hardcode.
- **Crew** (Thundering Chariot) — not a cascade/modular-style display-only keyword: both
  `CrewEnumerator.kt:42` and `CrewVehicleHandler.kt:70` read `KeywordAbility.Numeric(CREW, n)`. Note
  the bare `Keyword.CREW` marker does nothing on its own.
- **A granted triggered ability on an Aura** (Inevitable End) — `GrantTriggeredAbility` is
  deliberately not a layer effect (`StaticAbilityHandler.kt:930`); `TriggerDetector.kt:533-548` builds
  the `PendingTrigger` with the **enchanted permanent's** controller, so "your upkeep" is the creature's
  controller's upkeep, not the Aura controller's. `RelicBaneScenarioTest` already pins this.
- **A gated `ModifySpellCost`** (Naiad of Hidden Coves) — `CostGating.OnlyIf` is evaluated at *two*
  `CostCalculator` sites including the battlefield scan (line 139), so it is not the
  `Conditional(Composite)` silent-drop trap.

## Findings the sweep surfaced

Named here because they are the sweep's other product; none is fixed in this PR.

1. **`Effect.then` flattens a `CompositeEffect`.** `mill(2) then GainLife(2)` yields a flat
   `Composite[gather, move, GainLife]`, where Assay's model for "mill two cards **and** you gain 2 life"
   is `Composite[Composite[gather, move], GainLife]`. Any "mill N and <clause>" card needs
   `Effects.Composite(...)`, not `then`. Caught during authoring, so Mire Triton is correct — but this
   is a live trap for the next sweep.
2. **Pre-existing differential divergences in the "each opponent mills N" family.**
   `otj/DeepmuckDesperado.kt`, `ltr/SarumanOfManyColors.kt` and `AetherSyphon.kt` model it as
   `ForEachPlayerEffect(Player.EachOpponent, mill(3).effects)`, while Assay's grammar builds
   `mill(3, PlayerRef(EachOpponent))`. Those sets will show divergences when they are swept.
3. **A `ConditionalStaticAbility` wrapper hides a `ModifySpellCost` from the engine.**
   `scanBattlefieldModifySpellCost` matches a bare `is ModifySpellCost`, so the gate must go in the
   `gating` field. `SpeedDsl.kt:188-198` documents it; worth a compile-time guard.
4. **An `ATTACHED`-bound granted trigger silently never fires** —
   `TriggerIndex.triggerToCategories` returns `emptyList()` for `TriggerBinding.ATTACHED`. Fail-closed
   with no diagnostic.
5. **`Targets.*` facade coverage gaps.** No constant for "enchantment card in your graveyard" or
   "creature or planeswalker an opponent controls"; both had to be spelled as raw `TargetObject(...)`,
   as the corpus already does. Also `Targets.CreatureOrEnchantment` is a `TargetPermanent` while
   `Targets.Creature` is a `TargetObject` — a real asymmetry.
6. **`inBooster = false`** was needed on Eidolon of Inspiration (#271, planeswalker deck) and Sphinx
   Mindbreaker (#290, theme pack) — both are THB cards with `booster: false` on Scryfall. Matches the
   `kld/FlameLash.kt` convention.

No cards left the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQJkMSQCxYdRdbkBCV9BjT
