### PR TITLE
Read the entering permanent's controller, not its owner, for "you control" triggers

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1172,8 +1172,23 @@ class TriggerMatcher(
             // YOUR graveyard from the battlefield" cares about ownership, since a permanent
             // always goes to its owner's graveyard regardless of who last controlled it
             // (CR 400.3, e.g. Soulcatchers' Aerie).
+            //
+            // The three sources are ordered by which one can actually answer "who controlled it
+            // as it changed zones":
+            //  - leaving the battlefield: the entity is gone, so the LKI snapshot is the only
+            //    answer (CR 603.10);
+            //  - entering the battlefield: the permanent is live, so its projected controller is
+            //    authoritative — and it is NOT the owner whenever the entry carried a control
+            //    override. Reanimating a card out of its owner's graveyard under your control
+            //    (Virtue of Persistence, Shark Shredder) makes you the controller while the
+            //    opponent still owns it, so falling back to `ownerId` fired *their* "whenever a
+            //    creature you control enters" triggers off *your* permanent;
+            //  - anything that never touched the battlefield (a mill, a discard) has no
+            //    controller at all, and `ownerId` is the right and only reading.
             trigger.filter.controllerPredicate?.let { pred ->
-                val effectiveController = event.lastKnown?.controllerId ?: event.ownerId
+                val effectiveController = event.lastKnown?.controllerId
+                    ?: projected.getController(event.entityId)
+                    ?: event.ownerId
                 val controllerMatches = pred.evaluateWith { leaf ->
                     when (leaf) {
                         is ControllerPredicate.ControlledByYou -> effectiveController == controllerId

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/EntersUnderAnotherPlayersControlTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/EntersUnderAnotherPlayersControlTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.triggers
+
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.event.TriggerDetector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * "Whenever another creature **you control** enters" must read the entering permanent's
+ * *controller*, not its owner.
+ *
+ * Reanimation out of a graveyard under someone else's control (Virtue of Persistence,
+ * Shark Shredder — `Effects.PutOntoBattlefieldUnderYourControl`) is the case where the two differ
+ * while the permanent is on the battlefield: the card is still owned by the player whose graveyard
+ * it came from, but the reanimator controls it. `ZoneChangeEvent` carries only `ownerId` (the
+ * `lastKnown` snapshot is populated for battlefield *exits* only), so a controller predicate that
+ * fell back to `ownerId` on an entry fired the owner's "creature you control enters" payoffs —
+ * Virulent Emissary, Haliya Guided by Light, Essence Channeler downstream of them — off a creature
+ * their opponent had just stolen out of their graveyard.
+ */
+class EntersUnderAnotherPlayersControlTest : FunSpec({
+
+    // "Whenever another creature you control enters, you gain 1 life." (Virulent Emissary's shape.)
+    val observer = card("Life Observer") {
+        manaCost = "{0}"
+        typeLine = "Creature — Human"
+        power = 0
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.OtherCreatureEnters
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    val reanimated = CardDefinition.creature(
+        name = "Reanimated Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(observer, reanimated))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20))
+        return driver
+    }
+
+    /** Put [cardName] onto [controller]'s battlefield while [owner] still owns the card. */
+    fun GameTestDriver.putOnBattlefieldOwnedBy(
+        controller: EntityId,
+        owner: EntityId,
+        cardName: String
+    ): EntityId {
+        val id = putCreatureOnBattlefield(controller, cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                val card = container.get<CardComponent>()!!
+                container.with(card.copy(ownerId = owner))
+                    .with(OwnerComponent(owner))
+                    .with(ControllerComponent(controller))
+            }
+        )
+        return id
+    }
+
+    fun lifeObserverTriggers(driver: GameTestDriver, event: ZoneChangeEvent) =
+        TriggerDetector(driver.cardRegistry)
+            .detectTriggers(driver.state, listOf(event))
+            .filter { it.sourceName == "Life Observer" }
+
+    context("'another creature you control enters' when owner != controller") {
+
+        /**
+         * GIVEN both players control a "whenever another creature you control enters" observer,
+         *   AND player 2 reanimates a creature card player 1 owns, under player 2's control,
+         * WHEN the enter-the-battlefield event is detected,
+         * THEN only player 2's observer triggers — the owner's does not.
+         */
+        test("a creature reanimated under the opponent's control triggers the reanimator's payoff, not the owner's") {
+            val driver = createDriver()
+            driver.putCreatureOnBattlefield(driver.player1, "Life Observer")
+            driver.putCreatureOnBattlefield(driver.player2, "Life Observer")
+
+            val bear = driver.putOnBattlefieldOwnedBy(
+                controller = driver.player2,
+                owner = driver.player1,
+                cardName = "Reanimated Bear"
+            )
+
+            val entered = ZoneChangeEvent(
+                entityId = bear,
+                entityName = "Reanimated Bear",
+                fromZone = Zone.GRAVEYARD,
+                toZone = Zone.BATTLEFIELD,
+                // The event carries the card's OWNER, as ZoneTransitionService always does.
+                ownerId = driver.player1
+            )
+
+            val triggers = lifeObserverTriggers(driver, entered)
+
+            triggers shouldHaveSize 1
+            triggers.single().controllerId shouldBe driver.player2
+        }
+
+        /**
+         * The ordinary case must be unchanged: a creature entering under its own owner's control
+         * still fires that player's observer and not the opponent's.
+         */
+        test("a creature entering under its owner's control still triggers only that player's payoff") {
+            val driver = createDriver()
+            driver.putCreatureOnBattlefield(driver.player1, "Life Observer")
+            driver.putCreatureOnBattlefield(driver.player2, "Life Observer")
+
+            val bear = driver.putCreatureOnBattlefield(driver.player1, "Reanimated Bear")
+
+            val entered = ZoneChangeEvent(
+                entityId = bear,
+                entityName = "Reanimated Bear",
+                fromZone = Zone.GRAVEYARD,
+                toZone = Zone.BATTLEFIELD,
+                ownerId = driver.player1
+            )
+
+            val triggers = lifeObserverTriggers(driver, entered)
+
+            triggers shouldHaveSize 1
+            triggers.single().controllerId shouldBe driver.player1
+        }
+    }
+})


### PR DESCRIPTION
# Read the entering permanent's controller, not its owner, for "you control" triggers

## The bug

A player reported gaining life when their *opponent* reanimated a creature out of their graveyard:

```
Opponent's Virtue of Persistence triggered: ... put target creature card from a graveyard
    onto the battlefield under your control.
Your Tigra, Feline Fury entered the battlefield
Your Virulent Emissary triggered: a creature you control would enter the battlefield, you gain 1 life.
Your Haliya, Guided by Light triggered: ... you gain 1 life.
You gained 1 life
Your Amalia Benavides Aguirre triggered: ...
Your Essence Channeler triggered: ...
```

The permanent entered under the *opponent's* control, correctly. What misfired was the trigger
matcher: `TriggerMatcher.matchesZoneChangeTrigger` resolved the object's controller for a
`youControl()` filter as

```kotlin
val effectiveController = event.lastKnown?.controllerId ?: event.ownerId
```

`ZoneChangeEvent.lastKnown` is the frozen snapshot captured when a permanent *leaves* the
battlefield — it is `null` for every entry, by design. So an enters-the-battlefield event fell
through to `event.ownerId`, the card's owner.

Owner and controller coincide for nearly every entry, which is why this survived so long. The case
that separates them is reanimation out of somebody else's graveyard. Virtue of Persistence puts a
creature card from *a* graveyard onto the battlefield **under its own controller's control**
(CR 110.2a: "If an effect instructs a player to put an object onto the battlefield, that object
enters the battlefield under that player's control unless the effect states otherwise"), while
CR 400.3 keeps the card owned by the player whose graveyard it came from. The matcher then compared
that *owner* against every "whenever another creature you control enters" observer on the board, so
the owner's Virulent Emissary and Haliya, Guided by Light gained life off a creature their opponent
had just taken from them — and the life gain cascaded into their Amalia Benavides Aguirre and
Essence Channeler.

Every `youControl()` / `controlledByOpponent()` enters-the-battlefield trigger in the corpus was
affected the same way, not just these cards.

## The fix

`rules-engine/.../event/TriggerMatcher.kt` — order the three sources by which one can actually answer
"who controlled this object as it changed zones":

- **leaving the battlefield** — the entity is gone, so the LKI snapshot is the only answer
  (CR 603.10a: leaves-the-battlefield abilities look back in time). Unchanged.
- **entering the battlefield** — the permanent is live, so its projected controller is authoritative,
  and it is *not* the owner whenever the entry carried a control override. This is the same reading
  `TriggerDetector.causeMatchesDoublerFilter` already takes for an entering doubler cause ("the cause
  is live on the battlefield, so projected state is authoritative"), so the two sites now agree.
- **never touched the battlefield** (a mill, a discard) — no controller exists; `ownerId` is the right
  and only reading. Unchanged, and it needs no explicit branch: `StateProjector` only builds entries
  for battlefield permanents, so the projection read answers `null` for a card in a hidden zone on
  its own.

Owner predicates (`ownedByYou` / `ownedByOpponent`) still read `event.ownerId` and are untouched —
"put into *your* graveyard from the battlefield" is a statement about ownership, since a permanent
always goes to its owner's graveyard (CR 400.3).

No new SDK vocabulary: this is a read-site correction inside the matcher, invisible to card
definitions. `Effects.PutOntoBattlefieldUnderYourControl`, the executor, and `ZoneTransitionService`
were all already correct — `WoeCardsBatch12ScenarioTest` asserts the reanimated permanent's
controller directly, and that test passed before this change too.

## Test

`rules-engine/src/test/.../triggers/EntersUnderAnotherPlayersControlTest.kt` — an engine-level test
named for the mechanic rather than a card, since it covers the matcher, not a definition:

- a creature owned by player 1 entering the battlefield under player 2's control fires **only**
  player 2's "another creature you control enters" payoff;
- an ordinary owner-controlled entry still fires that player's payoff and not the opponent's.

Mutation-checked: with the fix neutralised the first case goes RED and the second stays green, so the
test pins this behaviour rather than passing incidentally.

## Verification

The diff is confined to `rules-engine/src/main`, so the gate is the engine suite plus the card
scenarios (`CLAUDE.local.md` → "Pick the gate by which modules the diff can reach").

| Command | Result |
|---|---|
| `just test-class EntersUnderAnotherPlayersControlTest` | 2/2 pass; mutation check RED as expected |
| `scripts/gradle-locked :rules-engine:test` | **3192 tests, 0 failures** (538 classes) |
| `scripts/gradle-locked :mtg-sets:<era>:tests:test` for all 9 eras, serially | **9594 tests, 0 failures** (3278 classes) |

The eras were run one at a time rather than through `:mtg-sets:scenarioTest`, whose fan-out
oversubscribes this box and trips `TestHangGuard` on timing rather than on a real defect.

**What this does not cover:** `game-server`, `:ai`, `:gym` and the web client were not run. None of
them hold trigger-matching logic and the diff cannot reach their sources, but that is a reasoned
scope decision, not evidence about them. No TypeScript was touched, so no JS tooling was run.

## Deliberately left out

`TriggerContext.fromEvent` (`TriggerContext.kt:213`) sets `triggeringPlayerId` with the same
`lastKnown?.controllerId ?: ownerId` fallback, so "that creature's controller" on an *entry* trigger
has the identical owner-vs-controller confusion. It is a separate defect with a wider blast radius:
`fromEvent` takes only a `GameEvent` and has no `GameState`, so fixing it means changing that
signature and every call site. Left for its own change rather than smuggled into this one.
