### PR TITLE
Destroy the ability object when an ability is countered

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -783,7 +783,21 @@ data class SpellCounteredEvent(
 @SerialName("AbilityCounteredEvent")
 data class AbilityCounteredEvent(
     val abilityEntityId: EntityId,
-    val description: String
+    val description: String,
+    /**
+     * The countered ability's source and controller, captured before the ability object is
+     * destroyed. Countering removes an ability from the stack and it ceases to exist
+     * (Rule 701.6a), so [abilityEntityId] resolves to nothing by the time this event is read —
+     * these fields are the only surviving record of what was countered.
+     *
+     * [controllerId] is the *ability's* controller, which need not be whoever controls
+     * [sourceId] now: once on the stack an ability exists independently of its source
+     * (Rule 113.7a). Null only for a stack object carrying neither ability component — the same
+     * case that yields the "Unknown ability" [description].
+     */
+    val sourceId: EntityId? = null,
+    val sourceName: String? = null,
+    val controllerId: EntityId? = null,
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3351,9 +3351,16 @@ class StackResolver(
         val container = state.getEntity(abilityId)
             ?: return ExecutionResult.error(state, "Ability not found: $abilityId")
 
-        val description = container.get<TriggeredAbilityOnStackComponent>()?.description
-            ?: container.get<ActivatedAbilityOnStackComponent>()?.let { "${it.sourceName}'s ability" }
+        val triggeredAbility = container.get<TriggeredAbilityOnStackComponent>()
+        val activatedAbility = container.get<ActivatedAbilityOnStackComponent>()
+        val description = triggeredAbility?.description
+            ?: activatedAbility?.let { "${it.sourceName}'s ability" }
             ?: "Unknown ability"
+        // Read the source and controller off the stack object while it still exists — the ability
+        // is about to cease to exist, and this is the last point either is knowable.
+        val sourceId = triggeredAbility?.sourceId ?: activatedAbility?.sourceId
+        val sourceName = triggeredAbility?.sourceName ?: activatedAbility?.sourceName
+        val controllerId = triggeredAbility?.controllerId ?: activatedAbility?.controllerId
 
         // "Abilities can't be countered" (Spider-Punk): a battlefield GrantCantBeCountered with
         // includesAbilities = true whose filter matches this ability makes the counter fizzle — the
@@ -3362,12 +3369,24 @@ class StackResolver(
             return ExecutionResult.success(state)
         }
 
-        // Remove from stack — abilities don't go to any zone
-        val newState = state.removeFromStack(abilityId)
+        // A countered ability is cancelled and removed from the stack (Rule 701.6a); it goes to no
+        // zone, and like a resolved ability (Rule 608.2n) it ceases to exist. Destroying the entity
+        // as well as the stack entry keeps that symmetry with the resolution paths, which all call
+        // removeEntity — otherwise every countered ability lingers in `entities` for the rest of the
+        // game and rides along in every serialized GameState.
+        val newState = state.removeEntity(abilityId)
 
         return ExecutionResult.success(
             newState,
-            listOf(AbilityCounteredEvent(abilityId, description))
+            listOf(
+                AbilityCounteredEvent(
+                    abilityEntityId = abilityId,
+                    description = description,
+                    sourceId = sourceId,
+                    sourceName = sourceName,
+                    controllerId = controllerId,
+                )
+            )
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/stack/CounteredAbilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/stack/CounteredAbilityTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.mechanics.stack
+
+import com.wingedsheep.engine.core.AbilityCounteredEvent
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * A countered ability is removed from the stack and ceases to exist (Rule 701.6a), which is why
+ * [AbilityCounteredEvent] has to carry the ability's source and controller: after the counter
+ * there is nothing left to read them off.
+ */
+class CounteredAbilityTest : FunSpec({
+    val resolver = StackResolver(cardRegistry = CardRegistry())
+
+    test("countering a triggered ability destroys the ability object") {
+        val abilityId = EntityId.of("countered-ability")
+        val state = GameState(
+            entities = mapOf(
+                abilityId to ComponentContainer.of(
+                    TriggeredAbilityOnStackComponent(
+                        sourceId = EntityId.of("source"),
+                        sourceName = "Source",
+                        controllerId = EntityId.of("controller"),
+                        effect = Effects.DrawCards(1),
+                        description = "Draw a card",
+                    )
+                )
+            ),
+            stack = listOf(abilityId),
+        )
+
+        val result = resolver.counterAbility(state, abilityId)
+
+        result.state.stack.shouldBeEmpty()
+        result.state.hasEntity(abilityId) shouldBe false
+    }
+
+    test("the countered event carries metadata the destroyed ability can no longer supply") {
+        val abilityId = EntityId.of("countered-ability")
+        val sourceId = EntityId.of("departed-source")
+        val controllerId = EntityId.of("ability-controller")
+        val state = GameState(
+            entities = mapOf(
+                abilityId to ComponentContainer.of(
+                    TriggeredAbilityOnStackComponent(
+                        sourceId = sourceId,
+                        sourceName = "Departed Source",
+                        controllerId = controllerId,
+                        effect = Effects.DrawCards(1),
+                        description = "Draw a card",
+                    )
+                )
+            ),
+            stack = listOf(abilityId),
+        )
+        // The source permanent has already left; the ability object was the last thing that knew
+        // about it, and countering destroys that too.
+        state.getEntity(sourceId) shouldBe null
+
+        val result = resolver.counterAbility(state, abilityId)
+
+        result.state.getEntity(abilityId) shouldBe null
+        val event = result.events.filterIsInstance<AbilityCounteredEvent>().single()
+        event.sourceId shouldBe sourceId
+        event.sourceName shouldBe "Departed Source"
+        event.controllerId shouldBe controllerId
+    }
+
+    test("an activated ability reports its own controller, not the source's current one") {
+        val abilityId = EntityId.of("activated-ability")
+        val sourceId = EntityId.of("stolen-source")
+        val abilityControllerId = EntityId.of("ability-controller")
+        val newSourceControllerId = EntityId.of("new-source-controller")
+        val state = GameState(
+            entities = mapOf(
+                // Rule 113.7a: an ability on the stack exists independently of its source, so the
+                // source changing hands afterwards doesn't change who controls the ability.
+                sourceId to ComponentContainer.of(ControllerComponent(newSourceControllerId)),
+                abilityId to ComponentContainer.of(
+                    ActivatedAbilityOnStackComponent(
+                        sourceId = sourceId,
+                        sourceName = "Stolen Source",
+                        controllerId = abilityControllerId,
+                        effect = Effects.DrawCards(1),
+                    )
+                ),
+            ),
+            stack = listOf(abilityId),
+        )
+
+        val result = resolver.counterAbility(state, abilityId)
+
+        val event = result.events.filterIsInstance<AbilityCounteredEvent>().single()
+        event.sourceId shouldBe sourceId
+        event.sourceName shouldBe "Stolen Source"
+        event.controllerId shouldBe abilityControllerId
+    }
+
+    test("a stack object with neither ability component is countered without metadata") {
+        val abilityId = EntityId.of("bare-stack-object")
+        val state = GameState(
+            entities = mapOf(abilityId to ComponentContainer.EMPTY),
+            stack = listOf(abilityId),
+        )
+
+        val event = resolver.counterAbility(state, abilityId)
+            .events.filterIsInstance<AbilityCounteredEvent>().single()
+
+        event.description shouldBe "Unknown ability"
+        event.sourceId shouldBe null
+        event.sourceName shouldBe null
+        event.controllerId shouldBe null
+    }
+})


### PR DESCRIPTION
Follow-up to #2117 (by @huxinq), taking the route the review landed on: fix the leak that makes the event metadata necessary, then capture the metadata.

### The leak

`StackResolver.counterAbility` removed the ability's id from the stack list (`removeFromStack` is `copy(stack = stack - entityId)`) but left the entity — with its `TriggeredAbilityOnStackComponent` / `ActivatedAbilityOnStackComponent` — in `GameState.entities`. Every resolution path already calls `removeEntity` (`StackResolver.kt` 2796, 2826, 2857, 2917, 2980); only the counter path didn't, so every countered ability lingered in `entities` for the rest of the game and rode along in every serialized `GameState`.

Countering cancels an ability and removes it from the stack (CR 701.6a); like a resolved ability (CR 608.2n) it then ceases to exist. The counter path now calls `removeEntity` too.

### The metadata

Destroying the entity is exactly what makes the ability's source and controller unrecoverable, so they're captured from the stack object before removal and carried on `AbilityCounteredEvent` — the fields #2117 added, now with a reader-visible reason to exist. The controller recorded is the *ability's*: once on the stack an ability exists independently of its source (CR 113.7a), so the source changing hands afterwards doesn't change it.

Client projection is unchanged — `ClientEvent.AbilityCountered` still carries only the description.

### Relative to #2117

- Keeps the three fields and the capture in `counterAbility`.
- Adds the `removeEntity` fix, which is what the fields are for.
- Drops the legacy-decode test: no `GameEvent` is persisted anywhere. Replays store `actions` (`CompactReplay.actions: List<GameAction>`), and `engineSerializersModule` serves the live WebSocket wire, which is never re-read from history.
- Drops the client-projection test: it asserted the new fields stay unused, which is the opposite of the intent here.
- New `CounteredAbilityTest` covers entity destruction, metadata surviving a source that has already left, the ability-vs-source controller split, and the no-component fallback.

### Verification

- `just test-class CounteredAbilityTest` — 4 tests, green.
- `just test-rules` — 12,792 tests, 0 failures. Includes `StifleTest` (counters an activated and a triggered ability), `SummaryDismissalScenarioTest` (`CounterAllOnStackExecutor`) and `SpiderPunkScenarioTest` (the abilities-can't-be-countered fizzle path, which returns before removal and is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)