### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/TellingTime.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/TellingTime.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Telling Time reprint in 10E.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in RAV's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * 10E-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TellingTimeReprint = Printing(
+    oracleId = "192f3c8a-1120-4f7f-ae0f-fe9bde59cd08",
+    name = "Telling Time",
+    setCode = "10E",
+    collectorNumber = "114",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3caf69d0-58bd-4cd1-9108-56e6cbf882e4.jpg?1783943047",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LurkingInformant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LurkingInformant.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lurking Informant — Ravnica: City of Guilds #249
+ * {1}{U/B} · Creature — Human Rogue · 1/2
+ *
+ * ({U/B} can be paid with either {U} or {B}.)
+ * {2}, {T}: Look at the top card of target player's library. You may put that card into that
+ * player's graveyard.
+ *
+ * Modelling notes:
+ * - `{U/B}` is a plain hybrid pip in `manaCost`; the parser derives mana value 2 and the
+ *   blue-and-black colour identity from it.
+ * - The "you may" is the *selection*, not a separate yes/no: gathering the top card and offering
+ *   `ChooseUpTo(1)` is one decision that both shows the card and asks whether to bin it — the
+ *   surveil shape, aimed at another player's library. The remainder goes back on top, so a
+ *   declined activation leaves the library exactly as it was.
+ * - The look and the choice both belong to this card's controller; the *targeted* player only
+ *   supplies the library and the graveyard.
+ */
+val LurkingInformant = card("Lurking Informant") {
+    manaCost = "{1}{U/B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 2
+    oracleText = "({U/B} can be paid with either {U} or {B}.)\n" +
+        "{2}, {T}: Look at the top card of target player's library. You may put that card into " +
+        "that player's graveyard."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        target("target player", Targets.Player)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.ContextPlayer(0)),
+                storeAs = "peeked"
+            ),
+            SelectFromCollectionEffect(
+                from = "peeked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "toGraveyard",
+                storeRemainder = "toTop",
+                selectedLabel = "Put into that player's graveyard",
+                remainderLabel = "Leave on top of that player's library"
+            ),
+            MoveCollectionEffect(
+                from = "toGraveyard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0))
+            ),
+            MoveCollectionEffect(
+                from = "toTop",
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY,
+                    Player.ContextPlayer(0),
+                    placement = ZonePlacement.Top
+                )
+            )
+        )
+        description = "{2}, {T}: Look at the top card of target player's library. You may put " +
+            "that card into that player's graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Ron Spears"
+        flavorText = "In the undercity, forgetfulness is often encouraged at the point of a blade."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg?1783943604"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MnemonicNexus.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MnemonicNexus.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mnemonic Nexus — Ravnica: City of Guilds #59
+ * {3}{U} · Instant
+ *
+ * Each player shuffles their graveyard into their library.
+ *
+ * Modelling notes:
+ * - Untargeted and symmetric, so it is [Effects.ForEachPlayer] over [Player.Each] rather than a
+ *   target requirement. Inside the iteration `Player.You` rebinds to the iterated player, which is
+ *   why the body can reuse the controller-scoped
+ *   [com.wingedsheep.sdk.dsl.Patterns.Library.shuffleGraveyardIntoLibrary] recipe unchanged.
+ * - The shuffle is part of the move (`ZonePlacement.Shuffled`), not a separate shuffle step, so a
+ *   player with an empty graveyard still shuffles nothing rather than shuffling their library.
+ */
+val MnemonicNexus = card("Mnemonic Nexus") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Each player shuffles their graveyard into their library."
+
+    spell {
+        effect = Effects.ForEachPlayer(
+            players = Player.Each,
+            effects = listOf(Patterns.Library.shuffleGraveyardIntoLibrary(EffectTarget.Controller))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Stephen Tappin"
+        flavorText = "True enlightenment comes not with a new thought, but with understanding of " +
+            "all the old ones."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg?1783943682"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PsychicDrain.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PsychicDrain.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Psychic Drain — Ravnica: City of Guilds #220
+ * {X}{U}{B} · Sorcery
+ *
+ * Target player mills X cards and you gain X life.
+ *
+ * Modelling notes:
+ * - Both halves read [DynamicAmount.XValue], the X chosen on casting. The life gain is *not*
+ *   scoped to how many cards were actually milled, so a library shorter than X still gains the
+ *   full X (CR 701.13b mills what it can; the second sentence is independent of it).
+ * - One target for the whole spell: if the player becomes an illegal target the spell doesn't
+ *   resolve at all and no life is gained, which falls out of the engine's fizzle path.
+ */
+val PsychicDrain = card("Psychic Drain") {
+    manaCost = "{X}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Target player mills X cards and you gain X life."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Patterns.Library.mill(DynamicAmount.XValue, player),
+            Effects.GainLife(DynamicAmount.XValue)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Nick Percival"
+        flavorText = "\"Gold can be reearned, goods restored. The moroii steal youth, more " +
+            "precious than either, and once gone, it's gone forever.\"\n—Berta Suszat, civic healer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg?1783943615"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TellingTime.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TellingTime.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Telling Time — Ravnica: City of Guilds #69
+ * {1}{U} · Instant
+ *
+ * Look at the top three cards of your library. Put one of those cards into your hand, one on top
+ * of your library, and one on the bottom of your library.
+ *
+ * Modelling notes:
+ * - Three destinations, so this is one gather feeding *two* selections rather than the single
+ *   keep/rest split [com.wingedsheep.sdk.dsl.Patterns.Library.lookAtTopAndKeep] models: pick the
+ *   card for your hand, then pick which of the two survivors goes back on top. The remainder of
+ *   the second selection is the bottom card, so no third decision is needed — with two cards
+ *   left, naming one names the other.
+ * - Every card the gather looked at is moved back explicitly. Nothing is left in the collection,
+ *   which is what keeps a three-card library (or a smaller one) from stranding cards.
+ * - A library with fewer than three cards simply looks at what is there: `ChooseExactly(1)` on an
+ *   empty or one-card collection resolves to what is available, and the later moves are no-ops.
+ */
+val TellingTime = card("Telling Time") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Look at the top three cards of your library. Put one of those cards into your " +
+        "hand, one on top of your library, and one on the bottom of your library."
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3)),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "toHand",
+                storeRemainder = "notTaken",
+                selectedLabel = "Put into your hand",
+                remainderLabel = "Keep in your library"
+            ),
+            MoveCollectionEffect(
+                from = "toHand",
+                destination = CardDestination.ToZone(Zone.HAND)
+            ),
+            SelectFromCollectionEffect(
+                from = "notTaken",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "toTop",
+                storeRemainder = "toBottom",
+                selectedLabel = "Put on top of your library",
+                remainderLabel = "Put on the bottom of your library"
+            ),
+            MoveCollectionEffect(
+                from = "toTop",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top)
+            ),
+            MoveCollectionEffect(
+                from = "toBottom",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Scott M. Fischer"
+        flavorText = "Mastery is achieved when \"telling time\" becomes \"telling time what to do.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg?1783943677"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThoughtpickerWitch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThoughtpickerWitch.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Thoughtpicker Witch — Ravnica: City of Guilds #109
+ * {B} · Creature — Human Wizard · 1/1
+ *
+ * {1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then exile
+ * one of them.
+ *
+ * Modelling notes:
+ * - `Costs.Sacrifice(GameObjectFilter.Creature)` is "a creature", not "another creature" — the
+ *   Witch is a legal sacrifice for her own ability, and the ability still resolves after she is
+ *   gone because the cost is paid on activation.
+ * - The exile is mandatory ("then exile one of them"), so the selection is `ChooseExactly(1)`
+ *   rather than the "you may" `ChooseUpTo` of a peek. The card that isn't exiled is moved back to
+ *   the top of that opponent's library, which is where it already was.
+ * - The look and the choice belong to this card's controller; the targeted opponent only supplies
+ *   the library.
+ */
+val ThoughtpickerWitch = card("Thoughtpicker Witch") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{1}, Sacrifice a creature: Look at the top two cards of target opponent's " +
+        "library, then exile one of them."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2), Player.ContextPlayer(0)),
+                storeAs = "peeked"
+            ),
+            SelectFromCollectionEffect(
+                from = "peeked",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "toExile",
+                storeRemainder = "toTop",
+                selectedLabel = "Exile",
+                remainderLabel = "Leave on top of that player's library"
+            ),
+            MoveCollectionEffect(
+                from = "toExile",
+                destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
+            ),
+            MoveCollectionEffect(
+                from = "toTop",
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY,
+                    Player.ContextPlayer(0),
+                    placement = ZonePlacement.Top
+                )
+            )
+        )
+        description = "{1}, Sacrifice a creature: Look at the top two cards of target opponent's " +
+            "library, then exile one of them."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Pete Venters"
+        flavorText = "\"Once the brew gets the brains nice and pickled, they're a lot easier to " +
+            "pick through.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg?1783943661"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3685,6 +3685,164 @@
     ]
 }
 
