### PR TITLE
Add the five Lorwyn vivid lands

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividCrag.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividCrag.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Vivid Crag
+ * Land
+ * This land enters tapped with two charge counters on it.
+ * {T}: Add {R}.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ *
+ * One of the five Lorwyn vivid lands. Two self-scoped replacement effects model the entry line —
+ * [EntersTapped] and [EntersWithCounters] apply to the same zone change — and the second mana
+ * ability spends a charge counter as part of its cost, so once both are gone only the
+ * mono-colored ability remains.
+ */
+val VividCrag = card("Vivid Crag") {
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "This land enters tapped with two charge counters on it.\n" +
+        "{T}: Add {R}.\n" +
+        "{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(Color.RED)
+        description = "{T}: Add {R}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE, 1))
+        manaAbility = true
+        effect = Effects.AddManaOfChoice()
+        description = "{T}, Remove a charge counter from this land: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "275"
+        artist = "Martina Pilcerova"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg?1783942847"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividCreek.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividCreek.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Vivid Creek
+ * Land
+ * This land enters tapped with two charge counters on it.
+ * {T}: Add {U}.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ *
+ * One of the five Lorwyn vivid lands. Two self-scoped replacement effects model the entry line —
+ * [EntersTapped] and [EntersWithCounters] apply to the same zone change — and the second mana
+ * ability spends a charge counter as part of its cost, so once both are gone only the
+ * mono-colored ability remains.
+ */
+val VividCreek = card("Vivid Creek") {
+    colorIdentity = "U"
+    typeLine = "Land"
+    oracleText = "This land enters tapped with two charge counters on it.\n" +
+        "{T}: Add {U}.\n" +
+        "{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(Color.BLUE)
+        description = "{T}: Add {U}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE, 1))
+        manaAbility = true
+        effect = Effects.AddManaOfChoice()
+        description = "{T}, Remove a charge counter from this land: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "276"
+        artist = "Fred Fields"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg?1783942846"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividGrove.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividGrove.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Vivid Grove
+ * Land
+ * This land enters tapped with two charge counters on it.
+ * {T}: Add {G}.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ *
+ * One of the five Lorwyn vivid lands. Two self-scoped replacement effects model the entry line —
+ * [EntersTapped] and [EntersWithCounters] apply to the same zone change — and the second mana
+ * ability spends a charge counter as part of its cost, so once both are gone only the
+ * mono-colored ability remains.
+ */
+val VividGrove = card("Vivid Grove") {
+    colorIdentity = "G"
+    typeLine = "Land"
+    oracleText = "This land enters tapped with two charge counters on it.\n" +
+        "{T}: Add {G}.\n" +
+        "{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(Color.GREEN)
+        description = "{T}: Add {G}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE, 1))
+        manaAbility = true
+        effect = Effects.AddManaOfChoice()
+        description = "{T}, Remove a charge counter from this land: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "277"
+        artist = "Howard Lyon"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg?1783942846"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividMarsh.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividMarsh.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Vivid Marsh
+ * Land
+ * This land enters tapped with two charge counters on it.
+ * {T}: Add {B}.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ *
+ * One of the five Lorwyn vivid lands. Two self-scoped replacement effects model the entry line —
+ * [EntersTapped] and [EntersWithCounters] apply to the same zone change — and the second mana
+ * ability spends a charge counter as part of its cost, so once both are gone only the
+ * mono-colored ability remains.
+ */
+val VividMarsh = card("Vivid Marsh") {
+    colorIdentity = "B"
+    typeLine = "Land"
+    oracleText = "This land enters tapped with two charge counters on it.\n" +
+        "{T}: Add {B}.\n" +
+        "{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(Color.BLACK)
+        description = "{T}: Add {B}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE, 1))
+        manaAbility = true
+        effect = Effects.AddManaOfChoice()
+        description = "{T}, Remove a charge counter from this land: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "278"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg?1783942846"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividMeadow.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/VividMeadow.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Vivid Meadow
+ * Land
+ * This land enters tapped with two charge counters on it.
+ * {T}: Add {W}.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ *
+ * One of the five Lorwyn vivid lands. Two self-scoped replacement effects model the entry line —
+ * [EntersTapped] and [EntersWithCounters] apply to the same zone change — and the second mana
+ * ability spends a charge counter as part of its cost, so once both are gone only the
+ * mono-colored ability remains.
+ */
+val VividMeadow = card("Vivid Meadow") {
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "This land enters tapped with two charge counters on it.\n" +
+        "{T}: Add {W}.\n" +
+        "{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(Color.WHITE)
+        description = "{T}: Add {W}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE, 1))
+        manaAbility = true
+        effect = Effects.AddManaOfChoice()
+        description = "{T}, Remove a charge counter from this land: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "279"
+        artist = "Rob Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg?1783942846"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VividCragScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VividCragScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Vivid Crag (LRW #275) — the vivid-land cycle.
+ *
+ * "This land enters tapped with two charge counters on it." is two self-scoped replacement effects
+ * on one zone change; the other four vivid lands are the same script with a different colour, so
+ * this file stands for the cycle. The counter-fed mana ability is the interesting half: its cost
+ * eats a charge counter, so after two activations only the mono-coloured ability remains.
+ */
+class VividCragScenarioTest : ScenarioTestBase() {
+
+    private val cragDef = cardRegistry.getCard("Vivid Crag")!!
+    private val redAbilityId = cragDef.activatedAbilities[0].id
+    private val anyColorAbilityId = cragDef.activatedAbilities[1].id
+
+    private fun charge(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) ?: 0
+
+    private fun pool(game: TestGame): ManaPoolComponent =
+        game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    init {
+        context("Vivid Crag") {
+
+            test("enters tapped with two charge counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Vivid Crag")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val inHand = game.findCardsInHand(1, "Vivid Crag").single()
+                game.execute(PlayLand(game.player1Id, inHand)).error shouldBe null
+
+                val crag = game.findPermanent("Vivid Crag")
+                crag shouldNotBe null
+                withClue("enters tapped") {
+                    (game.state.getEntity(crag!!)?.get<TappedComponent>() != null).shouldBeTrue()
+                }
+                withClue("with two charge counters — the land, not just creatures, takes the self entry") {
+                    charge(game, crag!!) shouldBe 2
+                }
+            }
+
+            test("the charge-counter ability adds a colour of choice and spends one counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vivid Crag")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crag = game.findPermanent("Vivid Crag")!!
+                game.state = game.state.updateEntity(crag) { c ->
+                    c.with((c.get<CountersComponent>() ?: CountersComponent()).withAdded(CounterType.CHARGE, 2))
+                }
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, crag, anyColorAbilityId, manaColorChoice = Color.GREEN)
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+
+                pool(game).green shouldBe 1
+                charge(game, crag) shouldBe 1
+                (game.state.getEntity(crag)?.get<TappedComponent>() != null).shouldBeTrue()
+            }
+
+            test("with no charge counters only the red ability is affordable") {
+                // The mana-ability enumerator flags rather than drops an unpayable ability; the flag
+                // is what the client greys out. Before the RemoveCounters gate it read affordable
+                // and the activation only failed at payment time.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vivid Crag")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crag = game.findPermanent("Vivid Crag")!!
+                val offered = game.getLegalActions(1)
+                    .filter { (it.action as? ActivateAbility)?.sourceId == crag }
+                    .associate { (it.action as ActivateAbility).abilityId to it.isAffordable }
+                withClue("offered abilities: $offered") {
+                    offered shouldBe mapOf(redAbilityId to true, anyColorAbilityId to false)
+                }
+
+                withClue("and the payment path agrees") {
+                    game.execute(
+                        ActivateAbility(game.player1Id, crag, anyColorAbilityId, manaColorChoice = Color.GREEN)
+                    ).error shouldNotBe null
+                }
+
+                game.execute(ActivateAbility(game.player1Id, crag, redAbilityId)).error shouldBe null
+                pool(game).red shouldBe 1
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividCragReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividCragReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Crag reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCragReprint = Printing(
+    oracleId = "d8e2efe0-33a4-4303-9e83-ac42ea5df8cb",
+    name = "Vivid Crag",
+    setCode = "C13",
+    collectorNumber = "333",
+    scryfallId = "d7ad5834-6ba3-4bdf-b394-33edc922dfda",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7ad5834-6ba3-4bdf-b394-33edc922dfda.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividCreekReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "C13",
+    collectorNumber = "334",
+    scryfallId = "724eedf6-94e1-474b-9ecf-10013bd8353c",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/724eedf6-94e1-474b-9ecf-10013bd8353c.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "C13",
+    collectorNumber = "335",
+    scryfallId = "d5ffbf08-d9b4-4087-83ea-f50ac3385065",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5ffbf08-d9b4-4087-83ea-f50ac3385065.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividMarshReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VividMarshReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Marsh reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMarshReprint = Printing(
+    oracleId = "20b32052-f66f-4eb8-b56e-00d531907f19",
+    name = "Vivid Marsh",
+    setCode = "C13",
+    collectorNumber = "336",
+    scryfallId = "e38203e9-acb8-4fa9-84f2-1a0560152503",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e38203e9-acb8-4fa9-84f2-1a0560152503.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividCragReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividCragReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Crag reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCragReprint = Printing(
+    oracleId = "d8e2efe0-33a4-4303-9e83-ac42ea5df8cb",
+    name = "Vivid Crag",
+    setCode = "C15",
+    collectorNumber = "316",
+    scryfallId = "ed2564b4-0fa2-49cc-b571-0a997fc73c56",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed2564b4-0fa2-49cc-b571-0a997fc73c56.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividCreekReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "C15",
+    collectorNumber = "317",
+    scryfallId = "05e8d46b-5c67-4829-b27d-d21526f1bc6a",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05e8d46b-5c67-4829-b27d-d21526f1bc6a.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "C15",
+    collectorNumber = "318",
+    scryfallId = "c88b7bbf-a6e0-4f40-8b07-dd1b54aadc27",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c88b7bbf-a6e0-4f40-8b07-dd1b54aadc27.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividMarshReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividMarshReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Marsh reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMarshReprint = Printing(
+    oracleId = "20b32052-f66f-4eb8-b56e-00d531907f19",
+    name = "Vivid Marsh",
+    setCode = "C15",
+    collectorNumber = "319",
+    scryfallId = "93be6165-5f95-49cd-890c-9c2dd4ec7e0a",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93be6165-5f95-49cd-890c-9c2dd4ec7e0a.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividMeadowReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/VividMeadowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Meadow reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMeadowReprint = Printing(
+    oracleId = "dee99df5-628f-4a4e-a203-4dfddc927373",
+    name = "Vivid Meadow",
+    setCode = "C15",
+    collectorNumber = "320",
+    scryfallId = "976fa482-b854-4f60-92f8-6e18064e852e",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/976fa482-b854-4f60-92f8-6e18064e852e.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividCragReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividCragReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Crag reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCragReprint = Printing(
+    oracleId = "d8e2efe0-33a4-4303-9e83-ac42ea5df8cb",
+    name = "Vivid Crag",
+    setCode = "CMD",
+    collectorNumber = "293",
+    scryfallId = "1451d84d-87ee-4c4b-ae2d-80636d7fd0e2",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/1451d84d-87ee-4c4b-ae2d-80636d7fd0e2.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividCreekReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "CMD",
+    collectorNumber = "294",
+    scryfallId = "b0021f1f-17d6-4732-863b-60c9c2a3366d",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0021f1f-17d6-4732-863b-60c9c2a3366d.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "CMD",
+    collectorNumber = "295",
+    scryfallId = "58b4e602-f41f-4653-84b8-354f47704da5",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58b4e602-f41f-4653-84b8-354f47704da5.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividMarshReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividMarshReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Marsh reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMarshReprint = Printing(
+    oracleId = "20b32052-f66f-4eb8-b56e-00d531907f19",
+    name = "Vivid Marsh",
+    setCode = "CMD",
+    collectorNumber = "296",
+    scryfallId = "722fe7c4-1296-4ec0-b549-cd816c09ea12",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/722fe7c4-1296-4ec0-b549-cd816c09ea12.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividMeadowReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/VividMeadowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Meadow reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMeadowReprint = Printing(
+    oracleId = "dee99df5-628f-4a4e-a203-4dfddc927373",
+    name = "Vivid Meadow",
+    setCode = "CMD",
+    collectorNumber = "297",
+    scryfallId = "59eddb1d-a8aa-4eaa-a3f1-14bd2cecadd9",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/59eddb1d-a8aa-4eaa-a3f1-14bd2cecadd9.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/VividCreekReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "PC2",
+    collectorNumber = "131",
+    scryfallId = "4904340d-27f8-4ba1-b4aa-2471e0788b22",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/4904340d-27f8-4ba1-b4aa-2471e0788b22.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividCragReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividCragReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Crag reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCragReprint = Printing(
+    oracleId = "d8e2efe0-33a4-4303-9e83-ac42ea5df8cb",
+    name = "Vivid Crag",
+    setCode = "C17",
+    collectorNumber = "289",
+    scryfallId = "71a2c58e-eb1f-4a8b-b040-419c9d5ccf65",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71a2c58e-eb1f-4a8b-b040-419c9d5ccf65.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividCreekReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "C17",
+    collectorNumber = "290",
+    scryfallId = "65887a2e-893e-429d-8831-bd6e60941300",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65887a2e-893e-429d-8831-bd6e60941300.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividGroveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "C17",
+    collectorNumber = "291",
+    scryfallId = "b9ec7aed-5d90-43f5-90e4-9c0541b54fa8",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9ec7aed-5d90-43f5-90e4-9c0541b54fa8.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividMarshReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividMarshReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Marsh reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMarshReprint = Printing(
+    oracleId = "20b32052-f66f-4eb8-b56e-00d531907f19",
+    name = "Vivid Marsh",
+    setCode = "C17",
+    collectorNumber = "292",
+    scryfallId = "b71b3df3-e188-45bb-8dc8-53fd4d527735",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b71b3df3-e188-45bb-8dc8-53fd4d527735.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividMeadowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/VividMeadowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Meadow reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMeadowReprint = Printing(
+    oracleId = "dee99df5-628f-4a4e-a203-4dfddc927373",
+    name = "Vivid Meadow",
+    setCode = "C17",
+    collectorNumber = "293",
+    scryfallId = "d9dd64b1-12f8-49f6-b12e-f5a1b4f219dc",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d9dd64b1-12f8-49f6-b12e-f5a1b4f219dc.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VividCreekReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "CMR",
+    collectorNumber = "500",
+    scryfallId = "7fde8caf-975e-4d43-b994-27199e0557fa",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fde8caf-975e-4d43-b994-27199e0557fa.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VividGroveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "CMR",
+    collectorNumber = "501",
+    scryfallId = "7fdfbba9-c5f7-426b-8219-8661304ea588",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fdfbba9-c5f7-426b-8219-8661304ea588.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividCreekReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividCreekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Creek reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val VividCreekReprint = Printing(
+    oracleId = "2da7c49f-cc1e-45d9-9cbf-067e92b0daef",
+    name = "Vivid Creek",
+    setCode = "NCC",
+    collectorNumber = "444",
+    scryfallId = "c9082527-aa88-42f7-b2f2-de21878cb179",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9082527-aa88-42f7-b2f2-de21878cb179.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividGroveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Grove reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val VividGroveReprint = Printing(
+    oracleId = "b7a68899-c0d3-49e0-854b-19268ae9b89d",
+    name = "Vivid Grove",
+    setCode = "NCC",
+    collectorNumber = "445",
+    scryfallId = "12ccc686-bbaa-4c34-a7b8-a1e763fe0ad0",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12ccc686-bbaa-4c34-a7b8-a1e763fe0ad0.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividMeadowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/VividMeadowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivid Meadow reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val VividMeadowReprint = Printing(
+    oracleId = "dee99df5-628f-4a4e-a203-4dfddc927373",
+    name = "Vivid Meadow",
+    setCode = "NCC",
+    collectorNumber = "446",
+    scryfallId = "625a42b4-d88c-48e0-96b1-77388ca48810",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/625a42b4-d88c-48e0-96b1-77388ca48810.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -6202,6 +6202,331 @@
     ]
 }
 
+// Vivid Crag
+{
+    "name": "Vivid Crag",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped with two charge counters on it.\n{T}: Add {R}.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {R}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a charge counter from this land: Add one mana of any color."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "rarity": "UNCOMMON",
+        "artist": "Martina Pilcerova",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/539001dc-69f0-42c0-b5c3-37d7b12eb79e.jpg?1783942847"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Vivid Creek
+{
+    "name": "Vivid Creek",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped with two charge counters on it.\n{T}: Add {U}.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {U}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a charge counter from this land: Add one mana of any color."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "276",
+        "rarity": "UNCOMMON",
+        "artist": "Fred Fields",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e3c2935-84ee-446d-b247-2f574ea84a8f.jpg?1783942846"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vivid Grove
+{
+    "name": "Vivid Grove",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped with two charge counters on it.\n{T}: Add {G}.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {G}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a charge counter from this land: Add one mana of any color."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "277",
+        "rarity": "UNCOMMON",
+        "artist": "Howard Lyon",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6646babe-edd8-4367-ba8f-89af4f859dd8.jpg?1783942846"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vivid Marsh
+{
+    "name": "Vivid Marsh",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped with two charge counters on it.\n{T}: Add {B}.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {B}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a charge counter from this land: Add one mana of any color."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "278",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31f806c7-0063-4270-b37c-5363c41a7621.jpg?1783942846"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vivid Meadow
+{
+    "name": "Vivid Meadow",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped with two charge counters on it.\n{T}: Add {W}.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {W}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Remove a charge counter from this land: Add one mana of any color."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "279",
+        "rarity": "UNCOMMON",
+        "artist": "Rob Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a535790b-d416-4807-bca0-acf6b192101c.jpg?1783942846"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Wanderer's Twig
 {
     "name": "Wanderer's Twig",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -391,6 +391,22 @@ class PlayLandHandler(
             ?: printedCardComponent
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
+        // "This land enters with two charge counters on it" (the vivid lands) and the global
+        // enters-with replacements other permanents carry (Doubling Season's extra counters,
+        // keyword grants). Lands bypass ZoneTransitionService, so the entry counters that every
+        // other permanent gets from ZoneMovementUtils / StackResolver are applied here — before the
+        // tapped and as-enters branches below, since each of those is its own exit and the counters
+        // belong to the entry regardless of which branch finishes it. The events are carried into
+        // every exit so counter-placement triggers still see them.
+        val entersWithEvents: List<com.wingedsheep.engine.core.GameEvent> = if (cardDef != null) {
+            val (afterOwn, ownEvents) = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                .applyFromDefinition(newState, action.cardId, cardDef, action.playerId)
+            val (afterGlobal, globalEvents) = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                .applyGlobal(afterOwn, action.cardId, action.playerId, cardRegistry)
+            newState = afterGlobal
+            ownEvents + globalEvents
+        } else emptyList()
+
         // OnEnterRunEffect — generic "as ~ enters, run [effect]" replacement.
         // Runs BEFORE the EntersTapped check so effects like
         // Effects.Tap(EffectTarget.Self) (Game Trail's "otherwise" rider) apply
@@ -414,6 +430,7 @@ class PlayLandHandler(
                     action.playerId,
                 )
                 val onEnterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>(zoneChangeEvent)
+                onEnterEvents.addAll(entersWithEvents)
                 riderPlayEvent?.let { onEnterEvents.add(it) }
                 onEnterEvents.add(landPlayedEvent)
                 newState = newState.tick()
@@ -523,7 +540,7 @@ class PlayLandHandler(
                         Zone.BATTLEFIELD,
                         action.playerId
                     )
-                    val events = listOf(zoneChangeEvent) + listOfNotNull(riderPlayEvent, landPlayedEvent)
+                    val events = listOf(zoneChangeEvent) + entersWithEvents + listOfNotNull(riderPlayEvent, landPlayedEvent)
                     newState = newState.tick()
 
                     val decisionId = "pay-life-or-enter-tapped-${action.cardId.value}"
@@ -609,7 +626,7 @@ class PlayLandHandler(
                     Zone.BATTLEFIELD,
                     action.playerId
                 )
-                val events = listOf(zoneChangeEvent) + listOfNotNull(riderPlayEvent, landPlayedEvent)
+                val events = listOf(zoneChangeEvent) + entersWithEvents + listOfNotNull(riderPlayEvent, landPlayedEvent)
                 newState = newState.tick()
 
                 // Build the choice prompt + entity-keyed continuation via the shared on-battlefield
@@ -648,7 +665,7 @@ class PlayLandHandler(
             action.playerId
         )
 
-        val events = listOf(zoneChangeEvent) + listOfNotNull(riderPlayEvent, landPlayedEvent)
+        val events = listOf(zoneChangeEvent) + entersWithEvents + listOfNotNull(riderPlayEvent, landPlayedEvent)
         newState = newState.tick()
 
         // Detect and process any triggers from the land entering (e.g., landfall)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -12,6 +12,8 @@ import com.wingedsheep.engine.mechanics.mana.LandManaColorInspector
 import com.wingedsheep.engine.mechanics.mana.ManaColorSetResolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -188,6 +190,12 @@ class ManaAbilityEnumerator : ActionEnumerator {
                         is CostAtom.ExileTopOfLibrary -> {
                             if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) affordable = false
                         }
+                        // "Remove a charge counter from this land: Add one mana of any color" (the
+                        // vivid lands) — unpayable once the counters are gone, and the same gate the
+                        // non-mana enumerator applies.
+                        is CostAtom.RemoveCounters -> {
+                            if (!canPayRemoveCounters(state, playerId, container.get<CountersComponent>(), atom, context)) affordable = false
+                        }
                         // Other atoms (mana, life, discard, …) — engine validates at payment.
                         else -> {}
                     }
@@ -251,6 +259,12 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     // CR 701.17b — see the single-atom branch above.
                                     is CostAtom.Mill -> {
                                         if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) {
+                                            affordable = false; break
+                                        }
+                                    }
+                                    // "{T}, Remove a charge counter from this land: …" — see above.
+                                    is CostAtom.RemoveCounters -> {
+                                        if (!canPayRemoveCounters(state, playerId, container.get<CountersComponent>(), atom, context)) {
                                             affordable = false; break
                                         }
                                     }
@@ -509,6 +523,31 @@ class ManaAbilityEnumerator : ActionEnumerator {
             controllerId = playerId,
             cardRegistry = context.cardRegistry,
         ).toList()
+    }
+
+    /**
+     * A fixed-count [CostAtom.RemoveCounters] is payable only when the counters are actually there —
+     * on the source for a self-scoped cost, or across the matching permanents otherwise. Mirrors
+     * the gate in [ActivatedAbilityEnumerator]; without it a mana ability whose cost eats a counter
+     * was offered (and failed at payment) long after the last counter was spent.
+     */
+    private fun canPayRemoveCounters(
+        state: GameState,
+        playerId: EntityId,
+        counters: CountersComponent?,
+        atom: CostAtom.RemoveCounters,
+        context: EnumerationContext,
+    ): Boolean {
+        val needed = (atom.count as? DynamicAmount.Fixed)?.amount ?: return true
+        if (needed <= 0) return true
+        val available = if (atom.self) {
+            val type = atom.counterType?.let { resolveCounterType(it) }
+            if (type != null) counters?.getCount(type) ?: 0 else counters?.counters?.values?.sum() ?: 0
+        } else {
+            context.costUtils.buildRemoveCountersPermanents(state, playerId, atom.filter, atom.counterType)
+                .sumOf { it.availableCounters }
+        }
+        return available >= needed
     }
 
     private fun pickChoiceEffect(effect: Effect): AddManaOfChoiceEffect? = when (effect) {


### PR DESCRIPTION
Five Lorwyn cards, one cycle: the vivid lands. All five compose existing primitives; a small engine fix was needed for the first land in the corpus that enters with counters.

## Cards
- **Vivid Crag** ({T}: Add {R}) — `EntersTapped` + `EntersWithCounters(charge, 2, selfOnly)`, a plain `Effects.AddMana` mana ability, and `Costs.Tap + Costs.RemoveCounterFromSelf(charge)` feeding `Effects.AddManaOfChoice()`. Carries `VividCragScenarioTest`, which stands for the cycle.
- **Vivid Creek** ({U}) — same script.
- **Vivid Grove** ({G}) — same script.
- **Vivid Marsh** ({B}) — same script.
- **Vivid Meadow** ({W}) — same script.

Each land is canonical in LRW (earliest real printing) and gets `Printing` rows in every scaffolded reprint set — CMD, C13, C15, C17, plus PC2/CMR/NCC where printed (25 rows, generated with `scripts/generate-reprints.py --card …`). `just check-card-printing` is clean for all five.

## Engine fix (first commit)
The scenario test surfaced two gaps, both fixed in the same PR since they are missing *calls*, not new vocabulary:
- **`PlayLandHandler`** never applied `EntersWithCounters` (own or global) — lands bypass `ZoneTransitionService`, and no land in the corpus entered with counters until now. It now runs `EntersWithReplacements.applyFromDefinition` + `applyGlobal` before the tapped / as-enters branches and carries the events into every exit.
- **`ManaAbilityEnumerator`** had no `RemoveCounters` payability gate, so a counter-fed mana ability stayed flagged affordable with zero counters and only failed at payment. Same gate `ActivatedAbilityEnumerator` already applies.

## Verification
- `just test-class VividCragScenarioTest` — 3/3 (enters tapped with two counters via a real land drop; any-colour ability spends a counter; with no counters the ability is unaffordable and the payment path rejects it)
- `just build` — green after `just rebless-cards`; the LRW golden diff adds exactly the five lands
- `just test-rules` — green
- `just assay-differential --set LRW` — 13 DIVERGENT rows, all pre-existing (Harbinger cycle, Boggart Birth Rite, Epic Proportions, Kithkin Greatheart, Scarred Vinebreeder, Wort); the vivid lands are declined on the entry line, not compared

No LRW backlog file exists, so nothing to tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)