### PR TITLE
Preserve hyphens in parsed subtypes (supersedes #2108)

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
@@ -51,7 +51,7 @@ data class TypeLine(
 
     companion object {
         fun parse(typeLineString: String): TypeLine {
-            val parts = typeLineString.split("—", "–", "-").map { it.trim() }
+            val parts = typeLineString.split(Regex("[—–]|\\s+-\\s+")).map { it.trim() }
             val typesPart = parts[0]
             val subtypesPart = parts.getOrNull(1)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TypeLine.kt
@@ -50,8 +50,15 @@ data class TypeLine(
     }
 
     companion object {
+        /**
+         * Splits the types from the subtypes. An em/en dash always separates; an ASCII "-"
+         * only when it stands alone between spaces, so hyphenated subtypes ("Assembly-Worker",
+         * "Power-Plant") keep their hyphen instead of being cut in half.
+         */
+        private val TYPE_SUBTYPE_SEPARATOR = Regex("[—–]|\\s+-\\s+")
+
         fun parse(typeLineString: String): TypeLine {
-            val parts = typeLineString.split(Regex("[—–]|\\s+-\\s+")).map { it.trim() }
+            val parts = typeLineString.split(TYPE_SUBTYPE_SEPARATOR).map { it.trim() }
             val typesPart = parts[0]
             val subtypesPart = parts.getOrNull(1)
 

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.sdk.core
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class TypeLineTest : DescribeSpec({
+
+    describe("TypeLine.parse") {
+        it("preserves hyphens inside subtype names") {
+            val parsed = TypeLine.parse("Artifact Creature — Assembly-Worker")
+
+            parsed.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+            parsed.subtypes shouldBe setOf(Subtype("Assembly-Worker"))
+        }
+
+        it("preserves another hyphenated subtype") {
+            val parsed = TypeLine.parse("Land — Urza's Power-Plant")
+
+            parsed.cardTypes shouldBe setOf(CardType.LAND)
+            parsed.subtypes shouldBe setOf(
+                Subtype("Urza's"),
+                Subtype("Power-Plant"),
+            )
+        }
+
+        it("still accepts an ASCII hyphen as a spaced type-subtype separator") {
+            val parsed = TypeLine.parse("Artifact Creature - Assembly-Worker")
+
+            parsed.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+            parsed.subtypes shouldBe setOf(Subtype("Assembly-Worker"))
+        }
+    }
+})

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/TypeLineTest.kt
@@ -13,7 +13,7 @@ class TypeLineTest : DescribeSpec({
             parsed.subtypes shouldBe setOf(Subtype("Assembly-Worker"))
         }
 
-        it("preserves another hyphenated subtype") {
+        it("splits Urza's Power-Plant into two land types, keeping the hyphen") {
             val parsed = TypeLine.parse("Land — Urza's Power-Plant")
 
             parsed.cardTypes shouldBe setOf(CardType.LAND)

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfAssemblerScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfAssemblerScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.kld.cards.SelfAssembler
+import com.wingedsheep.mtg.sets.definitions.mh2.cards.ArcboundPrototype
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Self-Assembler (KLD #232) — {5} Artifact Creature — Assembly-Worker, 4/4.
+ *
+ * "When this creature enters, you may search your library for an Assembly-Worker creature card,
+ *  reveal it, put it into your hand, then shuffle."
+ *
+ * The search filters on the *subtype*, which only works if `Assembly-Worker` survives type-line
+ * parsing intact — the hyphen used to be read as the type/subtype separator, leaving every printed
+ * Assembly-Worker in the corpus with the subtype `Assembly`, so this ability could never find
+ * anything. The negative case pins the filter to the subtype rather than the artifact-creature
+ * type: a Golem artifact creature is not offered.
+ */
+class SelfAssemblerScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SelfAssembler, ArcboundPrototype))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Cast Self-Assembler, accept its optional search, and take [pick] when the library offers it.
+     * Returns the names the search actually offered, so a test can assert on what was *not* findable.
+     */
+    fun GameTestDriver.castSelfAssembler(player: EntityId, pick: String? = null): List<String> {
+        val card = putCardInHand(player, "Self-Assembler")
+        giveMana(player, Color.WHITE, 5)
+        castSpell(player, card).isSuccess shouldBe true
+
+        val offered = mutableListOf<String>()
+        var guard = 0
+        while ((stackSize > 0 || isPaused) && guard++ < 40) {
+            when (val decision = pendingDecision) {
+                is YesNoDecision -> submitYesNo(player, true)
+                is SelectCardsDecision -> {
+                    offered += decision.options.mapNotNull { getCardName(it) }
+                    val chosen = decision.options.firstOrNull { getCardName(it) == pick }
+                    if (chosen != null) submitCardSelection(player, listOf(chosen))
+                    else submitCardSelection(player, emptyList())
+                }
+                null -> bothPass()
+                else -> autoResolveDecision()
+            }
+        }
+        return offered
+    }
+
+    test("the enters trigger finds an Assembly-Worker in the library and puts it into hand") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Arcbound Prototype")
+
+        val offered = driver.castSelfAssembler(me, pick = "Arcbound Prototype")
+
+        offered.contains("Arcbound Prototype") shouldBe true
+        (driver.findCardInHand(me, "Arcbound Prototype") != null) shouldBe true
+    }
+
+    test("an artifact creature that is not an Assembly-Worker is not offered") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Artifact Creature")
+
+        val offered = driver.castSelfAssembler(me, pick = "Artifact Creature")
+
+        offered.contains("Artifact Creature") shouldBe false
+        driver.findCardInHand(me, "Artifact Creature") shouldBe null
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -4637,7 +4637,7 @@
 {
     "name": "Urza's Power Plant",
     "manaCost": "",
-    "typeLine": "Land — Urza's Power",
+    "typeLine": "Land — Urza's Power-Plant",
     "oracleText": "{T}: Add {C}. If you control an Urza's Mine and an Urza's Tower, add {C}{C} instead.",
     "script": {
         "activatedAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -8120,7 +8120,7 @@
 {
     "name": "Mishra's Self-Replicator",
     "manaCost": "{5}",
-    "typeLine": "Artifact Creature — Assembly",
+    "typeLine": "Artifact Creature — Assembly-Worker",
     "oracleText": "Whenever you cast a historic spell, you may pay {1}. If you do, create a token that's a copy of Mishra's Self-Replicator. (Artifacts, legendaries, and Sagas are historic.)",
     "creatureStats": {
         "power": 2,

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -3780,7 +3780,7 @@
 {
     "name": "Self-Assembler",
     "manaCost": "{5}",
-    "typeLine": "Artifact Creature — Assembly",
+    "typeLine": "Artifact Creature — Assembly-Worker",
     "oracleText": "When this creature enters, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle.",
     "creatureStats": {
         "power": 4,

--- a/mtg-sets/src/test/resources/snapshots/cards/MH2.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH2.json
@@ -77,7 +77,7 @@
 {
     "name": "Arcbound Prototype",
     "manaCost": "{1}{W}",
-    "typeLine": "Artifact Creature — Assembly",
+    "typeLine": "Artifact Creature — Assembly-Worker",
     "oracleText": "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
     "creatureStats": {
         "power": 0,


### PR DESCRIPTION
Builds on #2108 (@huxinq) and finishes it: the parse fix is carried through unchanged, plus the corpus gates and the gameplay coverage it was missing. `origin/main` is merged in.

## The fix (from #2108)

`TypeLine.parse` treated every ASCII hyphen as the type/subtype separator, truncating hyphenated subtype names. ASCII `-` now separates only when it stands alone between spaces; the en/em dashes are unchanged.

## What this adds

**Re-blessed the four stale card snapshots.** The parse change moves four shipped cards' subtypes, so `:mtg-sets:test` failed on #2108 as it stood (`334 tests completed, 4 failed`):

| Set | Card | Before | After |
|-----|------|--------|-------|
| ATQ | Urza's Power Plant | `Land — Urza's Power` | `Land — Urza's Power-Plant` |
| KLD | Self-Assembler | `Artifact Creature — Assembly` | `… — Assembly-Worker` |
| DOM | Mishra's Self-Replicator | `Artifact Creature — Assembly` | `… — Assembly-Worker` |
| MH2 | Arcbound Prototype | `Artifact Creature — Assembly` | `… — Assembly-Worker` |

`just rebless-cards` moves exactly those four lines and nothing else.

**A card-level regression test, because this was a live gameplay bug.** Those three Assembly-Workers are the whole printed population of the subtype, and they all carried the subtype `Assembly` — so `Self-Assembler`'s ETB search (`GameObjectFilter.Creature.withSubtype("Assembly-Worker")`) could never find anything. Mishra's Factory's *"{T}: Target Assembly-Worker creature gets +1/+1"* had the same hole: it worked only on its own animated self, because `BecomeCreature` stamps the subtype string directly and never goes through `parse`. None of the three cards had a scenario test.

`SelfAssemblerScenarioTest` covers both axes — the enters trigger finds an Arcbound Prototype in the library and puts it in hand, and a Golem artifact creature is *not* offered (pinning the filter to the subtype rather than the artifact-creature type).

**Hoisted the separator regex** out of `parse` — it was compiled per call, and `parse` runs for every card at corpus load and on every type-line deserialization — with a line of KDoc on why the ASCII hyphen needs spaces. Renamed the `Urza's Power-Plant` case to name what it asserts (two land types, hyphen intact).

## Verification

- `just test-class TypeLineTest` — 3/3
- `just test-class SelfAssemblerScenarioTest` — 2/2
- `just test-class CardDefinitionSnapshotTest` — green after the re-bless
- `just test-rules` (`:rules-engine:test` + the full `:mtg-sets:scenarioTest` corpus) — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)