### PR TITLE
Make failed actions atomic

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
@@ -84,11 +84,21 @@ class ActionProcessor(
             return ProcessedAction(ExecutionResult.error(state, validationError))
         }
 
-        // Execute the action, then update which revealed/returned cards opponents may see
-        // (cards revealed into hand or bounced back to hand stay visible until a same-named
-        // card is played — see [RevealedInHandTracker]).
-        val result = com.wingedsheep.engine.mechanics.RevealedInHandTracker
-            .applyAfterAction(registry.execute(state, action))
+        val executed = registry.execute(state, action)
+
+        // Action handlers may compose several immutable intermediate states before a nested
+        // handler or resumed continuation rejects a later step. The public action contract is
+        // atomic on error: retain only the message and expose the exact entry state. In
+        // particular, do this before event-driven post-action bookkeeping so events from the
+        // rejected attempt cannot mutate the externally visible result.
+        val result = if (executed.error != null) {
+            ExecutionResult.error(state, executed.error)
+        } else {
+            // Cards revealed into hand or bounced back to hand stay visible until a same-named
+            // card is played — see [RevealedInHandTracker]. Paused actions are accepted in-flight
+            // actions, so they retain this existing bookkeeping just like completed successes.
+            com.wingedsheep.engine.mechanics.RevealedInHandTracker.applyAfterAction(executed)
+        }
         val undoPolicy = if (computeUndo) {
             UndoPolicyComputer.compute(action, state, result, services.cardRegistry)
         } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ExecutionResult.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ExecutionResult.kt
@@ -9,7 +9,12 @@ import kotlinx.serialization.Serializable
  * The engine operates as a reentrant state machine. Every operation returns one of:
  * - **Success**: error == null && pendingDecision == null
  * - **PausedForDecision**: pendingDecision != null (needs player input)
- * - **Error**: error != null (action was invalid, state unchanged)
+ * - **Error**: error != null (action was rejected, state unchanged)
+ *
+ * Nested engine steps also use `ExecutionResult` while composing an action and may have built
+ * intermediate immutable states before reporting an error. [ActionProcessor] is the public
+ * transaction boundary: a top-level error exposes the exact input state and retains only the error
+ * message, with no events, pending decision, or processed-trigger marker from the rejected attempt.
  *
  * Game-over is signaled via `state.gameOver` + a [GameEndedEvent] in `events`.
  */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ActionProcessorAtomicityTest : ScenarioTestBase() {
+    init {
+        test("a later nested continuation error rejects the whole submitted decision") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.ContextTarget(0))
+            )
+            val preActionState = game.state
+
+            val processed = actionProcessor.process(
+                preActionState,
+                SubmitDecision(
+                    playerId = game.player1Id,
+                    response = DistributionResponse(
+                        decisionId = decision.id,
+                        distribution = linkedMapOf(game.player2Id to 1)
+                    )
+                )
+            )
+            val result = processed.result
+
+            result.error shouldBe "No valid target for life gain"
+            assertSoftly {
+                result.state shouldBe preActionState
+                result.state.lifeTotal(game.player2Id) shouldBe 20
+                result.state.pendingDecision shouldBe decision
+                result.state.continuationStack shouldBe preActionState.continuationStack
+                result.events.shouldBeEmpty()
+                result.pendingDecision shouldBe null
+                result.triggersAlreadyProcessed shouldBe false
+                processed.undoPolicy shouldBe UndoCheckpointAction.PRESERVE
+            }
+        }
+
+        test("a successful nested continuation commits its state and events") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.Controller)
+            )
+            val preActionState = game.state
+
+            val result = game.submitDecision(
+                DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
+            )
+
+            result.error shouldBe null
+            result.pendingDecision shouldBe null
+            result.state.lifeTotal(game.player1Id) shouldBe 21
+            result.state.lifeTotal(game.player2Id) shouldBe 19
+            result.state.pendingDecision shouldBe null
+            result.state.continuationStack.shouldBeEmpty()
+            result.events.shouldNotBeEmpty()
+            result.events.filterIsInstance<LifeChangedEvent>().map { it.playerId to it.newLife } shouldBe
+                listOf(game.player2Id to 19, game.player1Id to 21)
+        }
+
+        test("a nested continuation that pauses keeps its in-flight state and events") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = MayEffect(Effects.GainLife(1, EffectTarget.Controller))
+            )
+            val preActionState = game.state
+
+            val result = game.submitDecision(
+                DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
+            )
+
+            result.error shouldBe null
+            result.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            result.state.lifeTotal(game.player1Id) shouldBe 20
+            result.state.lifeTotal(game.player2Id) shouldBe 19
+            result.state.pendingDecision shouldBe result.pendingDecision
+            result.state.continuationStack.shouldNotBeEmpty()
+            result.events.shouldNotBeEmpty()
+            result.events.filterIsInstance<LifeChangedEvent>().map { it.playerId to it.newLife } shouldBe
+                listOf(game.player2Id to 19)
+        }
+    }
+
+    private fun gameAwaitingDividedDamage(
+        then: Effect
+    ): Pair<ScenarioTestBase.TestGame, DistributeDecision> {
+        val game = scenario().withPlayers().build()
+        val decisionId = "divide-damage"
+        val gatedFollowUp = GatedActionContinuation(
+            decisionId = "evaluate-damage",
+            then = then,
+            otherwise = null,
+            successCriterion = SuccessCriterion.Always,
+            snapshot = GatedActionSnapshot(),
+            effectContext = EffectContext(
+                sourceId = null,
+                controllerId = game.player1Id,
+                targets = emptyList()
+            )
+        )
+        val damage = DistributeDamageContinuation(
+            decisionId = decisionId,
+            sourceId = null,
+            controllerId = game.player1Id,
+            targets = listOf(game.player2Id)
+        )
+        val decision = DistributeDecision(
+            id = decisionId,
+            playerId = game.player1Id,
+            prompt = "Divide 1 damage",
+            context = DecisionContext(),
+            totalAmount = 1,
+            targets = listOf(game.player2Id),
+            minPerTarget = 1
+        )
+        game.state = game.state
+            .pushContinuation(gatedFollowUp)
+            .pushContinuation(damage)
+            .withPendingDecision(decision)
+        return game to decision
+    }
+}


### PR DESCRIPTION
`ExecutionResult` documents an error as a rejected action with unchanged state, but a top-level action can currently expose partial execution when a nested continuation fails after earlier steps have already changed state.

A reproduced case submits a valid divided-damage decision. Damage is applied and its events are emitted, then a resumed continuation fails. Before this change, the error result exposed the damaged life total, emitted events, and consumed decision/continuation state.

Normalize handler errors at the `ActionProcessor` boundary so a rejected top-level action:

- returns the original input `GameState`;
- retains only the error message;
- does not expose events, pending decisions, or trigger-processing state from the failed attempt;
- skips post-action reveal bookkeeping;
- preserves the existing retryable decision and continuation state.

Successful actions and legitimately paused actions continue to commit their intermediate state and events normally.

Coverage includes:

- a nested continuation that mutates state and then fails;
- the corresponding successful nested execution;
- a nested execution that legitimately pauses for another decision.

Verification:

- `just test-class ActionProcessorAtomicityTest`
- `just test-class RevealedHandVisibilityScenarioTest`
- `just test-rules`