### PR TITLE
Scale battlefield card size with the number of cards in play

### DIFF
--- a/docs/plans/battlefield-sparse-layout.md
+++ b/docs/plans/battlefield-sparse-layout.md
@@ -1,0 +1,170 @@
+# Battlefield layout on sparse boards
+
+Status: implemented — `web-client/src/components/game/board/battlefieldLayout.ts` (pure solver),
+`usePooledBattlefieldLayout.ts`, `useBoardGroups.ts`. Scope: `web-client` only — no server or engine
+change. Numbers below are the implementation's (integer widths), pinned by `battlefieldLayout.test.ts`.
+
+Constraint (decided 2026-08-29): **card positions stay where they are.** Creatures/planeswalkers
+stay in the front row next to the HUD, lands/other stay in the back row at the outer edge, the
+opponent stays mirrored. Only card *size* changes with the number of cards on the board.
+
+## Problem
+
+With few permanents in play the battlefield renders cards at ~65 px wide on a 1546×795 viewport
+and leaves ~90 % of the width empty. A crowded board on the same viewport renders cards at the
+*same* size — the width is only used once a row holds 10+ stacks. Card size does not scale with
+the number of cards until the board is crowded, and never scales up.
+
+## Why it happens
+
+Battlefield card size is `min(heightCap, widthCap, SLOT_MAX_CARD_WIDTH=200)` computed per player
+slot by `useSlotSizedResponsive` (`web-client/src/components/game/board/shared.ts:86-302`). On a
+desktop two-player screen the **height cap binds for every board up to ~10 stacks per row**; the
+width cap is irrelevant until then. Given fixed positions, the height budget is the only lever, and
+today it is spent badly:
+
+1. **An empty row costs a full line.** The search in `shared.ts:168-196` starts at `front=1, back=1`
+   and both rows reserve `rowMinHeight(1)` unconditionally (`Battlefield.tsx:520-535`).
+2. **Overheads are sized from constants, not from the card.** `dividerMargin` is
+   `max(10, 0.1 × baseCardHeight)` where the base card is the 125-wide desktop card — 18 px per side
+   for a card that actually renders 92 px tall. `breathing` is 10 % of the *slot* (up to 48 px).
+   `dividerSpace` is subtracted even when the divider does not render (`Battlefield.tsx:500-511`).
+3. **Both players get the same slot height** — grid rows 2 and 4 are equal `1fr`
+   (`GameBoard.tsx:892-900`, `styles.ts:27-28`) — whatever each player holds, so a player with one
+   land and a player with fourteen permanents split the height 50/50.
+
+For the 290 px-tall slot measured from the 1546×795 dev screenshot:
+
+```
+breathing = clamp(round(290 × 0.10), 12, 48) = 29     dividerSpace = 24 + 2 × 18 = 60
+two lines = floor((290 − 60 − 29) / (2 × 1.4 + 0.224)) = 66 px   ← today, every board until it wraps
+```
+
+## Design
+
+Five steps, each independently shippable, each a pure function of `(slot size, per-row counts)`.
+Steps 1–2 change only `shared.ts` + `Battlefield.tsx`; step 3 lifts the solve to `GameBoard.tsx`;
+step 4 is optional; step 5 is CSS. All numbers below are for the reference 1200×290 slot.
+
+### Invariants kept
+
+- Row order and group placement are unchanged; only `battlefieldCardWidth` moves.
+- Nothing bleeds over the center HUD: every candidate is still sized from the measured slot with a
+  reserved gap to the HUD.
+- Both players render at the same card width (`styles.ts:27-28`). Step 3 keeps this by solving one
+  width for both slots.
+- No stored mode, no hysteresis: a card entering can change the size, and step 5 animates it.
+- `SLOT_MAX_CARD_WIDTH = 200` stays; badges, attachment peeks and stack offsets already scale from
+  `battlefieldCardWidth`.
+
+### Step 1 — an empty row costs nothing
+
+`useSlotSizedResponsive`: when `frontRowCount === 0` (or `backRowCount === 0`) search that row with
+`lines = 0`, and drop the divider from the height budget whenever either row is empty (matching when
+it renders). `Battlefield.tsx`: render the empty row at a fixed 8 px `minHeight` instead of
+`rowMinHeight(1)` — keep the element so `data-zone` spotlights and DOM order are unchanged.
+
+```
+lands only : floor(290 / (1.4 + 0.112 + 0.21)) = 168 px      (66 today, 2.5×)
+```
+
+Every turn-1 to turn-3 board. Zero visual change once both rows are populated.
+
+### Step 2 — overheads scale with the card, not with constants
+
+Replace the three fixed terms with functions of the card being solved for (`h = 1.4w`):
+
+| term | today | proposed |
+|------|-------|----------|
+| divider margin (each side) | `max(10, 0.1 × baseH)` = 18 | `max(6, 0.1h)` |
+| breathing toward HUD | `clamp(0.10 × slotH, 12, 48)` | `clamp(0.15h, 12, 48)` |
+| row padding | `0.08h` per row (unchanged) | `0.08h` per *present* row |
+
+The budget stays linear in `w`, so the search is unchanged except the divisor:
+
+```
+both rows, 1 line each :
+  290 − 24 ≥ w × (2 × 1.4 + 2 × 0.112 + 2 × 0.14 + 0.21)  →  w = 76 px   (66 today, 1.15×)
+```
+
+Small, but it applies to every populated board, and it makes the solve monotone in card count: on a
+crowded board (small `w`) the overheads shrink with the cards instead of eating a fixed 89 px.
+
+### Step 3 — pooled, demand-weighted slot heights (two-player)
+
+Replace the equal `minmax(0, 1fr)` rows 2 and 4 with heights derived from each player's line demand.
+One hook in `GameBoard` measures the pooled height (`row2 + row4`) and both players' counts, then
+finds the largest common width `w` such that
+
+```
+Σ players ( lines·1.4w + (lines − rows)·cardGap + rows·0.112w + [both rows]·(24 + 0.28w) + breathing(w) ) ≤ pooledH
+```
+
+subject to each player's width caps, and gives each slot the height its own terms need. Clamp the
+split to `[0.35, 0.65]` of the pooled height so the center HUD never drifts more than ~15 % from
+where it is today — that clamp is what keeps "positions roughly the same" for the HUD and the rows
+around it. Rows become `minmax(0, hA px) auto minmax(0, hB px)`.
+
+```
+lands only  vs  6 creatures + 6 lands  (580 px pooled):
+  3.514w + 24 ≤ 0.65 × 580  (the clamp binds)   →  w = 101 px, slots 203 / 377   (66 today, 1.5×; steps 1–2 alone: 76)
+2 lines  vs  3 lines  (24 creatures + 6 lands, wrapping to two creature lines on a 1200 px board):
+  today 46 px (it wraps today too)  →  52 px per slot (steps 1–2)  →  61 px pooled   (1.3×)
+```
+
+So pooling helps both ends: the sparse side gives height to the crowded side, and a board that wraps
+gets the line it needs without shrinking below the other player's size. `Battlefield` takes its
+layout as a prop; `useSlotSizedResponsive` remains the multiplayer per-cell path (strip cells sit
+side by side and do not pool). This is the only step needing a two-pass measure — if it proves
+fiddly, ship 1, 2 and 5 without it.
+
+### Step 4 — optional: back-row scale
+
+A single knob `BACK_ROW_SCALE ∈ [0.7, 1]` renders the land/other row at `r × w`. Positions are
+untouched; only the lands are smaller than the creatures. At `r = 0.7` on the reference slot,
+creatures go 76 → 87 px and lands 76 → 61 px. Recommendation: ship the knob at `1.0` and decide
+from a screenshot walk — it is a taste call (a second card size on the board) for a 1.16× gain.
+
+### Step 5 — size transitions
+
+`transition: width 180ms ease, height 180ms ease` on the battlefield card container; `CardStack`
+layer offsets derive from width so they follow. Off under `prefers-reduced-motion`. The arrow
+overlays already poll rects every 100 ms (`TargetingArrows.tsx:338`, `CombatArrows.tsx:613`,
+`SoulbondBonds.tsx:215`) and drag-drop resolves with `elementFromPoint` live, so both follow a
+transition without change. Confirm `DrawAnimations.tsx` / `DamageAnimations.tsx` measure their
+endpoints after layout — otherwise gate the transition off while an animation is in flight.
+
+### Extract a pure solver first
+
+Move the search out of the hook into `solveSlotLayout` / `solvePooledLayout` in a new
+`board/battlefieldLayout.ts` — plain data in, plain data out — with the hook reduced to measure +
+call. The hook has no tests today (only `attachmentStackLayout` in `shared.test.ts` is covered);
+this is what makes steps 1–4 unit-testable in `vitest` and gives the pooled and per-cell solves one
+implementation. Fold the duplicated geometry constants (tapped footprint `1.4w + 8`, stack offset
+12/18, divider margins, row padding) into that module so they have one home.
+
+Tests to write, reference 1200×290 slot unless stated:
+
+- empty front row → one line, no divider, width 168
+- 2 lands + 1 creature → two lines, width 76
+- 6 lands **tapped** + 6 creatures → still 76 (height-bound; tapped footprint irrelevant until wrap)
+- 60 stacks per row on a 360×400 phone slot → the floor (32 px, four lines per row)
+- pooled: lands-only vs 6 + 6 over 580 px → width 101, heights 203 / 377 (the 0.35 clamp binds)
+- pooled: 1 + 1 vs 24 creatures + 6 lands on 1200 wide → three lines on the crowded side, width 61 (46 today)
+
+## Rejected
+
+- **Merging lands and creatures onto one line** on sparse boards (up to 2.4× on the reference slot).
+  Rejected 2026-08-29: it moves groups around, which confuses existing players. The height ceiling
+  above is the price of that decision, and the design accepts it.
+- **A user-facing zoom slider** — none exists; the solver should make it unnecessary.
+- **Shrinking the hand reservation** (220 px desktop) — the fan needs full height for even two
+  cards, and a 150 → 125 hand card would buy ~5 px of battlefield width.
+
+## Verification
+
+`npm test` and `npm run lint` in `web-client/` (the new solver tests) plus `just client-typecheck`,
+then a screenshot walk of the dev scenarios used to write this doc — sparse (3 vs 2),
+stacked-heavy (18 vs 14 identical), varied (22 vs 16 distinct with attachments), lopsided
+(1 land vs 12), a 390×844 phone viewport — plus one combat with targeting arrows while a card size
+transition is in flight.

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -306,6 +306,37 @@ A restriction implemented *outside* the layer system (read directly by a manager
 restrictions are) would stop the untap while leaving the card visually identical to one that untaps
 normally. `UntapRestrictionVisibilityTest` pins the projected-keyword contract this depends on.
 
+## Battlefield card sizing
+
+Battlefield cards are sized from the slot the board grid gives them, not from the window: every
+row's fullest wrap line must fit the slot's width, and all lines, dividers, row paddings and the gap
+toward the center HUD must fit its height. Rows never move — creatures/planeswalkers stay in the
+front row by the HUD, lands/other in the back row at the outer edge — only the card size and the
+wrap-line count per row change with what is on the board. Design and worked numbers:
+[`plans/battlefield-sparse-layout.md`](plans/battlefield-sparse-layout.md).
+
+- **`board/battlefieldLayout.ts`** — the pure solver (`solveSlotLayout`, `solvePooledLayout`) and
+  every geometry constant (card aspect, size floor/ceiling, divider strip, tapped footprint, stack
+  peek, `BACK_ROW_SCALE`). No DOM, no React; `battlefieldLayout.test.ts` pins the reference numbers.
+  An empty row costs no line, and the divider margin / HUD gap / row padding scale with the card
+  actually rendered rather than with the desktop base card.
+- **`board/useBoardGroups.ts`** — groups one side's permanents into stacks (`groupCards`) and derives
+  the per-row stats the solver consumes (stack count, tapped count, capped peek depth).
+- **`board/shared.ts` — `useSlotSizedResponsive`** — measures one battlefield's slot with a
+  `ResizeObserver`, runs `solveSlotLayout`, and re-provides `ResponsiveContext` with the resulting
+  `battlefieldCardWidth` (badges and row padding rescaled by `sizesForCardWidth`). This is the path
+  for multiplayer strip cells, which size themselves per cell.
+- **`board/usePooledBattlefieldLayout.ts`** — the two-player path. `GameBoard` measures the height
+  grid rows 2 and 4 have *together* (container minus the hand reservations and the HUD) and both
+  sides' stats, and `solvePooledLayout` returns one shared card width plus the slot height each side
+  needs; the heights become the `fr` weights of rows 2/4 and the layout reaches both `Battlefield`s
+  through `PooledBattlefieldLayoutContext`. The split is clamped (`SLOT_SPLIT_MIN`) so the HUD stays
+  near the middle. No feedback loop: every measured input (viewport, HUD `auto` height, the fixed
+  zone-pile / command-zone columns) is independent of the layout it produces.
+- Battlefield card boxes ease size changes (`CARD_RESIZE_TRANSITION`, off under
+  `prefers-reduced-motion`); the arrow overlays poll rects every 100 ms and drag-drop resolves with
+  `elementFromPoint`, so both follow a transition without change.
+
 ## Battlefield card grouping (token quantity aggregation)
 
 Identical permanents on one player's board collapse into a single visual **stack**

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -261,17 +261,16 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // board hands height to a crowded one). The grid rows 2/4 take these heights
   // as weights below. Multiplayer strips size per cell instead (null here).
   // See docs/plans/battlefield-sparse-layout.md.
