### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CloudgoatRanger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CloudgoatRanger.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cloudgoat Ranger
+ * {3}{W}{W}
+ * Creature — Giant Warrior Ranger
+ * 3/3
+ * When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.
+ * Tap three untapped Kithkin you control: This creature gets +2/+0 and gains flying until end of turn.
+ *
+ * The pump's cost is [Costs.TapPermanents], not `{T}`: "untapped" and "you control" are carried by
+ * the atom, and because it isn't the tap symbol, summoning-sick Kithkin (the freshly made tokens
+ * included) can pay it (CR 302.6).
+ */
+val CloudgoatRanger = card("Cloudgoat Ranger") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant Warrior Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.\n" +
+        "Tap three untapped Kithkin you control: This creature gets +2/+0 and gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Kithkin", "Soldier"),
+            count = 3,
+            imageUri = "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839",
+        )
+        description = "create three 1/1 white Kithkin Soldier creature tokens."
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 3,
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.KITHKIN)
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+        description = "Tap three untapped Kithkin you control: This creature gets +2/+0 and gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg?1783942916"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GuardianOfCloverdell.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GuardianOfCloverdell.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Guardian of Cloverdell
+ * {5}{G}{G}
+ * Creature — Treefolk Shaman
+ * 4/5
+ * When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.
+ * {G}, Sacrifice a Kithkin: You gain 1 life.
+ */
+val GuardianOfCloverdell = card("Guardian of Cloverdell") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Shaman"
+    power = 4
+    toughness = 5
+    oracleText = "When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.\n" +
+        "{G}, Sacrifice a Kithkin: You gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Kithkin", "Soldier"),
+            count = 3,
+            imageUri = "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839",
+        )
+        description = "create three 1/1 white Kithkin Soldier creature tokens."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.KITHKIN))
+        )
+        effect = Effects.GainLife(1)
+        description = "{G}, Sacrifice a Kithkin: You gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Jesper Ejsing"
+        flavorText = "Although they're protective of all creatures, many treefolk are especially fond of the empathic kithkin."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg?1783942863"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HearthcageGiant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HearthcageGiant.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Hearthcage Giant
+ * {6}{R}{R}
+ * Creature — Giant Warrior
+ * 5/5
+ * When this creature enters, create two 3/1 red Elemental Shaman creature tokens.
+ * Sacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn.
+ *
+ * Hearthcage Giant is itself a Giant, so it is a legal target for its own pump.
+ */
+val HearthcageGiant = card("Hearthcage Giant") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 5
+    toughness = 5
+    oracleText = "When this creature enters, create two 3/1 red Elemental Shaman creature tokens.\n" +
+        "Sacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Elemental", "Shaman"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg?1783942839",
+        )
+        description = "create two 3/1 red Elemental Shaman creature tokens."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.ELEMENTAL))
+        val giant = target(
+            "target Giant creature",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.GIANT))
+        )
+        effect = Effects.ModifyStats(3, 1, giant)
+        description = "Sacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "The flamekin are mere kindling for his warmth."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg?1783942874"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SoaringHope.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SoaringHope.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Soaring Hope
+ * {4}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, you gain 3 life.
+ * Enchanted creature has flying.
+ * {W}: Put this Aura on top of its owner's library.
+ */
+val SoaringHope = card("Soaring Hope") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, you gain 3 life.\n" +
+        "Enchanted creature has flying.\n{W}: Put this Aura on top of its owner's library."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+        description = "you gain 3 life."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = Effects.PutOnTopOfLibrary(EffectTarget.Self)
+        description = "{W}: Put this Aura on top of its owner's library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Martina Pilcerova"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg?1783942908"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WydwenTheBitingGale.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WydwenTheBitingGale.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wydwen, the Biting Gale
+ * {2}{U}{B}
+ * Legendary Creature — Faerie Wizard
+ * 3/3
+ * Flash
+ * Flying
+ * {U}{B}, Pay 1 life: Return Wydwen to its owner's hand.
+ */
+val WydwenTheBitingGale = card("Wydwen, the Biting Gale") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Faerie Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\nFlying\n{U}{B}, Pay 1 life: Return Wydwen to its owner's hand."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{B}"), Costs.PayLife(1))
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+        description = "{U}{B}, Pay 1 life: Return Wydwen to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "253"
+        artist = "Matt Cavotta"
+        flavorText = "In a world of bright, cloudless skies, she is the dark storm on the horizon."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg?1783942852"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CloudgoatRangerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CloudgoatRangerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cloudgoat Ranger reprint in KHC. Canonical CardDefinition lives in Lorwyn.
+ */
+val CloudgoatRangerReprint = Printing(
+    oracleId = "e1c13a19-46cd-474b-a46b-a483be6b91bb",
+    name = "Cloudgoat Ranger",
+    setCode = "KHC",
+    collectorNumber = "21",
+    scryfallId = "6dfaa74a-0ef0-44bb-b8b5-6d121278b5a2",
+    artist = "Adam Rex",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6dfaa74a-0ef0-44bb-b8b5-6d121278b5a2.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -572,6 +572,92 @@
     ]
 }
 
