### PR TITLE
Don't offer a "you may" whose payment can't be completed

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2548,6 +2548,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     player "doesn't": the prompt is skipped and `otherwise` runs directly. Lets "you may sacrifice an
     artifact. If you don't, …" apply its else automatically when the controller has no artifact (the
     no-target analogue of a targeted "may" with no legal targets falling to its else branch).
+    The executor skips the prompt on its own in one more case, no authoring needed: a `then` that is
+    a `Gate.DoAction` scored by `SuccessCriterion.CollectionNonEmpty(name, min)` whose collection is
+    filled by a `SelectFromCollectionEffect(ChooseExactly)` over a `GatherCardsEffect` pool holding
+    fewer than `min` cards. No answer could clear that bar, so the option isn't a legal choice
+    (CR 608.2d) — **Emeritus of Ideation** with seven cards in the graveyard isn't asked whether to
+    exile eight, and the seven aren't spent for nothing. (CR 609.3's do-as-much-as-possible governs
+    *mandatory* instructions; it doesn't turn an unavailable option into a partial payment.)
   - `Gate.MayPay(cost)` — "You may [cost]. If you do, [then]." `cost` is a cost **effect**
     (`PayManaCostEffect`, `PayDynamicManaCostEffect`, `PayLifeEffect`, `SacrificeEffect`, or a
     `CompositeEffect` of them). An unaffordable cost (fixed mana, dynamic mana, and life are

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SkywarpSkaabScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SkywarpSkaabScenarioTest.kt
@@ -79,6 +79,34 @@ class SkywarpSkaabScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("one creature card in the graveyard: the may is never offered and nothing is exiled") {
+                // CR 608.2d — exiling two creature cards is impossible with one there, so the
+                // option isn't offered at all. The lone card must not be exiled for nothing.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Skywarp Skaab")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skywarp Skaab").error shouldBe null
+                game.resolveStack()
+
+                withClue("no yes/no is raised for an exile that can't be completed") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("the lone creature card stays in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Grizzly Bears") shouldBe false
+                }
+                withClue("no card was drawn") {
+                    game.isInHand(1, "Plains") shouldBe false
+                }
+            }
+
             test("declining the may leaves the graveyard untouched and draws no card") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.CollectEvidenceEffect
@@ -32,6 +33,7 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.DynamicHint
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
@@ -40,6 +42,8 @@ import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
 import com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect
 import com.wingedsheep.sdk.scripting.effects.DamageRecipient
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -73,6 +77,7 @@ class GatedEffectExecutor(
     private val manaSolver = ManaSolver(cardRegistry)
     private val conditionEvaluator = ConditionEvaluator()
     private val dynamicAmountEvaluator = DynamicAmountEvaluator()
+    private val predicateEvaluator = PredicateEvaluator()
 
     override fun execute(
         state: GameState,
@@ -159,6 +164,17 @@ class GatedEffectExecutor(
                         ?.let { effectExecutor(state, it, context) }
                         ?: EffectResult.success(state)
                 }
+            }
+            // CR 608.2d — a player can't choose an option that's impossible. "You may exile eight
+            // cards from your graveyard. If you do, this creature becomes prepared" can't be chosen
+            // with fewer than eight cards there: the inner action gate could never clear its
+            // CollectionNonEmpty bar. Offering the prompt anyway lets a "yes" partially perform the
+            // exile — CR 609.3's do-as-much-as-possible, which governs *mandatory* instructions,
+            // not an option that was never available — and spends those cards for nothing.
+            if (!optionalActionCanClearItsBar(state, effect.then, context)) {
+                return effect.otherwise
+                    ?.let { effectExecutor(state, it, context) }
+                    ?: EffectResult.success(state)
             }
         }
 
@@ -650,6 +666,62 @@ class GatedEffectExecutor(
             }
             else -> true
         }
