### PR TITLE
Add six Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Char.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Char.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Char
+ * {2}{R}
+ * Instant
+ *
+ * Char deals 4 damage to any target and 2 damage to you.
+ *
+ * The self-damage is not targeted, so it happens even when the chosen target has become
+ * illegal — the spell only fizzles if its single target is gone, in which case nothing at
+ * all resolves (CR 608.2b).
+ */
+val Char = card("Char") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Char deals 4 damage to any target and 2 damage to you."
+
+    spell {
+        val victim = target("any target", AnyTarget())
+        effect = Effects.DealDamage(4, victim) then
+            Effects.DealDamage(2, EffectTarget.PlayerRef(Player.You))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "Adam Rex"
+        flavorText = "Izzet mages often acquire their magic reagents from dubious sources, so the potency of their spells is never predictable."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg?1783943658"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Convolute.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Convolute.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Convolute
+ * {2}{U}
+ * Instant
+ *
+ * Counter target spell unless its controller pays {4}.
+ */
+val Convolute = card("Convolute") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell unless its controller pays {4}."
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.CounterUnlessPays("{4}")
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Dany Orizio"
+        flavorText = "The words came to the sorcerer's lips but refused to budge any further."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg?1783943688"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoreBroker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoreBroker.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Lore Broker
+ * {1}{U}
+ * Creature — Human Rogue
+ * 1/2
+ *
+ * {T}: Each player draws a card, then discards a card.
+ *
+ * Every player draws before any player discards, so the freshly drawn card is a legal
+ * discard. Both halves iterate in APNAP order (CR 101.4).
+ */
+val LoreBroker = card("Lore Broker") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "{T}: Each player draws a card, then discards a card."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = ForEachPlayerEffect(Player.ActivePlayerFirst, listOf(Effects.DrawCards(1))) then
+            Patterns.Hand.eachPlayerDiscards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Alan Pollack"
+        flavorText = "Lies are sold as often as truths—and used just as effectively."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg?1783943683"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PeelFromReality.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PeelFromReality.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Peel from Reality
+ * {1}{U}
+ * Instant
+ *
+ * Return target creature you control and target creature you don't control to their owners' hands.
+ *
+ * Two separate single-target requirements rather than one count-2 requirement: the two
+ * slots carry different filters, and each is checked for legality independently on
+ * resolution, so one illegal target still lets the other bounce (CR 608.2b).
+ */
+val PeelFromReality = card("Peel from Reality") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature you control and target creature you don't control to their owners' hands."
+
+    spell {
+        val yours = target("target creature you control", Targets.CreatureYouControl)
+        val theirs = target("target creature you don't control", Targets.CreatureOpponentControls)
+        effect = Effects.ReturnToHand(yours) then Effects.ReturnToHand(theirs)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Puddnhead"
+        flavorText = "When House Dimir's secrets are in danger of exposure, the guild takes drastic measures to cover its tracks."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg?1783943682"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SellSwordBrute.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SellSwordBrute.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sell-Sword Brute
+ * {1}{R}
+ * Creature — Human Mercenary
+ * 2/2
+ *
+ * When this creature dies, it deals 2 damage to you.
+ *
+ * "You" is the controller of the triggered ability — the player who controlled Sell-Sword
+ * Brute as it left the battlefield, per last-known information.
+ */
+val SellSwordBrute = card("Sell-Sword Brute") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "When this creature dies, it deals 2 damage to you."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.You))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Jeff Miracola"
+        flavorText = "\"Killing is easy. Just wrap your hand around the haft, and wrap your enemy around the blade.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg?1783943647"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ZephyrSpirit.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ZephyrSpirit.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Zephyr Spirit
+ * {5}{U}
+ * Creature — Spirit
+ * 0/6
+ *
+ * When this creature blocks, return it to its owner's hand.
+ *
+ * The trigger resolves during the declare blockers step, before combat damage — the
+ * attacker it blocked stays blocked (CR 506.4, 509.1h), so removing Zephyr Spirit does not
+ * let that creature through.
+ */
+val ZephyrSpirit = card("Zephyr Spirit") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "When this creature blocks, return it to its owner's hand."
+    power = 0
+    toughness = 6
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Tomas Giorello"
+        flavorText = "A spiteful force exists on Ravnica that binds these ghosts to the land of the living but forbids them to touch it."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg?1783943675"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/PeelFromRealityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/PeelFromRealityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Peel from Reality reprint in AVR. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val PeelFromRealityReprint = Printing(
+    oracleId = "65dc05d0-f885-4fe5-9a23-d6b75185c179",
+    name = "Peel from Reality",
+    setCode = "AVR",
+    collectorNumber = "71",
+    scryfallId = "7f41285b-5961-4653-96a0-fb6d27111390",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7f41285b-5961-4653-96a0-fb6d27111390.jpg?1783940713",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ConvoluteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ConvoluteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Convolute reprint in EMN. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val ConvoluteReprint = Printing(
+    oracleId = "cd201ded-cfaf-4a51-9fcc-6a61b3c910b0",
+    name = "Convolute",
+    setCode = "EMN",
+    collectorNumber = "53",
+    scryfallId = "e17cf756-ec41-4934-8906-4276277c1470",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e17cf756-ec41-4934-8906-4276277c1470.jpg?1783937502",
+    releaseDate = "2016-07-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/PeelFromRealityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/PeelFromRealityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Peel from Reality reprint in M15. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val PeelFromRealityReprint = Printing(
+    oracleId = "65dc05d0-f885-4fe5-9a23-d6b75185c179",
+    name = "Peel from Reality",
+    setCode = "M15",
+    collectorNumber = "74",
+    scryfallId = "284cd35c-056f-45c2-822f-d50527f79625",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/284cd35c-056f-45c2-822f-d50527f79625.jpg?1783939190",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PeelFromRealityReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PeelFromRealityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Peel from Reality reprint in CMR. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val PeelFromRealityReprint = Printing(
+    oracleId = "65dc05d0-f885-4fe5-9a23-d6b75185c179",
+    name = "Peel from Reality",
+    setCode = "CMR",
+    collectorNumber = "402",
+    scryfallId = "55aec3bd-b52f-4b23-a86a-429fa78a5a6a",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55aec3bd-b52f-4b23-a86a-429fa78a5a6a.jpg?1783928719",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ConvoluteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ConvoluteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Convolute reprint in IKO. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val ConvoluteReprint = Printing(
+    oracleId = "cd201ded-cfaf-4a51-9fcc-6a61b3c910b0",
+    name = "Convolute",
+    setCode = "IKO",
+    collectorNumber = "45",
+    scryfallId = "3fd8e607-8179-4ae8-ba7f-f5f22649dc18",
+    artist = "Jason Rainville",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3fd8e607-8179-4ae8-ba7f-f5f22649dc18.jpg?1783931078",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PeelFromRealityReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PeelFromRealityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Peel from Reality reprint in JMP. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val PeelFromRealityReprint = Printing(
+    oracleId = "65dc05d0-f885-4fe5-9a23-d6b75185c179",
+    name = "Peel from Reality",
+    setCode = "JMP",
+    collectorNumber = "163",
+    scryfallId = "e7d0f29b-fcc4-4135-af36-6539912ab3bb",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7d0f29b-fcc4-4135-af36-6539912ab3bb.jpg?1783930451",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ConvoluteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ConvoluteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Convolute reprint in M20. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val ConvoluteReprint = Printing(
+    oracleId = "cd201ded-cfaf-4a51-9fcc-6a61b3c910b0",
+    name = "Convolute",
+    setCode = "M20",
+    collectorNumber = "55",
+    scryfallId = "b8a68347-c0ef-46ff-9705-6d82d004d32c",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8a68347-c0ef-46ff-9705-6d82d004d32c.jpg?1783933012",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -743,6 +743,59 @@
     ]
 }
 