+// Lurking Informant
+{
+    "name": "Lurking Informant",
+    "manaCost": "{1}{U/B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "({U/B} can be paid with either {U} or {B}.)\n{2}, {T}: Look at the top card of target player's library. You may put that card into that player's graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "peeked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "peeked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Put into that player's graveyard",
+                            "remainderLabel": "Leave on top of that player's library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "placement": "Top"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}: Look at the top card of target player's library. You may put that card into that player's graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Ron Spears",
+        "flavorText": "In the undercity, forgetfulness is often encouraged at the point of a blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/012a7f5d-f798-4030-86e3-05956487a383.jpg?1783943604"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Mnemonic Nexus
+{
+    "name": "Mnemonic Nexus",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Each player shuffles their graveyard into their library.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Players",
+                "players": "Each"
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "GatherCards",
+                        "source": {
+                            "type": "FromZone",
+                            "zone": "Graveyard"
+                        },
+                        "storeAs": "graveyardCards"
+                    },
+                    {
+                        "type": "MoveCollection",
+                        "from": "graveyardCards",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Library",
+                            "placement": "Shuffled"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Tappin",
+        "flavorText": "True enlightenment comes not with a new thought, but with understanding of all the old ones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/200edda9-7ad9-47fc-837e-37ec9e5b4b51.jpg?1783943682"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moroii
 {
     "name": "Moroii",
@@ -4299,6 +4457,72 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Psychic Drain
+{
+    "name": "Psychic Drain",
+    "manaCost": "{X}{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player mills X cards and you gain X life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": "XValue",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "GainLife",
+                    "amount": "XValue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Nick Percival",
+        "flavorText": "\"Gold can be reearned, goods restored. The moroii steal youth, more precious than either, and once gone, it's gone forever.\"\n—Berta Suszat, civic healer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d00fd2d8-76ce-4334-b772-a5dc64fc2989.jpg?1783943615"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -5586,6 +5810,98 @@
     ]
 }
 
+// Telling Time
+{
+    "name": "Telling Time",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "toHand",
+                    "storeRemainder": "notTaken",
+                    "selectedLabel": "Put into your hand",
+                    "remainderLabel": "Keep in your library"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toHand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "notTaken",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "toTop",
+                    "storeRemainder": "toBottom",
+                    "selectedLabel": "Put on top of your library",
+                    "remainderLabel": "Put on the bottom of your library"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toTop",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Top"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toBottom",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "UNCOMMON",
+        "artist": "Scott M. Fischer",
+        "flavorText": "Mastery is achieved when \"telling time\" becomes \"telling time what to do.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/563e6cf4-e86f-4538-85a1-3abbc83b303d.jpg?1783943677"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Temple Garden
 {
     "name": "Temple Garden",
@@ -5619,6 +5935,120 @@
     "colorIdentityOverride": [
         "GREEN",
         "WHITE"
+    ]
+}
+
+// Thoughtpicker Witch
+{
+    "name": "Thoughtpicker Witch",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then exile one of them.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "peeked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "peeked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toExile",
+                            "storeRemainder": "toTop",
+                            "selectedLabel": "Exile",
+                            "remainderLabel": "Leave on top of that player's library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toExile",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "placement": "Top"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target opponent"
+                    }
+                ],
+                "descriptionOverride": "{1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then exile one of them."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Pete Venters",
+        "flavorText": "\"Once the brew gets the brains nice and pickled, they're a lot easier to pick through.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6f8df33-a955-403c-aafc-85e5589c5041.jpg?1783943661"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Five Ravnica: City of Guilds cards, all built from existing `Effects.*` / `Patterns.*` — no new SDK vocabulary. Four of them are the set's blue-black "look at a library" cluster, which lets one idea be reviewed four times.

- **Telling Time** `{1}{U}` — look at the top three, one to hand, one back on top, one to the bottom. One `GatherCardsEffect` feeding *two* `SelectFromCollectionEffect`s: the first picks the hand card, the second picks the top card and its remainder *is* the bottom card, so there is no third decision. Every looked-at card is moved back explicitly, which is what keeps a short library from stranding cards.
- **Psychic Drain** `{X}{U}{B}` — `Patterns.Library.mill(XValue, target)` + `Effects.GainLife(XValue)`. Both halves read the announced X, so a library shorter than X still gains the full X.
- **Mnemonic Nexus** `{3}{U}` — `Effects.ForEachPlayer(Player.Each, …)` over the controller-scoped `Patterns.Library.shuffleGraveyardIntoLibrary` recipe; `Player.You` rebinds to the iterated player. The shuffle is part of the move (`ZonePlacement.Shuffled`), so an empty graveyard shuffles nothing rather than shuffling the library.
- **Lurking Informant** `{1}{U/B}` — the "you may" is the *selection*, not a separate yes/no: `ChooseUpTo(1)` over the gathered top card both shows it and asks whether to bin it, and the remainder goes straight back on top. Plain hybrid pip in `manaCost`.
- **Thoughtpicker Witch** `{B}` — `Costs.Sacrifice(GameObjectFilter.Creature)` is "a creature", so the Witch is a legal sacrifice for her own ability. The exile is mandatory, hence `ChooseExactly(1)` rather than a peek's `ChooseUpTo`.

Chaining a `storeRemainder` collection into a later selection is established — 16 other cards do it (`In the Presence of Ages`, `Ojer Kaslem`, `Archghoul of Thraben`).

Also adds the **10E `Printing` row for Telling Time** (its only scaffolded reprint set); `just check-card-printing` is green for all five.

## Verification

- `just build` — compiles; `CardDefinitionSnapshotTest` diff was **only** these five cards (430 lines, pure insertions, nothing else moved). Re-blessed with `just rebless-cards`, which then passed.
- `just check-card-printing` — ok for all five.
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent. Honest limit: these five sit in the 28 the grammar doesn't read whole, so the differential does not itself vouch for them.
- No scenario tests: no new SDK vocabulary, so the snapshot and lint nets cover these per `add-card` Step 5. No new decision UI either — every choice routes to existing pipeline-selection, target-player and sacrifice-cost components.

**Unrelated flakes in the first `just build`:** `FreeForAllLobbyTest` (two lobby-count assertions) and a `:ai:test` executor crash (exit 13). Both fired while several other agents' Gradle builds were saturating the machine; `just test-class FreeForAllLobbyTest` re-run in isolation on this branch **passes**. Neither touches card definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)