### PR TITLE
Add three Innistrad: Crimson Vow cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 248 / 273
+**Implemented:** 251 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -88,7 +88,7 @@
 - [x] Edgar's Awakening
 - [x] Edgar, Charmed Groom
 - [x] End the Festivities
-- [ ] Eruth, Tormented Prophet
+- [x] Eruth, Tormented Prophet
 - [x] Estwald Shieldbasher
 - [x] Evolving Wilds
 - [ ] Faithbound Judge
@@ -141,7 +141,7 @@
 - [x] Investigator's Journal
 - [x] Island
 - [ ] Jacob Hauken, Inspector
-- [ ] Katilda, Dawnhart Martyr
+- [x] Katilda, Dawnhart Martyr
 - [ ] Kaya, Geist Hunter
 - [x] Kessig Flamebreather
 - [x] Kessig Wolfrider
@@ -162,7 +162,7 @@
 - [x] Massive Might
 - [x] Militia Rallier
 - [x] Mindleech Ghoul
-- [ ] Mirrorhall Mimic
+- [x] Mirrorhall Mimic
 - [x] Mischievous Catgeist
 - [x] Moldgraf Millipede
 - [x] Mountain

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EruthTormentedProphet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EruthTormentedProphet.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
+
+/**
+ * Eruth, Tormented Prophet (Innistrad: Crimson Vow #237)
+ * {1}{U}{R} · Legendary Creature — Human Wizard 2/4
+ *
+ * If you would draw a card, exile the top two cards of your library instead. You may play those
+ * cards this turn.
+ *
+ * Implementation: [ReplaceDrawWithEffect] (the Laboratory Maniac shape, applying to every draw)
+ * whose replacement is the impulse-draw composition [Patterns.Exile.impulse] at count 2 — exile
+ * the top two, then a may-play-from-exile grant on those cards that expires at end of turn. Each
+ * replaced draw is its own impulse, so "draw two" exiles four. An empty library exiles nothing and
+ * the draw was still replaced, so it can't be lost to (the card's own ruling).
+ */
+val EruthTormentedProphet = card("Eruth, Tormented Prophet") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 2
+    toughness = 4
+    oracleText = "If you would draw a card, exile the top two cards of your library instead. You may " +
+        "play those cards this turn."
+
+    replacementEffect(
+        ReplaceDrawWithEffect(
+            replacementEffect = Patterns.Exile.impulse(2),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "Ekaterina Burmak"
+        flavorText = "She is cursed with visions of monsters and suffering . . . and all her visions come true."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg?1783924793"
+        ruling(
+            "2021-11-19",
+            "You may choose to apply Eruth's replacement effect even if there are fewer than two cards " +
+                "in your library. If there are no cards in your library, you won't exile any cards this " +
+                "way, but you also won't lose the game for having attempted to draw from an empty library."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KatildaDawnhartMartyr.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KatildaDawnhartMartyr.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Katilda, Dawnhart Martyr // Katilda's Rising Dawn (Innistrad: Crimson Vow #21)
+ * {1}{W}{W} · Legendary Creature — Spirit Warlock * / * // Legendary Enchantment — Aura
+ *
+ * Front — Katilda, Dawnhart Martyr
+ *   Flying, lifelink, protection from Vampires
+ *   Katilda's power and toughness are each equal to the number of permanents you control that are
+ *   Spirits and/or enchantments.
+ *   Disturb {3}{W}{W}
+ *
+ * Back — Katilda's Rising Dawn (Legendary Enchantment — Aura, white color indicator)
+ *   Enchant creature
+ *   Enchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X
+ *   is the number of permanents you control that are Spirits and/or enchantments.
+ *   If Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: a disturb card (CR 702.146) in the shape of [TwinbladeGeist]. The front's
+ * star/star is a [SetBasePowerToughnessDynamicStatic] CDA over the same count the back's
+ * [GrantDynamicStatsEffect] adds as a Layer 7c bonus — one shared [spiritsAndEnchantmentsYouControl]
+ * amount, a homogeneous `or` of two filters so "Spirits and/or enchantments" counts an enchantment
+ * creature Spirit once. The front's protection is the intrinsic
+ * [KeywordAbility.protectionFromSubtype]; the Aura grants the same quality as the projected
+ * `PROTECTION_FROM_SUBTYPE_VAMPIRE` keyword string, which is the form every engine read site
+ * (targeting, blocking, combat damage) already checks for.
+ */
+
+/** The number of permanents you control that are Spirits and/or enchantments. */
+private val spiritsAndEnchantmentsYouControl: DynamicAmount = DynamicAmount.AggregateBattlefield(
+    Player.You,
+    GameObjectFilter.Permanent.withSubtype(Subtype.SPIRIT) or GameObjectFilter.Enchantment,
+)
+
+private const val PROTECTION_FROM_VAMPIRES = "PROTECTION_FROM_SUBTYPE_VAMPIRE"
+
+private val KatildaDawnhartMartyrFront = card("Katilda, Dawnhart Martyr") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Spirit Warlock"
+    power = 0
+    toughness = 0
+    oracleText = "Flying, lifelink, protection from Vampires\n" +
+        "Katilda's power and toughness are each equal to the number of permanents you control that " +
+        "are Spirits and/or enchantments.\n" +
+        "Disturb {3}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.protectionFromSubtype("Vampire"))
+
+    staticAbility {
+        ability = SetBasePowerToughnessDynamicStatic(
+            power = spiritsAndEnchantmentsYouControl,
+            toughness = spiritsAndEnchantmentsYouControl,
+        )
+    }
+
+    disturb("{3}{W}{W}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Manuel Castañón"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1783924922"
+        ruling(
+            "2021-09-24",
+            "When you cast a spell using a card's disturb ability, the card is put onto the stack " +
+                "with its back face up. The resulting spell has all the characteristics of that face."
+        )
+        ruling(
+            "2021-09-24",
+            "The mana value of a spell cast using disturb is determined by the mana cost on the " +
+                "front face of the card, no matter what the total cost to cast the spell was."
+        )
+        ruling(
+            "2021-09-24",
+            "The back face of each card with disturb has an ability that instructs its controller " +
+                "to exile it if it would be put into a graveyard from anywhere. This includes going " +
+                "to the graveyard from the stack, so if the spell is countered after you cast it " +
+                "using the disturb ability, it will be put into exile."
+        )
+    }
+}
+
+private val KatildasRisingDawn = card("Katilda's Rising Dawn") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W"
+    typeLine = "Legendary Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, " +
+        "where X is the number of permanents you control that are Spirits and/or enchantments.\n" +
+        "If Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+    staticAbility {
+        ability = GrantKeyword(PROTECTION_FROM_VAMPIRES)
+    }
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = spiritsAndEnchantmentsYouControl,
+            toughnessBonus = spiritsAndEnchantmentsYouControl,
+        )
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Manuel Castañón"
+        imageUri = "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1783924922"
+    }
+}
+
+val KatildaDawnhartMartyr: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = KatildaDawnhartMartyrFront,
+    backFace = KatildasRisingDawn,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MirrorhallMimic.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MirrorhallMimic.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mirrorhall Mimic // Ghastly Mimicry (Innistrad: Crimson Vow #68)
+ * {3}{U} · Creature — Spirit 0/0 // Enchantment — Aura
+ *
+ * Front — Mirrorhall Mimic
+ *   You may have this creature enter as a copy of any creature on the battlefield, except it's a
+ *   Spirit in addition to its other types.
+ *   Disturb {3}{U}{U}
+ *
+ * Back — Ghastly Mimicry (Enchantment — Aura, blue color indicator)
+ *   Enchant creature
+ *   At the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's
+ *   a Spirit in addition to its other types.
+ *   If Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: a disturb card (CR 702.146) in the shape of [TwinbladeGeist]. The front is the
+ * Clone shape — [EntersAsCopy] with `additionalSubtypes = ["Spirit"]` as the copy exception
+ * (CR 707.9b), so declining leaves a printed 0/0 that dies to state-based actions. The back's upkeep
+ * trigger is [Effects.CreateTokenCopyOfTarget] aimed at [EffectTarget.EnchantedCreature] with the
+ * same Spirit exception on the token.
+ */
+private val MirrorhallMimicFront = card("Mirrorhall Mimic") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 0
+    toughness = 0
+    oracleText = "You may have this creature enter as a copy of any creature on the battlefield, " +
+        "except it's a Spirit in addition to its other types.\n" +
+        "Disturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            additionalSubtypes = listOf("Spirit"),
+        )
+    )
+
+    disturb("{3}{U}{U}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "68"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1783924898"
+        ruling(
+            "2021-11-19",
+            "Mirrorhall Mimic copies exactly what was printed on the original creature (unless that " +
+                "creature is copying something else or is a token), except that it's also a Spirit. It " +
+                "doesn't copy whether that creature is tapped or untapped, whether it has any counters " +
+                "on it or any Auras and Equipment attached to it, or any non-copy effects that have " +
+                "changed its power, toughness, types, color, or so on."
+        )
+        ruling(
+            "2021-11-19",
+            "If the chosen creature is copying something else (for example, if the chosen creature is " +
+                "another Mirrorhall Mimic), then Mirrorhall Mimic enters the battlefield as whatever the " +
+                "chosen creature copied."
+        )
+        ruling(
+            "2021-11-19",
+            "If another creature becomes a copy of Mirrorhall Mimic, that creature is also a Spirit."
+        )
+        ruling(
+            "2021-11-19",
+            "Any enters-the-battlefield abilities of the copied creature will trigger when Mirrorhall " +
+                "Mimic enters the battlefield. Any \"as [this creature] enters the battlefield\" or " +
+                "\"[this creature] enters the battlefield with\" abilities of the chosen creature will " +
+                "also work."
+        )
+        ruling(
+            "2021-11-19",
+            "If Mirrorhall Mimic somehow enters the battlefield at the same time as another creature, " +
+                "it can't become a copy of that creature. You may choose only a creature that's already " +
+                "on the battlefield."
+        )
+    }
+}
+
+private val GhastlyMimicry = card("Ghastly Mimicry") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "At the beginning of your upkeep, create a token that's a copy of enchanted creature, except " +
+        "it's a Spirit in addition to its other types.\n" +
+        "If Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = EffectTarget.EnchantedCreature,
+            addedSubtypes = setOf(Subtype.SPIRIT),
+        )
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "68"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1783924898"
+    }
+}
+
+val MirrorhallMimic: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = MirrorhallMimicFront,
+    backFace = GhastlyMimicry,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -6007,6 +6007,70 @@
     ]
 }
 
