### PR TITLE
Cap battlefield card growth at the base card size; stop the center HUD shaking

### DIFF
--- a/docs/plans/battlefield-sparse-layout.md
+++ b/docs/plans/battlefield-sparse-layout.md
@@ -54,8 +54,14 @@ step 4 is optional; step 5 is CSS. All numbers below are for the reference 1200�
 - Both players render at the same card width (`styles.ts:27-28`). Step 3 keeps this by solving one
   width for both slots.
 - No stored mode, no hysteresis: a card entering can change the size, and step 5 animates it.
-- `SLOT_MAX_CARD_WIDTH = 200` stays; badges, attachment peeks and stack offsets already scale from
+- The ceiling is the window-derived base card (`useResponsive`'s `battlefieldCardWidth`, 125 px on
+  desktop), passed as `LayoutEnv.maxCardWidth`: a sparse board reclaims the ordinary card size and
+  never grows past it. (The first cut shipped with the raw `SLOT_MAX_CARD_WIDTH = 200`, which let a
+  lone permanent fill the board.) Badges, attachment peeks and stack offsets already scale from
   `battlefieldCardWidth`.
+- Slot and grid-row measurements are quantized to whole pixels and ignored when unchanged. The rows
+  are `fr` tracks weighted by the solve's own output, so fractional ResizeObserver readings fed
+  straight back made weights → rows → measurement → weights oscillate — the center HUD shook.
 
 ### Step 1 — an empty row costs nothing
 

--- a/web-client/src/components/game/board/battlefieldLayout.test.ts
+++ b/web-client/src/components/game/board/battlefieldLayout.test.ts
@@ -66,6 +66,17 @@ describe('solveSlotLayout', () => {
     expect(phone.frontLines).toBe(4)
   })
 
