### PR TITLE
Add four Innistrad: Crimson Vow transform cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 244 / 273
+**Implemented:** 248 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -39,7 +39,7 @@
 - [ ] Brine Comber
 - [x] By Invitation Only
 - [x] Cartographer's Survey
-- [ ] Catapult Fodder
+- [x] Catapult Fodder
 - [ ] Cemetery Desecrator
 - [x] Cemetery Gatekeeper
 - [ ] Cemetery Illuminator
@@ -76,7 +76,7 @@
 - [ ] Dollhouse of Horrors
 - [x] Dominating Vampire
 - [x] Doomed Dissenter
-- [ ] Dormant Grove
+- [x] Dormant Grove
 - [x] Dorothea, Vengeful Victim
 - [x] Dread Fugue
 - [x] Dreadfeast Demon
@@ -101,7 +101,7 @@
 - [x] Flame-Blessed Bolt
 - [x] Fleeting Spirit
 - [x] Flourishing Hunter
-- [ ] Foreboding Statue
+- [x] Foreboding Statue
 - [x] Forest
 - [x] Frenzied Devils
 - [x] Geistlight Snare
@@ -135,7 +135,7 @@
 - [x] Hungry Ridgewolf
 - [x] Ill-Tempered Loner
 - [x] Infestation Expert
