### PR TITLE
Preserve source metadata for countered abilities

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -783,7 +783,11 @@ data class SpellCounteredEvent(
 @SerialName("AbilityCounteredEvent")
 data class AbilityCounteredEvent(
     val abilityEntityId: EntityId,
-    val description: String
+    val description: String,
+    /** Last-known source metadata captured from the ability while it is still on the stack. */
+    val sourceId: EntityId? = null,
+    val sourceName: String? = null,
+    val controllerId: EntityId? = null,
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3351,9 +3351,14 @@ class StackResolver(
         val container = state.getEntity(abilityId)
             ?: return ExecutionResult.error(state, "Ability not found: $abilityId")
 
-        val description = container.get<TriggeredAbilityOnStackComponent>()?.description
-            ?: container.get<ActivatedAbilityOnStackComponent>()?.let { "${it.sourceName}'s ability" }
+        val triggeredAbility = container.get<TriggeredAbilityOnStackComponent>()
+        val activatedAbility = container.get<ActivatedAbilityOnStackComponent>()
+        val description = triggeredAbility?.description
+            ?: activatedAbility?.let { "${it.sourceName}'s ability" }
             ?: "Unknown ability"
+        val sourceId = triggeredAbility?.sourceId ?: activatedAbility?.sourceId
+        val sourceName = triggeredAbility?.sourceName ?: activatedAbility?.sourceName
+        val controllerId = triggeredAbility?.controllerId ?: activatedAbility?.controllerId
 
         // "Abilities can't be countered" (Spider-Punk): a battlefield GrantCantBeCountered with
         // includesAbilities = true whose filter matches this ability makes the counter fizzle — the
@@ -3367,7 +3372,15 @@ class StackResolver(
 
         return ExecutionResult.success(
             newState,
-            listOf(AbilityCounteredEvent(abilityId, description))
+            listOf(
+                AbilityCounteredEvent(
+                    abilityEntityId = abilityId,
+                    description = description,
+                    sourceId = sourceId,
+                    sourceName = sourceName,
+                    controllerId = controllerId,
+                )
+            )
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/stack/CounteredAbilityEventTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/stack/CounteredAbilityEventTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.mechanics.stack
+
+import com.wingedsheep.engine.core.AbilityCounteredEvent
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class CounteredAbilityEventTest : FunSpec({
+    val json = Json {
+        serializersModule = engineSerializersModule
+        encodeDefaults = true
+    }
+
+    test("countered ability retains source metadata after its source has disappeared") {
+        val abilityId = EntityId.of("countered-ability")
+        val sourceId = EntityId.of("departed-source")
+        val controllerId = EntityId.of("ability-controller")
+        val ability = TriggeredAbilityOnStackComponent(
+            sourceId = sourceId,
+            sourceName = "Departed Source",
+            controllerId = controllerId,
+            effect = Effects.DrawCards(1),
+            description = "Draw a card",
+        )
+        val state = GameState(
+            entities = mapOf(abilityId to ComponentContainer.of(ability)),
+            stack = listOf(abilityId),
+        )
+
+        // The source entity is already gone. The ability's stack component is the authoritative
+        // last-known relationship, and countering is the final chance to capture it.
+        state.getEntity(sourceId) shouldBe null
+
+        val result = StackResolver(cardRegistry = CardRegistry()).counterAbility(state, abilityId)
+
+        result.state.stack.shouldBeEmpty()
+        val event = result.events.filterIsInstance<AbilityCounteredEvent>().single()
+        event.sourceId shouldBe sourceId
+        event.sourceName shouldBe "Departed Source"
+        event.controllerId shouldBe controllerId
+
+        val encoded = json.parseToJsonElement(json.encodeToString<GameEvent>(event)).jsonObject
+        encoded["sourceId"]?.jsonPrimitive?.content shouldBe sourceId.value
+        encoded["sourceName"]?.jsonPrimitive?.content shouldBe "Departed Source"
+        encoded["controllerId"]?.jsonPrimitive?.content shouldBe controllerId.value
+    }
+
+    test("activated ability uses its stack controller rather than the source's current controller") {
+        val abilityId = EntityId.of("activated-ability")
+        val sourceId = EntityId.of("changed-controller-source")
+        val abilityControllerId = EntityId.of("ability-controller")
+        val currentSourceControllerId = EntityId.of("new-source-controller")
+        val ability = ActivatedAbilityOnStackComponent(
+            sourceId = sourceId,
+            sourceName = "Changed Source",
+            controllerId = abilityControllerId,
+            effect = Effects.DrawCards(1),
+        )
+        val state = GameState(
+            entities = mapOf(
+                sourceId to ComponentContainer.of(ControllerComponent(currentSourceControllerId)),
+                abilityId to ComponentContainer.of(ability),
+            ),
+            stack = listOf(abilityId),
+        )
+
+        val result = StackResolver(cardRegistry = CardRegistry()).counterAbility(state, abilityId)
+
+        val event = result.events.filterIsInstance<AbilityCounteredEvent>().single()
+        event.sourceId shouldBe sourceId
+        event.sourceName shouldBe "Changed Source"
+        event.controllerId shouldBe abilityControllerId
+    }
+
+    test("legacy serialized countered-ability events retain compatible defaults") {
+        val legacy = """{
+            "type":"AbilityCounteredEvent",
+            "abilityEntityId":"legacy-ability",
+            "description":"Legacy ability"
+        }""".trimIndent()
+
+        val decoded = json.decodeFromString<GameEvent>(legacy) as AbilityCounteredEvent
+
+        decoded.sourceId shouldBe null
+        decoded.sourceName shouldBe null
+        decoded.controllerId shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CounteredAbilityEventProjectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CounteredAbilityEventProjectionTest.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.AbilityCounteredEvent
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class CounteredAbilityEventProjectionTest : FunSpec({
+    test("client projection omits internal countered-ability source metadata") {
+        val event = AbilityCounteredEvent(
+            abilityEntityId = EntityId.of("internal-ability"),
+            description = "Ward ability",
+            sourceId = EntityId.of("internal-source"),
+            sourceName = "Hidden Source Name",
+            controllerId = EntityId.of("internal-controller"),
+        )
+
+        val projected = ClientEventTransformer.transform(
+            events = listOf(event),
+            viewingPlayerId = EntityId.of("viewer"),
+        ).single()
+
+        projected shouldBe ClientEvent.AbilityCountered(abilityDescription = "Ward ability")
+        val wirePayload = Json.encodeToString<ClientEvent>(projected)
+        wirePayload shouldNotContain "internal-ability"
+        wirePayload shouldNotContain "internal-source"
+        wirePayload shouldNotContain "Hidden Source Name"
+        wirePayload shouldNotContain "internal-controller"
+    }
+})


### PR DESCRIPTION
When an activated or triggered ability is countered, `AbilityCounteredEvent` currently retains only the ability entity ID and description. Once the stack object is removed, downstream engine consumers can no longer recover the ability's source or controller reliably.

Capture the ability's source ID, source name, and controller from the authoritative stack metadata before removal and carry them on `AbilityCounteredEvent`.

The new fields are nullable and defaulted so previously serialized events continue to decode. Countering behavior itself is unchanged.

Coverage includes:

- activated and triggered abilities;
- a source that has already left the battlefield;
- a source whose controller has changed after the ability was put on the stack;
- event serialization and legacy defaults;
- client projection, confirming the additional internal metadata is not exposed through the existing `ClientEvent`.

Verification:
- `just test-class CounteredAbilityEventTest`
- `just test-class CounteredAbilityEventProjectionTest`
- `just test-rules`