### PR TITLE
Preserve hyphens in parsed subtypes

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
@@ -51,7 +51,7 @@ data class TypeLine(
 
     companion object {
         fun parse(typeLineString: String): TypeLine {
-            val parts = typeLineString.split("—", "–", "-").map { it.trim() }
+            val parts = typeLineString.split(Regex("[—–]|\\s+-\\s+")).map { it.trim() }
             val typesPart = parts[0]
             val subtypesPart = parts.getOrNull(1)
 

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.sdk.core
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class TypeLineTest : DescribeSpec({
+
+    describe("TypeLine.parse") {
+        it("preserves hyphens inside subtype names") {
+            val parsed = TypeLine.parse("Artifact Creature — Assembly-Worker")
+
+            parsed.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+            parsed.subtypes shouldBe setOf(Subtype("Assembly-Worker"))
+        }
+
+        it("preserves another hyphenated subtype") {
+            val parsed = TypeLine.parse("Land — Urza's Power-Plant")
+
+            parsed.cardTypes shouldBe setOf(CardType.LAND)
+            parsed.subtypes shouldBe setOf(
+                Subtype("Urza's"),
+                Subtype("Power-Plant"),
+            )
+        }
+
+        it("still accepts an ASCII hyphen as a spaced type-subtype separator") {
+            val parsed = TypeLine.parse("Artifact Creature - Assembly-Worker")
+
+            parsed.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+            parsed.subtypes shouldBe setOf(Subtype("Assembly-Worker"))
+        }
+    }
+})


### PR DESCRIPTION
`TypeLine.parse` currently treats every ASCII hyphen as a type/subtype separator, which truncates hyphenated subtype names such as `Assembly-Worker` and `Power-Plant`.

This changes ASCII `-` to act as a separator only when surrounded by whitespace, while retaining support for the existing en/em dash separators.

Added focused regression coverage for:

- `Assembly-Worker`
- `Power-Plant`
- a spaced ASCII hyphen used as the type/subtype separator

Verification: `just test-class TypeLineTest`