-- [ ] Innocent Traveler
+- [x] Innocent Traveler
 - [x] Inspired Idea
 - [x] Into the Night
 - [x] Investigator's Journal

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CatapultFodder.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CatapultFodder.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Catapult Fodder // Catapult Captain (Innistrad: Crimson Vow)
+ * {2}{B}
+ * Creature — Zombie // Creature — Zombie
+ *
+ * Front — Catapult Fodder (1/5)
+ *   At the beginning of combat on your turn, if you control three or more creatures that each have
+ *   toughness greater than their power, transform this creature.
+ *
+ * Back — Catapult Captain (2/6)
+ *   {2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the sacrificed
+ *   creature's toughness.
+ *
+ * The front's clause is a true intervening "if" (CR 603.4) — it gates the trigger *and* is
+ * rechecked on resolution — so it rides `interveningIf` rather than wrapping the effect. Each of
+ * the three creatures is measured against **its own** power, per the release-note ruling, which is
+ * exactly what [ObjectFilter.toughnessGreaterThanPower] does: a per-permanent predicate counted by
+ * [Conditions.YouControlAtLeast], not an aggregate comparison across the board. The Fodder itself
+ * (1/5) is one of the three.
+ *
+ * The back reads the toughness of the creature paid as a *cost*, so the value comes from the
+ * sacrifice's last-known information via [DynamicAmounts.sacrificedToughness] — the permanent is
+ * already in the graveyard when the ability resolves. Same shape as Kheru Dreadmaw and Ayli,
+ * Eternal Pilgrim.
+ */
+
+private val CatapultFodderFront = card("Catapult Fodder") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 5
+    oracleText = "At the beginning of combat on your turn, if you control three or more creatures " +
+        "that each have toughness greater than their power, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        interveningIf = Conditions.YouControlAtLeast(
+            3,
+            GameObjectFilter.Creature.toughnessGreaterThanPower()
+        )
+        effect = TransformEffect(EffectTarget.Self)
+        description = "At the beginning of combat on your turn, if you control three or more " +
+            "creatures that each have toughness greater than their power, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Jesper Ejsing"
+        flavorText = "These days, ghouls are the only abundant resource in Thraben."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1783924882"
+
+        ruling(
+            "2021-11-19",
+            "To satisfy Catapult Fodder's condition, each of the three creatures must have " +
+                "toughness greater than its own power, regardless of the power and toughness of " +
+                "the other two creatures."
+        )
+    }
+}
+
+private val CatapultCaptain = card("Catapult Captain") {
+    manaCost = ""
+    colorIdentity = "B"
+    colorIndicator = "B" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 6
+    oracleText = "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the " +
+        "sacrificed creature's toughness."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}"),
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.LoseLife(DynamicAmounts.sacrificedToughness(), opponent)
+        description = "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal " +
+            "to the sacrificed creature's toughness."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Jesper Ejsing"
+        flavorText = "And they're more than happy to share the wealth."
+        imageUri = "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1783924882"
+    }
+}
+
+val CatapultFodder: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = CatapultFodderFront,
+    backFace = CatapultCaptain,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DormantGrove.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DormantGrove.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dormant Grove // Gnarled Grovestrider (Innistrad: Crimson Vow)
+ * {3}{G}
+ * Enchantment // Creature — Treefolk
+ *
+ * Front — Dormant Grove
+ *   At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.
+ *   Then if that creature has toughness 6 or greater, transform this enchantment.
+ *
+ * Back — Gnarled Grovestrider (3/6)
+ *   Vigilance
+ *   Other creatures you control have vigilance.
+ *
+ * The "Then if that creature …" clause is a resolution-time recheck of the *same* target, not a
+ * second condition on the ability, so it is a [ConditionalEffect] gated on
+ * [Conditions.TargetMatchesFilter] against target slot 0 — the handle returned by `target(…)`
+ * cannot itself carry a condition (a `target()` handle inside a `Condition` silently evaluates
+ * false). The toughness is read off projected state, so the +1/+1 counter this ability just placed
+ * counts toward the 6, which is exactly how the card plays: a 3/5 you pump becomes a 4/6 and flips
+ * the Grove that same combat.
+ *
+ * The back's "Other creatures you control have vigilance" is a plain [GrantKeyword] over
+ * [GroupFilter.OtherCreaturesYouControl] — the Grovestrider's own vigilance is the
+ * printed keyword above it, not a self-inclusion in the grant.
+ */
+
+private val DormantGroveFront = card("Dormant Grove") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on your turn, put a +1/+1 counter on target creature " +
+        "you control. Then if that creature has toughness 6 or greater, transform this enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature) then ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Creature.toughnessAtLeast(6),
+                targetIndex = 0
+            ),
+            effect = TransformEffect(EffectTarget.Self)
+        )
+        description = "At the beginning of combat on your turn, put a +1/+1 counter on target " +
+            "creature you control. Then if that creature has toughness 6 or greater, transform " +
+            "this enchantment."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Kekai Kotaki"
+        flavorText = "As the natural cycle of day and night grew twisted, old powers stirred deep " +
+            "in the Ulvenwald."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1783924820"
+    }
+}
+
+private val GnarledGrovestrider = card("Gnarled Grovestrider") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Treefolk"
+    power = 3
+    toughness = 6
+    oracleText = "Vigilance\nOther creatures you control have vigilance."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.OtherCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Kekai Kotaki"
+        flavorText = "Far from the bloodsoaked wedding, unseen by human eyes, a long-slumbering " +
+            "force arose to protect its home."
+        imageUri = "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1783924820"
+    }
+}
+
+val DormantGrove: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = DormantGroveFront,
+    backFace = GnarledGrovestrider,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ForebodingStatue.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ForebodingStatue.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Foreboding Statue // Forsaken Thresher (Innistrad: Crimson Vow)
+ * {3}
+ * Artifact Creature — Construct // Artifact Creature — Construct
+ *
+ * Front — Foreboding Statue (1/2)
+ *   {T}: Add one mana of any color. Put an omen counter on this creature.
+ *   At the beginning of your end step, if there are three or more omen counters on this creature,
+ *   untap it, then transform it.
+ *
+ * Back — Forsaken Thresher (5/5)
+ *   At the beginning of your first main phase, add one mana of any color.
+ *
+ * The activated ability is still a **mana ability** (CR 605.1a): it could add mana, it targets
+ * nothing, and it is not a loyalty ability — the omen-counter rider does not disqualify it. So it
+ * carries `manaAbility = true` / [TimingRule.ManaAbility] and resolves without using the stack,
+ * with the counter riding along in the same [Effects.Composite]. Consequence, and the release-note
+ * ruling: because the end-step trigger untaps the Statue only on *resolution*, you cannot tap it
+ * for one more mana while that trigger is resolving.
+ *
+ * The end-step clause is a true intervening "if" (CR 603.4) on `interveningIf`, so a Statue that
+ * loses its third counter in response never resolves the untap-and-flip.
+ */
+
+private val ForebodingStatueFront = card("Foreboding Statue") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Add one mana of any color. Put an omen counter on this creature.\n" +
+        "At the beginning of your end step, if there are three or more omen counters on this " +
+        "creature, untap it, then transform it."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddAnyColorMana(1),
+            Effects.AddCounters(Counters.OMEN, 1, EffectTarget.Self)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color. Put an omen counter on this creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        interveningIf = Conditions.SourceCounterCountAtLeast(Counters.OMEN, 3)
+        effect = Effects.Untap(EffectTarget.Self) then TransformEffect(EffectTarget.Self)
+        description = "At the beginning of your end step, if there are three or more omen counters " +
+            "on this creature, untap it, then transform it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Aaron Miller"
+        flavorText = "As the sand eroded, a faint sound could be heard whirling under the ground."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1783924791"
+
+        ruling(
+            "2021-11-19",
+            "You can't tap Foreboding Statue to get one more mana while resolving its triggered " +
+                "ability in your end step."
+        )
+    }
+}
+
+private val ForsakenThresher = card("Forsaken Thresher") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 5
+    toughness = 5
+    oracleText = "At the beginning of your first main phase, add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.AddAnyColorMana(1)
+        description = "At the beginning of your first main phase, add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Aaron Miller"
+        flavorText = "Were it not for the cultists' fatal curiosity, the terrible machine might " +
+            "have lain dormant for decades more."
+        imageUri = "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1783924791"
+    }
+}
+
+val ForebodingStatue: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ForebodingStatueFront,
+    backFace = ForsakenThresher,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/InnocentTraveler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/InnocentTraveler.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Innocent Traveler // Malicious Invader (Innistrad: Crimson Vow)
+ * {2}{B}{B}
+ * Creature — Human // Creature — Vampire
+ *
+ * Front — Innocent Traveler (1/3)
+ *   At the beginning of your upkeep, any opponent may sacrifice a creature of their choice.
+ *   If no one does, transform this creature.
+ *
+ * Back — Malicious Invader (3/3)
+ *   Flying
+ *   This creature gets +2/+0 as long as an opponent controls a Human.
+ *
+ * The upkeep ability is Desecration Demon's shape run the other way round: an
+ * [AnyPlayerMayPayEffect] scoped to [Player.EachOpponent], but with the transform hanging off
+ * `consequenceIfNonePaid` rather than `consequence`. That placement is the whole card — per the
+ * release-note ruling, each opponent decides in turn order knowing the earlier answers, every
+ * chosen creature is sacrificed simultaneously, and the Traveler flips **only** if that set came
+ * back empty. One opponent paying is enough to keep it face up, no matter how many others declined.
+ *
+ * The back's pump is a [ConditionalStaticAbility] over [Filters.Self] recomputed at projection, so
+ * the +2/+0 comes and goes with the opposing Human rather than latching. "A Human" is a permanent
+ * predicate, not a creature one — a noncreature permanent with the Human subtype turns it on too.
+ */
+
+private val InnocentTravelerFront = card("Innocent Traveler") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 3
+    oracleText = "At the beginning of your upkeep, any opponent may sacrifice a creature of their " +
+        "choice. If no one does, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = AnyPlayerMayPayEffect(
+            cost = Costs.pay.Sacrifice(GameObjectFilter.Creature, count = 1),
+            consequenceIfNonePaid = TransformEffect(EffectTarget.Self),
+            eligiblePlayers = Player.EachOpponent
+        )
+        description = "At the beginning of your upkeep, any opponent may sacrifice a creature of " +
+            "their choice. If no one does, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Aren't you going to invite me in?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1783924866"
+
+        ruling(
+            "2021-11-19",
+            "When Innocent Traveler's ability resolves, the next opponent in turn order chooses " +
+                "whether they want to sacrifice a creature at all and which creature to sacrifice " +
+                "if so, then each other opponent in turn order does the same, knowing the choices " +
+                "made before them. Then all the chosen creatures are sacrificed at the same time. " +
+                "If no creatures are sacrificed this way, Innocent Traveler is transformed."
+        )
+    }
+}
+
+private val MaliciousInvader = card("Malicious Invader") {
+    manaCost = ""
+    colorIdentity = "B"
+    colorIndicator = "B" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\nThis creature gets +2/+0 as long as an opponent controls a Human."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(2, 0, Filters.Self),
+            condition = Exists(
+                Player.EachOpponent,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Permanent.withSubtype("Human")
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Aren't you going to offer me a drink?\""
+        imageUri = "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1783924866"
+    }
+}
+
+val InnocentTraveler: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = InnocentTravelerFront,
+    backFace = MaliciousInvader,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -2407,6 +2407,137 @@
     ]
 }
 