+
+    /**
+     * Can the "if you do" action under a "you may" still clear its own success bar?
+     *
+     * Recognizes one idiom — "you may [choose exactly N cards from a gathered pool and move
+     * them]. If you do, …": a [Gate.DoAction] scored by [SuccessCriterion.CollectionNonEmpty]
+     * whose named collection is filled by a [SelectFromCollectionEffect] over a
+     * [GatherCardsEffect]'s pool. When that pool holds fewer cards than the criterion demands, no
+     * answer to the yes/no can make the gate succeed, so the option isn't a legal choice at all
+     * (CR 608.2d) and the prompt is skipped. Anything else answers `true` — prompt as before.
+     *
+     * The count is deliberately generous: a selection's `restrictions` can narrow it further, and
+     * they aren't applied here, so the prompt is only ever withheld when the payment is impossible
+     * outright. Gathering is a pure read — it stores a collection and changes no state and emits no
+     * events — so probing it here costs nothing and can't be observed.
+     */
+    private fun optionalActionCanClearItsBar(
+        state: GameState,
+        then: Effect,
+        context: EffectContext
+    ): Boolean {
+        var inner = then
+        while (true) {
+            val gated = inner as? GatedEffect ?: return true
+            when (val gate = gated.gate) {
+                // The `effectOncePerTurn` lowering sits between the consent gate and the action.
+                is Gate.OnceEachTurn -> inner = gated.then
+                is Gate.DoAction -> return actionCanClearItsBar(state, gate, context)
+                else -> return true
+            }
+        }
+    }
+
+    private fun actionCanClearItsBar(
+        state: GameState,
+        gate: Gate.DoAction,
+        context: EffectContext
+    ): Boolean {
+        val criterion = gate.successCriterion as? SuccessCriterion.CollectionNonEmpty ?: return true
+        val steps = (gate.action as? CompositeEffect)?.effects ?: listOf(gate.action)
+        val select = steps.filterIsInstance<SelectFromCollectionEffect>()
+            .firstOrNull { it.storeSelected == criterion.name } ?: return true
+        if (select.selection !is SelectionMode.ChooseExactly) return true
+        val gather = steps.filterIsInstance<GatherCardsEffect>()
+            .firstOrNull { it.storeAs == select.from } ?: return true
+        val pool = effectExecutor(state, gather, context).updatedCollections[select.from] ?: return true
+        val eligible = if (select.filter == GameObjectFilter.Any) {
+            pool
+        } else {
+            val predicateContext = PredicateContext.fromEffectContext(context)
+            pool.filter { cardId ->
+                predicateEvaluator.matches(state, state.projectedState, cardId, select.filter, predicateContext)
+            }
+        }
+        return eligible.size >= criterion.min
+    }
 
     /**
      * Resolve a [Gate.DoAction] gate (the lowered `IfYouDoEffect`). Follows the former

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmeritusCycleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmeritusCycleScenarioTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.state.components.battlefield.PreparedComponent
 import com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent
@@ -260,6 +261,79 @@ class EmeritusCycleScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Exiling eight cards re-prepares Emeritus of Ideation") {
                     game.isPrepared("Emeritus of Ideation") shouldBe true
+                }
+            }
+
+            test("fewer than eight cards in the graveyard: nothing is exiled and it stays unprepared") {
+                // CR 608.2d — a player can't choose an option that's impossible. With one card in
+                // the graveyard "exile eight cards" can't be performed, so the optional payment is
+                // not on offer at all: no card leaves the graveyard and it doesn't become prepared.
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Emeritus of Ideation", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .withCardInGraveyard(1, "Island")
+                repeat(5) { builder = builder.withCardInLibrary(1, "Island") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Emeritus of Ideation" to 2))
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                    game.resolveStack()
+                }
+                withClue("It does not become prepared") {
+                    game.isPrepared("Emeritus of Ideation") shouldBe false
+                }
+                withClue("The lone graveyard card is not exiled") {
+                    game.findCardsInGraveyard(1, "Island").size shouldBe 1
+                }
+            }
+
+            test("a graveyard shrunk in response takes the option away") {
+                // The option is judged as the trigger resolves, not when it triggered: eight cards
+                // at declare-attackers, seven by resolution, so there is nothing to offer — and the
+                // seven survivors must not be exiled for a payment that can't be completed.
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Emeritus of Ideation", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Withered Wretch", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(8) { builder = builder.withCardInGraveyard(1, "Island") }
+                repeat(5) { builder = builder.withCardInLibrary(1, "Island") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Emeritus of Ideation" to 2))
+                // The attack trigger is on the stack; eat one graveyard card in response to it.
+                val wretch = game.findPermanent("Withered Wretch")!!
+                val wretchAbility = cardRegistry.getCard("Withered Wretch")!!.activatedAbilities[0].id
+                val eaten = game.findCardsInGraveyard(1, "Island").first()
+                game.execute(
+                    ActivateAbility(
+                        game.player1Id, wretch, wretchAbility,
+                        targets = listOf(ChosenTarget.Card(eaten, game.player1Id, Zone.GRAVEYARD)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.answerYesNo(true)
+                    game.resolveStack()
+                }
+                withClue("Only the eaten card left the graveyard") {
+                    game.findCardsInGraveyard(1, "Island").size shouldBe 7
+                }
+                withClue("It does not become prepared") {
+                    game.isPrepared("Emeritus of Ideation") shouldBe false
                 }
             }
         }


### PR DESCRIPTION
# Don't offer a "you may" whose payment can't be completed

## The bug

From a playtest log: Emeritus of Ideation attacked with **one** card in its controller's graveyard.
The engine offered "you may exile eight cards from your graveyard", the controller said yes, and the
lone card was exiled — for nothing, since the payment could never be completed.

The selection filled with as many cards as it could reach (one), the `CollectionNonEmpty(min = 8)`
gate correctly scored the payment as failed, so the creature did *not* become prepared — but the
card was gone anyway.

CR 609.3 ("if an effect attempts to do something impossible, it does only as much as possible") is
what produced the partial exile, but it governs *mandatory* instructions. The rule that applies to an
optional payment is **CR 608.2d**: "The player can't choose an option that's illegal or impossible."
The prompt has to be absent, not offered and then scored. (Both quoted from
`MagicCompRules_20260808.txt`.)

Three other cards share the idiom and had the same hole: **Skywarp Skaab** (exile two creature cards
→ draw), **Aegis Sculptor** (exile two → +1/+1 counter), **Heated Argument** (exile one → 2 damage).

## The fix

No new SDK vocabulary — this is an engine-side gate decision, in the one place that already owns
"don't offer an impossible yes".

`GatedEffectExecutor`'s `Gate.MayDecide` branch now skips its prompt when the effect inside the gate
is a `Gate.DoAction` scored by `SuccessCriterion.CollectionNonEmpty(name, min)` whose named
collection is filled by a `SelectFromCollectionEffect(ChooseExactly)` over a `GatherCardsEffect`
pool holding fewer than `min` cards. No answer to the yes/no could clear that bar, so the option
isn't a legal choice at all. It sits with the branch's existing skips — an unaffordable `Gate.MayPay`
cost, a `ChooseActionEffect` with no feasible option, an unreachable collect-evidence threshold, and
a declared `FeasibilityCheck`.

Two properties worth stating, because both are load-bearing:

- **The pool is read at resolution**, not when the ability triggered — a graveyard emptied or shrunk
  in response takes the option away.
- **The check runs before the remembered-answer (auto-answer yield) path**, so a stored "yes" can't
  perform the impossible either.

The count is deliberately generous: a selection's `restrictions` could narrow it further and aren't
applied, so the prompt is only ever withheld when the payment is impossible outright. Every shape
that isn't this idiom prompts exactly as before.

`docs/card-sdk-language-reference.md` gains the corresponding paragraph under `Gate.MayDecide`.

## What this does not change

Mandatory instructions keep CR 609.3's do-as-much-as-possible behaviour — `SelectionMode.ChooseExactly`
still takes as many as it can reach when the instruction isn't an option. That's the correct reading
for "discard two cards" with one in hand, and changing it globally would have broken it.

## Verification

- `scripts/gradle-locked :rules-engine:test` — **BUILD SUCCESSFUL** (full engine suite, 2m14s).
- `just test-class EmeritusCycleScenarioTest` — green, including two new tests:
  - *fewer than eight cards in the graveyard: nothing is exiled and it stays unprepared*
  - *a graveyard shrunk in response takes the option away* (eight cards at declare-attackers, one
    eaten by Withered Wretch while the trigger is on the stack, seven survivors untouched)
- `just test-class SkywarpSkaabScenarioTest` — green, including a new test for the
  one-creature-card case (no prompt raised, the card stays in the graveyard, no draw).
- `just test-class HeatedArgumentScenarioTest`, `just test-class AegisSculptorScenarioTest` — green
  (the other two cards that reach the new branch).
- **Mutation check:** with the new branch disabled, both new Emeritus tests fail — the pre-fix engine
  exiles the lone card, and exiles all seven survivors in the in-response case.

**Not covered:** the full per-era card scenario suite (`just test-scenarios`) was not run. A grep of
`mtg-sets/*/src/main` shows the four cards above are the only ones that construct this shape, and no
`*Patterns` helper emits it, so no other card can reach the new branch; all four have green scenario
tests. Nothing outside Kotlin is touched — no client, server, or SDK code in the diff.

## Left out

The playtest report also said the creature became prepared. That half does not reproduce: with one
card in the graveyard the gate already scored the payment as failed and `BecomePrepared` never ran
(the new test asserts it). The likely explanation is that it was still prepared from entering the
battlefield — it enters prepared and stays so until the Ancestral Recall copy is cast — or a stale
server build. Nothing was changed on that basis.
