### PR TITLE
Add two Innistrad: Crimson Vow cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 260 / 273
+**Implemented:** 261 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -62,7 +62,7 @@
 - [x] Cruel Witness
 - [x] Crushing Canopy
 - [x] Cultivator Colossus
-- [ ] Curse of Hospitality
+- [x] Curse of Hospitality
 - [x] Dawnhart Disciple
 - [x] Dawnhart Geist
 - [x] Daybreak Combatants

--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 259 / 273
+**Implemented:** 260 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -42,7 +42,7 @@
 - [x] Catapult Fodder
 - [ ] Cemetery Desecrator
 - [x] Cemetery Gatekeeper
-- [ ] Cemetery Illuminator
+- [x] Cemetery Illuminator
 - [x] Cemetery Protector
 - [x] Cemetery Prowler
 - [x] Ceremonial Knife

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4168,6 +4168,15 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `.sharingCreatureTypeWith`. A reference that resolves to nothing matches nothing. Evaluated for real in
   targeting/search/count contexts; inert (false) in static-projection, permissive (true) in
   cost-calculation.
+- `.sharingCardTypeWithLinkedExile()` — `CardPredicate.SharesCardTypeWithLinkedExile`: shares ≥1 card type
+  with **any** card still exiled with the filtering ability's source (CR 607 linked abilities). The
+  pile-wide form of `.sharingCardTypeWith(EntityReference.LinkedExiledCard())`, which reads one index —
+  a card that keeps exiling (Cemetery Illuminator, one per enter *and* per attack) means "a card exiled
+  with this creature", which an index can't say. Card types only, per the cemetery cycle's shared ruling.
+  An empty pile matches nothing. Cemetery Illuminator:
+  `CastSpellTypesFromTopOfLibrary(GameObjectFilter.Any.sharingCardTypeWithLinkedExile(), maxCastsPerTurn = 1)`.
+  The cost-side reading of the same pile is `CostReductionSource.SharedCardTypesWithLinkedExile`
+  (Cemetery Prowler).
 - `.sharingColorWith(entity)` — `CardPredicate.SharesColorWith(entity)`: shares ≥1 (projected) color with
   a referenced entity (e.g. `EntityReference.Triggering`). Mirror of `.sharingCreatureTypeWith(entity)`.
   Colorless entities share no color (never match). Used by Spreading Plague ("destroy all other creatures
@@ -4628,6 +4637,14 @@ work for abilities-on-stack (which carry no `CardComponent`).
   so it matches regardless of who controls the attacker; fails closed without controller context and
   has no last-known fallback, exactly like its mirror. Tomik, Wielder of Law counts the attacking batch
   with it: `Compare(DynamicAmounts.battlefield(Player.Each, GameObjectFilter.Creature.attackingYouOrYourPlaneswalkers()).count(), GTE, Fixed(2))`.
+- `IsAttackingEnchantedPlayer` (filter builder `attackingEnchantedPlayer()`) — attacking the player the
+  filtering ability's **source Aura is attached to** (CR 303 enchant player). The attachment-scoped third
+  of the trio above: `IsAttackingAnOpponent` and `IsAttackingYouOrYourPlaneswalkers` both scope the
+  defender against the ability's *controller*, which is the wrong player for a Curse — a curse on one
+  opponent must not read as "any opponent". Only a player id matches, so a planeswalker the enchanted
+  player controls drops out; fails closed when the source isn't attached to a player, and has no
+  last-known fallback like its two siblings. Curse of Hospitality: `GrantKeyword(Keyword.TRAMPLE,
+  GroupFilter(GameObjectFilter.Creature.attackingEnchantedPlayer()))`.
 - `IsBlocking` — declared as blocker this combat.
 - `HasLockedDoor` (filter builder `hasLockedDoor()`) — a Room permanent (CR 709.5) with at least one locked
   door, i.e. a half lacking its "unlocked" designation (CR 709.5c). Reads the engine's
@@ -5300,6 +5317,16 @@ Named sugar for the common cases; reach for the factories for any other combinat
 - `OneOrMoreCreaturesDealCombatDamageToYou(filter = Creature)` — **defensive combat-damage batch trigger** (ANY binding): "whenever one or more creatures deal combat damage to *you*" (Witch-king of Angmar). Fires at most once per combat-damage batch regardless of how many creatures connected with the trigger's controller (the damaged player), unlike per-source `dealsDamage(recipient = You, …)` which fires once per connecting creature. The triggering entity is an arbitrary matching damager. Pair with the `dealtCombatDamageToSourceControllerThisTurn()` filter for "...each opponent sacrifices a creature that dealt combat damage to you this turn".
 - `TakesDamage` — source is dealt damage by any source (SELF binding).
 - `YouAreDealtDamage` — "whenever **you're** dealt damage" (ANY binding, `DealsDamageEvent(recipient = You)` with no source filter): the *player*-recipient sibling of `TakesDamage`, firing for **every** source — a creature in combat, a burn spell, an artifact. Fires once per damage instance; read the amount with `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)` for "put that many counters" payoffs (Sun Droplet), and the triggering entity is the damage source.
+- `RecipientFilter.EnchantedPlayer` — the *player* the observing ability's source Aura is attached to (CR
+  303 enchant player), the enchant-player sibling of `RecipientFilter.EnchantedCreature`. Scoped by the
+  source's **attachment**, not its controller, so a Curse on one opponent can't fire off damage dealt to
+  another — which is exactly why `RecipientFilter.Opponent` is wrong for a Curse. Matches only when the
+  attachment target is a player. Pair it with `binding = TriggerBinding.ANY` + a `sourceFilter`, **not**
+  with `ATTACHED`: the source filter is what binds the *damaging creature* as the triggering entity, which
+  is what "that creature's controller" needs. Curse of Hospitality: `Triggers.dealsDamage(damageType =
+  DamageType.Combat, recipient = RecipientFilter.EnchantedPlayer, sourceFilter = GameObjectFilter.Creature,
+  binding = TriggerBinding.ANY)`, paying off into `GrantMayPlayFromExileEffect(recipient =
+  EffectTarget.ControllerOfTriggeringEntity)`.
 - `damageDealtToYou(sourceFilter?, damageType?)` — the source-restricted factory behind `YouAreDealtDamage`: "whenever [a source matching the filter] deals damage to you". `GameObjectFilter.Creature` for Aurification's "whenever a creature deals damage to you"; `GameObjectFilter.Any.opponentControls()` for Farsight Mask's "a source an opponent controls". "You" is the controller of the permanent bearing the trigger, and the filter's controller-relative predicates resolve against that same player. **Always use one of these two for a player-recipient damage trigger** — `RecipientFilter.You` is unmatchable on the general observer path (`TriggerMatcher.matchesDealsDamageTrigger` returns false for it) and reaches its ability only through the dedicated damage-to-you index.
 - `CreatureDealtDamageByThisDies` — Etali / Sengir / Soul Collector shape (SELF binding): "whenever a creature dealt damage by *this* permanent this turn dies". Uses `CreatureDealtDamageBySourceDiesEvent(sourceFilter = null)`.
 - `CreatureDealtDamageByAttachedDies` — the same event and the same tracker read one object further out (ATTACHED binding): "whenever a creature dealt damage by **equipped** creature this turn dies" (Scythe of the Wretched). The only difference from `CreatureDealtDamageByThisDies` is where the damage tracker is read from — the attachment target rather than the permanent bearing the trigger. The attachment is resolved when the creature *dies*, not when the damage was dealt, so an Equipment that moved between the two moments still fires (its own ruling) and an unattached Equipment never fires. Use this for any Equipment or Aura whose text says "equipped creature" / "enchanted creature" in a dealt-damage-dies trigger; `creatureDealtDamageBySourceDies(filter)` is for the board-wide observer wording instead.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -103,6 +103,27 @@ sealed interface RecipientFilter {
         override val description = "enchanted creature"
     }
 