+// Char
+{
+    "name": "Char",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Char deals 4 damage to any target and 2 damage to you.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "You"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "Adam Rex",
+        "flavorText": "Izzet mages often acquire their magic reagents from dubious sources, so the potency of their spells is never predictable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg?1783943658"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Chord of Calling
 {
     "name": "Chord of Calling",
@@ -1133,6 +1186,42 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Convolute
+{
+    "name": "Convolute",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell unless its controller pays {4}.",
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "condition": {
+                "type": "CounterCondition.UnlessPaysMana",
+                "cost": "{4}"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Dany Orizio",
+        "flavorText": "The words came to the sorcerer's lips but refused to budge any further.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fac88052-96a3-4a4d-95a2-c5a652fcb275.jpg?1783943688"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3505,6 +3594,97 @@
     ]
 }
 
+// Lore Broker
+{
+    "name": "Lore Broker",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "{T}: Each player draws a card, then discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "ActivePlayerFirst"
+                            },
+                            "body": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "ActivePlayerFirst"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose a card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "flavorText": "Lies are sold as often as truths—and used just as effectively.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7935b2b-aebe-44b3-b91b-52978bb4ded5.jpg?1783943683"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moroii
 {
     "name": "Moroii",
@@ -3838,6 +4018,62 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Peel from Reality
+{
+    "name": "Peel from Reality",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature you control and target creature you don't control to their owners' hands.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you don't control"
+                    },
+                    "destination": "Hand"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "target creature you don't control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Puddnhead",
+        "flavorText": "When House Dimir's secrets are in danger of exposure, the guild takes drastic measures to cover its tracks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4e6ca71-ba17-4a16-a331-b787363874e2.jpg?1783943682"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4829,6 +5065,50 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Sell-Sword Brute
+{
+    "name": "Sell-Sword Brute",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "When this creature dies, it deals 2 damage to you.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "You"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Jeff Miracola",
+        "flavorText": "\"Killing is easy. Just wrap your hand around the haft, and wrap your enemy around the blade.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db513835-af5a-4ff3-8cf8-31936732a4db.jpg?1783943647"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -6225,5 +6505,39 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Zephyr Spirit
+{
+    "name": "Zephyr Spirit",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "When this creature blocks, return it to its owner's hand.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Tomas Giorello",
+        "flavorText": "A spiteful force exists on Ravnica that binds these ghosts to the land of the living but forbids them to touch it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6cbe78f-4325-416b-bf23-282efed5b407.jpg?1783943675"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }


### PR DESCRIPTION
Six RAV cards, each built entirely from existing `Effects.*` / `Patterns.*` / `Targets.*` — no new SDK vocabulary, so they share one PR per `CONTRIBUTING.md`.

| Card | What it does | Composes |
|---|---|---|
| **Char** `{2}{R}` | 4 damage to any target and 2 to you | `AnyTarget()` slot + two `Effects.DealDamage` (the self-damage untargeted) |
| **Convolute** `{2}{U}` | Counter target spell unless its controller pays `{4}` | `Targets.Spell` + `Effects.CounterUnlessPays("{4}")` |
| **Sell-Sword Brute** `{1}{R}` 2/2 | Dies → 2 damage to you | `Triggers.Dies` + `Effects.DealDamage(2, Player.You)` |
| **Peel from Reality** `{1}{U}` | Bounce one creature you control and one you don't | Two independent single-target slots (`Targets.CreatureYouControl`, `Targets.CreatureOpponentControls`) + two `Effects.ReturnToHand` |
| **Lore Broker** `{1}{U}` 1/2 | `{T}`: each player draws, then discards | `Costs.Tap` + `ForEachPlayerEffect(ActivePlayerFirst, DrawCards(1))` then `Patterns.Hand.eachPlayerDiscards(1)` |
| **Zephyr Spirit** `{5}{U}` 0/6 | Blocks → return to owner's hand | `Triggers.Blocks` + `Effects.ReturnToHand(EffectTarget.Self)` |

### Rules notes

- **Peel from Reality** uses two separate single-target requirements rather than one `count = 2` requirement, so each slot carries its own filter and is checked for legality independently on resolution (CR 608.2b) — one illegal target still lets the other bounce. Same shape as Plague Spores / Swift Kick.
- **Lore Broker** draws for every player *before* any player discards, so the freshly drawn card is a legal discard. Both halves iterate in APNAP order (CR 101.4).
- **Char**'s self-damage is untargeted: it happens regardless of the chosen target's state, though the spell fizzles entirely if its single target is gone.
- **Zephyr Spirit**'s trigger resolves in declare blockers; the attacker it blocked stays blocked (CR 509.1h), so removing the Spirit does not let that creature through.

### Canonical placement

RAV is the earliest real printing for all six. Convolute and Peel from Reality are reprinted in already-scaffolded sets, so those get `Printing` rows: Convolute → EMN, M20, IKO; Peel from Reality → AVR, M15, JMP, CMR. `just check-card-printing` is clean for all six.

### Verification

- `just build` — green (full suite).
- `just rebless-cards` — only the six new cards moved in `snapshots/cards/RAV.json` (314 pure insertions, no existing entry touched).
- `just assay-differential --set RAV` — 103/103 confirmed, **0 divergent**.
- `just check-card-printing` — ok for all six.
- Every `imageUri` verified HTTP 200 against Scryfall.

No scenario tests: no new engine vocabulary was added, so the snapshot and differential nets cover these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)