-  const boardContainerRef = useRef<HTMLDivElement>(null)
-  const centerHudRef = useRef<HTMLDivElement>(null)
+  const opponentRowRef = useRef<HTMLDivElement>(null)
+  const playerRowRef = useRef<HTMLDivElement>(null)
   const playerSlotRef = useRef<HTMLDivElement>(null)
   const playerBoard = useBoardGroups(false)
   const opponentBoard = useBoardGroups(true)
   const pooledLayout = usePooledBattlefieldLayout({
     enabled: !isMulti,
-    containerRef: boardContainerRef,
-    centerRef: centerHudRef,
+    opponentRowRef,
+    playerRowRef,
     slotRef: playerSlotRef,
-    reservedHeight: oppHandReservation + playerHandReservation,
     player: playerBoard.stats,
     opponent: opponentBoard.stats,
     base: responsive,
@@ -911,7 +910,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     <RenderProfiler id="GameBoard">
     <ResponsiveContext.Provider value={responsive}>
     <PooledBattlefieldLayoutContext.Provider value={pooledLayout}>
-    <div ref={boardContainerRef} style={{
+    <div style={{
       ...styles.container,
       padding: `0 ${responsive.containerPadding}px`,
       // Hand reservation rows (1 and 5) keep the battlefield rows from sliding
@@ -1054,6 +1053,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           spectatorMode={spectatorMode}
           isHijacking={isHijacking}
           hijackedSurfaceStyle={hijackedSurfaceStyle}
+          areaRef={opponentRowRef}
         />
       )}
       {isMulti && (
@@ -1224,7 +1224,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           can't cross. The outer flex row mirrors `playerRowWithZones` (main
           area + zone pile spacer) so the step strip aligns with the cards
           above/below rather than the viewport. */}
-      <div ref={centerHudRef} style={{
+      <div style={{
         gridRow: 3,
         display: 'flex',
         alignItems: 'center',
@@ -1559,7 +1559,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           })}
         </div>
       ) : isEliminatedSpectator ? null : (
-        <div style={styles.playerArea}>
+        <div ref={playerRowRef} style={styles.playerArea}>
           <div style={styles.playerRowWithZones}>
             {/* Player command zone (left side) — Commander format only; renders nothing otherwise. */}
             {effectiveViewingPlayer && <CommandZone player={effectiveViewingPlayer} />}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -27,6 +27,9 @@ import { ManaSymbol } from '../ui/ManaSymbols'
 // Import extracted components
 import { Battlefield, CardRow, CommandZone, OpponentBoardArea, BoardNamePlate, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, CELL_PLATE_BAND, useCellHandMetrics, StackDisplay, ZonePile, ResponsiveContext } from './board'
 import { RenderProfiler } from '@/utils/renderProfiler'
+import { PooledBattlefieldLayoutContext } from './board/shared'
+import { useBoardGroups } from './board/useBoardGroups'
+import { usePooledBattlefieldLayout } from './board/usePooledBattlefieldLayout'
 import { CardPreview } from './card'
 import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, SpeedGauge, DayNightBadge, ConcedeButton, FullscreenButton, SpectatorCountBadge, TeamLifeBanner, EliminationNotice } from './overlay'
 import { HelpDrawer, HelpDrawerButton } from '../help/HelpDrawer'
@@ -249,6 +252,34 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // Grid row 1: keeps the battlefield clear of the fixed/absolute opponent hand.
   const oppHandReservation =
     responsive.smallCardHeight + effectiveTopOffset + responsive.opponentHandBattlefieldGap
+  // Grid row 5: keeps the battlefield clear of the fixed player hand.
+  const playerHandReservation =
+    (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
+
+  // Two-player battlefield sizing, solved for both players together: one card
+  // width, and each battlefield the slot height its rows need (a lands-only
+  // board hands height to a crowded one). The grid rows 2/4 take these heights
+  // as weights below. Multiplayer strips size per cell instead (null here).
+  // See docs/plans/battlefield-sparse-layout.md.
+  const boardContainerRef = useRef<HTMLDivElement>(null)
+  const centerHudRef = useRef<HTMLDivElement>(null)
+  const playerSlotRef = useRef<HTMLDivElement>(null)
+  const playerBoard = useBoardGroups(false)
+  const opponentBoard = useBoardGroups(true)
+  const pooledLayout = usePooledBattlefieldLayout({
+    enabled: !isMulti,
+    containerRef: boardContainerRef,
+    centerRef: centerHudRef,
+    slotRef: playerSlotRef,
+    reservedHeight: oppHandReservation + playerHandReservation,
+    player: playerBoard.stats,
+    opponent: opponentBoard.stats,
+    base: responsive,
+  })
+  // fr weights: the browser hands the rows' actual remainder out in this ratio, so
+  // a measurement a few px off can't overflow the way fixed px tracks would.
+  const opponentRowWeight = pooledLayout ? Math.max(1, Math.round(pooledLayout.opponentHeight)) : 1
+  const playerRowWeight = pooledLayout ? Math.max(1, Math.round(pooledLayout.playerHeight)) : 1
 
   // Confirm mana selection: if pipeline is active, advance it; otherwise build
   // modified LegalActionInfo with Explicit payment and route through executeAction
@@ -879,12 +910,14 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   return (
     <RenderProfiler id="GameBoard">
     <ResponsiveContext.Provider value={responsive}>
-    <div style={{
+    <PooledBattlefieldLayoutContext.Provider value={pooledLayout}>
+    <div ref={boardContainerRef} style={{
       ...styles.container,
       padding: `0 ${responsive.containerPadding}px`,
       // Hand reservation rows (1 and 5) keep the battlefield rows from sliding
-      // under the position:fixed hand overlays. Both 1fr rows then receive
-      // identical heights → symmetric card sizes for player and opponent.
+      // under the position:fixed hand overlays. Rows 2 and 4 are weighted by
+      // what each battlefield needs (pooled solve above; equal until measured)
+      // — both players still render at one card width.
       // Eliminated spectator: a survivor's board takes over their dead bottom half, so the
       // rows stay spectator-shaped (small face-down hand at the bottom). Only when no living
       // seat is left to sit there (the game is effectively over) do rows 4-5 collapse and the
@@ -895,9 +928,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
               responsive.smallCardHeight + responsive.handBattlefieldGap
             }px`
           : `${oppHandReservation}px minmax(0, 1fr) auto 0px 0px`
-        : `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
-            (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
-          }px`,
+        : `${oppHandReservation}px minmax(0, ${opponentRowWeight}fr) auto minmax(0, ${playerRowWeight}fr) ${playerHandReservation}px`,
     }}>
       {/* Fullscreen button (top-left) */}
       <FullscreenButton />
@@ -1193,7 +1224,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           can't cross. The outer flex row mirrors `playerRowWithZones` (main
           area + zone pile spacer) so the step strip aligns with the cards
           above/below rather than the viewport. */}
-      <div style={{
+      <div ref={centerHudRef} style={{
         gridRow: 3,
         display: 'flex',
         alignItems: 'center',
@@ -1533,7 +1564,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             {/* Player command zone (left side) — Commander format only; renders nothing otherwise. */}
             {effectiveViewingPlayer && <CommandZone player={effectiveViewingPlayer} />}
 
-            <div style={{
+            <div ref={playerSlotRef} style={{
               ...styles.playerMainArea,
               ...(isHijacked ? hijackedSurfaceStyle : null),
             }}>
@@ -2388,6 +2419,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       )}
     </div>
     <HelpDrawer />
+    </PooledBattlefieldLayoutContext.Provider>
     </ResponsiveContext.Provider>
     </RenderProfiler>
   )

--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useBattlefieldCards, groupCards, visibleStackDepth, useSplitOutTargetIds, selectViewingPlayerId } from '@/store/selectors.ts'
+import { useBattlefieldCards, selectViewingPlayerId } from '@/store/selectors.ts'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
-import { ResponsiveContext, useResponsiveContext, useSlotSizedResponsive, handleImageError, attachmentStackLayout } from './shared'
+import { ResponsiveContext, PooledBattlefieldLayoutContext, useResponsiveContext, useSlotSizedResponsive, handleImageError, attachmentStackLayout } from './shared'
+import { useBoardGroups } from './useBoardGroups'
+import { DIVIDER_STRIP_HEIGHT, dividerMarginFor, rowMinHeightFor } from './battlefieldLayout'
+import type { ResponsiveSizes } from '@/hooks/useResponsive'
 import { styles } from './styles'
 import { CardStack } from '../card'
 import { GameCard } from '../card'
@@ -53,71 +56,23 @@ export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
   spectatorMode?: boolean
 }) {
   const slotRef = useRef<HTMLDivElement>(null)
-  const cards = useBattlefieldCards(isOpponent ? playerId : undefined, isOpponent ? undefined : playerId)
-  const lands = isOpponent ? cards.opponentLands : cards.playerLands
-  const creatures = isOpponent ? cards.opponentCreatures : cards.playerCreatures
-  const planeswalkers = isOpponent ? cards.opponentPlaneswalkers : cards.playerPlaneswalkers
-  const other = isOpponent ? cards.opponentOther : cards.playerOther
+  // Grouped into rendered stacks (see useBoardGroups) — the fit constraints
+  // below must count stacks, not raw cards.
+  const {
+    lands: groupedLands,
+    creatures: groupedCreatures,
+    planeswalkers: groupedPlaneswalkers,
+    other: groupedOther,
+    stats,
+  } = useBoardGroups(isOpponent, playerId)
 
-  // Group permanents that share exactly the same projected status (counters, P/T, tapped,
-  // combat assignment, attachments, chosen attributes, …) into a single overlapping stack —
-  // the same treatment lands have always had, now applied to every row. A horde of identical
-  // tokens collapses into one stack instead of sprawling across the row, and any one of them
-  // splits back out the moment it's buffed, tapped, attacks, etc. (see computeCardGroupKey).
-  // Memoized so these arrays keep stable identity across unrelated store updates —
-  // otherwise every battlefield re-render allocates fresh arrays that cascade
-  // into child re-renders and invalidate downstream useMemos.
-  // Grouped here rather than in BattlefieldContent because the fit constraints
-  // below must count rendered stacks, not raw cards.
-  // Permanents that are chosen targets / triggering sources keep their own card so
-  // their targeting arrows can anchor (a member hidden behind the stack render cap
-  // would drop its arrow) — see useSplitOutTargetIds / groupCards.
-  const splitOutIds = useSplitOutTargetIds()
-  const groupedLands = useMemo(() => groupCards(lands, splitOutIds), [lands, splitOutIds])
-  const groupedCreatures = useMemo(() => groupCards(creatures, splitOutIds), [creatures, splitOutIds])
-  const groupedPlaneswalkers = useMemo(() => groupCards(planeswalkers, splitOutIds), [planeswalkers, splitOutIds])
-  const groupedOther = useMemo(() => groupCards(other, splitOutIds), [other, splitOutIds])
-
-  // Per-row footprint stats drive the fit constraints in useSlotSizedResponsive
-  // — it picks card sizes plus how many wrap lines each row gets, trading
-  // unused vertical space for larger cards when a row is crowded (or the
-  // viewport is a narrow portrait phone).
-  //
-  // Tapped stacks are rotated 90° on the battlefield — their horizontal
-  // footprint is cardHeight (≈1.4×cardWidth) rather than cardWidth — and every
-  // card stacked behind a group's first adds a fixed peek offset. Counted per
-  // row so the horizontal-fit constraint reserves the true width; otherwise a
-  // crowded row on a narrow viewport overflows into an unbudgeted wrap line,
-  // which pushes the row up into the center HUD.
-  const rowStats = (...groupLists: (readonly GroupedCard[])[]) => {
-    let count = 0
-    let tapped = 0
-    let stackedExtra = 0
-    for (const groups of groupLists) {
-      for (const group of groups) {
-        count++
-        // Every member of a group shares its tapped state (it's part of the
-        // group key), so the representative answers for the whole stack.
-        if (group.card.isTapped) tapped++
-        // Only the *rendered* peek layers occupy horizontal space — a collapsed
-        // horde paints at most MAX_VISUAL_STACK_DEPTH cards, so the footprint
-        // (and thus the fit search) must use the capped depth, not the raw count.
-        stackedExtra += visibleStackDepth(group.count) - 1
-      }
-    }
-    return { count, tapped, stackedExtra }
-  }
-  const front = rowStats(groupedCreatures, groupedPlaneswalkers)
-  const back = rowStats(groupedLands, groupedOther)
-  const { sizes, frontRowLines, backRowLines } = useSlotSizedResponsive(
-    slotRef,
-    front.count,
-    front.tapped,
-    front.stackedExtra,
-    back.count,
-    back.tapped,
-    back.stackedExtra,
-  )
+  // Two-player board: GameBoard has solved both battlefields together over the
+  // height the grid gives the pair (one shared width, each side the height its
+  // rows need). Multiplayer strip cells and spectator bottom seats get no pooled
+  // layout and size themselves from their own slot.
+  const pooledLayout = useContext(PooledBattlefieldLayoutContext)
+  const pooled = pooledLayout ? (isOpponent ? pooledLayout.opponent : pooledLayout.player) : null
+  const { sizes, backSizes, frontRowLines, backRowLines } = useSlotSizedResponsive(slotRef, stats, pooled)
   return (
     <div
       ref={slotRef}
@@ -146,6 +101,7 @@ export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
           groupedOther={groupedOther}
           frontRowLines={frontRowLines}
           backRowLines={backRowLines}
+          backSizes={backSizes}
         />
       </ResponsiveContext.Provider>
     </div>
@@ -161,6 +117,7 @@ function BattlefieldContent({
   groupedOther,
   frontRowLines,
   backRowLines,
+  backSizes,
 }: {
   isOpponent: boolean
   spectatorMode?: boolean
@@ -168,8 +125,11 @@ function BattlefieldContent({
   groupedCreatures: readonly GroupedCard[]
   groupedPlaneswalkers: readonly GroupedCard[]
   groupedOther: readonly GroupedCard[]
+  /** Wrap lines each row is budgeted for; 0 for an empty row (which then reserves no height). */
   frontRowLines: number
   backRowLines: number
+  /** Sizes for the back row — the context sizes unless BACK_ROW_SCALE renders lands smaller. */
+  backSizes: ResponsiveSizes
 }) {
   const { attachmentsByCardId } = useBattlefieldCards()
   const responsive = useResponsiveContext()
@@ -196,7 +156,6 @@ function BattlefieldContent({
 
   // How much of each attachment card peeks out from behind its parent
   const attachmentPeek = responsive.isMobile ? 12 : 16
-  const cardHeight = Math.round(responsive.battlefieldCardWidth * 1.4)
 
   const hasActionableAttachment = (attachmentList: readonly TaggedAttachment[]): boolean => {
     const ids = new Set(attachmentList.map((a) => a.card.id))
@@ -229,7 +188,7 @@ function BattlefieldContent({
    * untapped Equipment upright (it's a separate permanent, CR 301.5d, and is still
    * available to tap), and a tapped Equipment reads as tapped on an untapped host.
    */
-  const renderWithAttachments = (group: GroupedCard) => {
+  const renderWithAttachments = (group: GroupedCard, rowSizes: ResponsiveSizes = responsive) => {
     const resolved = attachmentsByCardId.get(group.card.id)
     const attachmentCards = resolved?.attachments ?? EMPTY_ATTACHMENTS
     const linkedExileCards = resolved?.linkedExile ?? EMPTY_ATTACHMENTS
@@ -257,10 +216,10 @@ function BattlefieldContent({
     // still signalling that attachments exist.
     const collapsed = attachments.length >= ATTACHMENT_COLLAPSE_THRESHOLD
     const visibleAttachments = collapsed ? attachments.slice(0, 1) : attachments
-    const cardWidth = responsive.battlefieldCardWidth
+    const cardWidth = rowSizes.battlefieldCardWidth
     const layout = attachmentStackLayout({
       cardWidth,
-      cardHeight,
+      cardHeight: rowSizes.battlefieldCardHeight,
       peek: attachmentPeek,
       hostTapped: parentTapped,
       attachmentsTapped: visibleAttachments.map((tagged) => tagged.card.isTapped === true),
@@ -429,6 +388,7 @@ function BattlefieldContent({
     centerItems: readonly GroupedCard[],
     sideItems: readonly GroupedCard[],
     lines: number,
+    rowSizes: ResponsiveSizes,
     extra?: React.CSSProperties,
   ) => {
     const hasCenter = centerItems.length > 0
@@ -441,22 +401,22 @@ function BattlefieldContent({
       if (perLine >= centerItems.length) return undefined
       const tapped = centerItems.reduce((sum, g) => sum + (g.card.isTapped ? 1 : 0), 0)
       const tappedPerLine = Math.min(tapped, perLine)
-      const cw = responsive.battlefieldCardWidth
+      const cw = rowSizes.battlefieldCardWidth
       // Mirrors the per-line width model in useSlotSizedResponsive: tapped
       // cards occupy 1.4 × width + 8 (rotated container).
       return Math.ceil(
         perLine * cw +
         tappedPerLine * (0.4 * cw + 8) +
-        (perLine - 1) * responsive.cardGap,
+        (perLine - 1) * rowSizes.cardGap,
       ) + 2
     })()
-    return (
+    const rowElement = (
       <div style={{
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'flex-end',
         flexWrap: 'nowrap',
-        gap: responsive.cardGap,
+        gap: rowSizes.cardGap,
         width: '100%',
         ...extra,
       }}>
@@ -466,11 +426,11 @@ function BattlefieldContent({
             flexWrap: 'wrap',
             alignItems: 'flex-end',
             justifyContent: 'center',
-            gap: responsive.cardGap,
+            gap: rowSizes.cardGap,
             minWidth: 0,
             ...(balancedMaxWidth !== undefined ? { maxWidth: balancedMaxWidth } : {}),
           }}>
-            {centerItems.map((group) => renderWithAttachments(group))}
+            {centerItems.map((group) => renderWithAttachments(group, rowSizes))}
           </div>
         )}
         {showDividerBetween && (
@@ -487,22 +447,29 @@ function BattlefieldContent({
             display: 'flex',
             flexWrap: 'wrap',
             alignItems: 'flex-end',
-            gap: responsive.cardGap,
+            gap: rowSizes.cardGap,
             minWidth: 0,
           }}>
-            {sideItems.map((group) => renderWithAttachments(group))}
+            {sideItems.map((group) => renderWithAttachments(group, rowSizes))}
           </div>
         )}
       </div>
     )
+    // A row rendered at its own size (BACK_ROW_SCALE < 1) re-provides the
+    // responsive context so its cards, badges and attachment stacks all scale.
+    return rowSizes === responsive
+      ? rowElement
+      : <ResponsiveContext.Provider value={rowSizes}>{rowElement}</ResponsiveContext.Provider>
   }
 
-  const dividerMargin = Math.max(10, Math.round(responsive.battlefieldCardHeight * 0.1))
+  // Scales with the card actually rendered (see dividerMarginFor) — the fixed
+  // base-card margin used to cost 36 px around a 92 px-tall card.
+  const dividerMargin = dividerMarginFor(responsive.battlefieldCardHeight)
   const renderDivider = () => showDivider ? (
     <div
       style={{
         width: '70%',
-        height: 24,
+        height: DIVIDER_STRIP_HEIGHT,
         margin: `${dividerMargin}px 0`,
         background: 'radial-gradient(ellipse at center, rgba(120, 140, 180, 0.12) 0%, rgba(120, 140, 180, 0.04) 45%, transparent 75%)',
         pointerEvents: 'none',
@@ -517,21 +484,23 @@ function BattlefieldContent({
   // overflow into the divider / wrapped row's territory. The line counts come
   // from useSlotSizedResponsive, which already sized cards so the combined
   // reservation fits the slot.
-  const rowMinHeight = (lines: number) =>
-    lines * responsive.battlefieldCardHeight +
-    (lines - 1) * responsive.cardGap +
-    responsive.battlefieldRowPadding
+  // An empty row reserves nothing (rowMinHeightFor) — it costs no line, so a
+  // lands-only turn-1 board renders its lands at the full slot height.
+  const rowMinHeight = (lines: number, rowSizes: ResponsiveSizes) =>
+    rowMinHeightFor(lines, rowSizes.battlefieldCardHeight, rowSizes.cardGap)
   const frontRow = renderGridRow(
     groupedCreatures,
     groupedPlaneswalkers,
     frontRowLines,
-    { minHeight: rowMinHeight(frontRowLines) },
+    responsive,
+    { minHeight: rowMinHeight(frontRowLines, responsive) },
   )
   const backRow = renderGridRow(
     groupedLands,
     groupedOther,
     backRowLines,
-    { minHeight: rowMinHeight(backRowLines) },
+    backSizes,
+    { minHeight: rowMinHeight(backRowLines, backSizes) },
   )
 
   return (

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -108,6 +108,7 @@ export function OpponentBoardArea({
   plateAtBottom = false,
   liftHand = false,
   controlsTop,
+  areaRef,
 }: {
   opponent: ClientPlayer
   layout: 'grid' | 'strip'
@@ -195,6 +196,8 @@ export function OpponentBoardArea({
    * below that row.
    */
   controlsTop?: number
+  /** Grid layout only: ref to the board-area element (grid row 2) for GameBoard's pooled battlefield sizing. */
+  areaRef?: RefObject<HTMLDivElement | null>
   /**
    * This seat's hand is rendered *outside* the cell — the Two-Headed Giant ally fan at the bottom
    * of the screen. Without this, a cell being driven by this client (hotseat / Mindslaver) forces
@@ -267,6 +270,7 @@ export function OpponentBoardArea({
 
   const boardBlock = (
     <div
+      ref={layout === 'grid' ? areaRef : undefined}
       style={
         layout === 'grid'
           ? styles.opponentArea

--- a/web-client/src/components/game/board/battlefieldLayout.test.ts
+++ b/web-client/src/components/game/board/battlefieldLayout.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ABSOLUTE_MIN_CARD_WIDTH,
+  EMPTY_ROW,
+  PREFERRED_MIN_CARD_WIDTH,
+  SLOT_MAX_CARD_WIDTH,
+  SLOT_SPLIT_MIN,
+  rowMinHeightFor,
+  slotHeightNeeded,
+  solvePooledLayout,
+  solveSlotLayout,
+  type BoardStats,
+  type LayoutEnv,
+  type RowStats,
+} from './battlefieldLayout'
+
+// Desktop responsive values (useResponsive.ts): 8 px gaps, 18 px stack peeks.
+const DESKTOP: LayoutEnv = { cardGap: 8, stackOffset: 18 }
+const PHONE: LayoutEnv = { cardGap: 2, stackOffset: 12 }
+
+// The reference slot from docs/plans/battlefield-sparse-layout.md — measured off a
+// 1546×795 two-player window. Today's solver renders 66 px cards on it for any
+// board with both rows populated.
+const SLOT_W = 1200
+const SLOT_H = 290
+
+const row = (count: number, tapped = 0, stackedExtra = 0): RowStats => ({ count, tapped, stackedExtra })
+const board = (front: RowStats, back: RowStats): BoardStats => ({ front, back })
+
+describe('solveSlotLayout', () => {
+  it('an empty front row costs no line: lands-only grows to one tall line', () => {
+    const layout = solveSlotLayout(SLOT_W, SLOT_H, board(EMPTY_ROW, row(1)), DESKTOP)
+    expect(layout.frontLines).toBe(0)
+    expect(layout.backLines).toBe(1)
+    expect(layout.cardWidth).toBe(168)
+    expect(rowMinHeightFor(layout.frontLines, layout.cardHeight, DESKTOP.cardGap)).toBe(0)
+  })
+
+  it('a sparse board with both rows pays the divider, at margins scaled to the rendered card', () => {
+    const layout = solveSlotLayout(SLOT_W, SLOT_H, board(row(1), row(2)), DESKTOP)
+    expect(layout).toMatchObject({ frontLines: 1, backLines: 1, cardWidth: 76 })
+    // The whole budget is spent: one more pixel of card no longer fits.
+    expect(slotHeightNeeded(board(row(1), row(2)), 1, 1, 76, DESKTOP, false)).toBeLessThanOrEqual(SLOT_H)
+    expect(slotHeightNeeded(board(row(1), row(2)), 1, 1, 77, DESKTOP, false)).toBeGreaterThan(SLOT_H)
+  })
+
+  it('is height-bound until a row wraps: tapping every land changes nothing', () => {
+    const untapped = solveSlotLayout(SLOT_W, SLOT_H, board(row(6), row(6)), DESKTOP)
+    const tapped = solveSlotLayout(SLOT_W, SLOT_H, board(row(6), row(6, 6)), DESKTOP)
+    expect(untapped.cardWidth).toBe(76)
+    expect(tapped.cardWidth).toBe(76)
+  })
+
+  it('wraps a crowded row into more lines when that yields a larger card', () => {
+    const layout = solveSlotLayout(SLOT_W, SLOT_H, board(row(24), row(6)), DESKTOP)
+    expect(layout.frontLines).toBeGreaterThan(1)
+    // A single line of 24 stacks would cap the card at (1200 − 23 × 8) / 24 = 42 px.
+    expect(layout.cardWidth).toBeGreaterThan(42)
+  })
+
+  it('never returns a card wider than the slot ceiling or narrower than the floor', () => {
+    const roomy = solveSlotLayout(1600, 900, board(row(1), row(1)), DESKTOP)
+    expect(roomy.cardWidth).toBe(SLOT_MAX_CARD_WIDTH)
+    const phone = solveSlotLayout(360, 400, board(row(60), row(60)), PHONE)
+    expect(phone.cardWidth).toBe(ABSOLUTE_MIN_CARD_WIDTH)
+    expect(phone.frontLines).toBe(4)
+  })
+
+  it('trades the breathing gap for size before dropping under the readability floor', () => {
+    // 12 stacks per row on a short slot: comfortable pass lands under 60, tight pass recovers it.
+    const layout = solveSlotLayout(1200, 236, board(row(12), row(12)), DESKTOP)
+    expect(layout.cardWidth).toBeGreaterThanOrEqual(PREFERRED_MIN_CARD_WIDTH)
+    expect(
+      slotHeightNeeded(board(row(12), row(12)), layout.frontLines, layout.backLines, layout.cardWidth, DESKTOP, true),
+    ).toBeLessThanOrEqual(236)
+  })
+
+  it('renders the back row at BACK_ROW_SCALE and reclaims the height for the front row', () => {
+    const scaled = solveSlotLayout(SLOT_W, SLOT_H, board(row(1), row(2)), { ...DESKTOP, backRowScale: 0.7 })
+    expect(scaled.cardWidth).toBeGreaterThan(76)
+    expect(scaled.backCardWidth).toBe(Math.round(scaled.cardWidth * 0.7))
+  })
+})
+
+describe('solvePooledLayout', () => {
+  const POOLED = 2 * SLOT_H
+
+  it('gives both players one width and the crowded side the height it needs', () => {
+    const pooled = solvePooledLayout(SLOT_W, POOLED, board(row(6), row(6)), board(EMPTY_ROW, row(1)), DESKTOP)
+    expect(pooled.player.cardWidth).toBe(pooled.cardWidth)
+    expect(pooled.opponent.cardWidth).toBe(pooled.cardWidth)
+    // Per-slot the crowded side would be 76 px; pooled it grows to the clamp.
+    expect(pooled.cardWidth).toBeGreaterThan(76)
+    expect(pooled.playerHeight).toBeGreaterThan(pooled.opponentHeight)
+    expect(pooled.playerHeight + pooled.opponentHeight).toBeCloseTo(POOLED, 6)
+  })
+
+  it('clamps the split so the sparse side keeps SLOT_SPLIT_MIN of the pool', () => {
+    const pooled = solvePooledLayout(SLOT_W, POOLED, board(row(6), row(6)), board(EMPTY_ROW, row(1)), DESKTOP)
+    expect(pooled.opponentHeight).toBeGreaterThanOrEqual(SLOT_SPLIT_MIN * POOLED - 1e-9)
+    expect(pooled.playerHeight).toBeLessThanOrEqual((1 - SLOT_SPLIT_MIN) * POOLED + 1e-9)
+  })
+
+  it('lets a wrapping board take a third line without shrinking the other side', () => {
+    const perSlot = solveSlotLayout(SLOT_W, SLOT_H, board(row(24), row(6)), DESKTOP)
+    const pooled = solvePooledLayout(SLOT_W, POOLED, board(row(24), row(6)), board(row(1), row(1)), DESKTOP)
+    expect(pooled.player.frontLines).toBe(2)
+    expect(pooled.cardWidth).toBeGreaterThan(perSlot.cardWidth)
+  })
+
+  it('splits evenly when both boards are the same shape', () => {
+    const pooled = solvePooledLayout(SLOT_W, POOLED, board(row(3), row(4)), board(row(3), row(4)), DESKTOP)
+    expect(pooled.playerHeight).toBeCloseTo(pooled.opponentHeight, 6)
+    expect(pooled.cardWidth).toBe(solveSlotLayout(SLOT_W, SLOT_H, board(row(3), row(4)), DESKTOP).cardWidth)
+  })
+
+  it('falls back to the floor with a need-proportional split when nothing fits', () => {
+    const pooled = solvePooledLayout(360, 300, board(row(30), row(30)), board(row(30), row(30)), PHONE)
+    expect(pooled.cardWidth).toBe(ABSOLUTE_MIN_CARD_WIDTH)
+    expect(pooled.playerHeight + pooled.opponentHeight).toBeCloseTo(300, 6)
+  })
+})

--- a/web-client/src/components/game/board/battlefieldLayout.ts
+++ b/web-client/src/components/game/board/battlefieldLayout.ts
@@ -1,0 +1,464 @@
+/**
+ * Battlefield card sizing — the pure solver behind `useSlotSizedResponsive`
+ * (per-slot: one battlefield measuring its own bounded slot) and
+ * `usePooledBattlefieldLayout` (two-player: both battlefields solved together
+ * over the height the board grid gives them jointly).
+ *
+ * Plain data in, plain data out — no DOM, no React — so the geometry that used
+ * to live inline in the hook is unit-testable and has one home. The design and
+ * the worked numbers are in `docs/plans/battlefield-sparse-layout.md`.
+ *
+ * Each battlefield holds two rows: the front row (creatures + planeswalkers,
+ * nearest the center HUD) and the back row (lands + other, at the outer edge).
+ * Rows never move; only the card size and the number of wrap lines per row
+ * change with what is on the board. The solver picks the largest card width
+ * such that every row's fullest wrap line fits the slot's width and all lines,
+ * dividers, paddings and the gap toward the HUD fit its height.
+ */
+
+export const CARD_ASPECT = 1.4
+
+/**
+ * Hard ceiling on slot-derived card growth. The window-derived `useResponsive`
+ * caps the base battlefield card at 125 px (desktop); with the explicit-track
+ * grid a slot is often far taller than that estimate, so cards may grow to
+ * ~1.6× before clamping.
+ */
+export const SLOT_MAX_CARD_WIDTH = 200
+
+/**
+ * Upper bound on the wrap-line search per row. Four lines of tiny cards is the
+ * most a phone slot can ever usefully hold; a larger bound only adds work.
+ */
+export const MAX_LINES_PER_ROW = 4
+
+/**
+ * Preferred readability floor. When a board is so crowded that respecting it
+ * would make the layout taller than the slot (overlapping the center HUD),
+ * cards shrink further — fitting beats size.
+ */
+export const PREFERRED_MIN_CARD_WIDTH = 60
+
+/**
+ * Below this, cards are unrecognizable; clamp here for pathological boards
+ * (25+ permanents on a phone). The slot clips its content, so even then
+ * nothing bleeds over the center HUD.
+ */
+export const ABSOLUTE_MIN_CARD_WIDTH = 32
+
+/**
+ * Minimum gap kept toward the center HUD once the comfortable breathing margin
+ * has been sacrificed for card size. Clears the StepStrip's active-player
+ * chevron (~9 px) and its glow.
+ */
+export const TIGHT_HUD_GAP = 16
+
+/** Height of the radial-gradient strip drawn between the two rows. */
+export const DIVIDER_STRIP_HEIGHT = 24
+
+/**
+ * Height an empty row reserves. Zero: the row element stays in the DOM (its
+ * order and `data-zone` spotlights are unchanged) but costs no line — the
+ * turn-1 board no longer pays a full card height for a creature row with
+ * nothing in it.
+ */
+export const EMPTY_ROW_MIN_HEIGHT = 0
+
+/**
+ * Optional second size for the back row (lands + other) relative to the front
+ * row: 1 renders both rows at one size; 0.7 renders lands at 70 % so creatures
+ * can grow into the reclaimed height. Positions are unaffected either way.
+ * Shipped at 1 — a second card size on the board is a taste decision to take
+ * from a screenshot walk, not from the solver.
+ */
+export const BACK_ROW_SCALE = 1
+
+/**
+ * Two-player pooled solve: the smaller battlefield's share of the pooled
+ * height never drops under this fraction, so the center HUD stays within ~15 %
+ * of the middle of the screen however lopsided the boards are.
+ */
+export const SLOT_SPLIT_MIN = 0.35
+
+/**
+ * Extra width GameCard's own wrapper reserves for a card lying sideways on the
+ * battlefield (see the `needsLandscapeContainer` branch in GameCard.tsx). Kept
+ * in sync with that constant so the fit math reserves the footprint GameCard uses.
+ */
+export const LANDSCAPE_CONTAINER_PAD = 8
+
+/** Horizontal peek of each card stacked behind a group's first (see `CardStack`). */
+export const stackOffsetFor = (isMobile: boolean): number => (isMobile ? 12 : 18)
+
+/** Rendered stacks on one row (after `groupCards`), with the footprint modifiers the fit math needs. */
+export interface RowStats {
+  /** Stacks on the row. */
+  count: number
+  /** Stacks whose representative card is tapped — rotated 90°, so ~1.4× as wide. */
+  tapped: number
+  /** Cards peeking out behind a stack's first card (`visibleStackDepth(n) − 1` summed over stacks). */
+  stackedExtra: number
+}
+
+export interface BoardStats {
+  front: RowStats
+  back: RowStats
+}
+
+export interface LayoutEnv {
+  /** Flex gap between stacks and between wrap lines. */
+  cardGap: number
+  /** Horizontal peek of each card stacked behind a group's first (see `CardStack`). */
+  stackOffset: number
+  /** Back-row size relative to the front row; defaults to `BACK_ROW_SCALE`. */
+  backRowScale?: number
+}
+
+export interface SlotLayout {
+  /** Front-row card width; the size `ResponsiveContext` carries as `battlefieldCardWidth`. */
+  cardWidth: number
+  cardHeight: number
+  /** Back-row card size — equals the front size unless `backRowScale < 1`. */
+  backCardWidth: number
+  backCardHeight: number
+  /** Wrap lines each row is budgeted for; 0 for an empty row. */
+  frontLines: number
+  backLines: number
+}
+
+export interface PooledLayout {
+  /** Common card width both battlefields render at. */
+  cardWidth: number
+  player: SlotLayout
+  opponent: SlotLayout
+  /** Slot heights the grid should give each battlefield; they sum to the pooled height. */
+  playerHeight: number
+  opponentHeight: number
+}
+
+/**
+ * Transition applied to a battlefield card's box when the solver resizes it —
+ * the card's own `transform` / `box-shadow` transitions plus the size axes.
+ */
+export const CARD_RESIZE_TRANSITION = 'transform 0.15s, box-shadow 0.15s, width 0.18s ease, height 0.18s ease'
+
+/** Viewer asked for reduced motion: size changes then snap instead of easing. */
+export const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+export const EMPTY_ROW: RowStats = { count: 0, tapped: 0, stackedExtra: 0 }
+export const EMPTY_BOARD: BoardStats = { front: EMPTY_ROW, back: EMPTY_ROW }
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
+export const cardHeightFor = (cardWidth: number): number => Math.round(cardWidth * CARD_ASPECT)
+
+/**
+ * Margin above and below the between-rows divider strip. Scales with the card
+ * actually rendered — the old `max(10, 0.1 × baseCardHeight)` was sized for the
+ * 125 px desktop base card and cost 36 px around a 92 px-tall card.
+ */
+export const dividerMarginFor = (cardHeight: number): number => Math.max(6, Math.round(cardHeight * 0.1))
+
+/**
+ * Gap left between the battlefield cards and the center HUD. Scales with the
+ * card so a small crowded board doesn't spend up to 48 px of slot on air.
+ * Big enough at every size to clear the StepStrip chevron.
+ */
+export const breathingFor = (cardHeight: number): number => clamp(Math.round(cardHeight * 0.15), 12, 48)
+
+/** Min padding each populated row reserves (the `battlefieldRowPadding` responsive value). */
+export const rowPaddingFor = (cardHeight: number): number => Math.round(cardHeight * 0.08)
+
+/**
+ * Height a row's wrap lines reserve (`minHeight` in Battlefield.tsx): one card
+ * height per line, the flex gap between lines, plus the row padding. An empty
+ * row keeps only `EMPTY_ROW_MIN_HEIGHT` — it costs no line.
+ */
+export function rowMinHeightFor(lines: number, cardHeight: number, cardGap: number): number {
+  if (lines <= 0) return EMPTY_ROW_MIN_HEIGHT
+  return lines * cardHeight + (lines - 1) * cardGap + rowPaddingFor(cardHeight)
+}
+
+/**
+ * Largest card width that lets a row's fullest wrap line sit side-by-side in
+ * `slotWidth` (accounting for inter-card gaps). With 0–1 cards per line and no
+ * stacked peeks, no horizontal constraint applies.
+ *
+ * Each tapped stack's rotated container is cardHeight + LANDSCAPE_CONTAINER_PAD
+ * (= 1.4 × cardWidth + 8) wide rather than cardWidth, and every card stacked
+ * behind a group's first peeks out by `stackOffset`. Flex-wrap breaks lines
+ * greedily, so we can't control which items share a line — assume the worst
+ * case where a line holds as many tapped stacks (and all the stacked-extra
+ * cards) as possible. Solving for cardWidth with t tapped and e stacked-extra
+ * out of n items on a line:
+ *   slotWidth ≥ cw × (n + 0.4·t) + 8·t + stackOffset·e + (n − 1) × gap
+ *   cw ≤ (slotWidth − 8·t − stackOffset·e − (n − 1) × gap) / (n + 0.4·t)
+ */
+export function rowWidthCap(slotWidth: number, row: RowStats, lines: number, env: LayoutEnv): number {
+  if (lines <= 0 || row.count <= 0) return SLOT_MAX_CARD_WIDTH
+  const cardsPerLine = Math.ceil(row.count / lines)
+  if (cardsPerLine <= 1 && row.stackedExtra <= 0) return SLOT_MAX_CARD_WIDTH
+  const tappedOnLine = Math.max(0, Math.min(row.tapped, cardsPerLine))
+  const widthDivisor = cardsPerLine + (CARD_ASPECT - 1) * tappedOnLine
+  const totalGap = (cardsPerLine - 1) * env.cardGap
+  return Math.floor(
+    (slotWidth - totalGap - LANDSCAPE_CONTAINER_PAD * tappedOnLine - env.stackOffset * row.stackedExtra) /
+      widthDivisor,
+  )
+}
+
+/**
+ * Slot height a board needs at card width `cardWidth` with the given wrap
+ * lines: every line costs one card height, wrapped lines are separated by the
+ * flex gap, each populated row adds its padding, a divider is paid only when
+ * both rows are populated, and a gap toward the HUD is always reserved —
+ * `breathingFor` normally, `TIGHT_HUD_GAP` once size has been traded for it.
+ */
+export function slotHeightNeeded(
+  stats: BoardStats,
+  frontLines: number,
+  backLines: number,
+  cardWidth: number,
+  env: LayoutEnv,
+  tight: boolean,
+): number {
+  const scale = env.backRowScale ?? BACK_ROW_SCALE
+  const h = cardHeightFor(cardWidth)
+  const hb = cardHeightFor(cardWidth * scale)
+  const fl = stats.front.count > 0 ? frontLines : 0
+  const bl = stats.back.count > 0 ? backLines : 0
+  let total = 0
+  if (fl > 0) total += fl * h + (fl - 1) * env.cardGap + rowPaddingFor(h)
+  else total += EMPTY_ROW_MIN_HEIGHT
+  if (bl > 0) total += bl * hb + (bl - 1) * env.cardGap + rowPaddingFor(hb)
+  else total += EMPTY_ROW_MIN_HEIGHT
+  if (fl > 0 && bl > 0) total += DIVIDER_STRIP_HEIGHT + 2 * dividerMarginFor(h)
+  total += hudGapFor(h, tight)
+  return total
+}
+
+/**
+ * Gap reserved toward the center HUD: the comfortable breathing margin, or —
+ * once size is being traded for it — the tight gap, which is never *more* than
+ * the comfortable one (small cards already breathe less than `TIGHT_HUD_GAP`).
+ */
+export const hudGapFor = (cardHeight: number, tight: boolean): number =>
+  tight ? Math.min(TIGHT_HUD_GAP, breathingFor(cardHeight)) : breathingFor(cardHeight)
+
+interface LineCandidate {
+  frontLines: number
+  backLines: number
+}
+
+/**
+ * Every (frontLines, backLines) combination worth trying, fewest lines first
+ * so that a strict "larger card wins" comparison keeps the flat layout on ties.
+ * An empty row only ever has 0 lines.
+ */
+function lineCandidates(stats: BoardStats): LineCandidate[] {
+  const options = (row: RowStats): number[] => {
+    if (row.count <= 0) return [0]
+    const max = Math.min(MAX_LINES_PER_ROW, row.count)
+    return Array.from({ length: max }, (_, i) => i + 1)
+  }
+  const out: LineCandidate[] = []
+  for (const frontLines of options(stats.front)) {
+    for (const backLines of options(stats.back)) out.push({ frontLines, backLines })
+  }
+  out.sort((a, b) => a.frontLines + a.backLines - (b.frontLines + b.backLines))
+  return out
+}
+
+/** Largest width in [ABSOLUTE_MIN_CARD_WIDTH, maxWidth] whose horizontal caps admit it. */
+function widthCapFor(slotWidth: number, stats: BoardStats, c: LineCandidate, env: LayoutEnv, maxWidth: number): number {
+  const scale = env.backRowScale ?? BACK_ROW_SCALE
+  return Math.min(
+    maxWidth,
+    rowWidthCap(slotWidth, stats.front, c.frontLines, env),
+    Math.floor(rowWidthCap(slotWidth, stats.back, c.backLines, env) / scale),
+  )
+}
+
+/**
+ * Largest integer width in [lo, hi] for which `fits` holds, or null. `fits`
+ * must be monotone (true for every width below the first true one), which
+ * every height budget here is — a bigger card never needs less room.
+ */
+function largestFitting(lo: number, hi: number, fits: (w: number) => boolean): number | null {
+  if (hi < lo || !fits(lo)) return null
+  let good = lo
+  let bad = hi + 1
+  while (bad - good > 1) {
+    const mid = (good + bad) >> 1
+    if (fits(mid)) good = mid
+    else bad = mid
+  }
+  return good
+}
+
+function makeLayout(cardWidth: number, c: LineCandidate, stats: BoardStats, env: LayoutEnv): SlotLayout {
+  const scale = env.backRowScale ?? BACK_ROW_SCALE
+  const backCardWidth = Math.round(cardWidth * scale)
+  return {
+    cardWidth,
+    cardHeight: cardHeightFor(cardWidth),
+    backCardWidth,
+    backCardHeight: cardHeightFor(backCardWidth),
+    frontLines: stats.front.count > 0 ? c.frontLines : 0,
+    backLines: stats.back.count > 0 ? c.backLines : 0,
+  }
+}
+
+/**
+ * Wrap lines greedy flex-wrap actually produces for a row at the floor width,
+ * so the row's `minHeight` reservation tracks reality instead of an impossible
+ * plan once even unreadably small cards can't fit the board.
+ */
+function linesAtFloor(slotWidth: number, row: RowStats, env: LayoutEnv, cardWidth: number): number {
+  if (row.count <= 0) return 0
+  const contentWidth =
+    row.count * (cardWidth + env.cardGap) +
+    row.tapped * ((CARD_ASPECT - 1) * cardWidth + LANDSCAPE_CONTAINER_PAD) +
+    row.stackedExtra * env.stackOffset
+  const lineCapacity = slotWidth + env.cardGap
+  return Math.min(MAX_LINES_PER_ROW, Math.max(1, Math.ceil(contentWidth / lineCapacity)))
+}
+
+function floorLayout(slotWidth: number, stats: BoardStats, env: LayoutEnv): SlotLayout {
+  const w = ABSOLUTE_MIN_CARD_WIDTH
+  return makeLayout(
+    w,
+    {
+      frontLines: linesAtFloor(slotWidth, stats.front, env, w),
+      backLines: linesAtFloor(slotWidth, stats.back, env, Math.round(w * (env.backRowScale ?? BACK_ROW_SCALE))),
+    },
+    stats,
+    env,
+  )
+}
+
+/**
+ * Card size for one battlefield measuring its own slot (the multiplayer strip
+ * cells, and the two-player board before the pooled solve has measurements).
+ *
+ * Pass 1 keeps the comfortable breathing gap toward the HUD and lets cards grow
+ * to `SLOT_MAX_CARD_WIDTH`. If that lands under `PREFERRED_MIN_CARD_WIDTH`, pass
+ * 2 trades the breathing gap for size with the floor as the ceiling. If even
+ * that can't fit, cards clamp to `ABSOLUTE_MIN_CARD_WIDTH` and the line counts
+ * follow what greedy wrapping will actually do.
+ */
+export function solveSlotLayout(slotWidth: number, slotHeight: number, stats: BoardStats, env: LayoutEnv): SlotLayout {
+  const candidates = lineCandidates(stats)
+  const pass = (tight: boolean, maxWidth: number): SlotLayout | null => {
+    let best: SlotLayout | null = null
+    for (const c of candidates) {
+      const cap = widthCapFor(slotWidth, stats, c, env, maxWidth)
+      const w = largestFitting(ABSOLUTE_MIN_CARD_WIDTH, cap, (cw) =>
+        slotHeightNeeded(stats, c.frontLines, c.backLines, cw, env, tight) <= slotHeight,
+      )
+      if (w !== null && (best === null || w > best.cardWidth)) best = makeLayout(w, c, stats, env)
+    }
+    return best
+  }
+  const comfortable = pass(false, SLOT_MAX_CARD_WIDTH)
+  if (comfortable && comfortable.cardWidth >= PREFERRED_MIN_CARD_WIDTH) return comfortable
+  const squeezed = pass(true, PREFERRED_MIN_CARD_WIDTH)
+  if (squeezed) return squeezed
+  return floorLayout(slotWidth, stats, env)
+}
+
+/**
+ * Two-player solve: one card width for both battlefields, each given the slot
+ * height its own rows need out of the height the grid has for the pair. The
+ * sparse side hands height to the crowded side; a board that wraps gets its
+ * extra line without shrinking below the other player's size. The split is
+ * clamped so neither slot drops under `SLOT_SPLIT_MIN` of the pool — that is
+ * what keeps the center HUD roughly where it is today.
+ *
+ * `slotWidth` is the width both battlefield slots share (identical in the
+ * two-player grid: same command-zone column and zone-pile column each side).
+ */
+export function solvePooledLayout(
+  slotWidth: number,
+  pooledHeight: number,
+  player: BoardStats,
+  opponent: BoardStats,
+  env: LayoutEnv,
+): PooledLayout {
+  const playerCandidates = lineCandidates(player)
+  const opponentCandidates = lineCandidates(opponent)
+  const maxSlot = (1 - SLOT_SPLIT_MIN) * pooledHeight
+
+  // Cheapest (least height) line combination whose horizontal caps admit `w`.
+  const cheapest = (
+    stats: BoardStats,
+    candidates: LineCandidate[],
+    w: number,
+    tight: boolean,
+  ): { c: LineCandidate; need: number } | null => {
+    let best: { c: LineCandidate; need: number } | null = null
+    for (const c of candidates) {
+      if (widthCapFor(slotWidth, stats, c, env, SLOT_MAX_CARD_WIDTH) < w) continue
+      const need = slotHeightNeeded(stats, c.frontLines, c.backLines, w, env, tight)
+      if (best === null || need < best.need) best = { c, need }
+    }
+    return best
+  }
+
+  const pass = (tight: boolean, maxWidth: number): PooledLayout | null => {
+    const w = largestFitting(ABSOLUTE_MIN_CARD_WIDTH, maxWidth, (cw) => {
+      const a = cheapest(player, playerCandidates, cw, tight)
+      const b = cheapest(opponent, opponentCandidates, cw, tight)
+      return a !== null && b !== null && a.need + b.need <= pooledHeight && a.need <= maxSlot && b.need <= maxSlot
+    })
+    if (w === null) return null
+    const a = cheapest(player, playerCandidates, w, tight)!
+    const b = cheapest(opponent, opponentCandidates, w, tight)!
+    return splitHeights(w, makeLayout(w, a.c, player, env), a.need, makeLayout(w, b.c, opponent, env), b.need, pooledHeight)
+  }
+
+  const comfortable = pass(false, SLOT_MAX_CARD_WIDTH)
+  if (comfortable && comfortable.cardWidth >= PREFERRED_MIN_CARD_WIDTH) return comfortable
+  const squeezed = pass(true, PREFERRED_MIN_CARD_WIDTH)
+  if (squeezed) return squeezed
+  // Nothing fits: clamp to the floor and split the pool by what each side needs.
+  const a = floorLayout(slotWidth, player, env)
+  const b = floorLayout(slotWidth, opponent, env)
+  const needA = slotHeightNeeded(player, a.frontLines, a.backLines, a.cardWidth, env, true)
+  const needB = slotHeightNeeded(opponent, b.frontLines, b.backLines, b.cardWidth, env, true)
+  const share = needA / Math.max(1, needA + needB)
+  return {
+    cardWidth: ABSOLUTE_MIN_CARD_WIDTH,
+    player: a,
+    opponent: b,
+    playerHeight: pooledHeight * share,
+    opponentHeight: pooledHeight * (1 - share),
+  }
+}
+
+/**
+ * Give each side at least what it needs (and at least the clamp share), then
+ * hand any leftover out in proportion to need so the crowded side breathes more.
+ */
+function splitHeights(
+  cardWidth: number,
+  player: SlotLayout,
+  playerNeed: number,
+  opponent: SlotLayout,
+  opponentNeed: number,
+  pooledHeight: number,
+): PooledLayout {
+  const min = SLOT_SPLIT_MIN * pooledHeight
+  let playerHeight = Math.max(playerNeed, min)
+  let opponentHeight = Math.max(opponentNeed, min)
+  const leftover = pooledHeight - playerHeight - opponentHeight
+  if (leftover > 0) {
+    const total = Math.max(1, playerNeed + opponentNeed)
+    playerHeight += (leftover * playerNeed) / total
+    opponentHeight = pooledHeight - playerHeight
+  }
+  return { cardWidth, player, opponent, playerHeight, opponentHeight }
+}

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -143,11 +143,16 @@ export function useSlotSizedResponsive(
 
   const { front, back } = stats
   return useMemo(() => {
-    const layout =
-      pooled ??
-      (slotSize !== null && slotSize.height > 0 && slotSize.width > 0
+    const own =
+      slotSize !== null && slotSize.height > 0 && slotSize.width > 0
         ? solveSlotLayout(slotSize.width, slotSize.height, { front, back }, layoutEnvFor(base))
-        : null)
+        : null
+    // The pooled width was solved from the rows' measured heights, but this
+    // slot's own measurement can lag a frame behind a grid change — and
+    // whatever the source, a card that doesn't fit the slot it is in would be
+    // clipped against the center HUD. Never render wider than the slot fits;
+    // in a consistent frame the two agree and the pooled width wins as-is.
+    const layout = pooled !== null && own !== null && own.cardWidth < pooled.cardWidth ? own : (pooled ?? own)
     if (layout === null) {
       return { sizes: base, backSizes: base, frontRowLines: front.count > 0 ? 1 : 0, backRowLines: back.count > 0 ? 1 : 0 }
     }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -1,4 +1,16 @@
 import React, { createContext, useContext, useLayoutEffect, useMemo, useState, type RefObject } from 'react'
+import {
+  BACK_ROW_SCALE,
+  LANDSCAPE_CONTAINER_PAD,
+  cardHeightFor,
+  rowPaddingFor,
+  solveSlotLayout,
+  stackOffsetFor,
+  type BoardStats,
+  type LayoutEnv,
+  type PooledLayout,
+  type SlotLayout,
+} from './battlefieldLayout'
 import type { ResponsiveSizes, BadgeSizes } from '../../../hooks/useResponsive'
 import { getScryfallFallbackUrl } from '../../../utils/cardImages'
 import type { ClientCard, LegalActionInfo } from '../../../types'
@@ -14,70 +26,95 @@ export function useResponsiveContext(): ResponsiveSizes {
   return ctx
 }
 
-// Hard ceiling on slot-derived card growth. The window-derived `useResponsive`
-// caps base battlefieldCardWidth at 125 (desktop) — that estimate was tuned
-// for the legacy layout where hand reservations weren't explicit grid tracks.
-// With the explicit-track grid, slots are often substantially taller than that
-// budget anticipated, so we let cards grow up to ~1.6× before clamping.
-const SLOT_MAX_CARD_WIDTH = 200
+/**
+ * Two-player pooled layout, provided by `GameBoard` once it has measured the
+ * height the grid gives both battlefields jointly (`usePooledBattlefieldLayout`).
+ * Each `Battlefield` reads its own side and skips its per-slot solve; `null`
+ * (multiplayer strips, spectator bottom seats, or before the first measurement)
+ * means "size yourself from your own slot".
+ */
+export const PooledBattlefieldLayoutContext = createContext<PooledLayout | null>(null)
 
-// Upper bound on the wrap-line search per battlefield row. Four lines of
-// tiny cards per row is the most a phone slot can ever usefully hold; a
-// larger bound only adds search work.
-const MAX_LINES_PER_ROW = 4
-
-// Preferred readability floor for battlefield cards. When a board is so
-// crowded that respecting it would make the layout taller than the slot
-// (overlapping the center HUD), cards shrink further — fitting beats size.
-const PREFERRED_MIN_CARD_WIDTH = 60
-
-// Below this, cards are unrecognizable; clamp here for pathological boards
-// (25+ permanents on a phone). The slot clips its content (Battlefield.tsx),
-// so even then nothing can bleed over the center HUD.
-const ABSOLUTE_MIN_CARD_WIDTH = 32
-
-// Minimum gap kept toward the center HUD when the comfortable `breathing`
-// margin has been sacrificed for card size. Clears the StepStrip's
-// active-player chevron (~9px) and its glow, which paints over anything
-// closer and reads as cards tucked under the HUD.
-const TIGHT_HUD_GAP = 16
+/** The solver inputs that come from the responsive base (gap and stack peek). */
+export function layoutEnvFor(base: ResponsiveSizes): LayoutEnv {
+  return { cardGap: base.cardGap, stackOffset: stackOffsetFor(base.isMobile), backRowScale: BACK_ROW_SCALE }
+}
 
 /**
- * Slot-derived battlefield layout: the card sizes to render with, plus the
+ * The base responsive sizes with the battlefield card (and everything that
+ * scales with it — row padding, badges) replaced for `cardWidth`. Returns
+ * `base` itself when nothing would change, so downstream useMemos keyed on the
+ * sizes identity don't invalidate for no visual change.
+ */
+export function sizesForCardWidth(base: ResponsiveSizes, cardWidth: number): ResponsiveSizes {
+  const cardHeight = cardHeightFor(cardWidth)
+  if (cardWidth === base.battlefieldCardWidth && cardHeight === base.battlefieldCardHeight) return base
+
+  // Recompute the same badge scale formula useResponsive uses so badges
+  // stay proportionate to the (resized) battlefield card.
+  const DESKTOP_BF_WIDTH = 125
+  const bfScale = Math.max(0.5, Math.min(1.6, cardWidth / DESKTOP_BF_WIDTH))
+  const scaled = (desktop: number, floor: number) => Math.max(floor, Math.round(desktop * bfScale))
+  const badgeInset = scaled(4, 2)
+  const badgePadH = scaled(6, 3)
+  const badgePadV = scaled(2, 1)
+  const tightPadH = scaled(5, 3)
+  const tightPadV = scaled(2, 1)
+  const badges: BadgeSizes = {
+    ptFontSize: scaled(12, 9),
+    counterTextFontSize: scaled(11, 8),
+    counterIconFontSize: scaled(10, 7),
+    keywordIconSize: scaled(18, 12),
+    sicknessIconSize: scaled(24, 14),
+    smallLabelFontSize: scaled(9, 7),
+    manaCostFontSize: scaled(13, 9),
+    classLevelMarkerSize: scaled(18, 12),
+    classLevelMarkerFontSize: scaled(9, 7),
+    countBadgeSize: scaled(22, 16),
+    countBadgeFontSize: scaled(12, 9),
+    distributeBadgeSize: scaled(26, 18),
+    distributeBadgeFontSize: scaled(14, 10),
+    indicatorFontSize: scaled(13, 9),
+    badgePadding: `${badgePadV}px ${badgePadH}px`,
+    badgePaddingTight: `${tightPadV}px ${tightPadH}px`,
+    badgeInset,
+  }
+
+  return {
+    ...base,
+    battlefieldCardWidth: cardWidth,
+    battlefieldCardHeight: cardHeight,
+    battlefieldRowPadding: rowPaddingFor(cardHeight),
+    badges,
+  }
+}
+
+/**
+ * Slot-derived battlefield layout: the card sizes to render with (front row,
+ * and the back row — the same object unless `BACK_ROW_SCALE < 1`), plus the
  * number of wrap lines each row was budgeted for (used by Battlefield.tsx to
  * reserve matching minHeight per row so a wrapped row can't collapse or
- * overflow its neighbour).
+ * overflow its neighbour; 0 for an empty row).
  */
 export interface SlotSizedLayout {
   sizes: ResponsiveSizes
+  backSizes: ResponsiveSizes
   frontRowLines: number
   backRowLines: number
 }
 
 /**
  * Measures the bounded slot a battlefield occupies (set up by the grid in
- * board/styles.ts) and derives card sizes that fit inside it. Cards both
- * shrink (when slot is too small) and grow (when slot has unused height,
- * up to SLOT_MAX_CARD_WIDTH) so the slot is used as fully as possible
- * without overflow.
+ * board/styles.ts) and derives card sizes that fit inside it via
+ * `solveSlotLayout`. Cards both shrink (when the slot is too small) and grow
+ * (when it has unused height, up to SLOT_MAX_CARD_WIDTH) so the slot is used
+ * as fully as possible without overflow — an empty row costs no line, and the
+ * divider margins and the gap toward the HUD scale with the card rendered
+ * rather than with the desktop base card.
  *
- * Each row (front: creatures + planeswalkers, back: lands + other) may wrap
- * into multiple physical lines when that yields *larger* cards than squeezing
- * everything onto one line — e.g. many creatures on a wide board, or a narrow
- * portrait phone where vertical space is plentiful and horizontal space isn't.
- * The hook searches line-count combinations (1..MAX_LINES_PER_ROW per row)
- * and picks the one that maximizes card width while the combined height of
- * all lines still fits the slot. Single lines win ties, so roomy boards keep
- * today's flat layout.
- *
- * Counts are *rendered stacks* (after groupCards), not raw cards. The tapped
- * counts matter because tapped cards are rotated 90°: their horizontal
- * footprint is the portrait card *height* (≈1.4× card width) rather than the
- * width. The stackedExtra counts (cards hidden behind a stack's first card)
- * each add a fixed peek offset to their stack's footprint. The width
- * constraint assumes the worst-case line (as many tapped cards as can share a
- * line) so an unplanned extra wrap line — which would overflow the slot
- * vertically into the center HUD — stays geometrically impossible.
+ * When `pooled` is given (the two-player board, solved jointly by GameBoard so
+ * both players share one width and the crowded side gets the height it needs)
+ * the slot measurement is ignored and the pooled result is rendered as-is.
  *
  * Phase 2 of the no-overlap layout: makes overflow into the center HUD
  * geometrically impossible by sizing cards from the actual slot rather
@@ -85,12 +122,8 @@ export interface SlotSizedLayout {
  */
 export function useSlotSizedResponsive(
   slotRef: RefObject<HTMLElement | null>,
-  frontRowCount: number = 0,
-  frontRowTappedCount: number = 0,
-  frontRowStackedExtra: number = 0,
-  backRowCount: number = 0,
-  backRowTappedCount: number = 0,
-  backRowStackedExtra: number = 0,
+  stats: BoardStats,
+  pooled: SlotLayout | null = null,
 ): SlotSizedLayout {
   const base = useResponsiveContext()
   const [slotSize, setSlotSize] = useState<{ width: number; height: number } | null>(null)
@@ -108,205 +141,24 @@ export function useSlotSizedResponsive(
     return () => obs.disconnect()
   }, [slotRef])
 
+  const { front, back } = stats
   return useMemo(() => {
-    if (slotSize === null || slotSize.height <= 0 || slotSize.width <= 0) {
-      return { sizes: base, frontRowLines: 1, backRowLines: 1 }
+    const layout =
+      pooled ??
+      (slotSize !== null && slotSize.height > 0 && slotSize.width > 0
+        ? solveSlotLayout(slotSize.width, slotSize.height, { front, back }, layoutEnvFor(base))
+        : null)
+    if (layout === null) {
+      return { sizes: base, backSizes: base, frontRowLines: front.count > 0 ? 1 : 0, backRowLines: back.count > 0 ? 1 : 0 }
     }
-
-    // Each battlefield holds two card rows separated by a divider strip
-    // (24px + 2 × dividerMargin, see Battlefield.tsx). The `breathing` value
-    // is leftover slot height that ends up between the cards and the slot's
-    // anchored end — which, for both opponent (justify flex-start) and player
-    // (justify flex-end), is the center-HUD side. So this is effectively the
-    // gap between battlefield cards and the center HUD.
-    //
-    // Sized to clear the StepStrip's active-player chevron (6px triangle +
-    // 3px gap = ~9px protruding from the HUD into our slot's bottom edge)
-    // with room to spare. Scaled with slot height so tight viewports stay
-    // tight and roomy ones get a comfortable gap.
-    const dividerMargin = Math.max(10, Math.round(base.battlefieldCardHeight * 0.1))
-    const dividerSpace = 24 + 2 * dividerMargin
-    const breathing = Math.max(12, Math.min(48, Math.round(slotSize.height * 0.10)))
-
-    // Horizontal-fit cap for one row spread across `lines` wrap lines: the
-    // largest card width that lets the fullest line sit side-by-side in the
-    // slot's width (accounting for inter-card gaps). With 0–1 cards per line,
-    // no horizontal constraint applies.
-    //
-    // Each tapped stack's rotated container is cardHeight + 8 (= 1.4 ×
-    // cardWidth + 8, see GameCard's needsLandscapeContainer) wide rather than
-    // cardWidth, and every card stacked behind a group's first peeks out by a
-    // fixed offset (see CardStack). Flex-wrap breaks lines greedily, so we
-    // can't control which items share a line — assume the worst case where a
-    // line holds as many tapped stacks (and all the stacked-extra cards) as
-    // possible. Solving for cardWidth with t tapped and e stacked-extra out
-    // of n items on a line:
-    //   slotWidth ≥ cw × (n + 0.4·t) + 8·t + stackOffset·e + (n − 1) × gap
-    //   cw ≤ (slotWidth − 8·t − stackOffset·e − (n − 1) × gap) / (n + 0.4·t)
-    const stackOffset = base.isMobile ? 12 : 18
-    const widthCapForRow = (count: number, tappedCount: number, stackedExtra: number, lines: number): number => {
-      const cardsPerLine = Math.ceil(count / lines)
-      if (cardsPerLine <= 1 && stackedExtra <= 0) return SLOT_MAX_CARD_WIDTH
-      const tappedOnLine = Math.max(0, Math.min(tappedCount, cardsPerLine))
-      const widthDivisor = cardsPerLine + 0.4 * tappedOnLine
-      const totalGap = (cardsPerLine - 1) * base.cardGap
-      return Math.floor(
-        (slotSize.width - totalGap - 8 * tappedOnLine - stackOffset * stackedExtra) / widthDivisor,
-      )
-    }
-
-    // Search every (frontLines, backLines) combination and keep whichever
-    // yields the widest card. More lines relax the horizontal constraint but
-    // tighten the vertical one (each line costs cardHeight + a wrap gap), so
-    // the optimum depends on slot aspect ratio and card counts. Strict `>`
-    // with ascending iteration means fewer lines win ties — a board that fits
-    // comfortably on single lines keeps the flat layout.
-    //
-    // The vertical budget also reserves the two rows' minHeight padding
-    // (battlefieldRowPadding = 0.08 × cardHeight each, hence the 0.224·cw
-    // term folded into the divisor).
-    const maxFrontLines = Math.min(MAX_LINES_PER_ROW, Math.max(1, frontRowCount))
-    const maxBackLines = Math.min(MAX_LINES_PER_ROW, Math.max(1, backRowCount))
-    const search = (hudGap: number, maxWidth: number) => {
-      let width = 0
-      let frontLines = 1
-      let backLines = 1
-      for (let front = 1; front <= maxFrontLines; front++) {
-        for (let back = 1; back <= maxBackLines; back++) {
-          const totalLines = front + back
-          // Vertical-fit cap: every line costs one cardHeight, and wrapped
-          // lines within a row are separated by the flex `gap` (cardGap).
-          const heightBudget =
-            slotSize.height - dividerSpace - hudGap - (totalLines - 2) * base.cardGap
-          const widthFromHeight = Math.floor(heightBudget / (totalLines * 1.4 + 0.224))
-          const candidate = Math.min(
-            maxWidth,
-            widthFromHeight,
-            widthCapForRow(frontRowCount, frontRowTappedCount, frontRowStackedExtra, front),
-            widthCapForRow(backRowCount, backRowTappedCount, backRowStackedExtra, back),
-          )
-          if (candidate > width) {
-            width = candidate
-            frontLines = front
-            backLines = back
-          }
-        }
-      }
-      return { width, frontLines, backLines }
-    }
-
-    // Pass 1: comfortable layout — full breathing gap toward the center HUD.
-    let { width: slotCardWidth, frontLines: frontRowLines, backLines: backRowLines } =
-      search(breathing, SLOT_MAX_CARD_WIDTH)
-
-    if (slotCardWidth < PREFERRED_MIN_CARD_WIDTH) {
-      // Crowded board: cards would drop below the preferred readability
-      // floor. Re-search with the breathing margin sacrificed (keeping just
-      // enough to clear the StepStrip chevron) and the floor as the ceiling —
-      // trading the comfort gap for card size, but never letting the layout
-      // grow taller than the slot, which is what used to push cards over the
-      // center HUD on phones.
-      const tight = search(TIGHT_HUD_GAP, PREFERRED_MIN_CARD_WIDTH)
-      slotCardWidth = tight.width
-      frontRowLines = tight.frontLines
-      backRowLines = tight.backLines
-
-      if (slotCardWidth < ABSOLUTE_MIN_CARD_WIDTH) {
-        // Even unreadably small cards can't fit this board (20+ permanents on
-        // a phone). Clamp to the absolute minimum and re-derive each row's
-        // line count from what greedy flex-wrap actually produces at that
-        // width, so the minHeight reservations in Battlefield.tsx track
-        // reality instead of the impossible plan. Some overflow is now
-        // unavoidable.
-        slotCardWidth = ABSOLUTE_MIN_CARD_WIDTH
-        const linesAtFloor = (count: number, tappedCount: number, stackedExtra: number): number => {
-          if (count <= 0) return 1
-          const contentWidth =
-            count * (slotCardWidth + base.cardGap) +
-            tappedCount * (0.4 * slotCardWidth + 8) +
-            stackedExtra * stackOffset
-          const lineCapacity = slotSize.width + base.cardGap
-          return Math.min(
-            MAX_LINES_PER_ROW,
-            Math.max(1, Math.ceil(contentWidth / lineCapacity)),
-          )
-        }
-        frontRowLines = linesAtFloor(frontRowCount, frontRowTappedCount, frontRowStackedExtra)
-        backRowLines = linesAtFloor(backRowCount, backRowTappedCount, backRowStackedExtra)
-      }
-    }
-    const slotCardHeight = Math.round(slotCardWidth * 1.4)
-
-    // No-op if the resulting size matches what the base context already supplies
-    // (within rounding) — avoids creating a fresh ResponsiveSizes identity that
-    // would invalidate every downstream useMemo for no visual change.
-    if (
-      slotCardWidth === base.battlefieldCardWidth &&
-      slotCardHeight === base.battlefieldCardHeight
-    ) {
-      return { sizes: base, frontRowLines, backRowLines }
-    }
-
-    // Recompute the same badge scale formula useResponsive uses so badges
-    // stay proportionate to the (resized) battlefield card.
-    const DESKTOP_BF_WIDTH = 125
-    const bfScale = Math.max(0.5, Math.min(1.6, slotCardWidth / DESKTOP_BF_WIDTH))
-    const scaled = (desktop: number, floor: number) =>
-      Math.max(floor, Math.round(desktop * bfScale))
-    const badgeInset = scaled(4, 2)
-    const badgePadH = scaled(6, 3)
-    const badgePadV = scaled(2, 1)
-    const tightPadH = scaled(5, 3)
-    const tightPadV = scaled(2, 1)
-    const badges: BadgeSizes = {
-      ptFontSize: scaled(12, 9),
-      counterTextFontSize: scaled(11, 8),
-      counterIconFontSize: scaled(10, 7),
-      keywordIconSize: scaled(18, 12),
-      sicknessIconSize: scaled(24, 14),
-      smallLabelFontSize: scaled(9, 7),
-      manaCostFontSize: scaled(13, 9),
-      classLevelMarkerSize: scaled(18, 12),
-      classLevelMarkerFontSize: scaled(9, 7),
-      countBadgeSize: scaled(22, 16),
-      countBadgeFontSize: scaled(12, 9),
-      distributeBadgeSize: scaled(26, 18),
-      distributeBadgeFontSize: scaled(14, 10),
-      indicatorFontSize: scaled(13, 9),
-      badgePadding: `${badgePadV}px ${badgePadH}px`,
-      badgePaddingTight: `${tightPadV}px ${tightPadH}px`,
-      badgeInset,
-    }
-
-    return {
-      sizes: {
-        ...base,
-        battlefieldCardWidth: slotCardWidth,
-        battlefieldCardHeight: slotCardHeight,
-        battlefieldRowPadding: Math.round(slotCardHeight * 0.08),
-        badges,
-      },
-      frontRowLines,
-      backRowLines,
-    }
-  }, [
-    base,
-    slotSize,
-    frontRowCount,
-    frontRowTappedCount,
-    frontRowStackedExtra,
-    backRowCount,
-    backRowTappedCount,
-    backRowStackedExtra,
-  ])
+    const sizes = sizesForCardWidth(base, layout.cardWidth)
+    const backSizes = layout.backCardWidth === layout.cardWidth ? sizes : sizesForCardWidth(base, layout.backCardWidth)
+    return { sizes, backSizes, frontRowLines: layout.frontLines, backRowLines: layout.backLines }
+    // Keyed on the stats' numbers, not the objects, so an unrelated store
+    // update that rebuilds equal stats doesn't produce a fresh sizes identity.
+  }, [base, slotSize, pooled, front.count, front.tapped, front.stackedExtra, back.count, back.tapped, back.stackedExtra])
 }
 
-/**
- * Extra width GameCard's own wrapper reserves for a card lying sideways on the
- * battlefield (see the `needsLandscapeContainer` branch in GameCard.tsx). Kept in
- * sync with that constant so the stack reserves the same footprint GameCard uses.
- */
-const LANDSCAPE_CONTAINER_PAD = 8
 
 /** Placement of one card inside an attachment stack, in container-local pixels. */
 export interface AttachmentStackBox {

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -20,12 +20,14 @@ export const styles: Record<string, React.CSSProperties> = {
     // Five-row grid (template provided inline in GameBoard.tsx since rows 1
     // and 5 are sized from responsive values):
     //   1. opp-hand reservation     (px — keeps battlefield clear of fixed hand)
-    //   2. opp-board                (1fr — equal to row 4)
+    //   2. opp-board                (fr — weighted by what the opponent's rows need)
     //   3. center HUD               (auto — uncrossable partition)
-    //   4. player-board             (1fr — equal to row 2)
+    //   4. player-board             (fr — weighted by what the player's rows need)
     //   5. player-hand reservation  (px — keeps battlefield clear of fixed hand)
-    // Equal 1fr battlefield rows mean both players get the same card size
-    // via useSlotSizedResponsive, regardless of asymmetric hand sizes.
+    // Rows 2 and 4 are solved together (usePooledBattlefieldLayout): both
+    // players render at one card width, and each side gets the height its
+    // wrap lines need — equal until the first measurement, and clamped so
+    // the HUD stays near the middle (battlefieldLayout.ts, SLOT_SPLIT_MIN).
     display: 'grid',
     gridTemplateColumns: '100%',
     backgroundColor: '#0a0a15',

--- a/web-client/src/components/game/board/useBoardGroups.ts
+++ b/web-client/src/components/game/board/useBoardGroups.ts
@@ -1,0 +1,100 @@
+import { useMemo } from 'react'
+import {
+  groupCards,
+  useBattlefieldCards,
+  useSplitOutTargetIds,
+  visibleStackDepth,
+  type GroupedCard,
+} from '@/store/selectors.ts'
+import type { EntityId } from '@/types'
+import type { BoardStats, RowStats } from './battlefieldLayout'
+
+/** One battlefield's permanents grouped into rendered stacks, plus the footprint stats the sizing solver needs. */
+export interface BoardGroups {
+  lands: readonly GroupedCard[]
+  creatures: readonly GroupedCard[]
+  planeswalkers: readonly GroupedCard[]
+  other: readonly GroupedCard[]
+  stats: BoardStats
+}
+
+/**
+ * Per-row footprint stats for the fit constraints in `battlefieldLayout.ts`.
+ *
+ * Tapped stacks are rotated 90° on the battlefield — their horizontal footprint
+ * is cardHeight (≈1.4 × cardWidth) rather than cardWidth — and every card
+ * stacked behind a group's first adds a fixed peek offset. Counted per row so
+ * the horizontal-fit constraint reserves the true width; otherwise a crowded
+ * row on a narrow viewport overflows into an unbudgeted wrap line, which pushes
+ * the row up into the center HUD.
+ *
+ * Counts are *rendered stacks* (after `groupCards`), not raw cards: a collapsed
+ * horde paints at most MAX_VISUAL_STACK_DEPTH cards, so the footprint uses the
+ * capped depth (`visibleStackDepth`), not the raw count.
+ */
+export function rowStats(...groupLists: (readonly GroupedCard[])[]): RowStats {
+  let count = 0
+  let tapped = 0
+  let stackedExtra = 0
+  for (const groups of groupLists) {
+    for (const group of groups) {
+      count++
+      // Every member of a group shares its tapped state (it's part of the
+      // group key), so the representative answers for the whole stack.
+      if (group.card.isTapped) tapped++
+      stackedExtra += visibleStackDepth(group.count) - 1
+    }
+  }
+  return { count, tapped, stackedExtra }
+}
+
+/**
+ * Groups one side's permanents into stacks (see `groupCards`) and derives the
+ * row stats. Used by `Battlefield` to render, and by `GameBoard`'s pooled
+ * two-player solve, which needs both sides' stats before either battlefield
+ * renders — grouping twice per update is far cheaper than plumbing the groups
+ * up through the board.
+ *
+ * `isOpponent` + `playerId` follow `useBattlefieldCards`: an opponent board
+ * scoped to one seat (multiplayer strip cells) or, omitted, every non-viewing
+ * seat; a player-side board optionally showing another seat's permanents.
+ *
+ * Memoized so the arrays keep stable identity across unrelated store updates —
+ * otherwise every re-render allocates fresh arrays that cascade into child
+ * re-renders and invalidate downstream useMemos. Permanents that are chosen
+ * targets / triggering sources keep their own card so their targeting arrows
+ * can anchor (a member hidden behind the stack render cap would drop its
+ * arrow) — see `useSplitOutTargetIds` / `groupCards`.
+ */
+export function useBoardGroups(isOpponent: boolean, playerId?: EntityId): BoardGroups {
+  const cards = useBattlefieldCards(isOpponent ? playerId : undefined, isOpponent ? undefined : playerId)
+  const lands = isOpponent ? cards.opponentLands : cards.playerLands
+  const creatures = isOpponent ? cards.opponentCreatures : cards.playerCreatures
+  const planeswalkers = isOpponent ? cards.opponentPlaneswalkers : cards.playerPlaneswalkers
+  const other = isOpponent ? cards.opponentOther : cards.playerOther
+
+  const splitOutIds = useSplitOutTargetIds()
+  const groupedLands = useMemo(() => groupCards(lands, splitOutIds), [lands, splitOutIds])
+  const groupedCreatures = useMemo(() => groupCards(creatures, splitOutIds), [creatures, splitOutIds])
+  const groupedPlaneswalkers = useMemo(() => groupCards(planeswalkers, splitOutIds), [planeswalkers, splitOutIds])
+  const groupedOther = useMemo(() => groupCards(other, splitOutIds), [other, splitOutIds])
+
+  const stats = useMemo<BoardStats>(
+    () => ({
+      front: rowStats(groupedCreatures, groupedPlaneswalkers),
+      back: rowStats(groupedLands, groupedOther),
+    }),
+    [groupedCreatures, groupedPlaneswalkers, groupedLands, groupedOther],
+  )
+
+  return useMemo(
+    () => ({
+      lands: groupedLands,
+      creatures: groupedCreatures,
+      planeswalkers: groupedPlaneswalkers,
+      other: groupedOther,
+      stats,
+    }),
+    [groupedLands, groupedCreatures, groupedPlaneswalkers, groupedOther, stats],
+  )
+}

--- a/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
+++ b/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
@@ -1,0 +1,114 @@
+import { useLayoutEffect, useMemo, useState, type RefObject } from 'react'
+import type { ResponsiveSizes } from '@/hooks/useResponsive'
+import { solvePooledLayout, type BoardStats, type PooledLayout } from './battlefieldLayout'
+import { layoutEnvFor } from './shared'
+
+interface Size {
+  width: number
+  height: number
+}
+
+/** Live border-box size of an element, or null until it has been measured (or while disabled). */
+function useObservedSize(ref: RefObject<HTMLElement | null>, enabled: boolean): Size | null {
+  const [size, setSize] = useState<Size | null>(null)
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setSize(null)
+      return
+    }
+    const node = ref.current
+    if (!node) return
+    const rect = node.getBoundingClientRect()
+    setSize({ width: rect.width, height: rect.height })
+    const obs = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) setSize({ width: entry.contentRect.width, height: entry.contentRect.height })
+    })
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [ref, enabled])
+  return size
+}
+
+/**
+ * Two-player battlefield sizing, solved for both players at once.
+ *
+ * The board grid gives the two battlefields rows 2 and 4; this hook measures
+ * the height those rows have *together* (the container minus the hand
+ * reservation rows and the center HUD) and both players' row stats, and asks
+ * `solvePooledLayout` for one card width plus the slot height each side needs.
+ * GameBoard turns the heights into the grid's row weights and hands the layout
+ * to both `Battlefield`s through `PooledBattlefieldLayoutContext`.
+ *
+ * No feedback loop: every measured input is independent of the layout it
+ * produces — the container is viewport-sized, the center HUD's `auto` height
+ * depends only on its own content, and the slot width comes from the fixed
+ * command-zone and zone-pile columns, never from the cards.
+ *
+ * Returns null while disabled (multiplayer, where strip cells size themselves)
+ * or before the first measurement, in which case each battlefield falls back
+ * to its own per-slot solve.
+ */
+export function usePooledBattlefieldLayout({
+  enabled,
+  containerRef,
+  centerRef,
+  slotRef,
+  reservedHeight,
+  player,
+  opponent,
+  base,
+}: {
+  enabled: boolean
+  /** The board grid container (rows 1–5). */
+  containerRef: RefObject<HTMLElement | null>
+  /** The center HUD row (grid row 3, `auto`). */
+  centerRef: RefObject<HTMLElement | null>
+  /** One battlefield's slot — both slots share a width in the two-player grid. */
+  slotRef: RefObject<HTMLElement | null>
+  /** Sum of the hand reservation rows (1 and 5). */
+  reservedHeight: number
+  player: BoardStats
+  opponent: BoardStats
+  base: ResponsiveSizes
+}): PooledLayout | null {
+  const container = useObservedSize(containerRef, enabled)
+  const center = useObservedSize(centerRef, enabled)
+  const slot = useObservedSize(slotRef, enabled)
+
+  const containerHeight = container?.height ?? 0
+  const centerHeight = center?.height ?? 0
+  const slotWidth = slot?.width ?? 0
+  const centerMeasured = center !== null
+  const { front: pf, back: pb } = player
+  const { front: of, back: ob } = opponent
+  return useMemo(() => {
+    if (!enabled || slotWidth <= 0 || containerHeight <= 0 || !centerMeasured) return null
+    const pooledHeight = containerHeight - centerHeight - reservedHeight
+    if (pooledHeight <= 0) return null
+    return solvePooledLayout(slotWidth, pooledHeight, { front: pf, back: pb }, { front: of, back: ob }, layoutEnvFor(base))
+    // Keyed on the stats' numbers so an unrelated store update that rebuilds
+    // equal stats doesn't produce a fresh layout identity (which would re-render
+    // both battlefields for no visual change).
+  }, [
+    enabled,
+    slotWidth,
+    containerHeight,
+    centerMeasured,
+    centerHeight,
+    reservedHeight,
+    base,
+    pf.count,
+    pf.tapped,
+    pf.stackedExtra,
+    pb.count,
+    pb.tapped,
+    pb.stackedExtra,
+    of.count,
+    of.tapped,
+    of.stackedExtra,
+    ob.count,
+    ob.tapped,
+    ob.stackedExtra,
+  ])
+}

--- a/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
+++ b/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
@@ -34,58 +34,59 @@ function useObservedSize(ref: RefObject<HTMLElement | null>, enabled: boolean): 
  * Two-player battlefield sizing, solved for both players at once.
  *
  * The board grid gives the two battlefields rows 2 and 4; this hook measures
- * the height those rows have *together* (the container minus the hand
- * reservation rows and the center HUD) and both players' row stats, and asks
- * `solvePooledLayout` for one card width plus the slot height each side needs.
- * GameBoard turns the heights into the grid's row weights and hands the layout
- * to both `Battlefield`s through `PooledBattlefieldLayoutContext`.
+ * the height those rows have *together* — read straight off the two row
+ * elements, whose sum is fixed by the viewport, the HUD and the hand
+ * reservations however the pair is split — plus both players' row stats, and
+ * asks `solvePooledLayout` for one card width and the slot height each side
+ * needs. GameBoard turns the heights into the grid's row weights and hands the
+ * layout to both `Battlefield`s through `PooledBattlefieldLayoutContext`.
  *
- * No feedback loop: every measured input is independent of the layout it
- * produces — the container is viewport-sized, the center HUD's `auto` height
- * depends only on its own content, and the slot width comes from the fixed
- * command-zone and zone-pile columns, never from the cards.
+ * Measured from the rows rather than derived (container − HUD − reservations)
+ * on purpose: the reservations come from the window-derived responsive sizes,
+ * which update synchronously on `resize`, while element measurements arrive a
+ * frame later through ResizeObserver — mixing the two solved one frame with
+ * the new reservation against the old container height, oversizing the cards.
+ * Reading the rows keeps every input in one DOM state.
+ *
+ * No feedback loop: the rows' *sum* does not depend on the weights this hook
+ * produces, and the slot width comes from the fixed command-zone and zone-pile
+ * columns, never from the cards.
  *
  * Returns null while disabled (multiplayer, where strip cells size themselves)
  * or before the first measurement, in which case each battlefield falls back
- * to its own per-slot solve.
+ * to its own per-slot solve. `Battlefield` additionally clamps the pooled width
+ * to what its own measured slot fits, so a stale frame can never overflow.
  */
 export function usePooledBattlefieldLayout({
   enabled,
-  containerRef,
-  centerRef,
+  opponentRowRef,
+  playerRowRef,
   slotRef,
-  reservedHeight,
   player,
   opponent,
   base,
 }: {
   enabled: boolean
-  /** The board grid container (rows 1–5). */
-  containerRef: RefObject<HTMLElement | null>
-  /** The center HUD row (grid row 3, `auto`). */
-  centerRef: RefObject<HTMLElement | null>
+  /** Grid row 2 — the opponent board area. */
+  opponentRowRef: RefObject<HTMLElement | null>
+  /** Grid row 4 — the player board area. */
+  playerRowRef: RefObject<HTMLElement | null>
   /** One battlefield's slot — both slots share a width in the two-player grid. */
   slotRef: RefObject<HTMLElement | null>
-  /** Sum of the hand reservation rows (1 and 5). */
-  reservedHeight: number
   player: BoardStats
   opponent: BoardStats
   base: ResponsiveSizes
 }): PooledLayout | null {
-  const container = useObservedSize(containerRef, enabled)
-  const center = useObservedSize(centerRef, enabled)
+  const opponentRow = useObservedSize(opponentRowRef, enabled)
+  const playerRow = useObservedSize(playerRowRef, enabled)
   const slot = useObservedSize(slotRef, enabled)
 
-  const containerHeight = container?.height ?? 0
-  const centerHeight = center?.height ?? 0
+  const pooledHeight = (opponentRow?.height ?? 0) + (playerRow?.height ?? 0)
   const slotWidth = slot?.width ?? 0
-  const centerMeasured = center !== null
   const { front: pf, back: pb } = player
   const { front: of, back: ob } = opponent
   return useMemo(() => {
-    if (!enabled || slotWidth <= 0 || containerHeight <= 0 || !centerMeasured) return null
-    const pooledHeight = containerHeight - centerHeight - reservedHeight
-    if (pooledHeight <= 0) return null
+    if (!enabled || slotWidth <= 0 || pooledHeight <= 0) return null
     return solvePooledLayout(slotWidth, pooledHeight, { front: pf, back: pb }, { front: of, back: ob }, layoutEnvFor(base))
     // Keyed on the stats' numbers so an unrelated store update that rebuilds
     // equal stats doesn't produce a fresh layout identity (which would re-render
@@ -93,10 +94,7 @@ export function usePooledBattlefieldLayout({
   }, [
     enabled,
     slotWidth,
-    containerHeight,
-    centerMeasured,
-    centerHeight,
-    reservedHeight,
+    pooledHeight,
     base,
     pf.count,
     pf.tapped,

--- a/web-client/src/components/game/card/CardStack.tsx
+++ b/web-client/src/components/game/card/CardStack.tsx
@@ -2,6 +2,7 @@ import { memo, useState } from 'react'
 import type { GroupedCard } from '@/store/selectors.ts'
 import { MAX_VISUAL_STACK_DEPTH } from '@/store/selectors.ts'
 import { useResponsiveContext } from '../board/shared'
+import { stackOffsetFor } from '../board/battlefieldLayout'
 import { GameCard } from './GameCard'
 
 /**
@@ -127,7 +128,7 @@ function CardStackImpl({
   }
 
   // Calculate stack offset (how much each card is offset from the previous)
-  const stackOffset = responsive.isMobile ? 12 : 18
+  const stackOffset = stackOffsetFor(responsive.isMobile)
 
   // Render at most MAX_VISUAL_STACK_DEPTH overlapping layers regardless of how
   // many identical members the group has — the count badge conveys the true size.

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -54,6 +54,7 @@ import {
   getCounterCount,
   PASSIVE_COUNTER_TYPES,
 } from '../board/shared'
+import { CARD_RESIZE_TRANSITION, prefersReducedMotion } from '../board/battlefieldLayout'
 import { styles, bandColorFor, passiveCounterBadgeStyle, UNTAP_FROST_RIM, UNTAP_FROST_FILL } from '../board/styles'
 import {
   TARGET_COLOR, TARGET_COLOR_BRIGHT, TARGET_GLOW, TARGET_GLOW_BRIGHT, TARGET_GLOW_OUTER, TARGET_SHADOW,
@@ -1315,6 +1316,10 @@ function GameCardImpl({
         ...styles.card,
         width,
         height,
+        // Battlefield cards resize as the board fills up or empties out (see
+        // battlefieldLayout.ts); ease the size change so a card entering play
+        // reads as the board settling rather than everything jumping.
+        ...(battlefield && !prefersReducedMotion() ? { transition: CARD_RESIZE_TRANSITION } : {}),
         borderRadius: responsive.isMobile ? 4 : 8,
         cursor,
         border: isBeheldPulsing ? '3px solid #eab308' : borderStyle,
@@ -3043,7 +3048,7 @@ function GameCardImpl({
         display: 'flex',
         alignItems: 'flex-end',
         justifyContent: 'center',
-        transition: 'width 0.15s, height 0.15s',
+        ...(prefersReducedMotion() ? {} : { transition: 'width 0.18s ease, height 0.18s ease' }),
         pointerEvents: 'none',
         position: 'relative',
       }}>


### PR DESCRIPTION
## Summary

Battlefield card size now follows the number of cards on the board instead of a fixed two-line height budget. **Card positions are unchanged** — creatures by the HUD, lands at the outer edge, opponent mirrored — only the size and the wrap lines per row move.

Why the width was going unused: on a desktop two-player window the *height* cap binds for any board up to ~10 stacks per row, and that budget was spent on constants — an empty row still cost a full card height, the divider margins and the gap toward the HUD were sized from the 125 px desktop base card rather than the card actually rendered, and grid rows 2/4 were always equal. So a 3-permanent board rendered the same ~66 px cards as a 38-permanent one.

Design (with a live calculator): `docs/plans/battlefield-sparse-layout.md`.

### What changed

1. **Pure solver** — `board/battlefieldLayout.ts` (`solveSlotLayout`, `solvePooledLayout`) with every geometry constant in one place (card aspect, floor/ceiling, divider strip, tapped footprint, stack peek). `useSlotSizedResponsive` is now measure + call. `battlefieldLayout.test.ts` pins the reference numbers.
2. **An empty row costs nothing** — turn-1/2/3 boards render at up to the 200 px ceiling.
3. **Overheads scale with the rendered card** — divider margin `max(6, 0.1h)`, HUD gap `clamp(0.15h, 12, 48)`, row padding per *present* row.
4. **Pooled two-player solve** — `usePooledBattlefieldLayout` measures the height rows 2 and 4 have together and solves both battlefields at once: one shared card width, each side the slot height its rows need, split clamped to [0.35, 0.65] so the HUD stays near the middle. Heights become the grid rows' `fr` weights; `Battlefield` reads its side from `PooledBattlefieldLayoutContext`. Multiplayer strip cells keep sizing themselves per cell. No feedback loop: every measured input (viewport, HUD `auto` height, fixed zone-pile / command-zone columns) is independent of the layout it produces.
5. **`BACK_ROW_SCALE`** knob (lands smaller than creatures), shipped at `1` — a taste decision to take from a screenshot walk.
6. Battlefield card boxes ease size changes (0.18 s, off under `prefers-reduced-motion`). Arrow overlays already poll rects every 100 ms and drag-drop resolves with `elementFromPoint`, so both follow.

Reference 1200×290 slot (the 1546×795 window below): lands-only **66 → 168 px**, both rows populated **66 → 76 px**, lands-only vs 6+6 pooled **66 → 101 px**, a wrapping 24-creature board **46 → 61 px**.

### Screenshots (1600×1000 window; images on the throwaway `battlefield-sparse-layout-screenshots` branch)

| | Before | After |
|---|---|---|
| Sparse (3 vs 2) | ![before sparse](https://raw.githubusercontent.com/wingedsheep/argentum-engine/battlefield-sparse-layout-screenshots/before-sparse.jpg) | ![after sparse](https://raw.githubusercontent.com/wingedsheep/argentum-engine/battlefield-sparse-layout-screenshots/after-sparse.jpg) |
| Crowded (22 vs 16, attachments) | ![before crowded](https://raw.githubusercontent.com/wingedsheep/argentum-engine/battlefield-sparse-layout-screenshots/before-crowded.jpg) | ![after crowded](https://raw.githubusercontent.com/wingedsheep/argentum-engine/battlefield-sparse-layout-screenshots/after-crowded.jpg) |
| Lopsided (13 vs 1) | — | ![after lopsided](https://raw.githubusercontent.com/wingedsheep/argentum-engine/battlefield-sparse-layout-screenshots/after-lopsided.jpg) |

The lopsided shot shows the 0.35 clamp: the opponent's lone land keeps 35 % of the pooled height, the HUD sits at ~36 % of the screen, and both sides render at the same width.

### Verification

- `npm run typecheck` clean; `npx vitest run` — 53 files, 763 tests (12 new in `battlefieldLayout.test.ts`).
- Screenshot walk of the sparse / crowded / lopsided dev scenarios above on the worktree's dev client against the running game server.
- Not exercised: the 390×844 phone viewport and a combat with targeting arrows mid-transition — the solver's phone floor case is unit-tested, and the arrow overlays' polling path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLdV1HQjEuDGK7LytsmCmF