+    /**
+     * The *player* the observing ability's source Aura is attached to — "deals combat damage to
+     * enchanted player" (Curse of Hospitality). The enchant-player sibling of [EnchantedCreature]
+     * (CR 303, [com.wingedsheep.sdk.scripting.references.Player.EnchantedPlayer]).
+     *
+     * Scoped by the source's *attachment*, not by its controller, which is why an Aura curse can't
+     * reuse [Opponent]: a curse on one opponent must not fire off damage dealt to another. Matches
+     * only when the attachment target is a player, so a planeswalker that player controls never
+     * counts; fails closed when the source isn't attached to a player.
+     *
+     * Pair with `binding = TriggerBinding.ANY` and a `sourceFilter`, not with
+     * [com.wingedsheep.sdk.scripting.TriggerBinding.ATTACHED]: the text needs the *damaging
+     * creature* as the triggering entity ("that creature's controller"), and a source-filtered
+     * observer is what binds it there.
+     */
+    @SerialName("RecipientEnchantedPlayer")
+    @Serializable
+    data object EnchantedPlayer : RecipientFilter {
+        override val description = "enchanted player"
+    }
+
     @SerialName("RecipientEquippedCreature")
     @Serializable
     data object EquippedCreature : RecipientFilter {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -696,6 +696,16 @@ data class GameObjectFilter(
      * of [sharingCreatureTypeWith] — see [CardPredicate.SharesCardTypeWith] for why the two axes
      * stay apart.
      */
+    /**
+     * Must share a card type with **any** card exiled with the filtering ability's source — "shares
+     * a card type with a card exiled with this creature" (Cemetery Illuminator). The pile-wide form
+     * of [sharingCardTypeWith]`(EntityReference.LinkedExiledCard())`; see
+     * [CardPredicate.SharesCardTypeWithLinkedExile].
+     */
+    fun sharingCardTypeWithLinkedExile() = copy(
+        cardPredicates = cardPredicates + CardPredicate.SharesCardTypeWithLinkedExile
+    )
+
     fun sharingCardTypeWith(entity: EntityReference) = copy(
         cardPredicates = cardPredicates + CardPredicate.SharesCardTypeWith(entity)
     )
@@ -817,6 +827,15 @@ data class GameObjectFilter(
      */
     fun attackingYouOrYourPlaneswalkers() = copy(
         statePredicates = statePredicates + StatePredicate.IsAttackingYouOrYourPlaneswalkers
+    )
+
+    /**
+     * Must be attacking the player the filtering ability's source is attached to — "creatures
+     * attacking enchanted player" (Curse of Hospitality). The attachment-scoped sibling of
+     * [attackingAnOpponent]; only meaningful on an Aura that enchants a player.
+     */
+    fun attackingEnchantedPlayer() = copy(
+        statePredicates = statePredicates + StatePredicate.IsAttackingEnchantedPlayer
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -962,6 +962,27 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         }
     }
 
+    /**
+     * Matches objects that share a card type with **any** card exiled with the asking ability's
+     * source — "shares a card type with a card exiled with this creature" (Cemetery Illuminator).
+     *
+     * The pile-wide form of [SharesCardTypeWith]`(EntityReference.LinkedExiledCard())`, which reads
+     * one index. Cemetery Illuminator exiles on every enter *and* every attack, so its pile grows
+     * and "a card exiled with this creature" means any of them — an index can't say that. Its
+     * cycle-mate Cemetery Prowler already reads the same whole pile on the cost side
+     * ([com.wingedsheep.sdk.scripting.CostReductionSource.SharedCardTypesWithLinkedExile]); this is
+     * that reading as a filter.
+     *
+     * Card types only, per CR 205.2a and the cycle's shared ruling: legendary/basic/snow are
+     * supertypes and Human/Equipment/Aura are subtypes, and none of them count. An empty pile — or
+     * one whose cards have all since left exile — matches nothing.
+     */
+    @SerialName("SharesCardTypeWithLinkedExile")
+    @Serializable
+    data object SharesCardTypeWithLinkedExile : CardPredicate {
+        override val description: String = "that shares a card type with a card exiled with this permanent"
+    }
+
     /** Matches objects that share a color with the referenced entity */
     @SerialName("SharesColorWith")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -132,6 +132,28 @@ sealed interface StatePredicate {
         override val description: String = "attacking you or a planeswalker you control"
     }
 
+    /**
+     * Attacking the player the asking ability's *source* is attached to — "creatures attacking
+     * enchanted player" (Curse of Hospitality). The attachment-scoped sibling of
+     * [IsAttackingAnOpponent] and [IsAttackingYouOrYourPlaneswalkers]: those two scope the defender
+     * against the ability's *controller*, and an Aura curse has to scope it against the player its
+     * source enchants, who is neither the controller nor necessarily the only opponent.
+     *
+     * The defender must be the enchanted *player*, not a planeswalker they control or a battle they
+     * protect — [com.wingedsheep.sdk.scripting.references.Player.EnchantedPlayer] only ever resolves
+     * to a player, so those drop out by construction, the same way `getOpponents` makes them drop
+     * out of [IsAttackingAnOpponent].
+     *
+     * No last-known fallback, for [IsAttackingAnOpponent]'s reason: the frozen snapshot records only
+     * *that* a permanent was attacking, never whom. Fails closed when the source isn't an Aura
+     * attached to a player.
+     */
+    @SerialName("IsAttackingEnchantedPlayer")
+    @Serializable
+    data object IsAttackingEnchantedPlayer : Entity {
+        override val description: String = "attacking enchanted player"
+    }
+
     @SerialName("IsBlocking")
     @Serializable
     data object IsBlocking : Entity {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CemeteryIlluminator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CemeteryIlluminator.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Cemetery Illuminator
+ * {1}{U}{U}
+ * Creature — Spirit
+ * 2/3
+ * Flying
+ * Whenever this creature enters or attacks, exile a card from a graveyard.
+ * You may look at the top card of your library any time.
+ * Once each turn, you may cast a spell from the top of your library if it shares a card type with a
+ * card exiled with this creature.
+ *
+ * The blue half of the Crimson Vow cemetery cycle, and the last of the five. Like [CemeteryProwler]
+ * it keeps exiling — one card per enter *and* per attack — so its payoff reads the whole
+ * linked-exile pile (CR 607) rather than a single "the exiled card": `sharingCardTypeWithLinkedExile`
+ * is the filter form of the reading `CostReductionSource.SharedCardTypesWithLinkedExile` already
+ * takes on the Prowler's cost side. An index-keyed `EntityReference.LinkedExiledCard` would only
+ * ever see the first exile and go stale the moment it left exile.
+ *
+ * "Enters or attacks" is two triggered abilities for [CemeteryGatekeeper]'s reason: the corpus
+ * contracts the pair in *print* and writes it as two abilities in the model, which is the spelling
+ * Argentum Assay reads and prints.
+ *
+ * The last line splits cleanly onto two existing statics: [LookAtTopOfLibrary] for "you may look at
+ * the top card of your library any time", and [CastSpellTypesFromTopOfLibrary] with
+ * `maxCastsPerTurn = 1` for "once each turn, you may cast a spell from the top of your library if …".
+ * The allowance belongs to the *permanent*, so an Illuminator that leaves and returns brings a fresh
+ * one — which is what the second static's own contract says, and what a second Illuminator relies on.
+ *
+ * Per its 2021-11-19 ruling the comparison is against the **exiled** cards, not against the top
+ * card's other faces: a modal double-faced card whose back face shares a type may be cast even when
+ * its front face doesn't, because the shared type comes off the exile pile either way.
+ */
+val CemeteryIlluminator = card("Cemetery Illuminator") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever this creature enters or attacks, exile a card from a graveyard.\n" +
+        "You may look at the top card of your library any time.\n" +
+        "Once each turn, you may cast a spell from the top of your library if it shares a card " +
+        "type with a card exiled with this creature."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature enters …
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = exileFromAGraveyard()
+        description = "When Cemetery Illuminator enters, exile a card from a graveyard."
+    }
+
+    // … or attacks, exile a card from a graveyard.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = exileFromAGraveyard()
+        description = "Whenever Cemetery Illuminator attacks, exile a card from a graveyard."
+    }
+
+    // You may look at the top card of your library any time.
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    // Once each turn, you may cast a spell from the top of your library if it shares a card type
+    // with a card exiled with this creature.
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(
+            filter = GameObjectFilter.Any.sharingCardTypeWithLinkedExile(),
+            maxCastsPerTurn = 1,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "50"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg?1783924900"
+        ruling(
+            "2021-11-19",
+            "Card types that can be exiled from a graveyard include artifact, creature, " +
+                "enchantment, land, planeswalker, instant, and sorcery. Legendary, basic, and snow " +
+                "are supertypes, not card types. Human, Equipment, and Aura are subtypes, not card types."
+        )
+        ruling(
+            "2021-11-19",
+            "Cemetery Illuminator's ability allows you to cast a spell that shares a card type " +
+                "with the exiled card, even if the card on top of the library doesn't. For " +
+                "example, if you've exiled an artifact card, you could cast The Omenkeel from the " +
+                "top of your library, even though it's the back face of the modal double-faced " +
+                "card Cosima, God of the Voyage, which isn't an artifact."
+        )
+    }
+}
+
+/** "Exile a card from a graveyard.", linked to the Illuminator — the payload of both trigger halves. */
+private fun exileFromAGraveyard(): Effect = Effects.Pipeline {
+    val graveyards = gather(
+        CardSource.FromZone(Zone.GRAVEYARD, Player.Each, GameObjectFilter.Any),
+        name = "graveyards",
+    )
+    val exiled = chooseExactly(
+        1,
+        from = graveyards,
+        useTargetingUI = true,
+        prompt = "Exile a card from a graveyard",
+        selectedLabel = "Exile",
+        name = "exiled",
+    )
+    exile(exiled, linkToSource = true)
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CurseOfHospitality.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CurseOfHospitality.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Curse of Hospitality
+ * {2}{R}
+ * Enchantment — Aura Curse
+ * Enchant player
+ * Creatures attacking enchanted player have trample.
+ * Whenever a creature deals combat damage to enchanted player, that player exiles the top card of
+ * their library. Until end of turn, that creature's controller may play that card and they may
+ * spend mana as though it were mana of any color to cast that spell.
+ *
+ * A player-enchanting Aura ([Targets.Player], as Grievous Wound), and the first card whose payoffs
+ * are scoped by *who the Aura enchants* rather than by who controls it. Both halves needed one new
+ * attachment-scoped filter, because every existing "attacking / dealt damage to" scope in the SDK
+ * resolves its player against the ability's **controller** — which for a curse is exactly the wrong
+ * player, and would let a curse on one opponent fire off damage dealt to another.
+ *
+ *  - **"Creatures attacking enchanted player have trample"** is
+ *    [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingEnchantedPlayer], the
+ *    attachment-scoped sibling of `IsAttackingAnOpponent` (Oviya, Automech Artisan's "each creature
+ *    that's attacking one of your opponents has trample" — the same [GrantKeyword] shape, one scope
+ *    over). It is deliberately **not** "attacking creatures you control": the grant follows the
+ *    *defender*, so a creature an opponent controls that's attacking the cursed player gets trample
+ *    too, and a creature attacking a planeswalker the cursed player controls does not.
+ *
+ *  - **The damage trigger** is an ANY-bound observer with
+ *    [RecipientFilter.EnchantedPlayer] and `sourceFilter = Creature`, the shape Gonti, Night
+ *    Minister uses for the same "creature deals combat damage to a player, *its controller* may play
+ *    the exiled card" text. The source filter is what makes the engine bind the *damaging creature*
+ *    as the triggering entity and the *damaged player* as the triggering player — the exact pair the
+ *    text needs, since the card comes off the cursed player's library while the permission goes to
+ *    [EffectTarget.ControllerOfTriggeringEntity].
+ *
+ * Per its own ruling the trigger fires **once for each creature** that connected, so it is a plain
+ * per-event observer, never a `batch = true` one.
+ *
+ * The exile is face up and public, so the gather takes [LookAudience.None]: a look overlay would
+ * show the card to the Curse's controller, who is not necessarily the player who gets to play it.
+ */
+val CurseOfHospitality = card("Curse of Hospitality") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura Curse"
+    oracleText = "Enchant player\n" +
+        "Creatures attacking enchanted player have trample.\n" +
+        "Whenever a creature deals combat damage to enchanted player, that player exiles the top " +
+        "card of their library. Until end of turn, that creature's controller may play that card " +
+        "and they may spend mana as though it were mana of any color to cast that spell."
+
+    auraTarget = Targets.Player
+
+    // Creatures attacking enchanted player have trample.
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.attackingEnchantedPlayer())
+        )
+    }
+
+    // Whenever a creature deals combat damage to enchanted player, …
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.EnchantedPlayer,
+            sourceFilter = GameObjectFilter.Creature,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(
+                    count = DynamicAmount.Fixed(1),
+                    player = Player.TriggeringPlayer,
+                ),
+                storeAs = "cursedCard",
+                lookAudience = LookAudience.None,
+            ),
+            MoveCollectionEffect(
+                from = "cursedCard",
+                destination = CardDestination.ToZone(Zone.EXILE, Player.TriggeringPlayer),
+            ),
+            GrantMayPlayFromExileEffect(
+                from = "cursedCard",
+                expiry = MayPlayExpiry.EndOfTurn,
+                withAnyManaType = true,
+                recipient = EffectTarget.ControllerOfTriggeringEntity,
+            ),
+        )
+        description = "Whenever a creature deals combat damage to enchanted player, that player " +
+            "exiles the top card of their library. Until end of turn, that creature's controller " +
+            "may play that card and they may spend mana as though it were mana of any color to " +
+            "cast that spell."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg?1783924838"
+        ruling(
+            "2021-11-19",
+            "Curse of Hospitality's triggered ability triggers once for each creature that dealt " +
+                "combat damage to the enchanted player."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryIlluminatorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryIlluminatorScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cemetery Illuminator (VOW #50) — {1}{U}{U} Creature — Spirit, 2/3.
+ *
+ * "Flying
+ *  Whenever this creature enters or attacks, exile a card from a graveyard.
+ *  You may look at the top card of your library any time.
+ *  Once each turn, you may cast a spell from the top of your library if it shares a card type with
+ *  a card exiled with this creature."
+ *
+ * The new vocabulary is `CardPredicate.SharesCardTypeWithLinkedExile` — the *pile-wide* card-type
+ * comparison. Its cycle-mate Cemetery Prowler already reads the same pile on the cost side; what
+ * this card needed was that reading as a **filter**, evaluated against the granting permanent, and
+ * the cast-from-top permission path threaded with which permanent granted it.
+ *
+ * The tests below are the four the predicate can get wrong: an empty pile (matches nothing rather
+ * than everything), a card type actually shared, a card type merely *present in the pile but not on
+ * the spell*, and the `maxCastsPerTurn = 1` allowance that rides the same permission.
+ */
+class CemeteryIlluminatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cemetery Illuminator — casting from the top of your library") {
+
+            /**
+             * An Illuminator on player 1's battlefield with [exiled] already linked to it, and
+             * [topCard] on top of player 1's library. The linkage is seeded directly rather than
+             * driven through the ETB trigger: the trigger is a plain `Effects.Pipeline` copied
+             * verbatim from [CemeteryProwlerScenarioTest]'s card, and what is under test here is the
+             * *payoff*, not the exile.
+             */
+            fun illuminatorWithExile(topCard: String, vararg exiled: String): TestGame {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cemetery Illuminator")
+                    // Forests, because the spell cast from the top below is {1}{G}: an
+                    // unaffordable action is enumerated with `isAffordable = false`, and the
+                    // assertions here are about the *permission*, not the mana.
+                    .withCardOnBattlefield(1, "Forest")
+                    .withCardOnBattlefield(1, "Forest")
+                    .withCardOnBattlefield(1, "Forest")
+                    .withCardInLibrary(1, topCard)
+                    .withCardInLibrary(2, "Forest")
+                exiled.forEach { builder = builder.withCardInExile(2, it) }
+                val game = builder
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val illuminator = game.findPermanent("Cemetery Illuminator")!!
+                val exiledIds: List<EntityId> = game.state.getExile(game.player2Id).toList()
+                game.state = game.state.updateEntity(illuminator) { container ->
+                    container.with(LinkedExileComponent(exiledIds))
+                }
+                return game
+            }
+
+            /** Whether player 1 is currently offered a cast of [cardName] out of their library. */
+            fun canCastFromTop(game: TestGame, cardName: String): Boolean =
+                game.getLegalActions(1).any {
+                    it.actionType == "CastSpell" && it.description.contains(cardName)
+                }
+
+            test("nothing exiled → the top card is not castable") {
+                val game = illuminatorWithExile("Grizzly Bears")
+                withClue("an empty pile shares a card type with nothing — it must not match all") {
+                    canCastFromTop(game, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("an exiled creature card makes a creature spell on top castable") {
+                val game = illuminatorWithExile("Grizzly Bears", "Llanowar Elves")
+                canCastFromTop(game, "Grizzly Bears") shouldBe true
+            }
+
+            test("an exiled land does nothing for a creature spell on top") {
+                val game = illuminatorWithExile("Grizzly Bears", "Mountain")
+                withClue("a creature spell shares no card type with an exiled land") {
+                    canCastFromTop(game, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("the pile is read whole, not just its first card") {
+                // The case an index-keyed `LinkedExiledCard(0)` reading fails: the *second* exile is
+                // the one that shares a type. The Illuminator exiles on every enter and attack, so
+                // this is the ordinary state of its pile, not a corner.
+                val game = illuminatorWithExile("Grizzly Bears", "Mountain", "Llanowar Elves")
+                canCastFromTop(game, "Grizzly Bears") shouldBe true
+            }
+
+            test("once each turn — a used allowance closes the permission") {
+                val game = illuminatorWithExile("Grizzly Bears", "Llanowar Elves")
+                val illuminator = game.findPermanent("Cemetery Illuminator")!!
+                game.state = game.state.updateEntity(illuminator) { container ->
+                    container.with(CastFromTopOfLibraryUsesThisTurnComponent(uses = 1))
+                }
+                withClue("maxCastsPerTurn = 1, and this permanent has spent its use") {
+                    canCastFromTop(game, "Grizzly Bears") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CurseOfHospitalityScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CurseOfHospitalityScenarioTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Curse of Hospitality (VOW #152) — {2}{R} Enchantment — Aura Curse.
+ *
+ * "Enchant player
+ *  Creatures attacking enchanted player have trample.
+ *  Whenever a creature deals combat damage to enchanted player, that player exiles the top card of
+ *  their library. Until end of turn, that creature's controller may play that card and they may
+ *  spend mana as though it were mana of any color to cast that spell."
+ *
+ * Both new pieces of vocabulary here scope a *player* by the source Aura's **attachment**, where
+ * every pre-existing sibling scopes it by the ability's **controller** —
+ * `StatePredicate.IsAttackingEnchantedPlayer` for the static and `RecipientFilter.EnchantedPlayer`
+ * for the trigger. The self-curse test below is what separates the two readings: with the Curse on
+ * its own controller, a controller-scoped predicate goes quiet and an attachment-scoped one fires.
+ */
+class CurseOfHospitalityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Curse of Hospitality") {
+
+            // Distinct card names per player, because the harness's `declareAttackers` resolves an
+            // attacker by *name* and takes the first match on the battlefield — two same-named
+            // creatures silently declare the wrong player's, and every negative assertion here
+            // would then pass for the wrong reason.
+            val p1Attacker = "Grizzly Bears"
+            val p2Attacker = "Llanowar Elves"
+
+            /**
+             * A Curse controlled by player 1 and attached to [cursedPlayer], with one creature on
+             * each player's battlefield and a Lightning Bolt on top of each library.
+             *
+             * The Aura is attached directly rather than cast: "enchant player" needs an
+             * [AttachedToComponent] pointing at a *player* id, which the builder's
+             * `withCardAttachedTo` (permanent hosts only) can't produce.
+             */
+            fun cursed(cursedPlayer: Int, activePlayer: Int = 1): TestGame {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Curse of Hospitality")
+                    .withCardOnBattlefield(1, p1Attacker)
+                    .withCardOnBattlefield(2, p2Attacker)
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(2, "Lightning Bolt")
+                    .withActivePlayer(activePlayer)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val curse = game.findPermanent("Curse of Hospitality")!!
+                val victimId = if (cursedPlayer == 1) game.player1Id else game.player2Id
+                game.state = game.state.updateEntity(curse) { it.with(AttachedToComponent(victimId)) }
+                return game
+            }
+
+            fun attackerOf(game: TestGame, playerNumber: Int): EntityId =
+                game.findPermanent(if (playerNumber == 1) p1Attacker else p2Attacker)!!
+
+            context("Creatures attacking enchanted player have trample") {
+
+                test("an attacker pointed at the cursed player has trample") {
+                    val game = cursed(cursedPlayer = 2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p1Attacker to 2))
+                    game.state.projectedState
+                        .hasKeyword(attackerOf(game, 1), Keyword.TRAMPLE) shouldBe true
+                }
+
+                test("an attacker pointed at a player who isn't cursed has none") {
+                    // Player 2 attacks player 1; the Curse is on player 2. The grant follows the
+                    // *defender*, so nothing here qualifies.
+                    val game = cursed(cursedPlayer = 2, activePlayer = 2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p2Attacker to 1))
+                    withClue("the Curse is on player 2, and player 2 is not being attacked") {
+                        game.state.projectedState
+                            .hasKeyword(attackerOf(game, 2), Keyword.TRAMPLE) shouldBe false
+                    }
+                }
+
+                test("an opponent's attacker gets trample when the Curse's own controller is cursed") {
+                    // The discriminating case: player 1 controls the Curse and has put it on
+                    // themself, so player 2's attacker gets trample. A controller-scoped reading
+                    // gets this wrong — `attackingAnOpponent` asked by player 1 says false here.
+                    val game = cursed(cursedPlayer = 1, activePlayer = 2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p2Attacker to 1))
+                    game.state.projectedState
+                        .hasKeyword(attackerOf(game, 2), Keyword.TRAMPLE) shouldBe true
+                }
+
+                test("an unattached Curse grants nothing") {
+                    val game = scenario()
+                        .withPlayers("Player1", "Player2")
+                        .withCardOnBattlefield(1, "Curse of Hospitality")
+                        .withCardOnBattlefield(1, p1Attacker)
+                        .withCardInLibrary(1, "Lightning Bolt")
+                        .withCardInLibrary(2, "Lightning Bolt")
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p1Attacker to 2))
+                    withClue("no attachment target means no enchanted player — fail closed") {
+                        game.state.projectedState
+                            .hasKeyword(attackerOf(game, 1), Keyword.TRAMPLE) shouldBe false
+                    }
+                }
+            }
+
+            context("Whenever a creature deals combat damage to enchanted player") {
+
+                test("the cursed player exiles the top card of their library") {
+                    val game = cursed(cursedPlayer = 2)
+                    val libraryBefore = game.librarySize(2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p1Attacker to 2))
+                    game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                    game.resolveStack()
+
+                    withClue("the exile comes off the *cursed* player's library, not the attacker's") {
+                        game.isInExile(2, "Lightning Bolt") shouldBe true
+                        game.librarySize(2) shouldBe libraryBefore - 1
+                        game.isInExile(1, "Lightning Bolt") shouldBe false
+                    }
+                }
+
+                test("combat damage to a player who isn't cursed does nothing") {
+                    // Player 2 attacks player 1, who carries no Curse.
+                    val game = cursed(cursedPlayer = 2, activePlayer = 2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p2Attacker to 1))
+                    game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                    game.resolveStack()
+
+                    withClue("the recipient filter is the attachment, not 'any opponent'") {
+                        game.isInExile(1, "Lightning Bolt") shouldBe false
+                        game.isInExile(2, "Lightning Bolt") shouldBe false
+                    }
+                }
+
+                test("the damaging creature's controller gets the play permission, not the Curse's") {
+                    // Player 1 controls the Curse but puts it on themself; player 2 connects, so
+                    // *player 2* may play the card exiled off player 1's library. The permission
+                    // rides ControllerOfTriggeringEntity, which the source filter on the trigger is
+                    // what binds to the damaging creature.
+                    val game = cursed(cursedPlayer = 1, activePlayer = 2)
+                    game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    game.declareAttackers(mapOf(p2Attacker to 1))
+                    game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                    game.resolveStack()
+
+                    withClue("the exile is off the enchanted player's library — player 1's") {
+                        game.isInExile(1, "Lightning Bolt") shouldBe true
+                    }
+                    withClue("player 2 dealt the damage, so player 2 may cast it") {
+                        game.getLegalActions(2).any {
+                            it.actionType == "CastSpell" && it.description.contains("Lightning Bolt")
+                        } shouldBe true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -4541,6 +4541,94 @@
     ]
 }
 
+// Curse of Hospitality
+{
+    "name": "Curse of Hospitality",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment — Aura Curse",
+    "oracleText": "Enchant player\nCreatures attacking enchanted player have trample.\nWhenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "RecipientEnchantedPlayer",
+                    "sourceFilter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TriggeringPlayer"
+                            },
+                            "storeAs": "cursedCard",
+                            "lookAudience": "None"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "cursedCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": "TriggeringPlayer"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "cursedCard",
+                            "withAnyManaType": true,
+                            "recipient": "ControllerOfTriggeringEntity"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a creature deals combat damage to enchanted player, that player exiles the top card of their library. Until end of turn, that creature's controller may play that card and they may spend mana as though it were mana of any color to cast that spell."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsAttackingEnchantedPlayer"
+                        ]
+                    }
+                }
+            }
+        ],
+        "auraTarget": "TargetPlayer"
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg?1783924838",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Curse of Hospitality's triggered ability triggers once for each creature that dealt combat damage to the enchanted player."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Dawnhart Disciple
 {
     "name": "Dawnhart Disciple",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -2680,6 +2680,145 @@
     ]
 }
 
