### PR TITLE
Add two Innistrad: Crimson Vow cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 251 / 273
+**Implemented:** 253 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -50,7 +50,7 @@
 - [x] Change of Fortune
 - [x] Child of the Pack
 - [x] Chill of the Grave
-- [ ] Circle of Confinement
+- [x] Circle of Confinement
 - [x] Cloaked Cadet
 - [x] Cobbled Lancer
 - [x] Concealing Curtains
@@ -183,7 +183,7 @@
 - [x] Panicked Bystander
 - [x] Parasitic Grasp
 - [x] Parish-Blade Trainee
-- [ ] Patchwork Crawler
+- [x] Patchwork Crawler
 - [x] Path of Peril
 - [x] Persistent Specimen
 - [x] Piercing Light

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CircleOfConfinement.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CircleOfConfinement.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Circle of Confinement
+ * {1}{W}
+ * Enchantment
+ *
+ * When this enchantment enters, exile target creature an opponent controls with mana value 3 or
+ * less until this enchantment leaves the battlefield.
+ * Whenever an opponent casts a Vampire spell with the same name as a card exiled with this
+ * enchantment, you gain 2 life.
+ *
+ * The exile is linked (CR 610.3) — the Glass Casket shape: the leaves trigger returns only what
+ * this enchantment exiled. The life trigger reads that same linked pile through
+ * [EntityReference.LinkedExiledCard], so it fires only while the prisoner is still exiled; once the
+ * Circle leaves and the card returns, the reference resolves to nothing and no spell matches.
+ */
+val CircleOfConfinement = card("Circle of Confinement") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, exile target creature an opponent controls with " +
+        "mana value 3 or less until this enchantment leaves the battlefield.\n" +
+        "Whenever an opponent casts a Vampire spell with the same name as a card exiled with " +
+        "this enchantment, you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter.Creature.manaValueAtMost(3).opponentControls())
+        )
+        effect = Effects.ExileUntilLeaves(t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(
+            spellFilter = GameObjectFilter.Any
+                .withSubtype("Vampire")
+                .sharingNameWith(EntityReference.LinkedExiledCard()),
+        )
+        effect = Effects.GainLife(2)
+        description = "Whenever an opponent casts a Vampire spell with the same name as a card " +
+            "exiled with Circle of Confinement, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Lorenzo Mastroianni"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg?1783924926"
+        ruling(
+            "2021-11-19",
+            "If Circle of Confinement leaves the battlefield before its enters-the-battlefield " +
+                "ability resolves, the target creature won't be exiled."
+        )
+        ruling(
+            "2021-11-19",
+            "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PatchworkCrawler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PatchworkCrawler.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DonorCards
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Patchwork Crawler
+ * {1}{U}
+ * Creature — Zombie Horror
+ * 1/2
+ *
+ * {2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on this creature.
+ * This creature has all activated abilities of all creature cards exiled with it.
+ *
+ * The Territory Forge shape: the activated ability files each exiled card in this creature's
+ * linked-exile pile ([Effects.ExileLinkedToSource]), and [HasAllActivatedAbilitiesOfCards] over
+ * `LINKED_EXILE` surfaces every activated ability of that pile on the Crawler itself. Only creature
+ * cards can be exiled this way, so the pile never holds anything the static shouldn't read. Per the
+ * rulings the grant is activated abilities only, and it names the Crawler in place of the printed
+ * card — both are what the static already does.
+ */
+val PatchworkCrawler = card("Patchwork Crawler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Horror"
+    power = 1
+    toughness = 2
+    oracleText = "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter " +
+        "on this creature.\n" +
+        "This creature has all activated abilities of all creature cards exiled with it."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        val exiled = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Composite(
+            Effects.ExileLinkedToSource(exiled),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "Exile target creature card from your graveyard and put a +1/+1 counter " +
+            "on Patchwork Crawler."
+    }
+
+    staticAbility {
+        ability = HasAllActivatedAbilitiesOfCards(donors = DonorCards.LINKED_EXILE)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "72"
+        artist = "Fesbra"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg?1783924886"
+        ruling(
+            "2021-11-19",
+            "Patchwork Crawler gains only activated abilities. It doesn't gain triggered abilities " +
+                "or static abilities."
+        )
+        ruling(
+            "2021-11-19",
+            "If an activated ability of a card in exile references the card it's printed on by " +
+                "name, treat Patchwork Crawler's version of that ability as though it referenced " +
+                "Patchwork Crawler by name instead."
+        )
+        ruling(
+            "2021-11-19",
+            "Once Patchwork Crawler leaves the battlefield, it will no longer have the activated " +
+                "abilities of the creature cards exiled with it."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -3473,6 +3473,112 @@
     ]
 }
 
+// Circle of Confinement
+{
+    "name": "Circle of Confinement",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, exile target creature an opponent controls with mana value 3 or less until this enchantment leaves the battlefield.\nWhenever an opponent casts a Vampire spell with the same name as a card exiled with this enchantment, you gain 2 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Vampire"
+                            },
+                            {
+                                "type": "SharesNameWith",
+                                "entity": "LinkedExiledCard"
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent casts a Vampire spell with the same name as a card exiled with Circle of Confinement, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13031fb6-9d5a-4add-9a86-28b2a9373fd2.jpg?1783924926",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "If Circle of Confinement leaves the battlefield before its enters-the-battlefield ability resolves, the target creature won't be exiled."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cloaked Cadet
 {
     "name": "Cloaked Cadet",
@@ -12841,6 +12947,92 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Patchwork Crawler
+{
+    "name": "Patchwork Crawler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Zombie Horror",
+    "oracleText": "{2}{U}: Exile target creature card from your graveyard and put a +1/+1 counter on this creature.\nThis creature has all activated abilities of all creature cards exiled with it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "destination": "Exile",
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target creature card from your graveyard"
+                    }
+                ],
+                "descriptionOverride": "Exile target creature card from your graveyard and put a +1/+1 counter on Patchwork Crawler."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "HasAllActivatedAbilitiesOfCards",
+                "donors": "LinkedExile"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "RARE",
+        "artist": "Fesbra",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg?1783924886",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Patchwork Crawler gains only activated abilities. It doesn't gain triggered abilities or static abilities."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "If an activated ability of a card in exile references the card it's printed on by name, treat Patchwork Crawler's version of that ability as though it referenced Patchwork Crawler by name instead."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "Once Patchwork Crawler leaves the battlefield, it will no longer have the activated abilities of the creature cards exiled with it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Two VOW cards built entirely from existing primitives — the set's remaining backlog is its hard tail, so this batch is small on purpose.

- **Circle of Confinement** — Glass Casket's linked exile-until-leaves (`Effects.ExileUntilLeaves` + `ReturnLinkedExileUnderOwnersControl`) plus a `Triggers.opponentCasts` life trigger whose spell filter is `withSubtype("Vampire").sharingNameWith(EntityReference.LinkedExiledCard())`, so it only fires while the prisoner is still exiled.
- **Patchwork Crawler** — Territory Forge's shape: `{2}{U}` activated ability with `Effects.ExileLinkedToSource(target creature card in your graveyard)` + a +1/+1 counter on itself, and `HasAllActivatedAbilitiesOfCards(donors = LINKED_EXILE)` for the granted abilities.

Triaged and left out (each needs new engine vocabulary, so `add-feature` territory): Magma Pummeler (counter-removal prevention that removes *that many* and reflexively deals damage), Curse of Hospitality (no "attacking enchanted player" predicate / recipient filter), Cemetery Illuminator (cast-from-top filter is evaluated without the granting permanent's linked-exile context), Alluring Suitor and Creepy Puppeteer (exact-count attack triggers/conditions), plus the transform/DFC rares.

Verification: `just build` — only `CardDefinitionSnapshotTest` failed on the expected VOW golden diff; re-blessed with `just rebless-cards` and only the two new cards moved. `just check-card-printing` ok for both (VOW is the earliest real printing; DBL/promo have no scaffold). `just assay-differential --set VOW`: 0 DIVERGENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)