### PR TITLE
Add six Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CeruleanSphinx.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CeruleanSphinx.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cerulean Sphinx
+ * {4}{U}{U}
+ * Creature — Sphinx
+ * 5/5
+ * Flying
+ * {U}: This creature's owner shuffles it into their library.
+ *
+ * Alabaster Dragon's self-shuffle, on an activated ability instead of a dies trigger:
+ * [Effects.ShuffleIntoLibrary] over [EffectTarget.Self] is `MoveToZoneEffect(… LIBRARY, Shuffled)`,
+ * and a card moved to a library always lands in its *owner's* one — so the printed "its owner"
+ * needs no extra wiring, and a stolen Sphinx still shuffles back to the player who owns it.
+ */
+val CeruleanSphinx = card("Cerulean Sphinx") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    oracleText = "Flying\n{U}: This creature's owner shuffles it into their library."
+    power = 5
+    toughness = 5
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ShuffleIntoLibrary(EffectTarget.Self)
+        description = "This creature's owner shuffles it into their library."
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Jim Murray"
+        flavorText = "\"About the sphinx, I have mixed feelings. Their wisdom I crave, but their " +
+            "secrecy I can't tolerate.\"\n—Szadek"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CoalhaulerSwine.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CoalhaulerSwine.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Coalhauler Swine
+ * {4}{R}{R}
+ * Creature — Boar Beast
+ * 4/4
+ * Whenever this creature is dealt damage, it deals that much damage to each player.
+ *
+ * [Triggers.TakesDamage] is the any-source "is dealt damage" trigger (combat, burn, pingers alike);
+ * the amount rides the trigger context as [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT], the same way
+ * Tephraderm reads it. "Each player" includes the Swine's own controller, so the payoff is a single
+ * [DealDamageEffect] at [EffectTarget.PlayerRef] over [Player.Each] rather than an opponent loop.
+ */
+val CoalhaulerSwine = card("Coalhauler Swine") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Boar Beast"
+    oracleText = "Whenever this creature is dealt damage, it deals that much damage to each player."
+    power = 4
+    toughness = 4
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = DealDamageEffect(
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            target = EffectTarget.PlayerRef(Player.Each),
+        )
+        description = "Whenever this creature is dealt damage, it deals that much damage to each player."
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Daren Bader"
+        flavorText = "Nothing stops industry in Ravnica—certainly not the safety of its workers."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/EmptyTheCatacombs.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/EmptyTheCatacombs.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Empty the Catacombs
+ * {3}{B}
+ * Sorcery
+ * Each player returns all creature cards from their graveyard to their hand.
+ *
+ * Twilight's Call's symmetric gather, landing in hand instead of on the battlefield: one
+ * [GatherCardsEffect] over every graveyard ([Player.Each]) filtered to creature cards, then a
+ * [MoveCollectionEffect] to [Zone.HAND] — cards moved to hand always go to their *owner's* hand,
+ * so no ownership rebinding is needed.
+ */
+val EmptyTheCatacombs = card("Empty the Catacombs") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Each player returns all creature cards from their graveyard to their hand."
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each,
+                        filter = GameObjectFilter.Creature,
+                    ),
+                    storeAs = "graveyardCreatures",
+                ),
+                MoveCollectionEffect(
+                    from = "graveyardCreatures",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                ),
+            ),
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "86"
+        artist = "Mark A. Nelson"
+        flavorText = "When the dead are laid to rest in Ravnica, it's usually just a nap."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Junktroller.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Junktroller.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Junktroller
+ * {4}
+ * Artifact Creature — Golem
+ * 0/6
+ * Defender
+ * {T}: Put target card from a graveyard on the bottom of its owner's library.
+ *
+ * "A graveyard" is any graveyard and "card" is any card type, so the target is the unrestricted
+ * [TargetFilter.CardInGraveyard]. The move is [Effects.Move] to [Zone.LIBRARY] at
+ * [ZonePlacement.Bottom] — cards moved to a library land in their *owner's* one, which is what the
+ * printed "its owner's library" asks for.
+ */
+val Junktroller = card("Junktroller") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    oracleText = "Defender\n{T}: Put target card from a graveyard on the bottom of its owner's library."
+    power = 0
+    toughness = 6
+    keywords(Keyword.DEFENDER)
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Move(t, Zone.LIBRARY, ZonePlacement.Bottom)
+        description = "Put target card from a graveyard on the bottom of its owner's library."
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "264"
+        artist = "Chippy"
+        flavorText = "One man's trash is another man's troller."
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SeedsOfStrength.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SeedsOfStrength.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Seeds of Strength
+ * {G}{W}
+ * Instant
+ * Target creature gets +1/+1 until end of turn.
+ * Target creature gets +1/+1 until end of turn.
+ * Target creature gets +1/+1 until end of turn.
+ *
+ * Three independent "target creature" requirements, so the same creature may legally be chosen more
+ * than once for a cumulative +2/+2 or +3/+3 (Scryfall ruling, 2005-10-01).
+ */
+val SeedsOfStrength = card("Seeds of Strength") {
+    manaCost = "{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+1 until end of turn.\n" +
+        "Target creature gets +1/+1 until end of turn.\n" +
+        "Target creature gets +1/+1 until end of turn."
+    spell {
+        val first = target("first", TargetCreature(filter = TargetFilter.Creature))
+        val second = target("second", TargetCreature(filter = TargetFilter.Creature))
+        val third = target("third", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, first),
+            Effects.ModifyStats(1, 1, second),
+            Effects.ModifyStats(1, 1, third),
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Ralph Horsley"
+        flavorText = "Beneath the beauty of light and seed is the might of Vitu-Ghazi."
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg"
+        ruling(
+            "2005-10-01",
+            "You may choose the same creature as a target multiple times since the card says " +
+                "“target creature” multiple times. You may give three different creatures " +
+                "+1/+1 each, one creature +2/+2 and another creature +1/+1, or a single creature +3/+3.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SelesnyaSagittars.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SelesnyaSagittars.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanBlockAdditionalForCreatureGroup
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Selesnya Sagittars
+ * {3}{G}{W}
+ * Creature — Elf Archer
+ * 2/5
+ * Reach (This creature can block creatures with flying.)
+ * This creature can block an additional creature each combat.
+ *
+ * [CanBlockAdditionalForCreatureGroup] scoped to [GroupFilter.source] — the same static Brave the
+ * Sands hands to a whole team, pointed at just this Elf. Both the blocker-legality check
+ * (`BlockPhaseManager`) and the legal-action enumerator read `additionalBlockCount`, so the extra
+ * block is offered as well as allowed.
+ */
+val SelesnyaSagittars = card("Selesnya Sagittars") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Elf Archer"
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "This creature can block an additional creature each combat."
+    power = 2
+    toughness = 5
+    keywords(Keyword.REACH)
+    staticAbility {
+        ability = CanBlockAdditionalForCreatureGroup(
+            count = 1,
+            filter = GroupFilter.source(),
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"What's their strike range, you ask? Let's put it this way: sagittars aim " +
+            "their bows using *maps*.\"\n—Otak, Tin Street shopkeep"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CoalhaulerSwineReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CoalhaulerSwineReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coalhauler Swine reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.rav.cards.CoalhaulerSwine`.
+ */
+val CoalhaulerSwineReprint = Printing(
+    oracleId = "c00f082b-787f-4f96-8356-c10d35713bc4",
+    name = "Coalhauler Swine",
+    setCode = "J22",
+    collectorNumber = "516",
+    scryfallId = "a9b5e55b-e888-4bd5-a6a9-d253f6e406a6",
+    artist = "Daren Bader",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9b5e55b-e888-4bd5-a6a9-d253f6e406a6.jpg?1783918957",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/JunktrollerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/JunktrollerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Junktroller reprint in RNA. Canonical CardDefinition lives in Ravnica: City of Guilds (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.rav.cards.Junktroller`.
+ */
+val JunktrollerReprint = Printing(
+    oracleId = "6ef46fd7-82db-45d3-b02e-7312384577f3",
+    name = "Junktroller",
+    setCode = "RNA",
+    collectorNumber = "235",
+    scryfallId = "03fd8ee5-0a2a-4c68-9b09-01945c7189ab",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03fd8ee5-0a2a-4c68-9b09-01945c7189ab.jpg?1783933625",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -743,6 +743,52 @@
     ]
 }
 
+// Cerulean Sphinx
+{
+    "name": "Cerulean Sphinx",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying\n{U}: This creature's owner shuffles it into their library.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Library",
+                    "placement": "Shuffled"
+                },
+                "descriptionOverride": "This creature's owner shuffles it into their library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "Jim Murray",
+        "flavorText": "\"About the sphinx, I have mixed feelings. Their wisdom I crave, but their secrecy I can't tolerate.\"\n—Szadek",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Char
 {
     "name": "Char",
@@ -961,6 +1007,47 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Coalhauler Swine
+{
+    "name": "Coalhauler Swine",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Boar Beast",
+    "oracleText": "Whenever this creature is dealt damage, it deals that much damage to each player.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature is dealt damage, it deals that much damage to each player."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Daren Bader",
+        "flavorText": "Nothing stops industry in Ravnica—certainly not the safety of its workers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc001cef-3afd-4128-989f-ac99dc76b243.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2220,6 +2307,49 @@
     ]
 }
 
+// Empty the Catacombs
+{
+    "name": "Empty the Catacombs",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player returns all creature cards from their graveyard to their hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "player": "Each",
+                        "filter": "creature"
+                    },
+                    "storeAs": "graveyardCreatures"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "graveyardCreatures",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "RARE",
+        "artist": "Mark A. Nelson",
+        "flavorText": "When the dead are laid to rest in Ravnica, it's usually just a nap.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Farseek
 {
     "name": "Farseek",
@@ -3441,6 +3571,57 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Junktroller
+{
+    "name": "Junktroller",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Defender\n{T}: Put target card from a graveyard on the bottom of its owner's library.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Library",
+                    "placement": "Bottom"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Put target card from a graveyard on the bottom of its owner's library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "UNCOMMON",
+        "artist": "Chippy",
+        "flavorText": "One man's trash is another man's troller.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e2c5f0a-755f-4d4f-b5f8-a938562797f9.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Keening Banshee
@@ -4978,6 +5159,105 @@
     ]
 }
 
+// Seeds of Strength
+{
+    "name": "Seeds of Strength",
+    "manaCost": "{G}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.\nTarget creature gets +1/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "first"
+                    }
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "second"
+                    }
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "third"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "first"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "second"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "third"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Ralph Horsley",
+        "flavorText": "Beneath the beauty of light and seed is the might of Vitu-Ghazi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfa1ac13-adbd-439a-90b2-9c506aec0836.jpg",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "You may choose the same creature as a target multiple times since the card says “target creature” multiple times. You may give three different creatures +1/+1 each, one creature +2/+2 and another creature +1/+1, or a single creature +3/+3."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Seismic Spike
 {
     "name": "Seismic Spike",
@@ -5159,6 +5439,43 @@
         "rarity": "UNCOMMON",
         "artist": "Mark Zug",
         "imageUri": "https://cards.scryfall.io/normal/front/2/1/21061ce3-d098-4057-b341-c5db6ee1b6d4.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Selesnya Sagittars
+{
+    "name": "Selesnya Sagittars",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nThis creature can block an additional creature each combat.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanBlockAdditionalForCreatureGroup",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "\"What's their strike range, you ask? Let's put it this way: sagittars aim their bows using *maps*.\"\n—Otak, Tin Street shopkeep",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a72e933-d977-4be9-985f-8b8cf1267f8c.jpg"
     },
     "colorIdentityOverride": [
         "WHITE",


### PR DESCRIPTION
Six Ravnica: City of Guilds cards, each built entirely from existing `Effects.*` /
`Filters.*` / static-ability vocabulary — no new SDK types, so they share one PR
per `CONTRIBUTING.md`. RAV goes 142 → 148 of 291.

| Card | What it does | Composed from |
|---|---|---|
| **Seeds of Strength** `{G}{W}` | Three separate "target creature gets +1/+1 until end of turn" | Three independent `target()` requirements over `Effects.ModifyStats` in a `Composite` |
| **Selesnya Sagittars** `{3}{G}{W}` | Reach; can block an additional creature each combat | `CanBlockAdditionalForCreatureGroup(count = 1, GroupFilter.source())` |
| **Cerulean Sphinx** `{4}{U}{U}` | Flying; `{U}`: its owner shuffles it into their library | `Effects.ShuffleIntoLibrary(EffectTarget.Self)` |
| **Empty the Catacombs** `{3}{B}` | Each player returns all creature cards from their graveyard to their hand | `GatherCardsEffect(GRAVEYARD, Player.Each, Creature)` → `MoveCollectionEffect(ToZone(HAND))` |
| **Coalhauler Swine** `{4}{R}{R}` | Whenever it's dealt damage, it deals that much to each player | `Triggers.TakesDamage` + `TRIGGER_DAMAGE_AMOUNT` → `DealDamageEffect(PlayerRef(Player.Each))` |
| **Junktroller** `{4}` | Defender; `{T}`: put target card from a graveyard on the bottom of its owner's library | `TargetFilter.CardInGraveyard` + `Effects.Move(LIBRARY, ZonePlacement.Bottom)` |

### Notes on the rules corners

- **Seeds of Strength** keeps three *independent* target requirements rather than one
  `count = 3`, so the same creature can legally be chosen more than once for a cumulative
  +2/+2 or +3/+3. The 2005-10-01 Scryfall ruling that says so is recorded on the card.
- **Cerulean Sphinx** and **Junktroller** both print "its **owner's** library".
  `ZoneTransitionService` keys every non-battlefield destination to the card's owner, so
  neither needs an explicit `Player` reference — and a stolen Sphinx still shuffles back
  to the player who owns it.
- **Empty the Catacombs** is Twilight's Call's symmetric gather with `Zone.HAND` in place
  of the battlefield. Verified that the destination's default `Player.You` does not
  misroute: `MoveCollectionExecutor` only collapses to owner on battlefield *exits*, but
  `ZoneTransitionService` then keys the hand as `ZoneKey(ownerId, HAND)`, so each card
  really does land in its own owner's hand.
- **Coalhauler Swine**'s trigger is the any-source `Triggers.TakesDamage`, not a combat-only
  one — burn and pingers set it off too. "Each player" includes its own controller.
- **Selesnya Sagittars**' `additionalBlockCount` is read by *both* `BlockPhaseManager`
  (legality) and `CombatEnumerator` (legal actions), so the second block is offered in the
  UI as well as allowed by the validator.

### Reprint rows

RAV is the earliest real printing for all six. Two are reprinted into sets this repo has
scaffolded, and both get a `Printing` row rather than a duplicate canonical:

- Coalhauler Swine → **J22** `516`
- Junktroller → **RNA** `235`

(Cerulean Sphinx and Junktroller are also in RVR, which has no module here.)

### Dropped from the batch

**Screeching Griffin** (`{R}: Target creature can't block this creature this turn.`) was in
the original six and was dropped once it turned out to need new engine vocabulary. The SDK
has "can't block *at all*" (`CantBlockEffect`) and filter-based blocker restrictions
(`CanOnlyBlockCreaturesWith`, `CantBeBlockedBy`), but nothing entity-specific: the filters
are `GameObjectFilter`s with no "this particular entity" predicate, and
`CanOnlyBlockCreaturesWithRule` resolves `IsSource` against the **blocker**, so
`notSourceItself()` can't be borrowed either. The positive mirror does exist —
`ForceBlockEffect` → `MustBlockSpecificAttacker` — so the faithful fix is a
`CantBlockSpecificAttacker` modification plus one pair-scoped rule in
`defaultBlockEvasionRules`, which `BlockCheckContext` already keys on
`(attackerId, blockerId)`. That's `add-feature` work and belongs in its own PR. Shipping the
blanket `Effects.CantBlock` instead would have been wrong — it would stop the target
blocking *anything*.

### Verification

- `just build` — green, with the RAV `CardDefinitionSnapshotTest` re-blessed
  (`just rebless-cards`); the golden diff is **additions only**, no existing card moved.
- `just check-card-printing` — `ok` for all six.
- `just assay-differential --set RAV` — **103/103 confirmed, 0 divergent.**

**Pre-existing failure, not from this branch:** `:oracle-assay:test` fails one case,
`AmountsTest > "life keeps its numeral and declines the clause the damage verbs read"`
(a grammar rule now accepts a line the test expects declined). `:oracle-assay` depends only
on `:mtg-sdk`, and this branch touches nothing outside `mtg-sets/`, so it can't be the
cause. The gate above was run as `build -x :oracle-assay:test`; everything else is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