+// Cemetery Illuminator
+{
+    "name": "Cemetery Illuminator",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever this creature enters or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each"
+                            },
+                            "storeAs": "graveyards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "graveyards",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "exiled",
+                            "prompt": "Exile a card from a graveyard",
+                            "selectedLabel": "Exile",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Cemetery Illuminator enters, exile a card from a graveyard."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each"
+                            },
+                            "storeAs": "graveyards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "graveyards",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "exiled",
+                            "prompt": "Exile a card from a graveyard",
+                            "selectedLabel": "Exile",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Cemetery Illuminator attacks, exile a card from a graveyard."
+            }
+        ],
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": {
+                    "cardPredicates": [
+                        "SharesCardTypeWithLinkedExile"
+                    ]
+                },
+                "maxCastsPerTurn": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "MYTHIC",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg?1783924900",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Card types that can be exiled from a graveyard include artifact, creature, enchantment, land, planeswalker, instant, and sorcery. Legendary, basic, and snow are supertypes, not card types. Human, Equipment, and Aura are subtypes, not card types."
+            },
+            {
+                "date": "2021-11-19",
+                "text": "Cemetery Illuminator's ability allows you to cast a spell that shares a card type with the exiled card, even if the card on top of the library doesn't. For example, if you've exiled an artifact card, you could cast The Omenkeel from the top of your library, even though it's the back face of the modal double-faced card Cosima, God of the Voyage, which isn't an artifact."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cemetery Protector
 {
     "name": "Cemetery Protector",

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/AmountsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/AmountsTest.kt
@@ -154,12 +154,16 @@ class AmountsTest : StringSpec({
     // The counted verbs' second spelling
     // ---------------------------------------------------------------------------------------
 
-    // Life is not in the band: "for each" is its canonical spelling and outnumbers "equal to"
-    // 131 to 23, so offering both would be two printed forms for one model. See
-    // [Steps.countedSteps] for what it would take to unify them.
-    "life keeps its numeral and declines the clause the damage verbs read" {
+    // Life joined the band with the life-amount rewrite: the seven life rows became one
+    // `LifeChange` table over `countedStepPair`, so the clause the damage verbs read is now a
+    // second *input* spelling rather than a decline. It is an `alsoSpelled` alternate, not a
+    // second printed form — "for each" outnumbers "equal to" 131 to 23 in print and stays
+    // canonical, so the clause reads and reprints as the numeral form.
+    "life reads its numeral, and the damage verbs' clause reprints as it" {
         roundTrips("You gain 3 life.")
-        declines("You gain life equal to the number of creatures you control.")
+        Grammar.abilityLine.printLine(
+            fragment("You gain life equal to the number of creatures you control.")
+        ) shouldBe "You gain 1 life for each creature you control."
     }
 
     "damage puts the clause where the amount's shape says it goes" {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -553,6 +553,7 @@ class BeginningPhaseManager(
         StatePredicate.IsAttackingAlone,
         StatePredicate.IsAttackingAnOpponent,
         StatePredicate.IsAttackingYouOrYourPlaneswalkers,
+        StatePredicate.IsAttackingEnchantedPlayer,
         StatePredicate.IsBlocking,
         StatePredicate.IsBlocked,
         StatePredicate.IsUnblocked,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -55,7 +55,7 @@ class AttachmentTriggerDetector(
                     // aura's own ZoneChangeEvent. Only equipment stays on the battlefield.
                     if (isZoneChange && ability.trigger is EventPattern.ZoneChangeEvent &&
                         !entry.cardComponent.typeLine.isEquipment) continue
-                    if (matchesAttachedTrigger(ability.trigger, event, entityId, entry.controllerId, state)) {
+                    if (matchesAttachedTrigger(ability.trigger, event, entityId, entry.controllerId, entry.entityId, state)) {
                         triggers.add(
                             PendingTrigger(
                                 ability = ability,
@@ -171,6 +171,7 @@ class AttachmentTriggerDetector(
         event: EngineGameEvent,
         attachedEntityId: com.wingedsheep.sdk.model.EntityId,
         auraControllerId: com.wingedsheep.sdk.model.EntityId,
+        auraId: com.wingedsheep.sdk.model.EntityId,
         state: GameState
     ): Boolean {
         return when (trigger) {
@@ -180,7 +181,7 @@ class AttachmentTriggerDetector(
             is EventPattern.DealsDamageEvent -> {
                 event is DamageDealtEvent &&
                     event.sourceId == attachedEntityId &&
-                    matcher.matchesDealsDamageTrigger(trigger, event, state, auraControllerId)
+                    matcher.matchesDealsDamageTrigger(trigger, event, state, auraControllerId, auraId)
             }
             is EventPattern.AttackEvent -> {
                 event is AttackersDeclaredEvent && attachedEntityId in event.attackers &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
@@ -99,7 +99,7 @@ class DamageTriggerDetector(
             if (trigger is EventPattern.DealsDamageEvent && ability.binding == TriggerBinding.SELF) {
                 // Pass the ability's controller so RecipientFilter.Matching can evaluate
                 // controller-relative recipient filters (e.g. "a creature an opponent controls").
-                if (matcher.matchesDealsDamageTrigger(trigger, event, state, controllerId)) {
+                if (matcher.matchesDealsDamageTrigger(trigger, event, state, controllerId, sourceId)) {
                     triggers.add(
                         PendingTrigger(
                             ability = ability,
@@ -307,7 +307,7 @@ class DamageTriggerDetector(
         // Batch ("one or more") observers fire once per event batch, not once per
         // damage event — handled by detectDamageObserverBatchTriggers.
         if (trigger.batch) return
-        if (!matcher.matchesDealsDamageTrigger(trigger, event, state, controllerId)) return
+        if (!matcher.matchesDealsDamageTrigger(trigger, event, state, controllerId, sourceId)) return
         // When the trigger has a sourceFilter (e.g., "creature you control deals
         // combat damage"), the triggering entity is the damage SOURCE (the creature),
         // not the damage recipient. This allows effects like "exile it" to reference
@@ -372,7 +372,7 @@ class DamageTriggerDetector(
                 if (ability.binding != TriggerBinding.ANY) continue
 
                 val firstMatching = damageEvents.firstOrNull { event ->
-                    matcher.matchesDealsDamageTrigger(trigger, event, state, entry.controllerId)
+                    matcher.matchesDealsDamageTrigger(trigger, event, state, entry.controllerId, entry.entityId)
                 }
                 if (firstMatching != null) {
                     triggers.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1526,7 +1526,13 @@ class TriggerMatcher(
         trigger: EventPattern.DealsDamageEvent,
         event: DamageDealtEvent,
         state: GameState,
-        controllerId: EntityId? = null
+        controllerId: EntityId? = null,
+        /**
+         * The permanent bearing the observing ability. Only [RecipientFilter.EnchantedPlayer] reads
+         * it — that filter scopes the recipient by the source's *attachment* rather than by its
+         * controller — so callers that can't supply it leave it null and that filter fails closed.
+         */
+        abilitySourceId: EntityId? = null
     ): Boolean {
         val combatMatches = trigger.damageType == DamageType.Any ||
             (trigger.damageType == DamageType.Combat && event.isCombatDamage) ||
@@ -1570,6 +1576,18 @@ class TriggerMatcher(
                         state, state.projectedState, event.targetId, filter,
                         PredicateContext(controllerId = controllerId)
                     )
+            }
+            // "deals combat damage to enchanted player" (Curse of Hospitality). The recipient must
+            // be the player the observing Aura is attached to, so this reads `abilitySourceId`, not
+            // `controllerId`. The `in state.turnOrder` check is what keeps a planeswalker the
+            // enchanted player controls out: only a player id survives it.
+            RecipientFilter.EnchantedPlayer -> {
+                val enchanted = abilitySourceId
+                    ?.let { state.getEntity(it) }
+                    ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                    ?.targetId
+                    ?.takeIf { it in state.turnOrder }
+                enchanted != null && event.targetId == enchanted
             }
             RecipientFilter.Self -> false // handled elsewhere
             else -> false
@@ -2255,6 +2273,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingAlone,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingAnOpponent,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingYouOrYourPlaneswalkers,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingEnchantedPlayer,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsBlocking,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsBlocked,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsUnblocked,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -881,6 +881,25 @@ class PredicateEvaluator {
                 entityTypes.any { it in referenceTypes }
             }
 
+            // "shares a card type with a card exiled with this creature" (Cemetery Illuminator).
+            // The pile-wide sibling of SharesCardTypeWith: reads *every* card still in the source's
+            // linked-exile pile, because the Illuminator keeps exiling on each enter and attack and
+            // "a card exiled with this creature" means any of them. Printed type lines on both
+            // sides — a card in exile and a card in a library have no battlefield projection whose
+            // types a continuous effect could have changed (the same reading CostCalculator's
+            // SharedCardTypesWithLinkedExile takes). Fails closed with no source in context.
+            CardPredicate.SharesCardTypeWithLinkedExile -> {
+                val sourceId = context?.sourceId ?: return false
+                val exiledTypes = com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
+                    .exiledCards(state, sourceId)
+                    .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.typeLine?.cardTypes }
+                    .flatMapTo(mutableSetOf()) { types -> types.map { it.name } }
+                if (exiledTypes.isEmpty()) return false
+                val entityTypes = cardTypesOf(state, projected, entityId, projectedValues?.types)
+                    .ifEmpty { card.typeLine.cardTypes.mapTo(mutableSetOf()) { it.name } }
+                entityTypes.any { it in exiledTypes }
+            }
+
             is CardPredicate.SharesNameWith -> {
                 val referenceId = resolveEntityReference(state, predicate.entity, context) ?: return false
                 // Projected first so a renamed permanent (Layer 3, CR 613.1c) compares under its
@@ -1352,6 +1371,21 @@ class PredicateEvaluator {
                                 projected.isPlaneswalker(defenderId)
                             )
                     )
+            }
+            // "Attacking enchanted player": the defender has to be the player the *source* Aura is
+            // attached to (Curse of Hospitality). Scoped by attachment rather than by controller,
+            // so unlike the two predicates above it reads `context.sourceId`: a planeswalker or battle the
+            // enchanted player controls never matches (only a player id survives `in state.turnOrder`).
+            // No last-known fallback, for
+            // IsAttackingAnOpponent's reason.
+            StatePredicate.IsAttackingEnchantedPlayer -> {
+                val enchanted = context?.sourceId
+                    ?.let { state.getEntity(it) }
+                    ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                    ?.targetId
+                    ?.takeIf { it in state.turnOrder }
+                val defenderId = container.get<AttackingComponent>()?.defenderId
+                enchanted != null && defenderId == enchanted
             }
             StatePredicate.IsBlocking -> container.has<BlockingComponent>()
             StatePredicate.IsBlocked -> {
@@ -2065,6 +2099,7 @@ class PredicateEvaluator {
             CardPredicate.SharesColorWithRecipient,
             is CardPredicate.SharesCreatureTypeWith,
             is CardPredicate.SharesCardTypeWith,
+            CardPredicate.SharesCardTypeWithLinkedExile,
             is CardPredicate.SharesColorWith,
             is CardPredicate.SharesManaValueWith,
             is CardPredicate.SharesNameWith,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -661,7 +661,7 @@ class CastZoneResolver(
                         ?.get<CastFromTopOfLibraryUsesThisTurnComponent>()?.uses ?: 0
                     val maxCasts = unwrapped.maxCastsPerTurn
                     val hasUse = maxCasts == null || uses < maxCasts
-                    if (hasUse && matchesCardFilter(cardComponent, unwrapped.filter)) return true
+                    if (hasUse && matchesCardFilter(cardComponent, unwrapped.filter, state, entityId)) return true
                 }
                 if (unwrapped is PlayLandsAndCastFilteredFromTopOfLibrary) {
                     // A null spellFilter is a lands-only permission: nothing is castable.
@@ -702,7 +702,7 @@ class CastZoneResolver(
                     unwrapped.spellFilter?.let { matchesCardFilter(cardComponent, it) } == true
                 ) return null
                 if (unwrapped !is CastSpellTypesFromTopOfLibrary ||
-                    !matchesCardFilter(cardComponent, unwrapped.filter)
+                    !matchesCardFilter(cardComponent, unwrapped.filter, state, entityId)
                 ) continue
                 val maxCasts = unwrapped.maxCastsPerTurn ?: return null
                 val uses = state.getEntity(entityId)
@@ -875,14 +875,32 @@ class CastZoneResolver(
     }
 
     companion object {
-        fun matchesCardFilter(card: CardComponent, filter: GameObjectFilter): Boolean {
+        /**
+         * @param state the game state, and [grantingSourceId] the permanent whose static ability
+         *   supplies the filter. Both are optional and only
+         *   [CardPredicate.SharesCardTypeWithLinkedExile] reads them — a filter that talks about the
+         *   granting permanent's linked-exile pile (Cemetery Illuminator) can't be judged from the
+         *   card alone. Callers that have no source leave them null and that predicate fails closed,
+         *   which is the same policy the rest of this `when` applies to source-relative predicates.
+         */
+        fun matchesCardFilter(
+            card: CardComponent,
+            filter: GameObjectFilter,
+            state: GameState? = null,
+            grantingSourceId: EntityId? = null,
+        ): Boolean {
             for (predicate in filter.cardPredicates) {
-                if (!matchesCardPredicate(card, predicate)) return false
+                if (!matchesCardPredicate(card, predicate, state, grantingSourceId)) return false
             }
             return true
         }
 
-        private fun matchesCardPredicate(card: CardComponent, predicate: CardPredicate): Boolean {
+        private fun matchesCardPredicate(
+            card: CardComponent,
+            predicate: CardPredicate,
+            state: GameState? = null,
+            grantingSourceId: EntityId? = null,
+        ): Boolean {
             val cmc = card.manaCost.cmc
             val power = card.baseStats?.basePower
             val toughness = card.baseStats?.baseToughness
@@ -956,9 +974,9 @@ class CastZoneResolver(
                 is CardPredicate.HasActivatedAbility -> card.hasActivatedAbility
                 is CardPredicate.HasNonManaActivatedAbility -> card.hasNonManaActivatedAbility
                 // --- Combinators ---
-                is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(card, it) }
-                is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(card, it) }
-                is CardPredicate.Not -> !matchesCardPredicate(card, predicate.predicate)
+                is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(card, it, state, grantingSourceId) }
+                is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(card, it, state, grantingSourceId) }
+                is CardPredicate.Not -> !matchesCardPredicate(card, predicate.predicate, state, grantingSourceId)
                 // Predicates that can't be judged from a card's static characteristics alone —
                 // they need runtime/interaction context (a chosen value, another entity, X, a
                 // pipeline variable/stored group, the recipient/source of an effect), or describe
@@ -966,6 +984,21 @@ class CastZoneResolver(
                 // and matching a condition we can't verify would silently widen the grant, so they
                 // fail closed. This `when` is exhaustive: adding a CardPredicate forces a decision
                 // here rather than leaking through a permissive `else`.
+                // "shares a card type with a card exiled with this creature" (Cemetery
+                // Illuminator). Unlike its neighbours in the fail-closed bucket below this one
+                // *can* be judged here: the pile hangs off the granting permanent, which every
+                // caller that supplies a source already has in hand. Printed type lines on both
+                // sides — a card in a library and a card in exile have no battlefield projection.
+                CardPredicate.SharesCardTypeWithLinkedExile -> {
+                    val source = grantingSourceId
+                    if (state == null || source == null) false else {
+                        val exiledTypes = com.wingedsheep.engine.handlers.effects.linkedexile
+                            .LinkedExileLookup.exiledCards(state, source)
+                            .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.typeLine?.cardTypes }
+                            .flatMapTo(mutableSetOf()) { it }
+                        card.typeLine.cardTypes.any { it in exiledTypes }
+                    }
+                }
                 is CardPredicate.IsToken,
                 is CardPredicate.IsNontoken,
                 is CardPredicate.HasChosenColor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1803,9 +1803,16 @@ object DamageUtils {
             is RecipientFilter.AnyPlayer -> targetId in state.turnOrder
             is RecipientFilter.AnyPlayerOrPlaneswalker ->
                 targetId in state.turnOrder || projected.isPlaneswalker(targetId)
+            // The attachment target, whatever it is: a creature for the first two, a player for
+            // EnchantedPlayer. The `in state.turnOrder` check on the last one is what keeps the
+            // player-scoped filter from matching a permanent the Aura happens to be on.
             is RecipientFilter.EnchantedCreature, is RecipientFilter.EquippedCreature -> {
                 val attachedTo = state.getEntity(hostId)?.get<AttachedToComponent>()?.targetId
                 targetId == attachedTo
+            }
+            is RecipientFilter.EnchantedPlayer -> {
+                val attachedTo = state.getEntity(hostId)?.get<AttachedToComponent>()?.targetId
+                attachedTo != null && attachedTo in state.turnOrder && targetId == attachedTo
             }
             is RecipientFilter.AnyCreature -> projected.isCreature(targetId)
             is RecipientFilter.CreatureYouControl ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -210,16 +210,19 @@ class CastFromZoneEnumerator : ActionEnumerator {
         val playerId = context.playerId
 
         val canPlayAllFromTop = context.castPermissionUtils.hasPlayFromTopOfLibrary(state, playerId)
-        val castFromTopFilter = if (!canPlayAllFromTop) {
-            context.castPermissionUtils.getCastFromTopOfLibraryFilter(state, playerId)
-        } else null
+        // One entry per granting permanent: a source-relative filter (Cemetery Illuminator's
+        // "shares a card type with a card exiled with this creature") has to be evaluated against
+        // the permanent that granted it, so the pairs can't be folded into a single filter.
+        val castFromTopGrants = if (!canPlayAllFromTop) {
+            context.castPermissionUtils.getCastFromTopOfLibraryGrants(state, playerId)
+        } else emptyList()
         val canPlayLandsFromTop = canPlayAllFromTop ||
             context.castPermissionUtils.hasPlayLandsFromTopOfLibrary(state, playerId)
         val castFilteredFromTopFilter = if (!canPlayAllFromTop) {
             context.castPermissionUtils.getCastFilteredFromTopOfLibraryFilter(state, playerId)
         } else null
 
-        if (!canPlayAllFromTop && castFromTopFilter == null && !canPlayLandsFromTop && castFilteredFromTopFilter == null) return
+        if (!canPlayAllFromTop && castFromTopGrants.isEmpty() && !canPlayLandsFromTop && castFilteredFromTopFilter == null) return
 
         val library = state.getLibrary(playerId)
         if (library.isEmpty()) return
@@ -242,9 +245,12 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
         // Non-land spell on top of library
         val topCardMatchesFilter = canPlayAllFromTop ||
-            (castFromTopFilter != null && context.predicateEvaluator.matches(
-                state, state.projectedState, topCardId, castFromTopFilter, PredicateContext(controllerId = playerId)
-            )) ||
+            castFromTopGrants.any { (grantSourceId, grantFilter) ->
+                context.predicateEvaluator.matches(
+                    state, state.projectedState, topCardId, grantFilter,
+                    PredicateContext(controllerId = playerId, sourceId = grantSourceId)
+                )
+            } ||
             (castFilteredFromTopFilter != null && context.predicateEvaluator.matches(
                 state, state.projectedState, topCardId, castFilteredFromTopFilter, PredicateContext(controllerId = playerId)
             ))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -474,8 +474,18 @@ class CastPermissionUtils(
         return null
     }
 
-    fun getCastFromTopOfLibraryFilter(state: GameState, playerId: EntityId): GameObjectFilter? {
-        var filter: GameObjectFilter? = null
+    /**
+     * Every live [CastSpellTypesFromTopOfLibrary] permission [playerId] controls, paired with the
+     * permanent granting it. One entry per granting permanent rather than a single OR'd filter,
+     * because a filter can be *source-relative* — Cemetery Illuminator's "shares a card type with a
+     * card exiled with this creature" reads the granting permanent's own linked-exile pile, and
+     * folding two permanents' filters into one loses which pile to read. The caller matches the top
+     * card against each pair in turn; matching any of them is permission enough.
+     */
+    fun getCastFromTopOfLibraryGrants(
+        state: GameState,
+        playerId: EntityId
+    ): List<Pair<EntityId, GameObjectFilter>> = buildList {
         for (entityId in state.getBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
@@ -485,12 +495,10 @@ class CastPermissionUtils(
                         ?.get<CastFromTopOfLibraryUsesThisTurnComponent>()?.uses ?: 0
                     val maxCasts = ability.maxCastsPerTurn
                     if (maxCasts != null && uses >= maxCasts) continue
-                    if (ability.filter == GameObjectFilter.Any) return GameObjectFilter.Any
-                    filter = filter?.let { it or ability.filter } ?: ability.filter
+                    add(entityId to ability.filter)
                 }
             }
         }
-        return filter
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -367,7 +367,7 @@ internal class AffectsFilterResolver {
 
             // Check state predicates
             for (predicate in baseFilter.statePredicates) {
-                if (!matchesStatePredicateForProjection(state, entityId, predicate, container, isFaceDown, projectedValues, controller)) {
+                if (!matchesStatePredicateForProjection(state, entityId, predicate, container, isFaceDown, projectedValues, controller, sourceId)) {
                     return@filter false
                 }
             }
@@ -394,7 +394,14 @@ internal class AffectsFilterResolver {
          * [StatePredicate.IsEnchantedByAura]'s Aura). Null when the source has no controller, in
          * which case those predicates fail closed rather than matching everything.
          */
-        sourceController: EntityId?
+        sourceController: EntityId?,
+        /**
+         * The permanent whose static ability is being projected. Needed by predicates that read the
+         * source's own attachment rather than its controller — currently
+         * [StatePredicate.IsAttackingEnchantedPlayer], which has to find the player the source Aura
+         * enchants. Null when there is no source in scope, in which case those predicates fail closed.
+         */
+        sourceId: EntityId?
     ): Boolean = when (predicate) {
         // Everything this resolver is handed is already a battlefield permanent, so the predicate
         // is trivially satisfied here; it only does work in PredicateEvaluator, where an object
@@ -433,6 +440,20 @@ internal class AffectsFilterResolver {
                                 ?.contains(com.wingedsheep.sdk.core.CardType.PLANESWALKER) == true
                         )
                 )
+        }
+        // "Attacking enchanted player" — the defender must be the player the *source* Aura is
+        // attached to (Curse of Hospitality). Scoped by attachment rather than by controller, so
+        // unlike its two siblings above it reads `sourceId`, not `sourceController`. The
+        // `in state.turnOrder` check is what keeps a planeswalker or battle the enchanted player
+        // controls out: only a player id survives it.
+        StatePredicate.IsAttackingEnchantedPlayer -> {
+            val enchanted = sourceId
+                ?.let { state.getEntity(it) }
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                ?.targetId
+                ?.takeIf { it in state.turnOrder }
+            val defenderId = container.get<AttackingComponent>()?.defenderId
+            enchanted != null && defenderId == enchanted
         }
         StatePredicate.IsBlocking -> container.has<BlockingComponent>()
         StatePredicate.IsBlocked -> {
@@ -688,13 +709,13 @@ internal class AffectsFilterResolver {
         StatePredicate.HasLockedDoor ->
             container.get<RoomComponent>()?.lockedFaces?.isNotEmpty() == true
         is StatePredicate.Or -> predicate.predicates.any {
-            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController)
+            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController, sourceId)
         }
         is StatePredicate.And -> predicate.predicates.all {
-            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController)
+            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController, sourceId)
         }
         is StatePredicate.Not -> !matchesStatePredicateForProjection(
-            state, entityId, predicate.predicate, container, isFaceDown, projectedValues, sourceController
+            state, entityId, predicate.predicate, container, isFaceDown, projectedValues, sourceController, sourceId
         )
     }
 
@@ -903,6 +924,7 @@ internal class AffectsFilterResolver {
         CardPredicate.SharesColorWithRecipient,
         is CardPredicate.SharesCreatureTypeWith,
         is CardPredicate.SharesCardTypeWith,
+        CardPredicate.SharesCardTypeWithLinkedExile,
         is CardPredicate.SharesColorWith,
         is CardPredicate.SharesManaValueWith,
         is CardPredicate.SharesNameWith,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1367,6 +1367,7 @@ class CostCalculator(
             }
             is CardPredicate.SharesCreatureTypeWith -> true
             is CardPredicate.SharesCardTypeWith -> true
+            CardPredicate.SharesCardTypeWithLinkedExile -> true
             is CardPredicate.SharesColorWith -> true
             is CardPredicate.SharesManaValueWith -> true
             is CardPredicate.SharesNameWith -> true


### PR DESCRIPTION
Two cards off the Crimson Vow tail, and the three filters they needed. VOW goes 259 → 261 / 273.

Both cards needed new SDK vocabulary, which normally means one PR each; they share one PR here because the three filters land in one commit ahead of them and each card is its own droppable commit on top.

## Cards

- **Cemetery Illuminator** ({1}{U}{U} Creature — Spirit 2/3) — the blue half of the cemetery cycle, and the last of the five. Flying; two triggered abilities for "enters or attacks", each running Cemetery Prowler's verbatim linked-exile pipeline; `LookAtTopOfLibrary`; and `CastSpellTypesFromTopOfLibrary(maxCastsPerTurn = 1)` over the new pile-wide card-type filter.
- **Curse of Hospitality** ({2}{R} Enchantment — Aura Curse) — `auraTarget = Targets.Player`; a `GrantKeyword(TRAMPLE, …)` in Oviya, Automech Artisan's shape one scope over; and Gonti, Night Minister's ANY-bound `sourceFilter` damage observer paying off into `GrantMayPlayFromExileEffect(recipient = ControllerOfTriggeringEntity, withAnyManaType = true)`.

## Vocabulary (commit 1)

Three filters, each the missing *scope* of a family the SDK already had.

**Attachment-scoped player filters.** Every "attacking / dealt damage to" scope in the SDK resolves its player against the ability's **controller** — `IsAttackingAnOpponent`, `IsAttackingYouOrYourPlaneswalkers`, `RecipientFilter.Opponent`. That is the wrong player for an Aura Curse, which must read the player its *source* enchants: a curse on one opponent must not fire off damage dealt to another, and the same curse put on its own controller must still work. `StatePredicate.IsAttackingEnchantedPlayer` and `RecipientFilter.EnchantedPlayer` are those two scopes, resolved through `AttachedToComponent` and gated on the target being a player, so a planeswalker the enchanted player controls drops out by construction.

Both needed the *source* threaded to where the filter is matched — `AffectsFilterResolver.matchesStatePredicateForProjection` had only `sourceController`, `TriggerMatcher.matchesDealsDamageTrigger` only `controllerId` — and both already had the id one frame up at every call site.

**The pile-wide card-type filter.** `CardPredicate.SharesCardTypeWith` reads one `LinkedExiledCard(index)`. A card that keeps exiling means "a card exiled with this creature", any of them, which an index cannot say. `CardPredicate.SharesCardTypeWithLinkedExile` is that reading as a filter; the cost side already had it as `CostReductionSource.SharedCardTypesWithLinkedExile` (Cemetery Prowler).

Its consumer, the cast-from-top permission path, was source-blind: `CastZoneResolver.matchesCardFilter` judged a filter from the card alone, and `CastPermissionUtils.getCastFromTopOfLibraryFilter` OR'd several permanents' filters into one — losing which pile to read. That util now returns one `(grantingPermanent, filter)` pair per permission, and both the enumerator and the cast-time re-check evaluate each pair against its own source.

## Unrelated fix (commit 4)

`:oracle-assay:test` was red on main: `3f473bb10b` ("Assay: the life amount") made "You gain life equal to the number of creatures you control." readable but touched no test file, leaving `AmountsTest`'s `declines(...)` for exactly that line asserting the old behaviour. It is an `alsoSpelled` alternate, not a second printed form, so the assertion now pins that it reprints as the canonical "You gain 1 life for each creature you control." Fixed here at Vincent's request.

## Verification

- `just build` — green (whole gate, including `:oracle-assay:test`).
- `just test-rules` — green.
- `CemeteryIlluminatorScenarioTest` 5/5, `CurseOfHospitalityScenarioTest` 7/7. The tests that carry the weight are the ones a wrong-but-plausible reading passes: the Illuminator's "the pile is read whole" (an index-keyed reading fails it) and the Curse's two self-curse cases (a controller-scoped reading fails them).
- `just assay-differential --set VOW` — 70/70 confirmed, 0 divergent.
- `just check-card-printing` ok for both; canonical in VOW, the earliest real printing for each.
- `CardDefinitionSnapshotTest` re-blessed; only `VOW.json` moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)