+// Catapult Fodder
+{
+    "name": "Catapult Fodder",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "At the beginning of combat on your turn, if you control three or more creatures that each have toughness greater than their power, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "ToughnessGreaterThanPower"
+                            ]
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, if you control three or more creatures that each have toughness greater than their power, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Catapult Captain",
+        "manaCost": "",
+        "typeLine": "Creature — Zombie",
+        "oracleText": "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the sacrificed creature's toughness.",
+        "creatureStats": {
+            "power": 2,
+            "toughness": 6
+        },
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{B}"
+                                }
+                            },
+                            "CostTap",
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomSacrifice",
+                                    "filter": "creature",
+                                    "excludeSelf": true
+                                }
+                            }
+                        ]
+                    },
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Sacrificed",
+                            "numericProperty": "Toughness"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target opponent"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "target opponent"
+                        }
+                    ],
+                    "descriptionOverride": "{2}{B}, {T}, Sacrifice another creature: Target opponent loses life equal to the sacrificed creature's toughness."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "99",
+            "rarity": "UNCOMMON",
+            "artist": "Jesper Ejsing",
+            "flavorText": "And they're more than happy to share the wealth.",
+            "imageUri": "https://cards.scryfall.io/normal/back/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1783924882"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ],
+        "colorIndicator": [
+            "BLACK"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "These days, ghouls are the only abundant resource in Thraben.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e61b3afa-66e0-4f7b-84bc-7ae2cc6d28d4.jpg?1783924882",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "To satisfy Catapult Fodder's condition, each of the three creatures must have toughness greater than its own power, regardless of the power and toughness of the other two creatures."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cemetery Gatekeeper
 {
     "name": "Cemetery Gatekeeper",
@@ -4815,6 +4946,112 @@
     ]
 }
 
