### PR TITLE
Add 69 Assay-ready cards to Magic Origins

### DIFF
--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/apc/cards/SylvanMessenger.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/apc/cards/SylvanMessenger.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.apc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sylvan Messenger
+ * {3}{G}
+ * Creature — Elf
+ * 2/2
+ *
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ * When this creature enters, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order.
+ *
+ * [Patterns.Library.revealTopPutAllMatchingToHand] is the whole shape; the printed "in any order"
+ * overrides the pattern's default random rest-order with [CardOrder.ControllerChooses].
+ */
+val SylvanMessenger = card("Sylvan Messenger") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf"
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n" +
+        "When this creature enters, reveal the top four cards of your library. Put all Elf cards " +
+        "revealed this way into your hand and the rest on the bottom of your library in any order."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.revealTopPutAllMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.ELF),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/FleshbagMarauder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/FleshbagMarauder.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fleshbag Marauder
+ * {2}{B}
+ * Creature — Zombie Warrior
+ * 3/1
+ *
+ * When this creature enters, each player sacrifices a creature of their choice.
+ *
+ * "each player" includes you, and the Marauder itself is a legal choice for its own controller —
+ * `Player.Each` with no `excludeSelf`, matching the printed symmetry.
+ */
+val FleshbagMarauder = card("Fleshbag Marauder") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Warrior"
+    oracleText = "When this creature enters, each player sacrifices a creature of their choice."
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForceSacrificeEffect(
+            GameObjectFilter.Creature,
+            1,
+            EffectTarget.PlayerRef(Player.Each)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Pete Venters"
+        flavorText = "Grixis is a world where the only things found in abundance are death and decay. Corpses, whole or in part, are the standard currency among necromancers and demons."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/StratusWalk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/StratusWalk.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Stratus Walk
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)
+ * Enchanted creature can block only creatures with flying.
+ *
+ * The block restriction is a separate static from the flying grant — it constrains what the host
+ * may block rather than granting it anything, so the two cannot fold into one ability. Its `filter`
+ * must be spelled [GroupFilter.attachedCreature]: `CanOnlyBlockCreaturesWith` defaults to
+ * `GroupFilter.source()`, which on an Aura is the Aura itself — an enchantment that never blocks,
+ * so the restriction would silently do nothing and the enchanted creature would keep blocking
+ * anything.
+ */
+val StratusWalk = card("Stratus Walk") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\n" +
+        "Enchanted creature can block only creatures with flying."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(
+            blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+            filter = GroupFilter.attachedCreature()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Aaron Miller"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/WeightOfTheUnderworld.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/WeightOfTheUnderworld.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Weight of the Underworld
+ * {3}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets -3/-2.
+ */
+val WeightOfTheUnderworld = card("Weight of the Underworld") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets -3/-2."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-3, -2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Wesley Burt"
+        flavorText = "Proud Alkmenos, who would not bow to Erebos in death, is now bowed by his own hubris for all eternity."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "C15",
+    collectorNumber = "80",
+    scryfallId = "500005f0-77b5-4922-9563-8383f929aad7",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/500005f0-77b5-4922-9563-8383f929aad7.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FleshbagMarauderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FleshbagMarauderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fleshbag Marauder reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val FleshbagMarauderReprint = Printing(
+    oracleId = "4b1bf05e-753e-4350-a913-894cf3cecc0c",
+    name = "Fleshbag Marauder",
+    setCode = "CMD",
+    collectorNumber = "83",
+    scryfallId = "7cccf5f9-ec1a-4207-aaa1-69c9429ca4d3",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cccf5f9-ec1a-4207-aaa1-69c9429ca4d3.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "DDL",
+    collectorNumber = "9",
+    scryfallId = "9a7d0013-f631-4f88-b6b6-69813908e118",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a7d0013-f631-4f88-b6b6-69813908e118.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkaabGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkaabGoliath.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skaab Goliath
+ * {5}{U}
+ * Creature — Zombie Giant
+ * 6/9
+ *
+ * As an additional cost to cast this spell, exile two creature cards from your graveyard.
+ * Trample
+ */
+val SkaabGoliath = card("Skaab Goliath") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Giant"
+    oracleText = "As an additional cost to cast this spell, exile two creature cards from your graveyard.\n" +
+        "Trample"
+    power = 6
+    toughness = 9
+
+    keywords(Keyword.TRAMPLE)
+
+    additionalCost(Costs.additional.ExileCards(2, GameObjectFilter.Creature))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Volkan Baǵa"
+        flavorText = "\"Three heads, six arms, and some armor grafts are better than . . . the normal numbers of those things.\"\n" +
+            "—Stitcher Geralf"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/EagleOfTheWatch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/EagleOfTheWatch.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eagle of the Watch
+ * {2}{W}
+ * Creature — Bird
+ * 2/1
+ *
+ * Flying, vigilance
+ */
+val EagleOfTheWatch = card("Eagle of the Watch") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying, vigilance"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Scott Murphy"
+        flavorText = "\"Even from miles away, I could see our eagles circling. That's when I gave the command to pick up the pace. I knew we were needed at home.\"\n" +
+                "—Kanlos, Akroan captain"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/GoldForgedSentinel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/GoldForgedSentinel.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gold-Forged Sentinel
+ * {6}
+ * Artifact Creature — Chimera
+ * 4/4
+ *
+ * Flying
+ */
+val GoldForgedSentinel = card("Gold-Forged Sentinel") {
+    manaCost = "{6}"
+    typeLine = "Artifact Creature — Chimera"
+    oracleText = "Flying"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "James Zapata"
+        flavorText = "Blessed by the gods. Coveted by mortals. Beholden to neither."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "M12",
+    collectorNumber = "9",
+    scryfallId = "b702dc6d-4c05-4313-b303-c321847ad6a9",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b702dc6d-4c05-4313-b303-c321847ad6a9.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Watercourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Watercourser.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Watercourser
+ * {2}{U}
+ * Creature — Elemental
+ * 2/3
+ *
+ * {U}: This creature gets +1/-1 until end of turn.
+ */
+val Watercourser = card("Watercourser") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    oracleText = "{U}: This creature gets +1/-1 until end of turn."
+    power = 2
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Mathias Kollros"
+        flavorText = "\"Beware an eddy where there should be none or a stretch that flows too fast or too slow.\"\n" +
+            "—Old Fishbones, Martyne river guide"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/YevasForcemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/YevasForcemage.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yeva's Forcemage
+ * {2}{G}
+ * Creature — Elf Shaman
+ * 2/2
+ *
+ * When this creature enters, target creature gets +2/+2 until end of turn.
+ */
+val YevasForcemage = card("Yeva's Forcemage") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "When this creature enters, target creature gets +2/+2 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Eric Deschamps"
+        flavorText = "\"Nature can't be stopped. It rips and tears at Ravnica's tallest buildings to claim its place in the sun.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "M14",
+    collectorNumber = "6",
+    scryfallId = "0a3dc4ab-1c45-4495-91b6-27d62087380c",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0a3dc4ab-1c45-4495-91b6-27d62087380c.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CelestialFlare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CelestialFlare.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+
+/**
+ * Celestial Flare
+ * {W}{W}
+ * Instant
+ *
+ * Target player sacrifices an attacking or blocking creature of their choice.
+ *
+ * An edict, not removal: [ForceSacrificeEffect] makes the *targeted player* choose, so the
+ * attacking-or-blocking restriction is a filter on their choice rather than a target filter, and
+ * hexproof or protection on the creature is irrelevant.
+ */
+val CelestialFlare = card("Celestial Flare") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target player sacrifices an attacking or blocking creature of their choice."
+
+    spell {
+        val p = target("target player", Targets.Player)
+        effect = ForceSacrificeEffect(
+            GameObjectFilter.Creature.attackingOrBlocking(),
+            1,
+            p
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Clint Cearley"
+        flavorText = "\"You were defeated the moment you declared your aggression.\"\n" +
+            "—Gideon Jura"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChargingGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChargingGriffin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Charging Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2/2
+ *
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * Whenever this creature attacks, it gets +1/+1 until end of turn.
+ */
+val ChargingGriffin = card("Charging Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "Whenever this creature attacks, it gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Erica Yang"
+        flavorText = "Four claws, two wings, one beak, no fear."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AbbotOfKeralKeep.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AbbotOfKeralKeep.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abbot of Keral Keep
+ * {1}{R}
+ * Creature — Human Monk
+ * 2/1
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ * When this creature enters, exile the top card of your library. Until end of turn, you may play that card.
+ *
+ * The ETB is the named "impulse draw" mechanic — [Patterns.Exile.impulse] gathers the top card,
+ * moves the collection to exile and grants play permission expiring at end of turn. The card still
+ * costs its mana, which is why this is `impulse` rather than the play-free variant.
+ */
+val AbbotOfKeralKeep = card("Abbot of Keral Keep") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Monk"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n" +
+        "When this creature enters, exile the top card of your library. Until end of turn, you may play that card."
+    power = 2
+    toughness = 1
+
+    prowess()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Exile.impulse(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Deruchenko Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AerialVolley.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AerialVolley.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Aerial Volley
+ * {G}
+ * Instant
+ *
+ * Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.
+ *
+ * "one, two, or three target creatures" is the divided-damage target shape: a single `count = 3,
+ * minCount = 1` requirement rather than three requirements, with [Effects.DividedDamage] doing the
+ * assignment at cast time.
+ */
+val AerialVolley = card("Aerial Volley") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying."
+
+    spell {
+        target(
+            "target creatures with flying",
+            TargetCreature(filter = TargetFilter.Creature.withKeyword(Keyword.FLYING), count = 3, minCount = 1)
+        )
+        effect = Effects.DividedDamage(total = 3, minTargets = 1, maxTargets = 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Lake Hurwitz"
+        flavorText = "Drakes can swerve to avoid a single arrow, but they can't dodge the whole sky."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanJailer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanJailer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akroan Jailer
+ * {W}
+ * Creature — Human Soldier
+ * 1/1
+ *
+ * {2}{W}, {T}: Tap target creature.
+ */
+val AkroanJailer = card("Akroan Jailer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "{2}{W}, {T}: Tap target creature."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "He ensures escape attempts are just that—attempts."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanSergeant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AkroanSergeant.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Akroan Sergeant
+ * {2}{R}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * First strike (This creature deals combat damage before creatures without first strike.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val AkroanSergeant = card("Akroan Sergeant") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "First strike (This creature deals combat damage before creatures without first strike.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FIRST_STRIKE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Zack Stella"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AlchemistsVial.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AlchemistsVial.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Vial
+ * {2}
+ * Artifact
+ *
+ * When this artifact enters, draw a card.
+ * {1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn.
+ */
+val AlchemistsVial = card("Alchemist's Vial") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, draw a card.\n" +
+        "{1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.CantAttackOrBlock(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Lindsey Look"
+        flavorText = "A weapon best suited for those with good aim and steady hands."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AmprynTactician.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AmprynTactician.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ampryn Tactician
+ * {2}{W}{W}
+ * Creature — Human Soldier
+ * 3/3
+ *
+ * When this creature enters, creatures you control get +1/+1 until end of turn.
+ *
+ * A one-shot group pump, not a lord: [Patterns.Group.modifyStatsForAll] applies +1/+1 to each
+ * creature you control as the trigger resolves, so creatures that arrive later this turn miss it.
+ */
+val AmprynTactician = card("Ampryn Tactician") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "When this creature enters, creatures you control get +1/+1 until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Group.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Cynthia Sheppard"
+        flavorText = "\"It's all a game. You shouldn't get too attached to the pieces.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnointerOfChampions.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnointerOfChampions.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Anointer of Champions
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ *
+ * {T}: Target attacking creature gets +1/+1 until end of turn.
+ */
+val AnointerOfChampions = card("Anointer of Champions") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "{T}: Target attacking creature gets +1/+1 until end of turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target attacking creature", TargetCreature(filter = TargetFilter.Creature.attacking()))
+        effect = Effects.ModifyStats(1, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Arise. You have been anointed by the light. Go forth and fight without fear, for you shall be victorious.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "ORI",
+    collectorNumber = "5",
+    scryfallId = "598ebb91-57d6-4800-8931-4d0016e9fec1",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/598ebb91-57d6-4800-8931-4d0016e9fec1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AvenBattlePriest.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AvenBattlePriest.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aven Battle Priest
+ * {5}{W}
+ * Creature — Bird Cleric
+ * 3/3
+ *
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * When this creature enters, you gain 3 life.
+ */
+val AvenBattlePriest = card("Aven Battle Priest") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Cleric"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "When this creature enters, you gain 3 life."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "John Severin Brassell"
+        flavorText = "When the shadow of the aven falls across the battlefield, hope rises in the hearts of the soldiers."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BellowsLizardReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BellowsLizardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bellows Lizard reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val BellowsLizardReprint = Printing(
+    oracleId = "667dae0b-5006-4e38-be80-eae79c2a2a95",
+    name = "Bellows Lizard",
+    setCode = "ORI",
+    collectorNumber = "132",
+    scryfallId = "285d2e99-13f1-4ce8-9a54-139de193c1b3",
+    artist = "Jack Wang",
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/285d2e99-13f1-4ce8-9a54-139de193c1b3.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlazingHellhound.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlazingHellhound.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Blazing Hellhound
+ * {2}{B}{R}
+ * Creature — Elemental Dog
+ * 4/3
+ *
+ * {1}, Sacrifice another creature: This creature deals 1 damage to any target.
+ */
+val BlazingHellhound = card("Blazing Hellhound") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Elemental Dog"
+    oracleText = "{1}, Sacrifice another creature: This creature deals 1 damage to any target."
+    power = 4
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeAnother(GameObjectFilter.Creature))
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Eric Velhagen"
+        flavorText = "It tears the flesh from your bones and then swallows the ash with its fiery maw."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BloodCursedKnight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BloodCursedKnight.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blood-Cursed Knight
+ * {1}{W}{B}
+ * Creature — Vampire Knight
+ * 3/2
+ *
+ * As long as you control an enchantment, this creature gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)
+ *
+ * One printed sentence, two continuous modifications, so it is two `staticAbility { }` blocks —
+ * a `StaticAbility` is one modification and the builder takes one per block. Both carry the same
+ * [Conditions.YouControl] gate and [GroupFilter.source], the self-scoped group, so each applies
+ * only to this creature.
+ */
+val BloodCursedKnight = card("Blood-Cursed Knight") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Vampire Knight"
+    oracleText = "As long as you control an enchantment, this creature gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)"
+    power = 3
+    toughness = 2
+
+    staticAbility {
+        condition = Conditions.YouControl(GameObjectFilter.Enchantment)
+        ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter.source())
+    }
+
+    staticAbility {
+        condition = Conditions.YouControl(GameObjectFilter.Enchantment)
+        ability = GrantKeyword(keyword = Keyword.LIFELINK, filter = GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Winona Nelson"
+        flavorText = "\"The bloodlust shall not control me, for my oath is my greatest compulsion.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CelestialFlareReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CelestialFlareReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Celestial Flare reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val CelestialFlareReprint = Printing(
+    oracleId = "efdaa3eb-e5d1-4438-b21d-2ec0fff44721",
+    name = "Celestial Flare",
+    setCode = "ORI",
+    collectorNumber = "8",
+    scryfallId = "89bb3b06-b33b-4897-882e-75b75790ea02",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89bb3b06-b33b-4897-882e-75b75790ea02.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ChargingGriffinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ChargingGriffinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charging Griffin reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val ChargingGriffinReprint = Printing(
+    oracleId = "1c99a5cc-d974-4a4b-a03b-a78bfe738ed7",
+    name = "Charging Griffin",
+    setCode = "ORI",
+    collectorNumber = "9",
+    scryfallId = "d86bd259-bc2f-402c-9e7a-030f9a3781e2",
+    artist = "Erica Yang",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d86bd259-bc2f-402c-9e7a-030f9a3781e2.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CitadelCastellan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CitadelCastellan.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Citadel Castellan
+ * {1}{G}{W}
+ * Creature — Human Knight
+ * 2/3
+ *
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)
+ */
+val CitadelCastellan = card("Citadel Castellan") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.renown(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "\"I am the first line of defense. You will not encounter the second.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ConclaveNaturalists.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ConclaveNaturalists.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Conclave Naturalists
+ * {4}{G}
+ * Creature — Dryad
+ * 4/4
+ *
+ * When this creature enters, you may destroy target artifact or enchantment.
+ */
+val ConclaveNaturalists = card("Conclave Naturalists") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    oracleText = "When this creature enters, you may destroy target artifact or enchantment."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Howard Lyon"
+        flavorText = "\"Your swords and wards have no power here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EagleOfTheWatchReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EagleOfTheWatchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eagle of the Watch reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val EagleOfTheWatchReprint = Printing(
+    oracleId = "954836f8-c225-450a-bb51-f2adb6923ef5",
+    name = "Eagle of the Watch",
+    setCode = "ORI",
+    collectorNumber = "275",
+    scryfallId = "8af7956d-f811-49d3-bef7-07f294dcea3c",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8af7956d-f811-49d3-bef7-07f294dcea3c.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ElementalBond.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ElementalBond.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Elemental Bond
+ * {2}{G}
+ * Enchantment
+ *
+ * Whenever a creature you control with power 3 or greater enters, draw a card.
+ *
+ * `TriggerBinding.ANY` — the trigger watches every creature entering under your control, not the
+ * enchantment itself, and power is read off the entering creature's projected state.
+ */
+val ElementalBond = card("Elemental Bond") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control with power 3 or greater enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.powerAtLeast(3).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "David Gaillet"
+        flavorText = "\"I want to help Zendikar. Show me the way.\"\n" +
+            "—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EnlightenedAscetic.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/EnlightenedAscetic.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enlightened Ascetic
+ * {1}{W}
+ * Creature — Cat Monk
+ * 1/1
+ *
+ * When this creature enters, you may destroy target enchantment.
+ */
+val EnlightenedAscetic = card("Enlightened Ascetic") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Monk"
+    oracleText = "When this creature enters, you may destroy target enchantment."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target enchantment", Targets.Enchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "James Zapata"
+        flavorText = "\"I do not reject the gods. I reject their authority, their pettiness, and their arrogance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FirefiendElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FirefiendElemental.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Firefiend Elemental
+ * {3}{R}
+ * Creature — Elemental
+ * 3/2
+ *
+ * Haste (This creature can attack and {T} as soon as it comes under your control.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val FirefiendElemental = card("Firefiend Elemental") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Torstein Nordstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FleshbagMarauderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FleshbagMarauderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fleshbag Marauder reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val FleshbagMarauderReprint = Printing(
+    oracleId = "4b1bf05e-753e-4350-a913-894cf3cecc0c",
+    name = "Fleshbag Marauder",
+    setCode = "ORI",
+    collectorNumber = "98",
+    scryfallId = "9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9eb8ea7b-dfac-47bf-b608-efd54e4fe0f1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GhirapurAetherGrid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GhirapurAetherGrid.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ghirapur Aether Grid
+ * {2}{R}
+ * Enchantment
+ *
+ * Tap two untapped artifacts you control: This enchantment deals 1 damage to any target.
+ *
+ * [Costs.TapPermanents] is already "untapped … you control" — the filter only carries the type.
+ */
+val GhirapurAetherGrid = card("Ghirapur Aether Grid") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Tap two untapped artifacts you control: This enchantment deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(2, GameObjectFilter.Artifact)
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Cynthia Sheppard"
+        flavorText = "The city of Ghirapur is a living thing, and living things defend themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GoldForgedSentinelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GoldForgedSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gold-Forged Sentinel reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val GoldForgedSentinelReprint = Printing(
+    oracleId = "c338fb29-2dd2-4f76-ba3d-fa6770adcce8",
+    name = "Gold-Forged Sentinel",
+    setCode = "ORI",
+    collectorNumber = "226",
+    scryfallId = "c9fdf08b-b812-4ad9-a4ca-3a9b7000b749",
+    artist = "James Zapata",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9fdf08b-b812-4ad9-a4ca-3a9b7000b749.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardianAutomaton.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/GuardianAutomaton.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guardian Automaton
+ * {4}
+ * Artifact Creature — Construct
+ * 3/3
+ *
+ * When this creature dies, you gain 3 life.
+ */
+val GuardianAutomaton = card("Guardian Automaton") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "When this creature dies, you gain 3 life."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Vincent Proce"
+        flavorText = "The wealthy in the city of Ghirapur outfit their lives with grand machines, entrusting even their children to filigree and gears."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeavyInfantry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeavyInfantry.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Heavy Infantry
+ * {4}{W}
+ * Creature — Human Soldier
+ * 3/4
+ *
+ * When this creature enters, tap target creature an opponent controls.
+ */
+val HeavyInfantry = card("Heavy Infantry") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "When this creature enters, tap target creature an opponent controls."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature an opponent controls", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "David Gaillet"
+        flavorText = "Doors, walls, skulls . . . it matters not. All barriers will be broken."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeraldOfThePantheon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HeraldOfThePantheon.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Herald of the Pantheon
+ * {1}{G}
+ * Creature — Centaur Shaman
+ * 2/2
+ *
+ * Enchantment spells you cast cost {1} less to cast.
+ * Whenever you cast an enchantment spell, you gain 1 life.
+ *
+ * [CostModification.ReduceGeneric] shaves only the generic part (CR 601.2f), so a mono-coloured
+ * one-mana enchantment is unaffected. The life gain is a separate cast trigger — it fires whether
+ * or not the reduction applied.
+ */
+val HeraldOfThePantheon = card("Herald of the Pantheon") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Shaman"
+    oracleText = "Enchantment spells you cast cost {1} less to cast.\n" +
+        "Whenever you cast an enchantment spell, you gain 1 life."
+    power = 2
+    toughness = 2
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Enchantment),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "180"
+        artist = "Jason A. Engle"
+        flavorText = "The distinction of bearing the gods' banner is nothing compared to the glory of being closer to Nyx."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/InfernalScarring.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/InfernalScarring.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Infernal Scarring
+ * {1}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+0 and has "When this creature dies, draw a card."
+ *
+ * The quoted ability is granted to the *host*, not run by the Aura, so it is a
+ * [GrantTriggeredAbility] with the default self-scoped filter: the dies trigger belongs to the
+ * enchanted creature, and the card is drawn by that creature's controller.
+ */
+val InfernalScarring = card("Infernal Scarring") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 0)
+    }
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Dies.event,
+                binding = Triggers.Dies.binding,
+                effect = Effects.DrawCards(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Mike Bierek"
+        flavorText = "One who is marked by a demon in life is sure to be remembered as one in death."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/IroasSChampion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/IroasSChampion.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iroas's Champion
+ * {1}{R}{W}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * Double strike (This creature deals both first-strike and regular combat damage.)
+ */
+val IroasSChampion = card("Iroas's Champion") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Double strike (This creature deals both first-strike and regular combat damage.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Marco Nelor"
+        flavorText = "Accustomed to battling before an audience in the arena, Iroas's champions know how to put on a good show."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JhessianThief.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JhessianThief.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhessian Thief
+ * {2}{U}
+ * Creature — Human Rogue
+ * 1/3
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ * Whenever this creature deals combat damage to a player, draw a card.
+ */
+val JhessianThief = card("Jhessian Thief") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n" +
+        "Whenever this creature deals combat damage to a player, draw a card."
+    power = 1
+    toughness = 3
+
+    prowess()
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Miles Johnston"
+        flavorText = "\"Where's the fun in an escape if it's not at least a little daring?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightOfThePilgrimSRoad.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightOfThePilgrimSRoad.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Knight of the Pilgrim's Road
+ * {2}{W}
+ * Creature — Human Knight
+ * 3/2
+ *
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val KnightOfThePilgrimSRoad = card("Knight of the Pilgrim's Road") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 3
+    toughness = 2
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "David Gaillet"
+        flavorText = "\"To be a knight, Gideon, is to be the shield for the meek against the cruel.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KytheonsIrregulars.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KytheonsIrregulars.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Kytheon's Irregulars
+ * {2}{W}{W}
+ * Creature — Human Soldier
+ * 4/3
+ *
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ * {W}{W}: Tap target creature.
+ */
+val KytheonsIrregulars = card("Kytheon's Irregulars") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n" +
+        "{W}{W}: Tap target creature."
+    power = 4
+    toughness = 3
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{W}")
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Mark Winters"
+        flavorText = "Kytheon and his irregulars worked outside the law to bring justice to the streets of Akros."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LightningJavelin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LightningJavelin.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Javelin
+ * {3}{R}
+ * Sorcery
+ *
+ * Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val LightningJavelin = card("Lightning Javelin") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(3, t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Seb McKinnon"
+        flavorText = "The harpies descended without mercy upon Akros, only to find their attack put them within range of the javelineers."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagicOriginsBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagicOriginsBasicLands.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Magic Origins Basic Lands
+ *
+ * One printing of each basic land type, collector numbers 253/257/261/265/269. Discovered by
+ * `MagicOriginsSet.basicLands` via `CardDiscovery.findBasicLandsIn` — basics are never `Printing`
+ * rows.
+ */
+
+val OriPlains = basicLand("Plains") {
+    collectorNumber = "253"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88f96591-4f22-451e-bfb5-32561cc4640d.jpg"
+}
+
+val OriIsland = basicLand("Island") {
+    collectorNumber = "257"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3a9df3b-b542-4915-96ac-0c9027f6870a.jpg"
+}
+
+val OriSwamp = basicLand("Swamp") {
+    collectorNumber = "261"
+    artist = "Larry Elmore"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1ae0b13-c9f6-4659-ba85-a87a81f6e730.jpg"
+}
+
+val OriMountain = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7b95522-a9de-4ec1-8158-c66813919e62.jpg"
+}
+
+val OriForest = basicLand("Forest") {
+    collectorNumber = "269"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4ee8330-f1bf-460b-9345-00d08665e9cf.jpg"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagmaticInsight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MagmaticInsight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magmatic Insight
+ * {R}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, discard a land card.
+ * Draw two cards.
+ */
+val MagmaticInsight = card("Magmatic Insight") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, discard a land card.\n" +
+        "Draw two cards."
+
+    additionalCost(Costs.additional.DiscardCards(1, Filters.Land))
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Ryan Barger"
+        flavorText = "Chief among the tenets of Purphoros is that one must destroy in order to create."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MantleOfWebs.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MantleOfWebs.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Mantle of Webs
+ * {1}{G}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)
+ */
+val MantleOfWebs = card("Mantle of Webs") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 3)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Mathias Kollros"
+        flavorText = "\"Why does everything the Golgari touch end up sticky?\"\n" +
+            "—Arrester Lavinia, Tenth Precinct"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "ORI",
+    collectorNumber = "233",
+    scryfallId = "23a8969f-d7a6-479a-9277-1270ee533c4a",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23a8969f-d7a6-479a-9277-1270ee533c4a.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MoltenVortex.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MoltenVortex.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Molten Vortex
+ * {R}
+ * Enchantment
+ *
+ * {R}, Discard a land card: This enchantment deals 2 damage to any target.
+ */
+val MoltenVortex = card("Molten Vortex") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{R}, Discard a land card: This enchantment deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Discard(Filters.Land))
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "156"
+        artist = "Philip Straub"
+        flavorText = "If you can't take the heat . . . well, that's going to be a problem."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/NivixBarrier.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/NivixBarrier.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Nivix Barrier
+ * {3}{U}
+ * Creature — Illusion Wall
+ * 0/4
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Defender (This creature can't attack.)
+ * When this creature enters, target attacking creature gets -4/-0 until end of turn.
+ */
+val NivixBarrier = card("Nivix Barrier") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion Wall"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Defender (This creature can't attack.)\n" +
+        "When this creature enters, target attacking creature gets -4/-0 until end of turn."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.FLASH, Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target attacking creature", TargetCreature(filter = TargetFilter.Creature.attacking()))
+        effect = Effects.ModifyStats(-4, 0, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/OutlandColossus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/OutlandColossus.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Outland Colossus
+ * {3}{G}{G}
+ * Creature — Giant
+ * 6/6
+ *
+ * Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)
+ * This creature can't be blocked by more than one creature.
+ */
+val OutlandColossus = card("Outland Colossus") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Giant"
+    oracleText = "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)\n" +
+        "This creature can't be blocked by more than one creature."
+    power = 6
+    toughness = 6
+
+    keywordAbility(KeywordAbility.renown(6))
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PharikaSDisciple.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PharikaSDisciple.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Pharika's Disciple
+ * {3}{G}
+ * Creature — Centaur Warrior
+ * 2/3
+ *
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val PharikaSDisciple = card("Pharika's Disciple") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReturnedCentaurReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReturnedCentaurReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Returned Centaur reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val ReturnedCentaurReprint = Printing(
+    oracleId = "223c97fb-dc96-41ba-be9d-bad9b5e4876f",
+    name = "Returned Centaur",
+    setCode = "ORI",
+    collectorNumber = "116",
+    scryfallId = "103b369c-da58-40e7-98aa-5a5471434bca",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/103b369c-da58-40e7-98aa-5a5471434bca.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RhoxMaulers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RhoxMaulers.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rhox Maulers
+ * {4}{G}
+ * Creature — Rhino Soldier
+ * 4/4
+ *
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ * Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)
+ */
+val RhoxMaulers = card("Rhox Maulers") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino Soldier"
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n" +
+        "Renown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.renown(2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RingwardenOwl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/RingwardenOwl.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ringwarden Owl
+ * {3}{U}{U}
+ * Creature — Bird
+ * 3/3
+ *
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ */
+val RingwardenOwl = card("Ringwarden Owl") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    prowess()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Titus Lunter"
+        flavorText = "The owls learn of mana from the mages who know it best."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SeparatistVoidmage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SeparatistVoidmage.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Separatist Voidmage
+ * {3}{U}
+ * Creature — Human Wizard
+ * 2/2
+ *
+ * When this creature enters, you may return target creature to its owner's hand.
+ */
+val SeparatistVoidmage = card("Separatist Voidmage") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "When this creature enters, you may return target creature to its owner's hand."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Jason Rainville"
+        flavorText = "\"As long as each side thinks it can win, the balance holds, and the mage-rings stand.\"\n" +
+            "—Alhammarret"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "ORI",
+    collectorNumber = "31",
+    scryfallId = "386f050c-0233-490f-94ab-92a7b5dc65cf",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/386f050c-0233-490f-94ab-92a7b5dc65cf.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkaabGoliathReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkaabGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skaab Goliath reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SkaabGoliathReprint = Printing(
+    oracleId = "498707db-258f-423a-9ff6-9e294fce84d6",
+    name = "Skaab Goliath",
+    setCode = "ORI",
+    collectorNumber = "74",
+    scryfallId = "3682b3d3-cb3d-4c2c-a419-f08e3a370cd1",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/3682b3d3-cb3d-4c2c-a419-f08e3a370cd1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkysnareSpider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SkysnareSpider.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skysnare Spider
+ * {4}{G}{G}
+ * Creature — Spider
+ * 6/6
+ *
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Reach (This creature can block creatures with flying.)
+ */
+val SkysnareSpider = card("Skysnare Spider") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Reach (This creature can block creatures with flying.)"
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.VIGILANCE, Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Filip Burburan"
+        flavorText = "The only thing more ill-tempered than a griffin in a web is the spider that must subdue it."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SomberwaldAlpha.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SomberwaldAlpha.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Somberwald Alpha
+ * {3}{G}
+ * Creature — Wolf
+ * 3/2
+ *
+ * Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.
+ * {1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ *
+ * "it" in the trigger is the blocked creature, not the Alpha, so the pump targets
+ * [EffectTarget.TriggeringEntity] — the ANY-bound `becomesBlocked` binds the creature that became
+ * blocked, which is exactly what the pronoun refers to.
+ */
+val SomberwaldAlpha = card("Somberwald Alpha") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.\n" +
+        "{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess " +
+        "combat damage to the player or planeswalker it's attacking.)"
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.TriggeringEntity)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        val t = target("target creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SoulbladeDjinn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SoulbladeDjinn.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soulblade Djinn
+ * {3}{U}{U}
+ * Creature — Djinn
+ * 4/3
+ *
+ * Flying
+ * Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.
+ *
+ * Prowess for the whole team — the same cast trigger, but the body is a group pump rather than a
+ * self pump, so it is spelled out rather than reusing the `prowess()` shorthand.
+ */
+val SoulbladeDjinn = card("Soulblade Djinn") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn"
+    oracleText = "Flying\n" +
+        "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Patterns.Group.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Viktor Titov"
+        flavorText = "He grants endless wishes, as long as you always wish for a blade."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StalwartAven.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StalwartAven.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Stalwart Aven
+ * {2}{W}
+ * Creature — Bird Soldier
+ * 1/3
+ *
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val StalwartAven = card("Stalwart Aven") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Scott Murphy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StratusWalkReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/StratusWalkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stratus Walk reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val StratusWalkReprint = Printing(
+    oracleId = "eda37caa-d676-460a-804b-3ba9d8a8d044",
+    name = "Stratus Walk",
+    setCode = "ORI",
+    collectorNumber = "77",
+    scryfallId = "947bb8f3-51f5-4fbe-9098-7e48f9fe1452",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/947bb8f3-51f5-4fbe-9098-7e48f9fe1452.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SylvanMessengerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SylvanMessengerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Messenger reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanMessengerReprint = Printing(
+    oracleId = "ba310102-8272-4d64-a00b-9e7346cb5f46",
+    name = "Sylvan Messenger",
+    setCode = "ORI",
+    collectorNumber = "199",
+    scryfallId = "95e0550c-d3ad-4bd4-a259-d597991079b1",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95e0550c-d3ad-4bd4-a259-d597991079b1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ThunderclapWyvern.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ThunderclapWyvern.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thunderclap Wyvern
+ * {2}{W}{U}
+ * Creature — Drake
+ * 2/3
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Flying
+ * Other creatures you control with flying get +1/+1.
+ */
+val ThunderclapWyvern = card("Thunderclap Wyvern") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Drake"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Flying\n" +
+        "Other creatures you control with flying get +1/+1."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withKeyword(Keyword.FLYING).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Jason Felix"
+        flavorText = "Thunder doesn't always mean rain. Sometimes it means ruin."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TopanFreeblade.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TopanFreeblade.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Topan Freeblade
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val TopanFreeblade = card("Topan Freeblade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Johannes Voss"
+        flavorText = "\"My scars are my sigils. I will wear them with pride long after you're gone.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/UndercityTroll.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/UndercityTroll.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Undercity Troll
+ * {1}{G}
+ * Creature — Troll
+ * 2/2
+ *
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ * {2}{G}: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)
+ */
+val UndercityTroll = card("Undercity Troll") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll"
+    oracleText = "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n" +
+        "{2}{G}: Regenerate this creature. (The next time this creature would be destroyed this turn, " +
+        "instead tap it, remove it from combat, and heal all damage on it.)"
+    power = 2
+    toughness = 2
+
+    keywordAbility(KeywordAbility.renown(1))
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VeteransSidearm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VeteransSidearm.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Veteran's Sidearm
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1.
+ * Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val VeteransSidearm = card("Veteran's Sidearm") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Aaron Miller"
+        flavorText = "\"I've broken three swords, eighteen lances, and countless shields, but this little blade has survived every battle, just like I have.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VineSnare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VineSnare.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Vine Snare
+ * {2}{G}
+ * Instant
+ *
+ * Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.
+ *
+ * A source-side shield: [Effects.PreventCombatDamageFrom] installs the prevention keyed on the
+ * damage *source* group, so it catches every qualifying creature on both sides of combat rather
+ * than protecting one recipient.
+ */
+val VineSnare = card("Vine Snare") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less."
+
+    spell {
+        effect = Effects.PreventCombatDamageFrom(
+            GroupFilter(GameObjectFilter.Creature.powerAtMost(4))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Igor Kieryluk"
+        flavorText = "Nissa found that the vines of the marsh could ensnare just as well as forest vines could—maybe even better."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VolcanicRambler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VolcanicRambler.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Rambler
+ * {5}{R}
+ * Creature — Elemental
+ * 6/4
+ *
+ * {2}{R}: This creature deals 1 damage to target player or planeswalker.
+ */
+val VolcanicRambler = card("Volcanic Rambler") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "{2}{R}: This creature deals 1 damage to target player or planeswalker."
+    power = 6
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        val t = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Vincent Proce"
+        flavorText = "It moves through lava with the force of an erupting volcano."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VrynWingmare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VrynWingmare.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Vryn Wingmare
+ * {2}{W}
+ * Creature — Pegasus
+ * 2/1
+ *
+ * Flying
+ * Noncreature spells cost {1} more to cast.
+ *
+ * A symmetrical tax — [SpellCostTarget.AnyCaster], so it taxes its own controller too.
+ */
+val VrynWingmare = card("Vryn Wingmare") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Pegasus"
+    oracleText = "Flying\n" +
+        "Noncreature spells cost {1} more to cast."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Noncreature),
+            modification = CostModification.IncreaseGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Seb McKinnon"
+        flavorText = "It's the favored mount of military commanders as well as anyone with a flair for the dramatic."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarHorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarHorn.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * War Horn
+ * {3}
+ * Artifact
+ *
+ * Attacking creatures you control get +1/+0.
+ */
+val WarHorn = card("War Horn") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Attacking creatures you control get +1/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.attacking().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "243"
+        artist = "Lars Grant-West"
+        flavorText = "The reverberations course through the warriors' veins, beat with their hearts, and pound with their footfalls as they charge into battle."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarOracle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WarOracle.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * War Oracle
+ * {2}{W}{W}
+ * Creature — Human Cleric
+ * 3/3
+ *
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ * Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)
+ */
+val WarOracle = card("War Oracle") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\n" +
+        "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.renown(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Steve Prescott"
+        flavorText = "\"When you are felled by my mace, you shall know it was divine fate.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WatercourserReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WatercourserReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Watercourser reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val WatercourserReprint = Printing(
+    oracleId = "65dd4ae3-432c-4d57-ac14-4d827262ea0b",
+    name = "Watercourser",
+    setCode = "ORI",
+    collectorNumber = "82",
+    scryfallId = "60b12e87-ccd6-4c84-80b2-9ac7d099be89",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b12e87-ccd6-4c84-80b2-9ac7d099be89.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WeightOfTheUnderworldReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/WeightOfTheUnderworldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weight of the Underworld reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val WeightOfTheUnderworldReprint = Printing(
+    oracleId = "b960d17b-3679-4dc5-9a5d-c8e7fd81fa9a",
+    name = "Weight of the Underworld",
+    setCode = "ORI",
+    collectorNumber = "126",
+    scryfallId = "e2f31943-e26c-4bd2-bdbd-d980836f99b9",
+    artist = "Wesley Burt",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e2f31943-e26c-4bd2-bdbd-d980836f99b9.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YevaSForcemageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YevaSForcemageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yeva's Forcemage reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val YevaSForcemageReprint = Printing(
+    oracleId = "785e451d-87b6-4772-97e5-d2744818e0fd",
+    name = "Yeva's Forcemage",
+    setCode = "ORI",
+    collectorNumber = "208",
+    scryfallId = "50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50b9fdbf-d7c3-43f7-ad4c-54a6d37440c1.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarIncarnate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarIncarnate.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zendikar Incarnate
+ * {2}{R}{G}
+ * Creature — Elemental
+ * * / 4
+ *
+ * Zendikar Incarnate's power is equal to the number of lands you control.
+ *
+ * Only the *power* is characteristic-defining (CR 604.3), so this uses [dynamicPower] rather than
+ * `dynamicStats` — the printed toughness stays the fixed 4. `AggregateBattlefield` is the corpus's
+ * one-battlefield tally, and [Filters.Land] is the bare `IsLand` predicate, so every land you
+ * control counts regardless of subtype.
+ */
+val ZendikarIncarnate = card("Zendikar Incarnate") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Elemental"
+    oracleText = "Zendikar Incarnate's power is equal to the number of lands you control."
+    toughness = 4
+
+    dynamicPower(DynamicAmount.AggregateBattlefield(Player.You, Filters.Land))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Lucas Graciano"
+        flavorText = "\"Her people angered Zendikar, and they faced the land's wrath. That is why " +
+            "Nissa is the last of the animists.\"\n" +
+            "—Numa, Joraga chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/AuramancerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/AuramancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "PC2",
+    collectorNumber = "2",
+    scryfallId = "441012c4-b9f8-40dc-b0be-907d03573360",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/441012c4-b9f8-40dc-b0be-907d03573360.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "PC2",
+    collectorNumber = "11",
+    scryfallId = "1dff2430-506e-4ffa-86fc-aa655e2ba306",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1dff2430-506e-4ffa-86fc-aa655e2ba306.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/BellowsLizard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/BellowsLizard.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bellows Lizard
+ * {R}
+ * Creature — Lizard
+ * 1/1
+ *
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ */
+val BellowsLizard = card("Bellows Lizard") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    oracleText = "{1}{R}: This creature gets +1/+0 until end of turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Jack Wang"
+        flavorText = "As the price of wood and coal rose, smiths found creative ways to keep their forges burning."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ReturnedCentaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ReturnedCentaur.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Returned Centaur
+ * {3}{B}
+ * Creature — Zombie Centaur
+ * 2/4
+ *
+ * When this creature enters, target player mills four cards.
+ */
+val ReturnedCentaur = card("Returned Centaur") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Centaur"
+    oracleText = "When this creature enters, target player mills four cards."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(4, p)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Lucas Graciano"
+        flavorText = "Driven away by his living kin, he wanders mourning through the wilderness, seeking the dead city of Asphodel."
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SoulbladeDjinnReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SoulbladeDjinnReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soulblade Djinn reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val SoulbladeDjinnReprint = Printing(
+    oracleId = "a598e6ce-21ee-49c1-989e-ee864208262f",
+    name = "Soulblade Djinn",
+    setCode = "ANB",
+    collectorNumber = "34",
+    scryfallId = "3c7631df-2e6c-4472-8dd6-8b07fcc545fb",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c7631df-2e6c-4472-8dd6-8b07fcc545fb.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ElementalBondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ElementalBondReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elemental Bond reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val ElementalBondReprint = Printing(
+    oracleId = "d9a7e5a6-3e41-4fc6-987a-18fe1b9d67dd",
+    name = "Elemental Bond",
+    setCode = "C17",
+    collectorNumber = "148",
+    scryfallId = "7170ad9e-f43d-46e2-a9dd-97be31099c02",
+    artist = "David Gaillet",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/7170ad9e-f43d-46e2-a9dd-97be31099c02.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/FleshbagMarauderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/FleshbagMarauderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fleshbag Marauder reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val FleshbagMarauderReprint = Printing(
+    oracleId = "4b1bf05e-753e-4350-a913-894cf3cecc0c",
+    name = "Fleshbag Marauder",
+    setCode = "CMR",
+    collectorNumber = "128",
+    scryfallId = "4002b3a4-e00e-44ed-8989-d553e5d7d6c8",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/4002b3a4-e00e-44ed-8989-d553e5d7d6c8.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SkaabGoliathReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SkaabGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skaab Goliath reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val SkaabGoliathReprint = Printing(
+    oracleId = "498707db-258f-423a-9ff6-9e294fce84d6",
+    name = "Skaab Goliath",
+    setCode = "CMR",
+    collectorNumber = "97",
+    scryfallId = "d151fe63-3b3a-4cd4-9a2d-d80e7434e63c",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d151fe63-3b3a-4cd4-9a2d-d80e7434e63c.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlchemistSVialReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlchemistSVialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Vial reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val AlchemistSVialReprint = Printing(
+    oracleId = "f574bd9f-4246-42cb-bf4e-d2888daa44c9",
+    name = "Alchemist's Vial",
+    setCode = "J22",
+    collectorNumber = "753",
+    scryfallId = "8d22523a-bb2d-489d-994e-65455def4fc5",
+    artist = "Lindsey Look",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d22523a-bb2d-489d-994e-65455def4fc5.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SylvanMessengerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SylvanMessengerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Messenger reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanMessengerReprint = Printing(
+    oracleId = "ba310102-8272-4d64-a00b-9e7346cb5f46",
+    name = "Sylvan Messenger",
+    setCode = "KHC",
+    collectorNumber = "75",
+    scryfallId = "085f1b89-857b-4e2b-b796-0b95e53322bd",
+    artist = "PINDURSKI",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/085f1b89-857b-4e2b-b796-0b95e53322bd.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ThunderclapWyvernReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ThunderclapWyvernReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunderclap Wyvern reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val ThunderclapWyvernReprint = Printing(
+    oracleId = "15276d3b-a117-44bf-87c3-c17e032e4a26",
+    name = "Thunderclap Wyvern",
+    setCode = "KHC",
+    collectorNumber = "94",
+    scryfallId = "7fc3c21f-99d5-48dc-b36e-8db597da44bf",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fc3c21f-99d5-48dc-b36e-8db597da44bf.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InfernalScarringReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InfernalScarringReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infernal Scarring reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val InfernalScarringReprint = Printing(
+    oracleId = "3fc640dd-6292-4d36-82fb-bd366bc00bd3",
+    name = "Infernal Scarring",
+    setCode = "M19",
+    collectorNumber = "103",
+    scryfallId = "9cf7ff14-0de8-4ef9-8425-df15629adc4b",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/9/c/9cf7ff14-0de8-4ef9-8425-df15629adc4b.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/InfernalScarringReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/InfernalScarringReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infernal Scarring reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val InfernalScarringReprint = Printing(
+    oracleId = "3fc640dd-6292-4d36-82fb-bd366bc00bd3",
+    name = "Infernal Scarring",
+    setCode = "M21",
+    collectorNumber = "105",
+    scryfallId = "975e4b8e-add9-439c-9463-e2facee96c10",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/975e4b8e-add9-439c-9463-e2facee96c10.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "M21",
+    collectorNumber = "233",
+    scryfallId = "ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ec3a2c95-4e7a-43c5-90bd-6f1de7c82a5c.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/VrynWingmareReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/VrynWingmareReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vryn Wingmare reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val VrynWingmareReprint = Printing(
+    oracleId = "c7c241f2-d3cc-4032-a9da-149de73c2539",
+    name = "Vryn Wingmare",
+    setCode = "M21",
+    collectorNumber = "43",
+    scryfallId = "17b59819-4746-4c67-b6e5-4157d498a065",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17b59819-4746-4c67-b6e5-4157d498a065.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ElementalBondReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ElementalBondReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elemental Bond reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val ElementalBondReprint = Printing(
+    oracleId = "d9a7e5a6-3e41-4fc6-987a-18fe1b9d67dd",
+    name = "Elemental Bond",
+    setCode = "TLE",
+    collectorNumber = "40",
+    scryfallId = "da25ea1d-2fa6-42ca-bd06-a2edeb300eb5",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/da25ea1d-2fa6-42ca-bd06-a2edeb300eb5.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/MeteoriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "TLE",
+    collectorNumber = "54",
+    scryfallId = "3dd36ba1-4f96-415a-90ec-1d9e5e355eb9",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3dd36ba1-4f96-415a-90ec-1d9e5e355eb9.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1637,6 +1637,47 @@
     ]
 }
 
+// Fleshbag Marauder
+{
+    "name": "Fleshbag Marauder",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Warrior",
+    "oracleText": "When this creature enters, each player sacrifices a creature of their choice.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "flavorText": "Grixis is a world where the only things found in abundance are death and decay. Corpses, whole or in part, are the standard currency among necromancers and demons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f71e4391-04a8-4df8-9d52-3a3480bcd5b6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Glaze Fiend
 {
     "name": "Glaze Fiend",

--- a/mtg-sets/src/test/resources/snapshots/cards/APC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/APC.json
@@ -2511,6 +2511,89 @@
     ]
 }
 
+// Sylvan Messenger
+{
+    "name": "Sylvan Messenger",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen this creature enters, reveal the top four cards of your library. Put all Elf cards revealed this way into your hand and the rest on the bottom of your library in any order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "looked"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "permanent Elf"
+                            },
+                            "storeMatching": "kept",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Heather Hudson",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd67d17e-23d2-47a0-a10b-c3d63cbf969a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Temporal Spring
 {
     "name": "Temporal Spring",

--- a/mtg-sets/src/test/resources/snapshots/cards/BNG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BNG.json
@@ -38,6 +38,68 @@
     ]
 }
 
+// Stratus Walk
+{
+    "name": "Stratus Walk",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature has flying. (It can't be blocked except by creatures with flying or reach.)\nEnchanted creature can block only creatures with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Aaron Miller",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44744725-6ba7-40bd-b25b-788a1032ecf4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Swordwise Centaur
 {
     "name": "Swordwise Centaur",
@@ -229,5 +291,37 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Weight of the Underworld
+{
+    "name": "Weight of the Underworld",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets -3/-2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -3,
+                "toughnessBonus": -2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Wesley Burt",
+        "flavorText": "Proud Alkmenos, who would not bow to Erebos in death, is now bowed by his own hubris for all eternity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a99bcecd-0b5a-4806-824b-4885fcad1449.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -5362,6 +5362,44 @@
     ]
 }
 
+// Skaab Goliath
+{
+    "name": "Skaab Goliath",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Zombie Giant",
+    "oracleText": "As an additional cost to cast this spell, exile two creature cards from your graveyard.\nTrample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 9
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "filter": "creature",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"Three heads, six arms, and some armor grafts are better than . . . the normal numbers of those things.\"\n—Stitcher Geralf",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c1134a5-5434-4733-812b-3587b1817813.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Skirsdag Cultist
 {
     "name": "Skirsdag Cultist",

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -111,6 +111,31 @@
     ]
 }
 
+// Eagle of the Watch
+{
+    "name": "Eagle of the Watch",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Even from miles away, I could see our eagles circling. That's when I gave the command to pick up the pace. I knew we were needed at home.\"\n—Kanlos, Akroan captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc4b6fb1-dc06-48f4-aae2-aa8bbb573548.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Flurry of Horns
 {
     "name": "Flurry of Horns",
@@ -146,6 +171,28 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Gold-Forged Sentinel
+{
+    "name": "Gold-Forged Sentinel",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Chimera",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "James Zapata",
+        "flavorText": "Blessed by the gods. Coveted by mortals. Beholden to neither.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e154012-5922-45d1-8e20-d2a2b1de0785.jpg"
+    }
 }
 
 // Heroes' Bane

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -811,3 +811,104 @@
         "GREEN"
     ]
 }
+
+// Watercourser
+{
+    "name": "Watercourser",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{U}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Beware an eddy where there should be none or a stretch that flows too fast or too slow.\"\n—Old Fishbones, Martyne river guide",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a27c441a-b31d-4214-8fc5-054003e257dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Yeva's Forcemage
+{
+    "name": "Yeva's Forcemage",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "When this creature enters, target creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"Nature can't be stopped. It rips and tears at Ravnica's tallest buildings to claim its place in the sun.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f9ebf02-56b3-492e-88fb-2e95f13f5764.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -81,6 +81,96 @@
     ]
 }
 
+// Celestial Flare
+{
+    "name": "Celestial Flare",
+    "manaCost": "{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target player sacrifices an attacking or blocking creature of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "ForceSacrifice",
+            "filter": {
+                "cardPredicates": [
+                    "IsCreature"
+                ],
+                "statePredicates": [
+                    {
+                        "type": "StateOr",
+                        "predicates": [
+                            "IsAttacking",
+                            "IsBlocking"
+                        ]
+                    }
+                ]
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target player"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Clint Cearley",
+        "flavorText": "\"You were defeated the moment you declared your aggression.\"\n—Gideon Jura",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c8d1320-0f1a-4c66-86c9-9f8da0f1d9ef.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Charging Griffin
+{
+    "name": "Charging Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhenever this creature attacks, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Erica Yang",
+        "flavorText": "Four claws, two wings, one beak, no fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88637cc0-3b2a-402c-b491-26fcc2d21fb8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elvish Mystic
 {
     "name": "Elvish Mystic",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -1,3 +1,345 @@
+// Abbot of Keral Keep
+{
+    "name": "Abbot of Keral Keep",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, exile the top card of your library. Until end of turn, you may play that card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Deruchenko Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb7a2770-9a20-4f52-aac4-24502f50e374.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Aerial Volley
+{
+    "name": "Aerial Volley",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "DividedDamage",
+            "totalDamage": 3
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target creatures with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Lake Hurwitz",
+        "flavorText": "Drakes can swerve to avoid a single arrow, but they can't dodge the whole sky.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5178301-f766-48d3-af07-6bd6f822c725.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Akroan Jailer
+{
+    "name": "Akroan Jailer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{2}{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "He ensures escape attempts are just that—attempts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d96bc2b-2e31-4654-b192-c3f023d9fde6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Akroan Sergeant
+{
+    "name": "Akroan Sergeant",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike (This creature deals combat damage before creatures without first strike.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Zack Stella",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31913547-460c-45b3-be23-89f0e3a43325.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Alchemist's Vial
+{
+    "name": "Alchemist's Vial",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, draw a card.\n{1}, {T}, Sacrifice this artifact: Target creature can't attack or block this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CantAttack",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Lindsey Look",
+        "flavorText": "A weapon best suited for those with good aim and steady hands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/251f89c5-d4da-4754-83fa-218c8864ef41.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Ampryn Tactician
+{
+    "name": "Ampryn Tactician",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "\"It's all a game. You shouldn't get too attached to the pieces.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82a2e1d9-6763-4024-a18b-982d96395553.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Anchor to the Aether
 {
     "name": "Anchor to the Aether",
@@ -41,6 +383,60 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Anointer of Champions
+{
+    "name": "Anointer of Champions",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Target attacking creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target attacking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Arise. You have been anointed by the light. Go forth and fight without fear, for you shall be victorious.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36d060c9-8385-40af-87eb-b4688ebb8e7c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -96,6 +492,115 @@
     ]
 }
 
+// Aven Battle Priest
+{
+    "name": "Aven Battle Priest",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Bird Cleric",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen this creature enters, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "John Severin Brassell",
+        "flavorText": "When the shadow of the aven falls across the battlefield, hope rises in the hearts of the soldiers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0060e75-a5a4-4d9a-894c-45bb7e2feffc.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blazing Hellhound
+{
+    "name": "Blazing Hellhound",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "{1}, Sacrifice another creature: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Velhagen",
+        "flavorText": "It tears the flesh from your bones and then swallows the ash with its fiery maw.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/332769b1-1eb5-4c77-8317-27addc28650b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Blessed Spirits
 {
     "name": "Blessed Spirits",
@@ -146,6 +651,68 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Blood-Cursed Knight
+{
+    "name": "Blood-Cursed Knight",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "As long as you control an enchantment, this creature gets +1/+1 and has lifelink. (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "enchantment"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"The bloodlust shall not control me, for my oath is my greatest compulsion.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/644bb558-113e-4e49-a395-7e0036c3419c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 
@@ -262,6 +829,93 @@
         "flavorText": "The foundries of Kaladesh run like clockwork under the supervision of their formidable overseers.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2c65947-bc1d-4f47-b60b-2f76ab5ebde9.jpg?1783938311"
     }
+}
+
+// Citadel Castellan
+{
+    "name": "Citadel Castellan",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "\"I am the first line of defense. You will not encounter the second.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9aa11f30-f2b7-4279-9176-c336c74538bf.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Conclave Naturalists
+{
+    "name": "Conclave Naturalists",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "When this creature enters, you may destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment"
+                    },
+                    "id": "target artifact or enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Your swords and wards have no power here.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3759fc28-9adb-41ed-851c-566a3a424e09.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Demonic Pact
@@ -523,6 +1177,96 @@
     ]
 }
 
+// Elemental Bond
+{
+    "name": "Elemental Bond",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control with power 3 or greater enters, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow>=3 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "David Gaillet",
+        "flavorText": "\"I want to help Zendikar. Show me the way.\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/554a8769-c840-4c9d-9959-b075c174457b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Enlightened Ascetic
+{
+    "name": "Enlightened Ascetic",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Monk",
+    "oracleText": "When this creature enters, you may destroy target enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "enchantment"
+                    },
+                    "id": "target enchantment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "James Zapata",
+        "flavorText": "\"I do not reject the gods. I reject their authority, their pettiness, and their arrogance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76549fc3-5798-4c70-bb70-802b6f597eb7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Eyeblight Assassin
 {
     "name": "Eyeblight Assassin",
@@ -668,6 +1412,87 @@
     ]
 }
 
+// Firefiend Elemental
+{
+    "name": "Firefiend Elemental",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Torstein Nordstrand",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55051412-8749-4b65-ac76-c20ef57fd2e3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ghirapur Aether Grid
+{
+    "name": "Ghirapur Aether Grid",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Tap two untapped artifacts you control: This enchantment deals 1 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "The city of Ghirapur is a living thing, and living things defend themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e4a0c29-a759-465f-9136-9d709b6f30fc.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Gilt-Leaf Winnower
 {
     "name": "Gilt-Leaf Winnower",
@@ -721,6 +1546,44 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Guardian Automaton
+{
+    "name": "Guardian Automaton",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "When this creature dies, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Vincent Proce",
+        "flavorText": "The wealthy in the city of Ghirapur outfit their lives with grand machines, entrusting even their children to filigree and gears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e8916b7-f5e4-4fae-8db8-9859d69212ec.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Harbinger of the Tides
@@ -782,6 +1645,110 @@
     ]
 }
 
+// Heavy Infantry
+{
+    "name": "Heavy Infantry",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "David Gaillet",
+        "flavorText": "Doors, walls, skulls . . . it matters not. All barriers will be broken.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b904b1c-bf35-4bc1-8022-7f632160733d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Herald of the Pantheon
+{
+    "name": "Herald of the Pantheon",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Centaur Shaman",
+    "oracleText": "Enchantment spells you cast cost {1} less to cast.\nWhenever you cast an enchantment spell, you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "enchantment"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "flavorText": "The distinction of bearing the gods' banner is nothing compared to the glory of being closer to Nyx.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ffeca7a7-2a14-4166-9e89-0f4eb94b79f5.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hitchclaw Recluse
 {
     "name": "Hitchclaw Recluse",
@@ -803,6 +1770,150 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Infernal Scarring
+{
+    "name": "Infernal Scarring",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+0 and has \"When this creature dies, draw a card.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "from": "Battlefield",
+                        "to": "Graveyard"
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Mike Bierek",
+        "flavorText": "One who is marked by a demon in life is sure to be remembered as one in death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1ead8cc-5b7d-4a6d-a56f-95da91a958d2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Iroas's Champion
+{
+    "name": "Iroas's Champion",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Double strike (This creature deals both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Nelor",
+        "flavorText": "Accustomed to battling before an audience in the arena, Iroas's champions know how to put on a good show.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0441583-c9d5-47a1-8754-c9162cec64bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Jhessian Thief
+{
+    "name": "Jhessian Thief",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever this creature deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Miles Johnston",
+        "flavorText": "\"Where's the fun in an escape if it's not at least a little daring?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33b8553d-d326-4280-bc3a-2fffdd377cd2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -857,6 +1968,99 @@
     ]
 }
 
+// Knight of the Pilgrim's Road
+{
+    "name": "Knight of the Pilgrim's Road",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "David Gaillet",
+        "flavorText": "\"To be a knight, Gideon, is to be the shield for the meek against the cruel.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9de5f39-b07a-4272-8992-ed971132c9c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kytheon's Irregulars
+{
+    "name": "Kytheon's Irregulars",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{W}{W}: Tap target creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Mark Winters",
+        "flavorText": "Kytheon and his irregulars worked outside the law to bring justice to the streets of Akros.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/440f9dbb-6d31-4c03-9c6d-c4910adc5497.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Languish
 {
     "name": "Languish",
@@ -898,6 +2102,87 @@
     ]
 }
 
+// Lightning Javelin
+{
+    "name": "Lightning Javelin",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Lightning Javelin deals 3 damage to any target. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Seb McKinnon",
+        "flavorText": "The harpies descended without mercy upon Akros, only to find their attack put them within range of the javelineers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1ccaeed-9670-4432-8a45-d5c06119fa9f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Magmatic Insight
+{
+    "name": "Magmatic Insight",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, discard a land card.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomDiscard",
+                    "filter": "land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Barger",
+        "flavorText": "Chief among the tenets of Purphoros is that one must destroy in order to create.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f00192e0-439d-43b2-882c-90a2d52103f8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Managorger Hydra
 {
     "name": "Managorger Hydra",
@@ -935,6 +2220,230 @@
         "rarity": "RARE",
         "artist": "Lucas Graciano",
         "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1783938321"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Mantle of Webs
+{
+    "name": "Mantle of Webs",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+3 and has reach. (It can block creatures with flying.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 3
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Why does everything the Golgari touch end up sticky?\"\n—Arrester Lavinia, Tenth Precinct",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b09e36a-ad53-44ae-8586-2b658e3c533c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Molten Vortex
+{
+    "name": "Molten Vortex",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "{R}, Discard a land card: This enchantment deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "RARE",
+        "artist": "Philip Straub",
+        "flavorText": "If you can't take the heat . . . well, that's going to be a problem.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Nivix Barrier
+{
+    "name": "Nivix Barrier",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Illusion Wall",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nDefender (This creature can't attack.)\nWhen this creature enters, target attacking creature gets -4/-0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "target attacking creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b9b968d-b0cc-411d-9366-8358be28aef2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Outland Colossus
+{
+    "name": "Outland Colossus",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Renown 6 (When this creature deals combat damage to a player, if it isn't renowned, put six +1/+1 counters on it and it becomes renowned.)\nThis creature can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 6
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Pharika's Disciple
+{
+    "name": "Pharika's Disciple",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Karl Kopinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0b3d8f7-6a41-49ba-b111-d34a345394c0.jpg"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -1138,6 +2647,141 @@
     ]
 }
 
+// Rhox Maulers
+{
+    "name": "Rhox Maulers",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Rhino Soldier",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nRenown 2 (When this creature deals combat damage to a player, if it isn't renowned, put two +1/+1 counters on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64c3c972-82f6-46ea-8f9f-090c65c22e44.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ringwarden Owl
+{
+    "name": "Ringwarden Owl",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Titus Lunter",
+        "flavorText": "The owls learn of mana from the mages who know it best.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1acf216d-ef8f-431b-9b65-1e2e91285517.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Separatist Voidmage
+{
+    "name": "Separatist Voidmage",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, you may return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Jason Rainville",
+        "flavorText": "\"As long as each side thinks it can win, the balance holds, and the mage-rings stand.\"\n—Alhammarret",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5634d1a-ca4b-4528-9e0e-b88f1025d434.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shambling Ghoul
 {
     "name": "Shambling Ghoul",
@@ -1189,6 +2833,199 @@
     ]
 }
 
+// Skysnare Spider
+{
+    "name": "Skysnare Spider",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nReach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "The only thing more ill-tempered than a griffin in a web is the spider that must subdue it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1743227-94fd-44c0-884d-fa269bcfd67d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Somberwald Alpha
+{
+    "name": "Somberwald Alpha",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Whenever a creature you control becomes blocked, it gets +1/+1 until end of turn.\n{1}{G}: Target creature you control gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/492808ec-7e23-4266-adc5-519e74a06bbb.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Soulblade Djinn
+{
+    "name": "Soulblade Djinn",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Djinn",
+    "oracleText": "Flying\nWhenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Viktor Titov",
+        "flavorText": "He grants endless wishes, as long as you always wish for a blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2a48455-dde4-4263-9146-af547c0aad48.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stalwart Aven
+{
+    "name": "Stalwart Aven",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Scott Murphy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc4dccbe-877a-4c1e-b46c-711d7c45a506.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Subterranean Scout
 {
     "name": "Subterranean Scout",
@@ -1234,6 +3071,127 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Thunderclap Wyvern
+{
+    "name": "Thunderclap Wyvern",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nOther creatures you control with flying get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature kw:flying ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "Thunder doesn't always mean rain. Sometimes it means ruin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd20971a-11aa-452b-8507-0f48229062a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Topan Freeblade
+{
+    "name": "Topan Freeblade",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Johannes Voss",
+        "flavorText": "\"My scars are my sigils. I will wear them with pride long after you're gone.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9ef727b-3e67-46d2-80f9-b1d483977b05.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Undercity Troll
+{
+    "name": "Undercity Troll",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Troll",
+    "oracleText": "Renown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)\n{2}{G}: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/873d901f-1425-4a0e-a820-015dcf4803f6.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1293,6 +3251,274 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Veteran's Sidearm
+{
+    "name": "Veteran's Sidearm",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Aaron Miller",
+        "flavorText": "\"I've broken three swords, eighteen lances, and countless shields, but this little blade has survived every battle, just like I have.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c1b3e7d-0fd8-4324-be7b-382e75ae9c17.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Vine Snare
+{
+    "name": "Vine Snare",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn by creatures with power 4 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly",
+            "direction": "FromTarget",
+            "sourceFilter": {
+                "type": "FromGroup",
+                "filter": {
+                    "baseFilter": "creature pow<=4"
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Nissa found that the vines of the marsh could ensnare just as well as forest vines could—maybe even better.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2241f71-4319-49bf-905a-b6b774ffcb27.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Volcanic Rambler
+{
+    "name": "Volcanic Rambler",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{2}{R}: This creature deals 1 damage to target player or planeswalker.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Vincent Proce",
+        "flavorText": "It moves through lava with the force of an erupting volcano.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fc075ee-16e9-4cf5-bbb0-7b3b4b9eb3f4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Vryn Wingmare
+{
+    "name": "Vryn Wingmare",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Pegasus",
+    "oracleText": "Flying\nNoncreature spells cost {1} more to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": "noncreature"
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "RARE",
+        "artist": "Seb McKinnon",
+        "flavorText": "It's the favored mount of military commanders as well as anyone with a flair for the dramatic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// War Horn
+{
+    "name": "War Horn",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Attacking creatures you control get +1/+0.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "The reverberations course through the warriors' veins, beat with their hearts, and pound with their footfalls as they charge into battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45c17671-7c4a-4114-b2b7-d34af4e2f8c1.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// War Oracle
+{
+    "name": "War Oracle",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nRenown 1 (When this creature deals combat damage to a player, if it isn't renowned, put a +1/+1 counter on it and it becomes renowned.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK",
+        "RENOWN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "RENOWN",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "\"When you are felled by my mace, you shall know it was divine fate.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d8827bf-11c3-4f78-b7aa-ae953442c709.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Zendikar Incarnate
+{
+    "name": "Zendikar Incarnate",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Zendikar Incarnate's power is equal to the number of lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            }
+        },
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"Her people angered Zendikar, and they faced the land's wrath. That is why Nissa is the last of the animists.\"\n—Numa, Joraga chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb12b1d8-c53e-4d48-89e5-2168ff34a853.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -106,6 +106,53 @@
     ]
 }
 
+// Bellows Lizard
+{
+    "name": "Bellows Lizard",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Jack Wang",
+        "flavorText": "As the price of wood and coal rose, smiths found creative ways to keep their forges burning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5da4a644-9809-4591-9007-6b70b5f9d923.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Brushstrider
 {
     "name": "Brushstrider",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -2040,6 +2040,75 @@
     ]
 }
 
+// Returned Centaur
+{
+    "name": "Returned Centaur",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Centaur",
+    "oracleText": "When this creature enters, target player mills four cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Lucas Graciano",
+        "flavorText": "Driven away by his living kin, he wanders mourning through the wilderness, seeking the dead city of Asphodel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1067cf71-a270-4b1b-aa06-0ec0e732ed16.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Satyr Rambler
 {
     "name": "Satyr Rambler",


### PR DESCRIPTION
Sweeps every Assay-ready card in Magic Origins: the 69 cards Argentum Assay reads whole that the set
had not authored. **69 → 0.**

ORI had a sweep before (#2053, 65 cards); the grammar has grown since, and this is the tail that
opened up behind it.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 48 | canonical authored in ORI |
| `elsewhere` | 13 | canonical authored in the earlier set (RTR, M14 ×2, JOU ×2, ALA, THS, ISD, BNG ×2, APC, M13 ×2), `Printing` row in ORI |
| `row-only` | 3 | `Printing` row only — Auramancer (ODY), Meteorite (M15), Sigil of the Empty Throne (CON) |
| `basic` | 5 | `MagicOriginsBasicLands.kt` — `basicLand(...)` vals, never `Printing` rows |

**61 canonicals + 36 `Printing` rows across 15 sets.** The reprint tail is the half that gets
forgotten: authoring the 13 `elsewhere` canonicals made `check-card-printing` able to see that their
*other* scaffolded printings had no rows either, so 20 rows land in sets outside this sweep (M21 ×3,
CMR/KHC/PC2/TLE ×2 each, ANB, C15, C17, CMD, DDL, J22, M12, M14, M19).

## Verification

| Gate | Result |
|---|---|
| `just build` | green |
| `just rebless-cards` | 61 cards added across 10 goldens; **0 pre-existing cards changed, 0 removed** (verified per-card, not by line count) |
| differential | **5817/5766/51 → 5875/5824/51** — +58 compared, +58 confirmed, **no new divergence** |
| `check-card-printing` | 64/64 clean |
| `just assay-ready ORI` | **69 → 0** (re-run on the branch, not inferred) |

Three cards leave the compared set into "script slot not modelled yet" (122 → 125): Abbot of Keral
Keep, Jhessian Thief, Ringwarden Owl. All three are prowess. `prowess()` wires the CR 702.108
triggered ability, which Assay models as a bare keyword — the card correctly carries more than the
text does, so the differential excuses rather than compares them. That is the right lowering: the
bare `Keyword.PROWESS` is display-only, read by `CreateTokenExecutor` and nothing else.

## Capability pre-flight

Every SDK type the batch touches has a live `rules-engine` consumer — no engine work needed. Renown
(12 of the 69 cards, and the set's signature mechanic) is engine-live from #2051: the card declares
`KeywordAbility.renown(n)` and `TriggerAbilityResolver` expands it into CR 702.112a's
intervening-`if` trigger. **This is renown's first use anywhere in the corpus.**

Two types looked dead on a name search and are not — `CantBlockTargetCreatures` and
`PreventDamageShield` are `@SerialName`s whose Kotlin classes (`CantBlockEffect`,
`PreventDamageEffect`) both have executors.

## One card bug, caught by the differential

**Stratus Walk** shipped with an inert block restriction. `CanOnlyBlockCreaturesWith.filter` defaults
to `GroupFilter.source()` — on an Aura that is *the Aura itself*, an enchantment that can never
block, so "enchanted creature can block only creatures with flying" would have done nothing at all
and the enchanted creature would have kept blocking anything. Fixed to
`GroupFilter.attachedCreature()` (`Scope.AttachedTo`) and noted in the card's KDoc, since the
neighbouring corpus users (Cloud Sprite, Rishadan Airship) put the ability on a creature where the
default *is* correct — the wrong precedent to copy for an Aura.

This was the sweep's only divergence, and it is exactly the class the differential exists to catch:
a filter-layer default that no other gate looks at.

## Note on the gates

`just build` exceeded this session's command cap twice mid-run, so the suites were run individually
rather than as one recipe: `:mtg-sets:test` (snapshots + `FacadeBoundaryTest`), plus the scenario
suites for every era this touches — `2008-2016`, `2000-2002`, `1993-1999`. All green, and every
module compiles. CI runs the full suite.

One flake worth recording: `AbuJafarTest` failed in the first full-suite run but passes in isolation
in this worktree *and* on clean main. It is unrelated to this change (nothing here touches ARN) —
parallel-load flake, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYW7dMhHTpdjUtxQxeAwRs