+  it('a LayoutEnv ceiling caps growth: a lone permanent renders at the base card, not the slot max', () => {
+    // The app passes useResponsive's battlefieldCardWidth (125 px on desktop) as the ceiling.
+    const env: LayoutEnv = { ...DESKTOP, maxCardWidth: 125 }
+    expect(solveSlotLayout(1600, 900, board(EMPTY_ROW, row(1)), env).cardWidth).toBe(125)
+    expect(solveSlotLayout(SLOT_W, SLOT_H, board(EMPTY_ROW, row(1)), env).cardWidth).toBe(125)
+    const pooled = solvePooledLayout(SLOT_W, 2 * SLOT_H, board(EMPTY_ROW, row(1)), board(EMPTY_ROW, row(1)), env)
+    expect(pooled.cardWidth).toBe(125)
+    // The ceiling only binds when the slot would allow more.
+    expect(solveSlotLayout(SLOT_W, SLOT_H, board(row(1), row(2)), env).cardWidth).toBe(76)
+  })
+
   it('trades the breathing gap for size before dropping under the readability floor', () => {
     // 12 stacks per row on a short slot: comfortable pass lands under 60, tight pass recovers it.
     const layout = solveSlotLayout(1200, 236, board(row(12), row(12)), DESKTOP)

--- a/web-client/src/components/game/board/battlefieldLayout.ts
+++ b/web-client/src/components/game/board/battlefieldLayout.ts
@@ -19,10 +19,11 @@
 export const CARD_ASPECT = 1.4
 
 /**
- * Hard ceiling on slot-derived card growth. The window-derived `useResponsive`
- * caps the base battlefield card at 125 px (desktop); with the explicit-track
- * grid a slot is often far taller than that estimate, so cards may grow to
- * ~1.6× before clamping.
+ * Absolute ceiling on slot-derived card growth, used when a `LayoutEnv` names
+ * no `maxCardWidth`. In the app the ceiling is the window-derived base card
+ * (`useResponsive`'s `battlefieldCardWidth`, 125 px on desktop — see
+ * `layoutEnvFor`): a sparse board reclaims the size the base card would have
+ * had, never more. Growing past it made a lone permanent fill the board.
  */
 export const SLOT_MAX_CARD_WIDTH = 200
 
@@ -112,7 +113,17 @@ export interface LayoutEnv {
   stackOffset: number
   /** Back-row size relative to the front row; defaults to `BACK_ROW_SCALE`. */
   backRowScale?: number
+  /**
+   * Largest card the solver may render; defaults to `SLOT_MAX_CARD_WIDTH`.
+   * The app passes the window-derived base card so a sparse board grows back
+   * up to the ordinary card size and no further.
+   */
+  maxCardWidth?: number
 }
+
+/** The ceiling this environment allows (see `LayoutEnv.maxCardWidth`). */
+export const maxCardWidthFor = (env: LayoutEnv): number =>
+  Math.max(ABSOLUTE_MIN_CARD_WIDTH, env.maxCardWidth ?? SLOT_MAX_CARD_WIDTH)
 
 export interface SlotLayout {
   /** Front-row card width; the size `ResponsiveContext` carries as `battlefieldCardWidth`. */
@@ -345,7 +356,7 @@ function floorLayout(slotWidth: number, stats: BoardStats, env: LayoutEnv): Slot
  * cells, and the two-player board before the pooled solve has measurements).
  *
  * Pass 1 keeps the comfortable breathing gap toward the HUD and lets cards grow
- * to `SLOT_MAX_CARD_WIDTH`. If that lands under `PREFERRED_MIN_CARD_WIDTH`, pass
+ * to the environment's ceiling (`maxCardWidthFor`). If that lands under `PREFERRED_MIN_CARD_WIDTH`, pass
  * 2 trades the breathing gap for size with the floor as the ceiling. If even
  * that can't fit, cards clamp to `ABSOLUTE_MIN_CARD_WIDTH` and the line counts
  * follow what greedy wrapping will actually do.
@@ -363,7 +374,7 @@ export function solveSlotLayout(slotWidth: number, slotHeight: number, stats: Bo
     }
     return best
   }
-  const comfortable = pass(false, SLOT_MAX_CARD_WIDTH)
+  const comfortable = pass(false, maxCardWidthFor(env))
   if (comfortable && comfortable.cardWidth >= PREFERRED_MIN_CARD_WIDTH) return comfortable
   const squeezed = pass(true, PREFERRED_MIN_CARD_WIDTH)
   if (squeezed) return squeezed
@@ -401,7 +412,7 @@ export function solvePooledLayout(
   ): { c: LineCandidate; need: number } | null => {
     let best: { c: LineCandidate; need: number } | null = null
     for (const c of candidates) {
-      if (widthCapFor(slotWidth, stats, c, env, SLOT_MAX_CARD_WIDTH) < w) continue
+      if (widthCapFor(slotWidth, stats, c, env, maxCardWidthFor(env)) < w) continue
       const need = slotHeightNeeded(stats, c.frontLines, c.backLines, w, env, tight)
       if (best === null || need < best.need) best = { c, need }
     }
@@ -420,7 +431,7 @@ export function solvePooledLayout(
     return splitHeights(w, makeLayout(w, a.c, player, env), a.need, makeLayout(w, b.c, opponent, env), b.need, pooledHeight)
   }
 
-  const comfortable = pass(false, SLOT_MAX_CARD_WIDTH)
+  const comfortable = pass(false, maxCardWidthFor(env))
   if (comfortable && comfortable.cardWidth >= PREFERRED_MIN_CARD_WIDTH) return comfortable
   const squeezed = pass(true, PREFERRED_MIN_CARD_WIDTH)
   if (squeezed) return squeezed

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -37,7 +37,14 @@ export const PooledBattlefieldLayoutContext = createContext<PooledLayout | null>
 
 /** The solver inputs that come from the responsive base (gap and stack peek). */
 export function layoutEnvFor(base: ResponsiveSizes): LayoutEnv {
-  return { cardGap: base.cardGap, stackOffset: stackOffsetFor(base.isMobile), backRowScale: BACK_ROW_SCALE }
+  return {
+    cardGap: base.cardGap,
+    stackOffset: stackOffsetFor(base.isMobile),
+    backRowScale: BACK_ROW_SCALE,
+    // A sparse board grows cards back up to the ordinary window-derived size,
+    // never past it — one permanent should not fill the board.
+    maxCardWidth: base.battlefieldCardWidth,
+  }
 }
 
 /**
@@ -131,11 +138,19 @@ export function useSlotSizedResponsive(
   useLayoutEffect(() => {
     const node = slotRef.current
     if (!node) return
+    // Whole pixels, and no state change for a same-size report: fractional
+    // ResizeObserver readings would otherwise re-solve (and re-render) on every
+    // sub-pixel wobble of the grid rows.
+    const update = (width: number, height: number) =>
+      setSlotSize((prev) => {
+        const next = { width: Math.round(width), height: Math.round(height) }
+        return prev !== null && prev.width === next.width && prev.height === next.height ? prev : next
+      })
     const rect = node.getBoundingClientRect()
-    setSlotSize({ width: rect.width, height: rect.height })
+    update(rect.width, rect.height)
     const obs = new ResizeObserver((entries) => {
       const entry = entries[0]
-      if (entry) setSlotSize({ width: entry.contentRect.width, height: entry.contentRect.height })
+      if (entry) update(entry.contentRect.width, entry.contentRect.height)
     })
     obs.observe(node)
     return () => obs.disconnect()

--- a/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
+++ b/web-client/src/components/game/board/usePooledBattlefieldLayout.ts
@@ -18,11 +18,22 @@ function useObservedSize(ref: RefObject<HTMLElement | null>, enabled: boolean): 
     }
     const node = ref.current
     if (!node) return
+    // Whole pixels, and no state change for a same-size report. The grid rows
+    // are fr tracks weighted by this hook's own output, so their measured
+    // heights come back fractional and slightly different every time the
+    // weights change; feeding those fractions straight back into the solve made
+    // weights → rows → measurement → weights oscillate, and the center HUD
+    // between the rows visibly shook. Integer sizes make the loop settle.
+    const update = (width: number, height: number) =>
+      setSize((prev) => {
+        const next = { width: Math.round(width), height: Math.round(height) }
+        return prev !== null && prev.width === next.width && prev.height === next.height ? prev : next
+      })
     const rect = node.getBoundingClientRect()
-    setSize({ width: rect.width, height: rect.height })
+    update(rect.width, rect.height)
     const obs = new ResizeObserver((entries) => {
       const entry = entries[0]
-      if (entry) setSize({ width: entry.contentRect.width, height: entry.contentRect.height })
+      if (entry) update(entry.contentRect.width, entry.contentRect.height)
     })
     obs.observe(node)
     return () => obs.disconnect()


### PR DESCRIPTION
## Summary
- **Cards no longer grow past the ordinary card size.** The sparse-board sizing (c2e84400f8) capped growth at `SLOT_MAX_CARD_WIDTH = 200`, so a single permanent rendered ~1.6× the desktop card. The solver ceiling is now `LayoutEnv.maxCardWidth`; `layoutEnvFor` passes `useResponsive`'s window-derived `battlefieldCardWidth` (125 px desktop). A sparse board reclaims the base size and stops there — matching the attached reference screenshot.
- **Center HUD no longer vibrates.** Grid rows 2/4 are `fr` tracks weighted by the pooled solve, and the solve read those rows' heights back through ResizeObserver. Fractional readings differed slightly after every re-weight, so weights → rows → measurement → weights oscillated. Slot and row measurements are now rounded to whole pixels and same-size reports don't touch state, so the loop settles.
- Design doc updated (`docs/plans/battlefield-sparse-layout.md`); new vitest pinning the ceiling.

## Verification
- `npx vitest run src/components/game/board/battlefieldLayout.test.ts` — 13/13 pass
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)