+// Dormant Grove
+{
+    "name": "Dormant Grove",
+    "manaCost": "{3}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has toughness 6 or greater, transform this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature tou>=6"
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if that creature has toughness 6 or greater, transform this enchantment."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Gnarled Grovestrider",
+        "manaCost": "",
+        "typeLine": "Creature — Treefolk",
+        "oracleText": "Vigilance\nOther creatures you control have vigilance.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 6
+        },
+        "keywords": [
+            "VIGILANCE"
+        ],
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "198",
+            "rarity": "UNCOMMON",
+            "artist": "Kekai Kotaki",
+            "flavorText": "Far from the bloodsoaked wedding, unseen by human eyes, a long-slumbering force arose to protect its home.",
+            "imageUri": "https://cards.scryfall.io/normal/back/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1783924820"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Kekai Kotaki",
+        "flavorText": "As the natural cycle of day and night grew twisted, old powers stirred deep in the Ulvenwald.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7d3012e-1798-4f72-8d9a-b2d16f817502.jpg?1783924820"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dorothea, Vengeful Victim
 {
     "name": "Dorothea, Vengeful Victim",
@@ -6376,6 +6613,129 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Foreboding Statue
+{
+    "name": "Foreboding Statue",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{T}: Add one mana of any color. Put an omen counter on this creature.\nAt the beginning of your end step, if there are three or more omen counters on this creature, untap it, then transform it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        },
+                        "Transform"
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "omen"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if there are three or more omen counters on this creature, untap it, then transform it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "AddManaOfChoice",
+                        {
+                            "type": "AddCounters",
+                            "counterType": "omen",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color. Put an omen counter on this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Forsaken Thresher",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Construct",
+        "oracleText": "At the beginning of your first main phase, add one mana of any color.",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "PRECOMBAT_MAIN"
+                    },
+                    "binding": "ANY",
+                    "effect": "AddManaOfChoice",
+                    "descriptionOverride": "At the beginning of your first main phase, add one mana of any color."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "256",
+            "rarity": "UNCOMMON",
+            "artist": "Aaron Miller",
+            "flavorText": "Were it not for the cultists' fatal curiosity, the terrible machine might have lain dormant for decades more.",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1783924791"
+        },
+        "colorIdentityOverride": [],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "UNCOMMON",
+        "artist": "Aaron Miller",
+        "flavorText": "As the sand eroded, a faint sound could be heard whirling under the ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a27b9d82-f613-4789-9e8b-f37db5597027.jpg?1783924791",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "You can't tap Foreboding Statue to get one more mana while resolving its triggered ability in your end step."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Frenzied Devils
@@ -9129,6 +9489,108 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Innocent Traveler
+{
+    "name": "Innocent Traveler",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Human",
+    "oracleText": "At the beginning of your upkeep, any opponent may sacrifice a creature of their choice. If no one does, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AnyPlayerMayPay",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "creature"
+                        }
+                    },
+                    "consequenceIfNonePaid": "Transform",
+                    "eligiblePlayers": "EachOpponent"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, any opponent may sacrifice a creature of their choice. If no one does, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Malicious Invader",
+        "manaCost": "",
+        "typeLine": "Creature — Vampire",
+        "oracleText": "Flying\nThis creature gets +2/+0 as long as an opponent controls a Human.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ConditionalStaticAbility",
+                    "ability": {
+                        "type": "ModifyStats",
+                        "powerBonus": 2,
+                        "toughnessBonus": 0,
+                        "filter": {
+                            "baseFilter": "permanent",
+                            "scope": "Self"
+                        }
+                    },
+                    "condition": {
+                        "type": "Exists",
+                        "player": "EachOpponent",
+                        "zone": "Battlefield",
+                        "filter": "permanent Human"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "121",
+            "rarity": "UNCOMMON",
+            "artist": "Cristi Balanescu",
+            "flavorText": "\"Aren't you going to offer me a drink?\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1783924866"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ],
+        "colorIndicator": [
+            "BLACK"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"Aren't you going to invite me in?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13a5e5fd-a67a-4c0e-97ae-923bdbc1be20.jpg?1783924866",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "When Innocent Traveler's ability resolves, the next opponent in turn order chooses whether they want to sacrifice a creature at all and which creature to sacrifice if so, then each other opponent in turn order does the same, knowing the choices made before them. Then all the chosen creatures are sacrificed at the same time. If no creatures are sacrificed this way, Innocent Traveler is transformed."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Four VOW double-faced cards, each built entirely from existing SDK primitives — no new engine vocabulary. VOW's backlog goes 244 → 248 / 273.

- **Dormant Grove // Gnarled Grovestrider** — `Triggers.BeginCombat` puts a +1/+1 counter on a target creature you control, then a `ConditionalEffect` gated on `Conditions.TargetMatchesFilter(…toughnessAtLeast(6), 0)` transforms it. The toughness is read off projected state, so the counter this ability just placed counts toward the 6. The back is `GrantKeyword(VIGILANCE, GroupFilter.OtherCreaturesYouControl)` under its own printed vigilance.
- **Catapult Fodder // Catapult Captain** — a true intervening "if" (`interveningIf`) over `Conditions.YouControlAtLeast(3, Creature.toughnessGreaterThanPower())`. That filter is a per-permanent predicate, which is exactly the release-note ruling: each of the three is measured against *its own* power. The back reads its drain from `DynamicAmounts.sacrificedToughness()` off the sacrifice cost's LKI — the Kheru Dreadmaw / Ayli shape.
- **Innocent Traveler // Malicious Invader** — Desecration Demon's `AnyPlayerMayPayEffect` run the other way round: the transform hangs off `consequenceIfNonePaid`, not `consequence`, so one opponent paying keeps it face up no matter how many declined. The back's +2/+0 is a `ConditionalStaticAbility` over `Filters.Self`, recomputed at projection.
- **Foreboding Statue // Forsaken Thresher** — `{T}: Add one mana of any color. Put an omen counter` is still a mana ability under CR 605.1a (it could add mana, targets nothing, isn't a loyalty ability), so the counter rides along in the same `Effects.Composite` behind `manaAbility = true`. The end-step untap-and-flip is an intervening "if" on `Conditions.SourceCounterCountAtLeast(Counters.OMEN, 3)`.

Rulings captured in `metadata` for Catapult Fodder, Innocent Traveler, and Foreboding Statue.

## Verification

- `just build` green.
- `just rebless-cards` — only these four cards moved in `snapshots/cards/VOW.json` (462 insertions, no deletions).
- `just assay-differential --set VOW` — 68/68 confirmed, 0 divergent.
- `just check-card-printing` ok for all four: VOW is the earliest real printing (DBL is a 2022 draft-innovation reprint, not scaffolded).

## Assay coverage — deliberately not in this PR

These four cards are **not** covered by Assay, and can't be without a product change. `CardCompiler` declines any card with more than one face (`DeclineKind.MULTI_FACE`) and `Differential` buckets multi-face cards out of the comparison entirely, so the differential's clean VOW run above says nothing about them. On top of that, six of their printed lines decline today — one distinct grammar family each:

1. `Then if that creature has toughness 6 or greater, <effect>` — a resolution-time recheck of the same target
2. `creatures that each have toughness greater than their power` — a filter layer on the plural noun phrase
3. `equal to the sacrificed creature's toughness` — a cost-LKI amount
4. `any opponent may sacrifice …. If no one does, <effect>` — the `AnyPlayerMayPayEffect` construct
5. `{T}: Add one mana of any color. Put an <named> counter on ~.` — a mana clause joined to a counter rider
6. `if there are three or more <named> counters on ~, untap it, then transform it` — a source-counter condition

Worth noting for whoever picks this up: `just assay-ready VOW` reports **0 Assay-ready** among the set's 25 remaining cards, so VOW's whole tail is grammar work rather than authoring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCdMY96CNfqkuV5SApwAcv