+// Eruth, Tormented Prophet
+{
+    "name": "Eruth, Tormented Prophet",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "ReplaceDrawWith",
+                "replacementEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "RARE",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "She is cursed with visions of monsters and suffering . . . and all her visions come true.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f764077-df2d-4ac7-b507-2c8e08386d49.jpg?1783924793",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "You may choose to apply Eruth's replacement effect even if there are fewer than two cards in your library. If there are no cards in your library, you won't exile any cards this way, but you also won't lose the game for having attempted to draw from an empty library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Estwald Shieldbasher
 {
     "name": "Estwald Shieldbasher",
@@ -9818,6 +9882,221 @@
     "colorIdentityOverride": []
 }
 
+// Katilda, Dawnhart Martyr
+{
+    "name": "Katilda, Dawnhart Martyr",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Legendary Creature — Spirit Warlock",
+    "oracleText": "Flying, lifelink, protection from Vampires\nKatilda's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.\nDisturb {3}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK",
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Subtype",
+                "subtype": "Vampire"
+            }
+        },
+        {
+            "type": "Disturb",
+            "cost": "{3}{W}{W}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "SetBasePowerToughnessDynamicStatic",
+                "power": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsPermanent",
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Spirit"
+                                            }
+                                        ]
+                                    },
+                                    "IsEnchantment"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "toughness": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsPermanent",
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Spirit"
+                                            }
+                                        ]
+                                    },
+                                    "IsEnchantment"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Katilda's Rising Dawn",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment — Aura",
+        "oracleText": "Enchant creature\nEnchanted creature has flying, lifelink, and protection from Vampires, and it gets +X/+X, where X is the number of permanents you control that are Spirits and/or enchantments.\nIf Katilda's Rising Dawn would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING"
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK"
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "PROTECTION_FROM_SUBTYPE_VAMPIRE"
+                },
+                {
+                    "type": "GrantDynamicStats",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "AttachedTo"
+                    },
+                    "powerBonus": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        {
+                                            "type": "And",
+                                            "predicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Spirit"
+                                                }
+                                            ]
+                                        },
+                                        "IsEnchantment"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "toughnessBonus": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        {
+                                            "type": "And",
+                                            "predicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Spirit"
+                                                }
+                                            ]
+                                        },
+                                        "IsEnchantment"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "21",
+            "rarity": "RARE",
+            "artist": "Manuel Castañón",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1783924922"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "RARE",
+        "artist": "Manuel Castañón",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0ef240aa-2a88-4ec4-888a-918466372adb.jpg?1783924922",
+        "rulings": [
+            {
+                "date": "2021-09-24",
+                "text": "When you cast a spell using a card's disturb ability, the card is put onto the stack with its back face up. The resulting spell has all the characteristics of that face."
+            },
+            {
+                "date": "2021-09-24",
+                "text": "The mana value of a spell cast using disturb is determined by the mana cost on the front face of the card, no matter what the total cost to cast the spell was."
+            },
+            {
+                "date": "2021-09-24",
+                "text": "The back face of each card with disturb has an ability that instructs its controller to exile it if it would be put into a graveyard from anywhere. This includes going to the graveyard from the stack, so if the spell is countered after you cast it using the disturb ability, it will be put into exile."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kessig Flamebreather
 {
     "name": "Kessig Flamebreather",
@@ -11193,6 +11472,123 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Mirrorhall Mimic
+{
+    "name": "Mirrorhall Mimic",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "You may have this creature enter as a copy of any creature on the battlefield, except it's a Spirit in addition to its other types.\nDisturb {3}{U}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{3}{U}{U}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "additionalSubtypes": [
+                    "Spirit"
+                ]
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Ghastly Mimicry",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature, except it's a Spirit in addition to its other types.\nIf Ghastly Mimicry would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "CreateTokenCopyOfTarget",
+                        "target": "EnchantedCreature",
+                        "addedSubtypes": [
+                            "Spirit"
+                        ]
+                    }
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "68",
+            "rarity": "RARE",
+            "artist": "Justine Cruz",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1783924898"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "RARE",
+        "artist": "Justine Cruz",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/823ad188-bd56-476d-9853-bed90bfad582.jpg?1783924898",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Mirrorhall Mimic copies exactly what was printed on the original creature (unless that creature is copying something else or is a token), except that it's also a Spirit. It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "If the chosen creature is copying something else (for example, if the chosen creature is another Mirrorhall Mimic), then Mirrorhall Mimic enters the battlefield as whatever the chosen creature copied."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "If another creature becomes a copy of Mirrorhall Mimic, that creature is also a Spirit."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "Any enters-the-battlefield abilities of the copied creature will trigger when Mirrorhall Mimic enters the battlefield. Any \"as [this creature] enters the battlefield\" or \"[this creature] enters the battlefield with\" abilities of the chosen creature will also work."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "If Mirrorhall Mimic somehow enters the battlefield at the same time as another creature, it can't become a copy of that creature. You may choose only a creature that's already on the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Three VOW cards built entirely from existing primitives (backlog 248 → 251 / 273).

- **Katilda, Dawnhart Martyr // Katilda's Rising Dawn** — disturb DFC. Front: flying, lifelink, `KeywordAbility.protectionFromSubtype("Vampire")`, and a `SetBasePowerToughnessDynamicStatic` CDA over `AggregateBattlefield(You, Permanent.withSubtype(Spirit) or Enchantment)`. Back Aura: `GrantKeyword` ×3 (flying, lifelink, the projected `PROTECTION_FROM_SUBTYPE_VAMPIRE` string every protection read site already checks) + `GrantDynamicStatsEffect` sharing the same amount, plus the disturb `RedirectZoneChange` exile clause.
- **Mirrorhall Mimic // Ghastly Mimicry** — disturb DFC. Front: `EntersAsCopy(optional, additionalSubtypes = ["Spirit"])`. Back Aura: `Triggers.YourUpkeep` → `Effects.CreateTokenCopyOfTarget(EnchantedCreature, addedSubtypes = {Spirit})`, plus the disturb exile clause.
- **Eruth, Tormented Prophet** — `ReplaceDrawWithEffect(Patterns.Exile.impulse(2))`: every draw becomes exile-top-two with a may-play-until-end-of-turn grant.

Considered and left out (each needs new engine vocabulary, so `add-feature` territory): Faithbound Judge (no judgment counter type), Brine Comber (`BecomesTargetEvent` has no spell-type filter for "Aura spell"), Cemetery Illuminator (`PlayFromTopOfLibrary` has no once-per-turn / shares-type gate), Creepy Puppeteer ("attacked with exactly one other creature" condition), Circle of Confinement (same-name-as-linked-exile cast trigger), Curse of Hospitality.

## Verification
- `just build` — green apart from the expected `CardDefinitionSnapshotTest` diff; `just rebless-cards` moved only the three new cards in `VOW.json`.
- `just check-card-printing` ok for all three (VOW is the earliest printing).
- `just assay-differential --set VOW` — 0 DIVERGENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)