### PR TITLE
Add three Innistrad: Crimson Vow cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 253 / 273
+**Implemented:** 256 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -54,11 +54,11 @@
 - [x] Cloaked Cadet
 - [x] Cobbled Lancer
 - [x] Concealing Curtains
-- [ ] Consuming Tide
+- [x] Consuming Tide
 - [x] Courier Bat
 - [x] Cradle of Safety
 - [x] Crawling Infestation
-- [ ] Creepy Puppeteer
+- [x] Creepy Puppeteer
 - [x] Cruel Witness
 - [x] Crushing Canopy
 - [x] Cultivator Colossus
@@ -172,7 +172,7 @@
 - [x] Necroduality
 - [x] Nurturing Presence
 - [x] Oakshade Stalker
-- [ ] Odric, Blood-Cursed
+- [x] Odric, Blood-Cursed
 - [x] Old Rutstein
 - [x] Olivia's Attendants
 - [ ] Olivia, Crimson Bride

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ConsumingTide.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ConsumingTide.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Consuming Tide (Innistrad: Crimson Vow #53)
+ * {2}{U}{U} · Sorcery
+ *
+ * Each player chooses a nonland permanent they control. Return all nonland permanents not chosen
+ * this way to their owners' hands. Then you draw a card for each opponent who has more cards in
+ * their hand than you.
+ *
+ * Implementation: the Liliana, Dreadhorde General −9 shape with the fate swapped — gather every
+ * nonland permanent (the pool's controllers are the choosers, asked in APNAP order per the card's
+ * ruling), `chooseOnePerCategory` over the single category "nonland permanent", then bounce
+ * `exclude(pool, kept)`. A battlefield → hand move always routes to each card's *owner*, so
+ * "their owners' hands" needs no per-owner loop. The draw runs after the bounce, so hand sizes
+ * are read post-return, which is what "Then" means; the per-opponent count is the Wojek
+ * Investigator idiom ([DynamicAmount.CountPlayersWith] rebinding `Player.You` to the tested
+ * opponent, [Player.ControllerOfSource] falling back to the caster for a resolving spell).
+ */
+val ConsumingTide = card("Consuming Tide") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Each player chooses a nonland permanent they control. Return all nonland " +
+        "permanents not chosen this way to their owners' hands. Then you draw a card for each " +
+        "opponent who has more cards in their hand than you."
+
+    spell {
+        effect = Effects.Pipeline {
+            val pool = gather(Filters.NonlandPermanent)
+            val kept = chooseOnePerCategory(pool, listOf(Filters.NonlandPermanent))
+            toHand(exclude(pool, kept))
+            run(
+                Effects.DrawCards(
+                    DynamicAmount.CountPlayersWith(
+                        scope = Player.EachOpponent,
+                        condition = Conditions.CompareAmounts(
+                            left = DynamicAmount.Count(Player.You, Zone.HAND),
+                            operator = ComparisonOperator.GT,
+                            right = DynamicAmount.Count(Player.ControllerOfSource, Zone.HAND),
+                        ),
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "53"
+        artist = "Viko Menezes"
+        flavorText = "\"Nephalia's tides obey an unforgiving moon.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg?1783924899"
+        ruling(
+            "2021-11-19",
+            "Starting with the player whose turn it is, each player chooses a nonland permanent they " +
+                "control. Players get to know what permanents have been chose by players that chose " +
+                "before them as they make their choice. Then all nonland permanents that weren't " +
+                "chosen by any player are returned to their owners' hands at the same time."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CreepyPuppeteer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CreepyPuppeteer.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Creepy Puppeteer (Innistrad: Crimson Vow #151)
+ * {3}{R} · Creature — Human Rogue 4/3
+ *
+ * Haste
+ * Whenever this creature attacks, if you attacked with exactly one other creature this combat, you
+ * may have that creature's base power and toughness become 4/3 until end of turn.
+ *
+ * Implementation: the intervening "if" is an exact count of *other* creatures you control that
+ * attacked this combat ([DynamicAmount.AggregateBattlefield] with `excludeSelf`, compared `EQ 1`
+ * — the Stensia Uprising idiom, since the `AtLeast` helpers can't say "exactly"). Once that
+ * holds, "that creature" *is* the one-member group "other creatures you control that attacked
+ * this combat", so the set-base-P/T is fanned out with [Effects.ForEachInGroup] over the same
+ * filter (a `GroupRef` on a stats effect is not expanded per-permanent — see Sanguine
+ * Evangelist). `optional = true` puts the "you may" outermost, so there is a single prompt and
+ * the intervening-if is re-checked on resolution (CR 603.4) before it is asked.
+ * [Effects.SetBasePowerAndToughness] is Layer 7b, so the creature's own counters and pumps still
+ * apply on top of the new 4/3 base.
+ */
+val CreepyPuppeteer = card("Creepy Puppeteer") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    power = 4
+    toughness = 3
+    oracleText = "Haste\n" +
+        "Whenever this creature attacks, if you attacked with exactly one other creature this " +
+        "combat, you may have that creature's base power and toughness become 4/3 until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        interveningIf = Conditions.CompareAmounts(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature.attackedThisCombat(),
+                excludeSelf = true,
+            ),
+            ComparisonOperator.EQ,
+            DynamicAmount.Fixed(1),
+        )
+        optional = true
+        effect = Effects.ForEachInGroup(
+            GroupFilter(
+                baseFilter = GameObjectFilter.Creature.youControl().attackedThisCombat(),
+                excludeSelf = true,
+            ),
+            Effects.SetBasePowerAndToughness(4, 3, EffectTarget.Self, Duration.EndOfTurn),
+        )
+        description = "Whenever this creature attacks, if you attacked with exactly one other " +
+            "creature this combat, you may have that creature's base power and toughness become " +
+            "4/3 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Marie Magny"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg?1783924838"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OdricBloodCursed.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OdricBloodCursed.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Odric, Blood-Cursed (Innistrad: Crimson Vow #243)
+ * {1}{R}{W} · Legendary Creature — Vampire Soldier 3/3
+ *
+ * When Odric enters, create X Blood tokens, where X is the number of abilities from among flying,
+ * first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace,
+ * reach, trample, and vigilance found among creatures you control. (Count each ability only once.)
+ *
+ * Implementation: the printed list is a fixed twelve keywords, so X is the sum of twelve 0/1
+ * terms — `1 if you control a creature with K, otherwise 0` — folded with [DynamicAmount.Add] and
+ * fed to the dynamic [Effects.CreateBlood] overload, so all X tokens are created by one effect at
+ * resolution (not one at a time). "Count each ability only once" falls out of the shape: each
+ * keyword contributes at most one, however many creatures carry it. The keyword filter reads
+ * projected state, so granted keywords count, and Odric itself is on the battlefield when the
+ * trigger resolves, so keywords it has been given count too (it has none of its own).
+ */
+private val COUNTED_KEYWORDS = listOf(
+    Keyword.FLYING,
+    Keyword.FIRST_STRIKE,
+    Keyword.DOUBLE_STRIKE,
+    Keyword.DEATHTOUCH,
+    Keyword.HASTE,
+    Keyword.HEXPROOF,
+    Keyword.INDESTRUCTIBLE,
+    Keyword.LIFELINK,
+    Keyword.MENACE,
+    Keyword.REACH,
+    Keyword.TRAMPLE,
+    Keyword.VIGILANCE,
+)
+
+val OdricBloodCursed = card("Odric, Blood-Cursed") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Vampire Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "When Odric enters, create X Blood tokens, where X is the number of abilities from " +
+        "among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, " +
+        "lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count " +
+        "each ability only once.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateBlood(
+            COUNTED_KEYWORDS
+                .map<Keyword, DynamicAmount> { keyword ->
+                    DynamicAmount.Conditional(
+                        condition = Conditions.ControlCreatureWithKeyword(keyword),
+                        ifTrue = DynamicAmount.Fixed(1),
+                        ifFalse = DynamicAmount.Fixed(0),
+                    )
+                }
+                .reduce { acc, term -> DynamicAmount.Add(acc, term) }
+        )
+        description = "When Odric enters, create X Blood tokens, where X is the number of abilities " +
+            "from among flying, first strike, double strike, deathtouch, haste, hexproof, " +
+            "indestructible, lifelink, menace, reach, trample, and vigilance found among creatures " +
+            "you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "243"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg?1783924793"
+        ruling(
+            "2021-11-19",
+            "Odric, Blood-Cursed counts the number of the listed abilities found, not the number of " +
+                "creatures with those abilities. If you control a single creature with both reach and " +
+                "vigilance as Odric enters the battlefield, you create two Blood tokens. On the other " +
+                "hand, if you control two creatures that each have flying, you create a single Blood token."
+        )
+        ruling(
+            "2021-11-19",
+            "Variants of an ability are counted as that ability and are not counted multiple times. " +
+                "For example, if you control a creature with hexproof from blue and another creature " +
+                "with hexproof from black, you create a single Blood token."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumingTideScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumingTideScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Consuming Tide (VOW #53) — {2}{U}{U} Sorcery.
+ *
+ *   Each player chooses a nonland permanent they control. Return all nonland permanents not chosen
+ *   this way to their owners' hands. Then you draw a card for each opponent who has more cards in
+ *   their hand than you.
+ *
+ * Both players hold two nonland permanents; the active player picks first (APNAP), each keeps one,
+ * and the other two go back to their owners' hands. The draw is counted *after* the bounce.
+ */
+class ConsumingTideScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Consuming Tide") {
+
+            test("each player keeps one, the rest bounce to their owners, then you draw per richer opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Consuming Tide")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardOnBattlefield(2, "Wind Drake")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val angel = game.findPermanent("Serra Angel")!!
+
+                game.castSpell(1, "Consuming Tide").error shouldBe null
+                game.resolveStack()
+
+                withClue("the caster (active player) chooses first") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+                withClue("then the opponent chooses") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(angel)).error shouldBe null
+                game.resolveStack()
+
+                withClue("kept permanents stay") {
+                    game.findPermanent("Grizzly Bears") shouldBe bears
+                    game.findPermanent("Serra Angel") shouldBe angel
+                }
+                withClue("the rest return to their owners' hands") {
+                    game.findPermanent("Hill Giant") shouldBe null
+                    game.findPermanent("Wind Drake") shouldBe null
+                    game.findCardsInHand(1, "Hill Giant").size shouldBe 1
+                    game.findCardsInHand(2, "Wind Drake").size shouldBe 1
+                }
+                withClue("lands are untouched") {
+                    game.findPermanents("Island").size shouldBe 4
+                }
+                // Post-bounce hands: P1 = Hill Giant (1); P2 = Grizzly Bears + Wind Drake (2).
+                // One opponent with more cards than you → draw one → P1 hand = 2.
+                withClue("you draw one card for the single richer opponent") {
+                    game.handSize(2) shouldBe 2
+                    game.handSize(1) shouldBe 2
+                }
+            }
+
+            test("no opponent with a bigger hand — no draw") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Consuming Tide")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Consuming Tide").error shouldBe null
+                game.resolveStack()
+                withClue("a single candidate per player auto-resolves without a prompt") {
+                    game.hasPendingDecision() shouldBe false
+                }
+
+                game.findPermanents("Grizzly Bears").size shouldBe 1
+                game.findPermanents("Serra Angel").size shouldBe 1
+                withClue("hands are 0 vs 0 — nothing drawn") {
+                    game.handSize(1) shouldBe 0
+                    game.handSize(2) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepyPuppeteerScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepyPuppeteerScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Creepy Puppeteer (VOW #151) — {3}{R} Creature — Human Rogue 4/3, haste.
+ *
+ *   Whenever this creature attacks, if you attacked with exactly one other creature this combat,
+ *   you may have that creature's base power and toughness become 4/3 until end of turn.
+ *
+ * The "exactly one" boundary is the whole card: zero other attackers and two other attackers both
+ * leave the intervening "if" false, so nothing is asked and nothing changes. With one other
+ * attacker, accepting the "may" rewrites that creature's base P/T; declining leaves it alone.
+ */
+class CreepyPuppeteerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Creepy Puppeteer") {
+
+            test("exactly one other attacker — accepting the may makes it 4/3") {
+                val game = puppeteerGame().build()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.declareAttackers(mapOf("Creepy Puppeteer" to 2, "Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the trigger's 'you may' should be pending") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(bears) shouldBe 4
+                game.state.projectedState.getToughness(bears) shouldBe 3
+            }
+
+            test("declining the may leaves the other attacker unchanged") {
+                val game = puppeteerGame().build()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.declareAttackers(mapOf("Creepy Puppeteer" to 2, "Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getToughness(bears) shouldBe 2
+            }
+
+            test("attacking alone — the intervening if fails, nothing is asked") {
+                val game = puppeteerGame().build()
+
+                game.declareAttackers(mapOf("Creepy Puppeteer" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+            }
+
+            test("two other attackers — the intervening if fails, nothing changes") {
+                val game = puppeteerGame()
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .build()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.declareAttackers(
+                    mapOf("Creepy Puppeteer" to 2, "Grizzly Bears" to 2, "Hill Giant" to 2)
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getToughness(bears) shouldBe 2
+            }
+        }
+    }
+
+    private fun puppeteerGame(): ScenarioBuilder = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardOnBattlefield(1, "Creepy Puppeteer", summoningSickness = false)
+        .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+        .withActivePlayer(1)
+        .withTurnNumber(3)
+        .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OdricBloodCursedScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OdricBloodCursedScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Odric, Blood-Cursed (VOW #243) — {1}{R}{W} Legendary Creature — Vampire Soldier 3/3.
+ *
+ *   When Odric enters, create X Blood tokens, where X is the number of abilities from among
+ *   flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink,
+ *   menace, reach, trample, and vigilance found among creatures you control. (Count each ability
+ *   only once.)
+ *
+ * The ruling is the whole test: abilities are counted, not creatures. Two fliers make one Blood;
+ * one creature with two listed keywords makes two.
+ */
+class OdricBloodCursedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Odric, Blood-Cursed") {
+
+            test("no keyworded creatures — no Blood tokens") {
+                val game = odricGame().build()
+                game.castSpell(1, "Odric, Blood-Cursed").error shouldBe null
+                game.resolveStack()
+
+                withClue("Odric has none of the listed abilities itself") {
+                    game.findPermanents("Blood").size shouldBe 0
+                }
+            }
+
+            test("each listed ability counts once, however many creatures carry it") {
+                // Serra Angel: flying + vigilance. Wind Drake: flying (already counted).
+                val game = odricGame()
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .build()
+                game.castSpell(1, "Odric, Blood-Cursed").error shouldBe null
+                game.resolveStack()
+
+                withClue("flying + vigilance = 2, the second flier adds nothing") {
+                    game.findPermanents("Blood").size shouldBe 2
+                }
+            }
+
+            test("opponents' creatures are not counted") {
+                val game = odricGame()
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .build()
+                game.castSpell(1, "Odric, Blood-Cursed").error shouldBe null
+                game.resolveStack()
+
+                game.findPermanents("Blood").size shouldBe 0
+            }
+        }
+    }
+
+    private fun odricGame(): ScenarioBuilder = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Odric, Blood-Cursed")
+        .withLandsOnBattlefield(1, "Mountain", 2)
+        .withLandsOnBattlefield(1, "Plains", 1)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -3861,6 +3861,96 @@
     ]
 }
 
+// Consuming Tide
+{
+    "name": "Consuming Tide",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player chooses a nonland permanent they control. Return all nonland permanents not chosen this way to their owners' hands. Then you draw a card for each opponent who has more cards in their hand than you.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "nonland permanent"
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "ChooseOnePerCategory",
+                    "from": "gathered0",
+                    "categories": [
+                        {
+                            "cardPredicates": [
+                                "IsNonland",
+                                "IsPermanent"
+                            ]
+                        }
+                    ],
+                    "storeAs": "kept1"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "gathered0",
+                    "filter": {
+                        "type": "ExcludeOtherCollection",
+                        "otherCollectionName": "kept1"
+                    },
+                    "storeMatching": "matching2"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "matching2",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "CountPlayersWith",
+                        "scope": "EachOpponent",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Hand"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "Count",
+                                "player": "ControllerOfSource",
+                                "zone": "Hand"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "RARE",
+        "artist": "Viko Menezes",
+        "flavorText": "\"Nephalia's tides obey an unforgiving moon.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg?1783924899",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Starting with the player whose turn it is, each player chooses a nonland permanent they control. Players get to know what permanents have been chose by players that chose before them as they make their choice. Then all nonland permanents that weren't chosen by any player are returned to their owners' hands at the same time."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Courier Bat
 {
     "name": "Courier Bat",
@@ -4058,6 +4148,96 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Creepy Puppeteer
+{
+    "name": "Creepy Puppeteer",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Haste\nWhenever this creature attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        "AttackedThisCombat"
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
+                                },
+                                "excludeSelf": true
+                            }
+                        },
+                        "body": {
+                            "type": "SetBaseStats",
+                            "target": "Self",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "duration": "EndOfTurn"
+                        }
+                    },
+                    "descriptionOverride": "Whenever this creature attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn."
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "AttackedThisCombat"
+                            ]
+                        },
+                        "excludeSelf": true
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, if you attacked with exactly one other creature this combat, you may have that creature's base power and toughness become 4/3 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Marie Magny",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg?1783924838"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -12162,6 +12342,291 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Odric, Blood-Cursed
+{
+    "name": "Odric, Blood-Cursed",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Legendary Creature — Vampire Soldier",
+    "oracleText": "When Odric enters, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control. (Count each ability only once.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood",
+                    "dynamicCount": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Add",
+                            "left": {
+                                "type": "Add",
+                                "left": {
+                                    "type": "Add",
+                                    "left": {
+                                        "type": "Add",
+                                        "left": {
+                                            "type": "Add",
+                                            "left": {
+                                                "type": "Add",
+                                                "left": {
+                                                    "type": "Add",
+                                                    "left": {
+                                                        "type": "Add",
+                                                        "left": {
+                                                            "type": "Add",
+                                                            "left": {
+                                                                "type": "Add",
+                                                                "left": {
+                                                                    "type": "Conditional",
+                                                                    "condition": {
+                                                                        "type": "Exists",
+                                                                        "player": "You",
+                                                                        "zone": "Battlefield",
+                                                                        "filter": "creature kw:flying"
+                                                                    },
+                                                                    "ifTrue": {
+                                                                        "type": "Fixed",
+                                                                        "amount": 1
+                                                                    },
+                                                                    "ifFalse": {
+                                                                        "type": "Fixed",
+                                                                        "amount": 0
+                                                                    }
+                                                                },
+                                                                "right": {
+                                                                    "type": "Conditional",
+                                                                    "condition": {
+                                                                        "type": "Exists",
+                                                                        "player": "You",
+                                                                        "zone": "Battlefield",
+                                                                        "filter": "creature kw:first_strike"
+                                                                    },
+                                                                    "ifTrue": {
+                                                                        "type": "Fixed",
+                                                                        "amount": 1
+                                                                    },
+                                                                    "ifFalse": {
+                                                                        "type": "Fixed",
+                                                                        "amount": 0
+                                                                    }
+                                                                }
+                                                            },
+                                                            "right": {
+                                                                "type": "Conditional",
+                                                                "condition": {
+                                                                    "type": "Exists",
+                                                                    "player": "You",
+                                                                    "zone": "Battlefield",
+                                                                    "filter": "creature kw:double_strike"
+                                                                },
+                                                                "ifTrue": {
+                                                                    "type": "Fixed",
+                                                                    "amount": 1
+                                                                },
+                                                                "ifFalse": {
+                                                                    "type": "Fixed",
+                                                                    "amount": 0
+                                                                }
+                                                            }
+                                                        },
+                                                        "right": {
+                                                            "type": "Conditional",
+                                                            "condition": {
+                                                                "type": "Exists",
+                                                                "player": "You",
+                                                                "zone": "Battlefield",
+                                                                "filter": "creature kw:deathtouch"
+                                                            },
+                                                            "ifTrue": {
+                                                                "type": "Fixed",
+                                                                "amount": 1
+                                                            },
+                                                            "ifFalse": {
+                                                                "type": "Fixed",
+                                                                "amount": 0
+                                                            }
+                                                        }
+                                                    },
+                                                    "right": {
+                                                        "type": "Conditional",
+                                                        "condition": {
+                                                            "type": "Exists",
+                                                            "player": "You",
+                                                            "zone": "Battlefield",
+                                                            "filter": "creature kw:haste"
+                                                        },
+                                                        "ifTrue": {
+                                                            "type": "Fixed",
+                                                            "amount": 1
+                                                        },
+                                                        "ifFalse": {
+                                                            "type": "Fixed",
+                                                            "amount": 0
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "type": "Conditional",
+                                                    "condition": {
+                                                        "type": "Exists",
+                                                        "player": "You",
+                                                        "zone": "Battlefield",
+                                                        "filter": "creature kw:hexproof"
+                                                    },
+                                                    "ifTrue": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    },
+                                                    "ifFalse": {
+                                                        "type": "Fixed",
+                                                        "amount": 0
+                                                    }
+                                                }
+                                            },
+                                            "right": {
+                                                "type": "Conditional",
+                                                "condition": {
+                                                    "type": "Exists",
+                                                    "player": "You",
+                                                    "zone": "Battlefield",
+                                                    "filter": "creature kw:indestructible"
+                                                },
+                                                "ifTrue": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                },
+                                                "ifFalse": {
+                                                    "type": "Fixed",
+                                                    "amount": 0
+                                                }
+                                            }
+                                        },
+                                        "right": {
+                                            "type": "Conditional",
+                                            "condition": {
+                                                "type": "Exists",
+                                                "player": "You",
+                                                "zone": "Battlefield",
+                                                "filter": "creature kw:lifelink"
+                                            },
+                                            "ifTrue": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            },
+                                            "ifFalse": {
+                                                "type": "Fixed",
+                                                "amount": 0
+                                            }
+                                        }
+                                    },
+                                    "right": {
+                                        "type": "Conditional",
+                                        "condition": {
+                                            "type": "Exists",
+                                            "player": "You",
+                                            "zone": "Battlefield",
+                                            "filter": "creature kw:menace"
+                                        },
+                                        "ifTrue": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "ifFalse": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        }
+                                    }
+                                },
+                                "right": {
+                                    "type": "Conditional",
+                                    "condition": {
+                                        "type": "Exists",
+                                        "player": "You",
+                                        "zone": "Battlefield",
+                                        "filter": "creature kw:reach"
+                                    },
+                                    "ifTrue": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "ifFalse": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                }
+                            },
+                            "right": {
+                                "type": "Conditional",
+                                "condition": {
+                                    "type": "Exists",
+                                    "player": "You",
+                                    "zone": "Battlefield",
+                                    "filter": "creature kw:trample"
+                                },
+                                "ifTrue": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "ifFalse": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                }
+                            }
+                        },
+                        "right": {
+                            "type": "Conditional",
+                            "condition": {
+                                "type": "Exists",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": "creature kw:vigilance"
+                            },
+                            "ifTrue": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "ifFalse": {
+                                "type": "Fixed",
+                                "amount": 0
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "When Odric enters, create X Blood tokens, where X is the number of abilities from among flying, first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance found among creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "RARE",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81a79f5f-a65a-4b43-b58c-cdfa09cc7855.jpg?1783924793",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Odric, Blood-Cursed counts the number of the listed abilities found, not the number of creatures with those abilities. If you control a single creature with both reach and vigilance as Odric enters the battlefield, you create two Blood tokens. On the other hand, if you control two creatures that each have flying, you create a single Blood token."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "Variants of an ability are counted as that ability and are not counted multiple times. For example, if you control a creature with hexproof from blue and another creature with hexproof from black, you create a single Blood token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Three VOW cards built entirely from existing primitives, each with its own scenario test. Backlog 253 → 256/273.

- **Consuming Tide** — each player chooses a nonland permanent they control, the rest bounce to their owners' hands, then draw one per opponent with a bigger hand. The Liliana, Dreadhorde General −9 pipeline (`gather → chooseOnePerCategory → exclude → toHand`) with the Wojek Investigator `CountPlayersWith` hand comparison; the draw runs after the bounce so "Then" reads post-return hand sizes.
- **Odric, Blood-Cursed** — ETB creates X Blood where X is the number of distinct listed keywords among your creatures: twelve `DynamicAmount.Conditional(ControlCreatureWithKeyword)` 0/1 terms folded with `Add` into one dynamic `Effects.CreateBlood`, so each ability counts once and all tokens are created by one effect.
- **Creepy Puppeteer** — attack trigger with an exact-count intervening if (`AggregateBattlefield(Creature.attackedThisCombat(), excludeSelf) EQ 1`), then an optional `ForEachInGroup` `SetBasePowerAndToughness(4, 3)` over that one-member group (Layer 7b, so counters/pumps still apply on top).

**Dropped from the batch:** Cemetery Desecrator — its "Remove X counters from target permanent, where X is the mana value of the exiled card" needs a `DynamicAmount`-typed `RemoveAnyNumberOfCountersEffect` (every counter-removal effect is `Int`-typed today). That's new vocabulary → its own PR.

## Verification
- `just test-class` for all three scenario tests (9/9 pass)
- `just build` green; `just rebless-cards` moved only `VOW.json` (additions only)
- `just assay-differential --set VOW` → 0 DIVERGENT
- `just check-card-printing` ok for all three (VOW is the earliest real printing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)