### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartLoggers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartLoggers.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Boggart Loggers
+ * {2}{B}
+ * Creature — Goblin Rogue
+ * 2/1
+ * Forestwalk
+ * {2}{B}, Sacrifice this creature: Destroy target Treefolk or Forest.
+ *
+ * The printed target names two subtypes and no card type — a Treefolk is any permanent with that
+ * creature type and a Forest is any land with that land type — so this is one
+ * [GameObjectFilter.Permanent] with a [GameObjectFilter.withAnySubtype] union, not two clauses and not
+ * a creature-typed filter. An animated Forest satisfies both halves; either is enough.
+ */
+val BoggartLoggers = card("Boggart Loggers") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\n" +
+        "{2}{B}, Sacrifice this creature: Destroy target Treefolk or Forest."
+
+    keywords(Keyword.FORESTWALK)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.SacrificeSelf)
+        val treefolkOrForest = target(
+            "target Treefolk or Forest",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.withAnySubtype(Subtype.TREEFOLK.value, Subtype.FOREST.value)
+                )
+            )
+        )
+        effect = Effects.Destroy(treefolkOrForest)
+        description = "Destroy target Treefolk or Forest."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Auntie Flint lent axes to Nibb and Gyik, thinking they'd share their experiences with her. She's still waiting for them to come back.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg?1783942893"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CennsHeir.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CennsHeir.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cenn's Heir
+ * {1}{W}
+ * Creature — Kithkin Soldier
+ * 1/1
+ * Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.
+ *
+ * The printed count has no controller clause, so it is [Player.Each] rather than the more common
+ * `Player.You` — in a multiplayer attack a teammate's Kithkin counts too. "Other" is the aggregate's
+ * own `excludeSelf`, not a subtract-one, so the count stays right even in the corner where the source
+ * has stopped being a Kithkin by the time the trigger resolves.
+ */
+val CennsHeir = card("Cenn's Heir") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val otherAttackingKithkin = DynamicAmount.AggregateBattlefield(
+            Player.Each,
+            GameObjectFilter.Creature.withSubtype(Subtype.KITHKIN).attacking(),
+            excludeSelf = true
+        )
+        effect = Effects.ModifyStats(
+            power = otherAttackingKithkin,
+            toughness = otherAttackingKithkin,
+            target = EffectTarget.Self
+        )
+        description = "Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Steven Belledin"
+        flavorText = "\"His home clachan's familial spirit bolsters his own, but he will be ready to preside over the town as cenn only after he learns to project that strength to others.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg?1783942917"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SilvergillDouser.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SilvergillDouser.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Silvergill Douser
+ * {1}{U}
+ * Creature — Merfolk Wizard
+ * 1/1
+ * {T}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control.
+ *
+ * "Merfolk and/or Faeries" is a subtype union over permanents you control, so it is one
+ * [GameObjectFilter.withAnySubtype] count — a changeling is counted once, not twice. The penalty is
+ * the Spontaneous Mutation idiom, `Multiply(count, -1)`, since [DynamicAmount] has no negation of its
+ * own. The Douser itself is a Merfolk and counts, so the floor is -1/-0.
+ */
+val SilvergillDouser = card("Silvergill Douser") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(
+            power = DynamicAmount.Multiply(
+                DynamicAmount.AggregateBattlefield(
+                    Player.You,
+                    GameObjectFilter.Permanent.withAnySubtype(Subtype.MERFOLK.value, Subtype.FAERIE.value)
+                ),
+                -1
+            ),
+            toughness = DynamicAmount.Fixed(0),
+            target = creature
+        )
+        description = "Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Daren Bader"
+        flavorText = "\"The Silvergill school monitors traffic on the Lanes, ensuring that the riffraff don't interfere with travelers.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg?1783942898"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WarrenPilferers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WarrenPilferers.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Warren Pilferers
+ * {4}{B}
+ * Creature — Goblin Rogue
+ * 3/3
+ * When this creature enters, return target creature card from your graveyard to your hand. If that
+ * card is a Goblin card, this creature gains haste until end of turn.
+ *
+ * The Cemetery Recruitment shape: the "if that card is a Goblin card" rider is read off the *target*
+ * while it is still the graveyard card, so it is a [Conditions.TargetMatchesFilter] wrapping the whole
+ * resolution rather than a second effect that would have to chase the card into the hand. The haste
+ * lands on the Pilferers itself ([EffectTarget.Self]), not on the returned card.
+ */
+val WarrenPilferers = card("Warren Pilferers") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Rogue"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, return target creature card from your graveyard to your hand. " +
+        "If that card is a Goblin card, this creature gains haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        val returnToHand = Effects.Move(creatureCard, Zone.HAND)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN)),
+            effect = returnToHand.then(Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)),
+            elseEffect = returnToHand
+        )
+        description = "Return target creature card from your graveyard to your hand. " +
+            "If that card is a Goblin card, this creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Wayne Reynolds"
+        flavorText = "\"What do they need all this stuff for? They're dead. We're alive. Simple enough.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg?1783942882"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WellgabberApothecary.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WellgabberApothecary.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Wellgabber Apothecary
+ * {4}{W}
+ * Creature — Merfolk Cleric
+ * 2/3
+ * {1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.
+ *
+ * "Tapped Merfolk or Kithkin creature" is one noun phrase, so it is one filter — `tapped()` plus a
+ * [GameObjectFilter.withAnySubtype] union — not a [TargetFilter.or] of two clauses, which is for
+ * targets that span different zones. Every [PreventDamageEffect] field stays at its default: a null
+ * `amount` is "prevent all", the scope covers non-combat damage, and the duration is "this turn".
+ * The ability has no tap symbol, so it can be activated repeatedly.
+ */
+val WellgabberApothecary = card("Wellgabber Apothecary") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Merfolk Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val t = target(
+            "target tapped Merfolk or Kithkin creature",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature
+                        .tapped()
+                        .withAnySubtype(Subtype.MERFOLK.value, Subtype.KITHKIN.value)
+                )
+            )
+        )
+        effect = PreventDamageEffect(target = t)
+        description = "Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Brandon Dorman"
+        flavorText = "\"You've discovered that boggarts bite, I see. And will the militia be chasing this lot? . . . Ah, you're staying in town to avoid Nath's hunt. Wise. Now this poultice . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg?1783942907"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoggartLoggersScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoggartLoggersScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.BoggartLoggers
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Boggart Loggers (LRW #103) — "Forestwalk. {2}{B}, Sacrifice this creature: Destroy target
+ * Treefolk or Forest."
+ *
+ * The printed target names two subtypes and no card type, so it is one permanent filter with a
+ * subtype union. That is exactly the thing worth proving from the outside: a Forest *land* has to be
+ * a legal target, not just a Treefolk creature, and an unrelated creature must not be.
+ */
+class BoggartLoggersScenarioTest : FunSpec({
+
+    val destroyAbility = BoggartLoggers.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BoggartLoggers)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("a Forest land is a legal target and is destroyed") {
+        val d = driver()
+        val loggers = d.putCreatureOnBattlefield(d.player1, "Boggart Loggers")
+        val forest = d.putLandOnBattlefield(d.player2, "Forest")
+        d.giveColorlessMana(d.player1, 2)
+        d.giveMana(d.player1, Color.BLACK, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, loggers, destroyAbility, targets = listOf(ChosenTarget.Permanent(forest)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("The Forest should be destroyed by the subtype-union target") {
+            d.state.getBattlefield().contains(forest) shouldBe false
+        }
+        withClue("Sacrificing itself is part of the cost, so the Loggers are gone too") {
+            d.state.getBattlefield().contains(loggers) shouldBe false
+        }
+    }
+
+    test("a Treefolk creature is a legal target and is destroyed") {
+        val d = driver()
+        val loggers = d.putCreatureOnBattlefield(d.player1, "Boggart Loggers")
+        val oak = d.putCreatureOnBattlefield(d.player2, "Cloudcrown Oak")
+        d.giveColorlessMana(d.player1, 2)
+        d.giveMana(d.player1, Color.BLACK, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, loggers, destroyAbility, targets = listOf(ChosenTarget.Permanent(oak)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(oak) shouldBe false
+    }
+
+    test("a creature that is neither Treefolk nor Forest is not a legal target") {
+        val d = driver()
+        val loggers = d.putCreatureOnBattlefield(d.player1, "Boggart Loggers")
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 2)
+        d.giveMana(d.player1, Color.BLACK, 1)
+
+        d.submitExpectFailure(
+            ActivateAbility(d.player1, loggers, destroyAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        )
+
+        withClue("An illegal activation pays nothing — the Loggers are still around") {
+            d.state.getBattlefield().contains(loggers) shouldBe true
+            d.state.getBattlefield().contains(bear) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CennsHeirScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CennsHeirScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cenn's Heir (LRW #8, {1}{W}, Creature — Kithkin Soldier 1/1).
+ *
+ *   Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.
+ *
+ * The count is an `excludeSelf` aggregate, so the two things worth proving are that the Heir does not
+ * count itself (a lone attack leaves it a 1/1, not a 2/2) and that a *non*-attacking Kithkin sitting
+ * back does not feed it either.
+ */
+class CennsHeirScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Cenn's Heir") {
+
+            test("attacking alone leaves it a 1/1 — it never counts itself") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Cenn's Heir", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val heir = game.findPermanent("Cenn's Heir")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Cenn's Heir" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Zero other attacking Kithkin is +0/+0") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(heir) shouldBe 1
+                    after.getToughness(heir) shouldBe 1
+                }
+            }
+
+            test("two other attacking Kithkin make it a 3/3") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Cenn's Heir", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Goldmeadow Harrier", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Kinsbaile Skirmisher", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val heir = game.findPermanent("Cenn's Heir")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf(
+                        "Cenn's Heir" to 2,
+                        "Goldmeadow Harrier" to 2,
+                        "Kinsbaile Skirmisher" to 2
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Two other attacking Kithkin is +2/+2 on a 1/1") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(heir) shouldBe 3
+                    after.getToughness(heir) shouldBe 3
+                }
+            }
+
+            test("a Kithkin left at home is not counted, and a non-Kithkin attacker is not either") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Cenn's Heir", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Goldmeadow Harrier", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val heir = game.findPermanent("Cenn's Heir")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // The Harrier stays home; the Bears attack but are no Kithkin.
+                game.declareAttackers(mapOf("Cenn's Heir" to 2, "Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Neither an idle Kithkin nor an attacking non-Kithkin counts") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(heir) shouldBe 1
+                    after.getToughness(heir) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvergillDouserScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvergillDouserScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AvianChangeling
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.NightshadeStinger
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SilvergillDouser
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Silvergill Douser (LRW #87) — "{T}: Target creature gets -X/-0 until end of turn, where X is the
+ * number of Merfolk and/or Faeries you control."
+ *
+ * X is one subtype-union count, so the two things worth proving are that a Faerie feeds the same
+ * tally a Merfolk does, and that a changeling — which is *both* — is counted once rather than twice.
+ * The Douser itself is a Merfolk, so the floor is -1/-0, never -0/-0.
+ */
+class SilvergillDouserScenarioTest : FunSpec({
+
+    val douseAbility = SilvergillDouser.activatedAbilities.single().id
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + SilvergillDouser + NightshadeStinger + AvianChangeling)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("the Douser alone counts itself: -1/-0") {
+        val d = driver()
+        val douser = d.putCreatureOnBattlefield(d.player1, "Silvergill Douser")
+        d.removeSummoningSickness(douser)
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+
+        d.submit(
+            ActivateAbility(d.player1, douser, douseAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        val after = projector.project(d.state)
+        withClue("One Merfolk (the Douser) is -1/-0 on a 2/2") {
+            after.getPower(bear) shouldBe 1
+            after.getToughness(bear) shouldBe 2
+        }
+    }
+
+    test("a Faerie feeds the same tally a Merfolk does") {
+        val d = driver()
+        val douser = d.putCreatureOnBattlefield(d.player1, "Silvergill Douser")
+        d.removeSummoningSickness(douser)
+        d.putCreatureOnBattlefield(d.player1, "Nightshade Stinger")
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+
+        d.submit(
+            ActivateAbility(d.player1, douser, douseAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        val after = projector.project(d.state)
+        withClue("A Merfolk plus a Faerie is -2/-0") {
+            after.getPower(bear) shouldBe 0
+            after.getToughness(bear) shouldBe 2
+        }
+    }
+
+    test("a changeling is both halves of the union but is counted once") {
+        val d = driver()
+        val douser = d.putCreatureOnBattlefield(d.player1, "Silvergill Douser")
+        d.removeSummoningSickness(douser)
+        d.putCreatureOnBattlefield(d.player1, "Avian Changeling")
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+
+        d.submit(
+            ActivateAbility(d.player1, douser, douseAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        val after = projector.project(d.state)
+        withClue("The changeling is one permanent, so the tally is 2, not 3") {
+            after.getPower(bear) shouldBe 0
+        }
+    }
+
+    test("an opponent's Merfolk does not count — the tally is yours only") {
+        val d = driver()
+        val douser = d.putCreatureOnBattlefield(d.player1, "Silvergill Douser")
+        d.removeSummoningSickness(douser)
+        d.putCreatureOnBattlefield(d.player2, "Nightshade Stinger")
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+
+        d.submit(
+            ActivateAbility(d.player1, douser, douseAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        val after = projector.project(d.state)
+        withClue("Bob's Faerie is on Bob's side of the count") {
+            after.getPower(bear) shouldBe 1
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WarrenPilferersScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WarrenPilferersScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Warren Pilferers (LRW #146, {4}{B}, Creature — Goblin Rogue 3/3).
+ *
+ *   When this creature enters, return target creature card from your graveyard to your hand.
+ *   If that card is a Goblin card, this creature gains haste until end of turn.
+ *
+ * The rider reads the *target*, not the Pilferers, and it is checked while the card is still in the
+ * graveyard — so the tests prove both branches of that gate plus the graveyard-ownership restriction.
+ */
+class WarrenPilferersScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Warren Pilferers") {
+
+            test("returning a Goblin card grants the Pilferers haste") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Warren Pilferers")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInGraveyard(1, "Boggart Forager")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Warren Pilferers").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("The enters trigger should ask for a graveyard target; got $decision") {
+                    decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                }
+                val forager = game.findCardsInGraveyard(1, "Boggart Forager").single()
+                game.selectTargets(listOf(forager))
+                game.resolveStack()
+
+                withClue("Boggart Forager should be back in Alice's hand") {
+                    game.isInHand(1, "Boggart Forager") shouldBe true
+                    game.isInGraveyard(1, "Boggart Forager") shouldBe false
+                }
+                withClue("A Goblin card was returned, so the Pilferers gains haste") {
+                    val pilferers = game.findPermanent("Warren Pilferers")!!
+                    stateProjector.project(game.state).hasKeyword(pilferers, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("returning a non-Goblin creature card returns it but grants no haste") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Warren Pilferers")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Warren Pilferers").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("The return happens on both branches of the gate") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Grizzly Bears is no Goblin, so no haste") {
+                    val pilferers = game.findPermanent("Warren Pilferers")!!
+                    stateProjector.project(game.state).hasKeyword(pilferers, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("an opponent's graveyard is never a legal source") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Warren Pilferers")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Boggart Forager")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Warren Pilferers").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                val opponentsForager = game.findCardsInGraveyard(2, "Boggart Forager").single()
+                withClue("Bob's Boggart Forager is not a legal target for Alice's Pilferers") {
+                    decision.legalTargets[0].orEmpty() shouldNotContain opponentsForager
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WellgabberApothecaryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WellgabberApothecaryScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Wellgabber Apothecary (LRW #47) — "{1}{W}: Prevent all damage that would be dealt to target tapped
+ * Merfolk or Kithkin creature this turn."
+ *
+ * "Tapped Merfolk or Kithkin creature" is one noun phrase and therefore one filter, so the tests pin
+ * all three of its conjuncts: an untapped Merfolk is not a legal target, a tapped non-Merfolk /
+ * non-Kithkin is not either, and a tapped one of each tribe is. Prodigal Sorcerer is the damage
+ * source, which also proves the shield is not combat-only.
+ */
+class WellgabberApothecaryScenarioTest : ScenarioTestBase() {
+
+    private val pingAbilityId by lazy {
+        cardRegistry.getCard("Prodigal Sorcerer")!!.activatedAbilities[0].id
+    }
+    private val shieldAbilityId by lazy {
+        cardRegistry.getCard("Wellgabber Apothecary")!!.activatedAbilities[0].id
+    }
+
+    init {
+        fun board() = scenario()
+            .withPlayers("Alice", "Bob")
+            .withCardOnBattlefield(1, "Wellgabber Apothecary", summoningSickness = false)
+            .withLandsOnBattlefield(1, "Plains", 4)
+            .withCardOnBattlefield(1, "Fallowsage", tapped = true, summoningSickness = false)
+            .withCardOnBattlefield(1, "Kinsbaile Skirmisher", tapped = true, summoningSickness = false)
+            .withCardOnBattlefield(1, "Goldmeadow Harrier", summoningSickness = false)
+            .withCardOnBattlefield(1, "Grizzly Bears", tapped = true, summoningSickness = false)
+            .withCardOnBattlefield(1, "Prodigal Sorcerer", summoningSickness = false)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        fun TestGame.autoPayIfAsked() {
+            if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+        }
+
+        fun TestGame.shield(targetName: String) = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = findPermanent("Wellgabber Apothecary")!!,
+                abilityId = shieldAbilityId,
+                targets = listOf(ChosenTarget.Permanent(findPermanent(targetName)!!))
+            )
+        )
+
+        fun TestGame.ping(targetName: String) {
+            val result = execute(
+                ActivateAbility(
+                    playerId = player1Id,
+                    sourceId = findPermanent("Prodigal Sorcerer")!!,
+                    abilityId = pingAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(findPermanent(targetName)!!))
+                )
+            )
+            withClue("ping activation failed: ${result.error}") { result.error shouldBe null }
+            autoPayIfAsked()
+            resolveStack()
+        }
+
+        fun TestGame.markedDamage(id: EntityId): Int =
+            state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+        test("a tapped Merfolk is shielded from noncombat damage") {
+            val game = board()
+            val fallowsage = game.findPermanent("Fallowsage")!!
+
+            withClue("a tapped Merfolk is a legal target") {
+                game.shield("Fallowsage").error shouldBe null
+            }
+            game.autoPayIfAsked()
+            game.resolveStack()
+
+            game.ping("Fallowsage")
+            withClue("the shield prevents all damage this turn") {
+                game.markedDamage(fallowsage) shouldBe 0
+            }
+        }
+
+        test("a tapped Kithkin is shielded too — the union has two halves") {
+            val game = board()
+            val skirmisher = game.findPermanent("Kinsbaile Skirmisher")!!
+
+            game.shield("Kinsbaile Skirmisher").error shouldBe null
+            game.autoPayIfAsked()
+            game.resolveStack()
+
+            game.ping("Kinsbaile Skirmisher")
+            game.markedDamage(skirmisher) shouldBe 0
+        }
+
+        test("an untapped Kithkin is not a legal target") {
+            val game = board()
+            withClue("the Harrier is a Kithkin but is untapped") {
+                game.shield("Goldmeadow Harrier").error shouldNotBe null
+            }
+        }
+
+        test("a tapped creature of neither tribe is not a legal target") {
+            val game = board()
+            withClue("Grizzly Bears is tapped but is no Merfolk and no Kithkin") {
+                game.shield("Grizzly Bears").error shouldNotBe null
+            }
+        }
+
+        test("an unshielded tapped Merfolk still takes the damage") {
+            val game = board()
+            val fallowsage = game.findPermanent("Fallowsage")!!
+
+            game.ping("Fallowsage")
+            withClue("without the ability there is nothing to prevent the ping") {
+                game.markedDamage(fallowsage) shouldBe 1
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -5703,6 +5703,65 @@
     "colorIdentityOverride": []
 }
 
+// Silvergill Douser
+{
+    "name": "Silvergill Douser",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{T}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "permanent Merfolk|Faerie"
+                        },
+                        "multiplier": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Daren Bader",
+        "flavorText": "\"The Silvergill school monitors traffic on the Lanes, ensuring that the riffraff don't interfere with travelers.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/8875c883-8d56-406b-bd89-42199a6e79f5.jpg?1783942898"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Skeletal Changeling
 {
     "name": "Skeletal Changeling",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -7177,6 +7177,58 @@
     ]
 }
 
+// Wellgabber Apothecary
+{
+    "name": "Wellgabber Apothecary",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Merfolk Cleric",
+    "oracleText": "{1}{W}: Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target tapped Merfolk or Kithkin creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Merfolk|Kithkin tapped"
+                        },
+                        "id": "target tapped Merfolk or Kithkin creature"
+                    }
+                ],
+                "descriptionOverride": "Prevent all damage that would be dealt to target tapped Merfolk or Kithkin creature this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Brandon Dorman",
+        "flavorText": "\"You've discovered that boggarts bite, I see. And will the militia be chasing this lot? . . . Ah, you're staying in town to avoid Nath's hunt. Wise. Now this poultice . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg?1783942907"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Wispmare
 {
     "name": "Wispmare",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -7066,6 +7066,87 @@
     "colorIdentityOverride": []
 }
 
+// Warren Pilferers
+{
+    "name": "Warren Pilferers",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "When this creature enters, return target creature card from your graveyard to your hand. If that card is a Goblin card, this creature gains haste until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "creature Goblin"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature card from your graveyard"
+                                },
+                                "destination": "Hand"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card from your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                },
+                "descriptionOverride": "Return target creature card from your graveyard to your hand. If that card is a Goblin card, this creature gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"What do they need all this stuff for? They're dead. We're alive. Simple enough.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc98177b-34a6-44e1-9abd-6fd8df09fc70.jpg?1783942882"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Warren-Scourge Elf
 {
     "name": "Warren-Scourge Elf",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -680,6 +680,52 @@
     ]
 }
 
+// Cenn's Heir
+{
+    "name": "Cenn's Heir",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "AggregateBattlefield",
+                        "player": "Each",
+                        "filter": "creature Kithkin attacking",
+                        "excludeSelf": true
+                    },
+                    "toughnessModifier": {
+                        "type": "AggregateBattlefield",
+                        "player": "Each",
+                        "filter": "creature Kithkin attacking",
+                        "excludeSelf": true
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature attacks, it gets +1/+1 until end of turn for each other attacking Kithkin."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Steven Belledin",
+        "flavorText": "\"His home clachan's familial spirit bolsters his own, but he will be ready to preside over the town as cenn only after he learns to project that strength to others.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7610d2f-e35f-42fa-a3fb-fcae54bf5a1d.jpg?1783942917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cloudcrown Oak
 {
     "name": "Cloudcrown Oak",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -527,6 +527,69 @@
     ]
 }
 
+// Boggart Loggers
+{
+    "name": "Boggart Loggers",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)\n{2}{B}, Sacrifice this creature: Destroy target Treefolk or Forest.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Treefolk or Forest"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Treefolk|Forest"
+                        },
+                        "id": "target Treefolk or Forest"
+                    }
+                ],
+                "descriptionOverride": "Destroy target Treefolk or Forest."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Auntie Flint lent axes to Nibb and Gyik, thinking they'd share their experiences with her. She's still waiting for them to come back.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ed9a638-c3f9-48dd-9633-5c52146e0dcd.jpg?1783942893"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Boggart Sprite-Chaser
 {
     "name": "Boggart Sprite-Chaser",


### PR DESCRIPTION
Five Lorwyn commons, all built from existing `Effects.*` / `Filters` vocabulary — no new SDK types. Lorwyn goes 132 → 137 cards.

| Card | What it does | Composed from |
|---|---|---|
| **Cenn's Heir** {1}{W} 1/1 | Whenever it attacks, +1/+1 for each other attacking Kithkin | `Triggers.Attacks` + `DynamicAmount.AggregateBattlefield(Player.Each, …, excludeSelf = true)` → `Effects.ModifyStats(target = Self)` |
| **Silvergill Douser** {1}{U} 1/1 | `{T}`: target creature gets -X/-0, X = Merfolk and/or Faeries you control | `Costs.Tap` + `Multiply(AggregateBattlefield(Player.You, Permanent.withAnySubtype(…)), -1)` |
| **Boggart Loggers** {2}{B} 2/1 | Forestwalk; `{2}{B}`, sac: destroy target Treefolk or Forest | `Keyword.FORESTWALK` + `Costs.SacrificeSelf` + `Effects.Destroy` over a `Permanent.withAnySubtype("Treefolk","Forest")` target |
| **Warren Pilferers** {4}{B} 3/3 | ETB: return a creature card from your graveyard; if it's a Goblin card, gain haste | `ConditionalEffect(Conditions.TargetMatchesFilter(…))` around `Effects.Move(…, HAND)` + `Effects.GrantKeyword(HASTE, Self)` — the Cemetery Recruitment shape |
| **Wellgabber Apothecary** {4}{W} 2/3 | `{1}{W}`: prevent all damage to target tapped Merfolk or Kithkin creature this turn | `PreventDamageEffect` with every field defaulted, over `Creature.tapped().withAnySubtype(…)` |

### Modelling notes

- **Subtype unions are one filter, not two clauses.** "Tapped Merfolk or Kithkin creature" and "Treefolk or Forest" are each a single printed noun phrase, so each is one `GameObjectFilter.withAnySubtype(…)`. `TargetFilter.or` is for *cross-zone* unions and is deliberately not used here. A consequence worth stating: a changeling satisfies both halves of the Douser's union and is therefore counted **once** — there's a test for it.
- **"each other attacking Kithkin" has no controller clause**, so Cenn's Heir counts over `Player.Each`, not the more common `Player.You` — in a multiplayer attack a teammate's Kithkin counts. "Other" is the aggregate's own `excludeSelf` rather than a subtract-one, which stays right in the corner where the source has stopped being a Kithkin by the time the trigger resolves.
- **Warren Pilferers' rider reads the target, not the source**, and it is checked while the card is still in the graveyard — hence one `ConditionalEffect` around the whole resolution rather than a second effect chasing the card into hand.
- **Boggart Loggers targets a permanent, not a creature.** The printed line names two subtypes and no card type, so a Forest *land* is a legal target; that is the half most likely to be modelled wrong, and it has its own test.

### Tests

Argentum Assay **declines all five oracle texts** (grammar gaps, not SDK gaps: `-X/-0`, the `or` in a subtype union, the `If that card is…` rider, `tapped` as an adjective). A decline is not a pass, so the differential gate cannot see these cards at all — I wrote scenario tests instead of relying on it. One file per card, 18 tests, all passing:

- `CennsHeirScenarioTest` — attacking alone is +0/+0 (never counts itself); two other attacking Kithkin is +2/+2; an idle Kithkin and an attacking non-Kithkin both count for nothing.
- `SilvergillDouserScenarioTest` — the Douser alone is -1/-0; a Faerie feeds the same tally a Merfolk does; a changeling is counted once, not twice; an opponent's Faerie is on the opponent's side of the count.
- `BoggartLoggersScenarioTest` — a Forest **land** is a legal target and dies; a Treefolk creature likewise; an unrelated creature is rejected and the cost is not paid.
- `WarrenPilferersScenarioTest` — both branches of the Goblin gate (haste / no haste, return happens either way); an opponent's graveyard is never a legal source.
- `WellgabberApothecaryScenarioTest` — all three conjuncts of the filter (untapped Kithkin rejected, tapped non-tribal rejected, tapped Merfolk and tapped Kithkin accepted); the shield stops noncombat damage; an unshielded tapped Merfolk still takes it.

### Verification

- `just build` — compiles clean.
- `just rebless-cards` — only `LRW.json` moved, pure insertion, only these five cards. Each commit carries its own snapshot block, so every commit is independently green.
- `just test-scenarios 2003-2007` and `:mtg-sets:test` (FacadeBoundaryTest + snapshots) — green.
- `just check-card-printing` for all five — each is canonical in its earliest real printing (all five are LRW-first); the `plst` and `mma` reprints are in unscaffolded sets, so no `Printing` rows are owed.
- `just assay-differential --set LRW` — 13 DIVERGENT, **unchanged from main** and none of them these cards (the pre-existing harbinger cycle and target-id folds).

### Pre-existing failure on main, disclosed

`just build` fails at `:oracle-assay:test` → `AmountsTest > "life keeps its numeral and declines the clause the damage verbs read"` (expects `Declined`, gets an `Accepted` `GainLifeEffect`). This is **not from this branch**: `:oracle-assay` depends only on `:mtg-sdk` — explicitly *not* on `:mtg-sets` — and this branch touches nothing but LRW card files, their tests, and the LRW snapshot. It looks like fallout from #2114 (`assay-life-equal-to`), already on main. I have not touched it. Everything else above passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