+// Cloudgoat Ranger
+{
+    "name": "Cloudgoat Ranger",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Giant Warrior Ranger",
+    "oracleText": "When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.\nTap three untapped Kithkin you control: This creature gets +2/+0 and gains flying until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Kithkin",
+                        "Soldier"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839"
+                },
+                "descriptionOverride": "create three 1/1 white Kithkin Soldier creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "permanent Kithkin"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Tap three untapped Kithkin you control: This creature gets +2/+0 and gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e344859-7248-4498-8303-252f196a007b.jpg?1783942916"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cloudthresher
 {
     "name": "Cloudthresher",
@@ -2483,6 +2569,177 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Guardian of Cloverdell
+{
+    "name": "Guardian of Cloverdell",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Treefolk Shaman",
+    "oracleText": "When this creature enters, create three 1/1 white Kithkin Soldier creature tokens.\n{G}, Sacrifice a Kithkin: You gain 1 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Kithkin",
+                        "Soldier"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839"
+                },
+                "descriptionOverride": "create three 1/1 white Kithkin Soldier creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Kithkin"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{G}, Sacrifice a Kithkin: You gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Although they're protective of all creatures, many treefolk are especially fond of the empathic kithkin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/311c5f1d-7e3b-4397-b05b-f20bde2dc164.jpg?1783942863"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hearthcage Giant
+{
+    "name": "Hearthcage Giant",
+    "manaCost": "{6}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "When this creature enters, create two 3/1 red Elemental Shaman creature tokens.\nSacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Elemental",
+                        "Shaman"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/2/a280aee2-e15a-4625-b429-4032eae08a41.jpg?1783942839"
+                },
+                "descriptionOverride": "create two 3/1 red Elemental Shaman creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Elemental"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Giant creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Giant"
+                        },
+                        "id": "target Giant creature"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice an Elemental: Target Giant creature gets +3/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "The flamekin are mere kindling for his warmth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg?1783942874"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -4959,6 +5216,72 @@
     ]
 }
 
+// Soaring Hope
+{
+    "name": "Soaring Hope",
+    "manaCost": "{4}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, you gain 3 life.\nEnchanted creature has flying.\n{W}: Put this Aura on top of its owner's library.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "you gain 3 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Library",
+                    "placement": "Top"
+                },
+                "descriptionOverride": "{W}: Put this Aura on top of its owner's library."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Martina Pilcerova",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f6c24b1-af9d-4a9c-9167-faa8a397a361.jpg?1783942908"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Spiderwig Boggart
 {
     "name": "Spiderwig Boggart",
@@ -5850,6 +6173,65 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Wydwen, the Biting Gale
+{
+    "name": "Wydwen, the Biting Gale",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Legendary Creature — Faerie Wizard",
+    "oracleText": "Flash\nFlying\n{U}{B}, Pay 1 life: Return Wydwen to its owner's hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "descriptionOverride": "{U}{B}, Pay 1 life: Return Wydwen to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "flavorText": "In a world of bright, cloudless skies, she is the dark storm on the horizon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff6b558b-74a5-497d-8be4-474c375d7ca7.jpg?1783942852"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, all Assay-ready (read whole by \`just assay parse\`) and built from existing primitives — no new SDK vocabulary.

- **Cloudgoat Ranger** — ETB three 1/1 Kithkin Soldier tokens (\`Effects.CreateToken\`); "tap three untapped Kithkin you control" pump via \`Costs.TapPermanents\` + \`Composite(ModifyStats, GrantKeyword(FLYING))\`. Canonical in LRW; \`Printing\` row added for the Kaldheim Commander (KHC) reprint.
- **Guardian of Cloverdell** — ETB three Kithkin Soldier tokens; \`{G}, Sacrifice a Kithkin: gain 1 life\` via \`Costs.Composite(Mana, Sacrifice(Permanent.withSubtype(KITHKIN)))\` + \`Effects.GainLife\`.
- **Hearthcage Giant** — ETB two 3/1 Elemental Shaman tokens; \`Sacrifice an Elemental: target Giant creature gets +3/+1\` via \`Costs.Sacrifice\` + \`TargetCreature(withSubtype(GIANT))\` + \`Effects.ModifyStats\`.
- **Soaring Hope** — Aura: ETB \`GainLife(3)\`, static \`GrantKeyword(FLYING)\`, \`{W}: Effects.PutOnTopOfLibrary(Self)\`.
- **Wydwen, the Biting Gale** — Flash, Flying; \`{U}{B}, Pay 1 life: Effects.ReturnToHand(Self)\` via \`Costs.Composite(Mana, PayLife(1))\`.

Token art taken from the TLRW token printings. Nothing dropped from the batch.

## Verification
- \`just build\` green; \`CardDefinitionSnapshotTest\` re-blessed — only the five new LRW cards moved in the golden.
- \`just check-card-printing\` ok for all five.
- \`just assay-differential --set LRW\`: all five confirmed; the set's 13 DIVERGENT rows are pre-existing (Harbingers, Boggart Birth Rite, etc.), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)