### PR TITLE
Respect no responses in mulligan parsing

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/llm/AiResponseParser.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/llm/AiResponseParser.kt
@@ -167,7 +167,7 @@ class AiResponseParser {
         if (lower.contains("keep") || lower == "a" || lower == "[a]") return true
         if (lower.contains("mulligan") || lower == "b" || lower == "[b]") return false
 
-        return parseYesNo(response)?.let { true } // "yes" = keep
+        return parseYesNo(response) // "yes" = keep, "no" = mulligan
     }
 
     /**

--- a/ai/src/test/kotlin/com/wingedsheep/ai/llm/AiResponseParserTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/llm/AiResponseParserTest.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.ai.llm
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class AiResponseParserTest : StringSpec({
+
+    val parser = AiResponseParser()
+
+    "parses explicit keep and mulligan responses" {
+        parser.parseMulliganChoice("Keep this hand") shouldBe true
+        parser.parseMulliganChoice("Take a mulligan") shouldBe false
+    }
+
+    "parses lettered mulligan choices" {
+        parser.parseMulliganChoice("A") shouldBe true
+        parser.parseMulliganChoice("[A]") shouldBe true
+        parser.parseMulliganChoice("B") shouldBe false
+        parser.parseMulliganChoice("[B]") shouldBe false
+    }
+
+    "preserves the boolean from the yes-no fallback" {
+        parser.parseMulliganChoice("yes") shouldBe true
+        parser.parseMulliganChoice("no") shouldBe false
+    }
+
+    "returns null for an unparseable mulligan response" {
+        parser.parseMulliganChoice("Draw seven cards").shouldBeNull()
+    }
+})


### PR DESCRIPTION
`AiResponseParser.parseMulliganChoice` currently maps any successfully parsed yes/no fallback to `true`, so a response of `no` is interpreted as keep.

Return the result of `parseYesNo` directly so the fallback preserves its meaning:

- `yes` → keep
- `no` → mulligan
- unparseable → `null`

Existing explicit `keep` / `mulligan` and A/B handling is unchanged.

Added focused regression coverage for the explicit choices, A/B choices, yes/no fallback, and unparseable input.

Verification:
- `just test-class AiResponseParserTest`
- `just test-ai`