### PR TITLE
Add six Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BlindSpotGiant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BlindSpotGiant.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Blind-Spot Giant
+ * {2}{R}
+ * Creature — Giant Warrior
+ * 4/3
+ * This creature can't attack or block unless you control another Giant.
+ *
+ * "Can't attack or block" is two separate restrictions in the SDK — one checked at attacker
+ * declaration, one at blocker declaration — so it takes two static abilities over the same
+ * condition. `excludeSelf` is what makes it "*another* Giant".
+ */
+val BlindSpotGiant = card("Blind-Spot Giant") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "This creature can't attack or block unless you control another Giant."
+
+    val anotherGiant = Conditions.YouControl(
+        GameObjectFilter.Permanent.withSubtype(Subtype.GIANT),
+        excludeSelf = true
+    )
+
+    staticAbility {
+        ability = CantAttackUnless(anotherGiant)
+    }
+    staticAbility {
+        ability = CantBlockUnless(anotherGiant)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Jim Murray"
+        flavorText = "Among the solitude-loving giantkind, teamwork is unusual. But he appreciates hearing the occasional \"Swing down and to your left.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg?1783942880"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartForager.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartForager.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+
+/**
+ * Boggart Forager
+ * {R}
+ * Creature — Goblin Rogue
+ * 1/1
+ * {R}, Sacrifice this creature: Target player shuffles their library.
+ *
+ * `ShuffleLibraryEffect` defaults to the controller's library, so the target handle has to be
+ * passed explicitly — otherwise the Forager would shuffle its own controller's library no matter
+ * who was targeted.
+ */
+val BoggartForager = card("Boggart Forager") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "{R}, Sacrifice this creature: Target player shuffles their library."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.SacrificeSelf
+        )
+        val player = target("target player", Targets.Player)
+        effect = ShuffleLibraryEffect(target = player)
+        description = "{R}, Sacrifice this creature: Target player shuffles their library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Ron Spencer"
+        flavorText = "\"Reach in this hole, lose a hand. Reach in that hole, find a sparkly.\"\n—Auntie wisdom"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg?1783942881"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ElvishEulogist.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ElvishEulogist.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Elvish Eulogist
+ * {G}
+ * Creature — Elf Shaman
+ * 1/1
+ * Sacrifice this creature: You gain 1 life for each Elf card in your graveyard.
+ *
+ * The sacrifice is a cost, so the Eulogist is already in the graveyard when the ability resolves
+ * and counts itself — the filter matches any Elf *card*, not only Elf creatures, so an Elf Kindred
+ * spell in the yard counts too. `Count` rather than `AggregateZone` is the canonical spelling off
+ * the battlefield.
+ */
+val ElvishEulogist = card("Elvish Eulogist") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: You gain 1 life for each Elf card in your graveyard."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.GainLife(
+            DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.GRAVEYARD,
+                filter = GameObjectFilter.Any.withSubtype(Subtype.ELF)
+            )
+        )
+        description = "Sacrifice this creature: You gain 1 life for each Elf card in your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Ben Thompson"
+        flavorText = "\"No matter how adept our artistic skill, our effigies can never hope to capture the vibrant beauty of a living elf. Perhaps that is truly why we mourn.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg?1783942865"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GlimmerdustNap.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GlimmerdustNap.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Glimmerdust Nap
+ * {2}{U}
+ * Enchantment — Aura
+ * Enchant tapped creature
+ * Enchanted creature doesn't untap during its controller's untap step.
+ *
+ * The "tapped" restriction lives in the enchant clause only, so it is checked when the Aura is
+ * cast and by the state-based attachment check — a creature that untaps later (through another
+ * effect) keeps the Aura. `DOESNT_UNTAP` is the narrow untap-step flag rather than
+ * `CANT_BECOME_UNTAPPED`: a Twiddle still untaps the napper.
+ */
+val GlimmerdustNap = card("Glimmerdust Nap") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step."
+
+    auraTarget = Targets.TappedCreature
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Greg Staples"
+        flavorText = "The dreams of giants are as long as time and as deep as the earth. Thus they are prized by the dream-harvesting fae."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg?1783942901"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HamletbackGoliath.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HamletbackGoliath.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Hamletback Goliath
+ * {6}{R}
+ * Creature — Giant Warrior
+ * 6/6
+ * Whenever another creature enters, you may put X +1/+1 counters on this creature, where X is
+ * that creature's power.
+ *
+ * "Another creature" here means *any* creature, including an opponent's — so this is the bare
+ * `Triggers.entersBattlefield(Creature, OTHER)` factory, not `Triggers.OtherCreatureEnters`,
+ * which carries a "you control" clause the printed text doesn't have.
+ */
+val HamletbackGoliath = card("Hamletback Goliath") {
+    manaCost = "{6}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 6
+    toughness = 6
+    oracleText = "Whenever another creature enters, you may put X +1/+1 counters on this creature, " +
+        "where X is that creature's power."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature,
+            binding = TriggerBinding.OTHER
+        )
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power),
+            EffectTarget.Self
+        )
+        description = "you may put X +1/+1 counters on this creature, where X is that creature's power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "173"
+        artist = "Paolo Parente & Brian Snõddy"
+        flavorText = "\"If you live on a giant's back, there's only one individual you'll ever need to fear.\"\n—Gaddock Teeg"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg?1783942876"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SeedguideAsh.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SeedguideAsh.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Seedguide Ash
+ * {4}{G}
+ * Creature — Treefolk Druid
+ * 4/4
+ * When this creature dies, you may search your library for up to three Forest cards, put them
+ * onto the battlefield tapped, then shuffle.
+ *
+ * "Forest cards" — not *basic* Forest cards — so the filter is any land with the Forest subtype;
+ * a dual such as Stomping Ground qualifies. The whole-trigger "you may" is `optional = true`
+ * rather than a wrapped `MayEffect`, and `SelectionMode.ChooseUpTo` is what `searchLibrary`'s
+ * `count` already means, so "up to three" needs nothing extra.
+ */
+val SeedguideAsh = card("Seedguide Ash") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Druid"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature dies, you may search your library for up to three Forest cards, " +
+        "put them onto the battlefield tapped, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land.withSubtype(Subtype.FOREST),
+            count = 3,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            shuffleAfter = true
+        )
+        description = "you may search your library for up to three Forest cards, put them onto the " +
+            "battlefield tapped, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "John Avon"
+        flavorText = "\"May you shade three generations of seedlings.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg?1783942856"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HamletbackGoliathReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HamletbackGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hamletback Goliath reprint in C15. Canonical CardDefinition lives in Lorwyn, its earliest set.
+ */
+val HamletbackGoliathReprint = Printing(
+    oracleId = "ae45b04e-c52d-45e1-a752-0b76f64d7c8d",
+    name = "Hamletback Goliath",
+    setCode = "C15",
+    collectorNumber = "156",
+    scryfallId = "8ebf5844-8c3c-45fb-9f55-fdcc6ca3d986",
+    artist = "Paolo Parente & Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8ebf5844-8c3c-45fb-9f55-fdcc6ca3d986.jpg?1783938076",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/HamletbackGoliathReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/HamletbackGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hamletback Goliath reprint in M13. Canonical CardDefinition lives in Lorwyn, its earliest set.
+ */
+val HamletbackGoliathReprint = Printing(
+    oracleId = "ae45b04e-c52d-45e1-a752-0b76f64d7c8d",
+    name = "Hamletback Goliath",
+    setCode = "M13",
+    collectorNumber = "136",
+    scryfallId = "01ddeef1-f6f9-48c0-a93c-7bb3877c0e59",
+    artist = "Paolo Parente & Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01ddeef1-f6f9-48c0-a93c-7bb3877c0e59.jpg?1783940483",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HamletbackGoliathReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HamletbackGoliathReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hamletback Goliath reprint in JMP. Canonical CardDefinition lives in Lorwyn, its earliest set.
+ */
+val HamletbackGoliathReprint = Printing(
+    oracleId = "ae45b04e-c52d-45e1-a752-0b76f64d7c8d",
+    name = "Hamletback Goliath",
+    setCode = "JMP",
+    collectorNumber = "332",
+    scryfallId = "368ee4e3-c9eb-4898-99cd-bbe148936f99",
+    artist = "Paolo Parente & Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg?1783930390",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -257,6 +257,51 @@
     ]
 }
 
+// Blind-Spot Giant
+{
+    "name": "Blind-Spot Giant",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "This creature can't attack or block unless you control another Giant.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Giant",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Giant",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Jim Murray",
+        "flavorText": "Among the solitude-loving giantkind, teamwork is unusual. But he appreciates hearing the occasional \"Swing down and to your left.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75aaca31-8ed5-4e8a-8332-1cca77903f88.jpg?1783942880"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Bog-Strider Ash
 {
     "name": "Bog-Strider Ash",
@@ -353,6 +398,61 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Boggart Forager
+{
+    "name": "Boggart Forager",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "{R}, Sacrifice this creature: Target player shuffles their library.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ShuffleLibrary",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{R}, Sacrifice this creature: Target player shuffles their library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Ron Spencer",
+        "flavorText": "\"Reach in this hole, lose a hand. Reach in that hole, find a sparkly.\"\n—Auntie wisdom",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbc26374-d8de-4740-b1ec-ac92cfedbebc.jpg?1783942881"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1188,6 +1288,45 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Elvish Eulogist
+{
+    "name": "Elvish Eulogist",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "Sacrifice this creature: You gain 1 life for each Elf card in your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Elf"
+                    }
+                },
+                "descriptionOverride": "Sacrifice this creature: You gain 1 life for each Elf card in your graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Ben Thompson",
+        "flavorText": "\"No matter how adept our artistic skill, our effigies can never hope to capture the vibrant beauty of a living elf. Perhaps that is truly why we mourn.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/564b9d31-3079-45e3-acb3-a74169aa332e.jpg?1783942865"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -2509,6 +2648,37 @@
     ]
 }
 
+// Glimmerdust Nap
+{
+    "name": "Glimmerdust Nap",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant tapped creature\nEnchanted creature doesn't untap during its controller's untap step.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature tapped"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Greg Staples",
+        "flavorText": "The dreams of giants are as long as time and as deep as the earth. Thus they are prized by the dream-harvesting fae.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e05a4ce4-dbd5-4c47-8b40-c145c7f5d06c.jpg?1783942901"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Goldmeadow Dodger
 {
     "name": "Goldmeadow Dodger",
@@ -2684,6 +2854,57 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Hamletback Goliath
+{
+    "name": "Hamletback Goliath",
+    "manaCost": "{6}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "Whenever another creature enters, you may put X +1/+1 counters on this creature, where X is that creature's power.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Triggering",
+                            "numericProperty": "Power"
+                        },
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "you may put X +1/+1 counters on this creature, where X is that creature's power."
+                },
+                "descriptionOverride": "you may put X +1/+1 counters on this creature, where X is that creature's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "RARE",
+        "artist": "Paolo Parente & Brian Snõddy",
+        "flavorText": "\"If you live on a giant's back, there's only one individual you'll ever need to fear.\"\n—Gaddock Teeg",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96f71692-6389-462f-933e-b18b5aa7d76b.jpg?1783942876"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5280,6 +5501,83 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Seedguide Ash
+{
+    "name": "Seedguide Ash",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Treefolk Druid",
+    "oracleText": "When this creature dies, you may search your library for up to three Forest cards, put them onto the battlefield tapped, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land Forest"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "descriptionOverride": "you may search your library for up to three Forest cards, put them onto the battlefield tapped, then shuffle."
+                },
+                "descriptionOverride": "you may search your library for up to three Forest cards, put them onto the battlefield tapped, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "flavorText": "\"May you shade three generations of seedlings.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/eca605c0-6270-4238-bb77-0bbfd7568807.jpg?1783942856"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Six Lorwyn cards, each composing existing SDK primitives — no new engine vocabulary, so no new scenario tests (the snapshot and lint nets cover them).

- **Blind-Spot Giant** {2}{R} 4/3 — "can't attack or block unless you control another Giant". Two restrictions over one condition: `CantAttackUnless` + `CantBlockUnless` with `Conditions.YouControl(Permanent.withSubtype(GIANT), excludeSelf = true)`. There is no combined can't-attack-or-block type; `excludeSelf` is what spells "another".
- **Boggart Forager** {R} 1/1 — `Costs.Composite(Mana, SacrificeSelf)` + `ShuffleLibraryEffect`. That effect defaults to the *controller's* library, so the bound target-player handle is passed explicitly; leaving it off would have shuffled the wrong library no matter who was targeted.
- **Elvish Eulogist** {G} 1/1 — `Costs.SacrificeSelf` + `Effects.GainLife(DynamicAmount.Count(You, GRAVEYARD, Any.withSubtype(ELF)))`. `Any`, not `Creature`: "Elf **card**" catches Kindred cards in the yard. `Count` rather than `AggregateZone` is the canonical spelling off the battlefield. The Eulogist counts itself, since the sacrifice is a cost.
- **Glimmerdust Nap** {2}{U} — Aura. `auraTarget = Targets.TappedCreature` for the enchant clause, `GrantKeyword(AbilityFlag.DOESNT_UNTAP)` for the body. `DOESNT_UNTAP` is the narrow untap-step flag, not `CANT_BECOME_UNTAPPED` — a Twiddle still untaps the napper.
- **Seedguide Ash** {4}{G} 4/4 — `Triggers.Dies` with `optional = true` (the whole-trigger "you may") over `Patterns.Library.searchLibrary(destination = BATTLEFIELD, entersTapped = true)`. "Forest cards" is any land with the Forest subtype, not basics only, so a dual qualifies. `count = 3` already means `ChooseUpTo`.
- **Hamletback Goliath** {6}{R} 6/6 — `Triggers.entersBattlefield(Creature, OTHER)`, deliberately **not** `Triggers.OtherCreatureEnters`, which carries a "you control" clause the printed text doesn't have: an opponent's creature triggers it too. Counters from `EntityProperty(Triggering, Power)`.

Also adds the three `Printing` rows Hamletback Goliath's canonical placement owes M13, C15 and JMP — `just check-card-printing` flagged them as drift.

All six are LRW-canonical (Lorwyn is their earliest real printing). Lorwyn has no `backlog/sets/` entry, so there was no checklist to tick.

## Verification

- `just build` — everything compiles; `just rebless-cards` moved **only** `snapshots/cards/LRW.json`, insertions only, and every field (mana cost, P/T, rarity, collector number, artist, image) was re-checked against Scryfall.
- `just check-card-printing` — ok for all six.
- `just assay-differential --set LRW` — 108 compared, 13 divergent, none of them these six (Assay's grammar declines all six lines, so they aren't in the compared set; the 13 are pre-existing).
- Six tests failed in the full run — `ArenaHarnessTest`, `FrozenBaselineTest`, `PodArenaHarnessTest`, `AgelessSentinelsTest`, `AbattoirGhoulScenarioTest`, `AccursedCentaurTest`. Three were 120s coroutine timeouts and the AI ones are load-sensitive; the box was running a `just dev` server alongside three parallel era suites. **All six pass when re-run in isolation on this branch**, and `FrozenBaselineTest` also passes on clean `main`. Its deck is Portal-only (four vanilla creatures and 24 Mountains), so nothing in this PR can reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)