### PR TITLE
Add six Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HarpoonSniper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HarpoonSniper.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Harpoon Sniper
+ * {2}{W}
+ * Creature — Merfolk Archer
+ * 2/2
+ * {W}, {T}: This creature deals X damage to target attacking or blocking creature, where X is the
+ * number of Merfolk you control.
+ *
+ * "Attacking or blocking creature" is one printed noun phrase and one shipped filter,
+ * [TargetFilter.AttackingOrBlockingCreature] — not an or of two clauses.
+ *
+ * X counts Merfolk *permanents* you control, so the filter is [GameObjectFilter.Permanent] rather
+ * than `.Creature`: Lorwyn's Kindred noncreature permanents carry creature types, and a Kindred
+ * Enchantment — Merfolk you control is a Merfolk. Note the scope has to be
+ * `battlefield(Player.You, …)` and not `DynamicAmounts.creaturesWithSubtype`, which is
+ * [Player.Each] and would count an opponent's Merfolk too. The count is read on resolution, so
+ * the Sniper itself is included and a Merfolk that died in response is not.
+ */
+val HarpoonSniper = card("Harpoon Sniper") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Merfolk Archer"
+    power = 2
+    toughness = 2
+    oracleText = "{W}, {T}: This creature deals X damage to target attacking or blocking " +
+        "creature, where X is the number of Merfolk you control."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = DealDamageEffect(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK)
+            ).count(),
+            t
+        )
+        description = "{W}, {T}: This creature deals X damage to target attacking or blocking " +
+            "creature, where X is the number of Merfolk you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Dominick Domingo"
+        flavorText = "Made from whiskergill bones, merrow spinebows can fire bolts through tree trunks."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg?1783942914"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HealTheScars.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HealTheScars.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Heal the Scars
+ * {3}{G}
+ * Instant
+ *
+ * Regenerate target creature. You gain life equal to that creature's toughness.
+ *
+ * Both clauses read the same target, so the life gain is an
+ * [DynamicAmount.EntityProperty] on [EntityReference.Target] rather than a fixed number — it is
+ * measured on resolution, after the regeneration shield goes up, so a pumped or shrunken creature
+ * pays out its current toughness. There is no `Effects.Regenerate` facade; [RegenerateEffect] is
+ * the shipped spelling (see Reknit).
+ */
+val HealTheScars = card("Heal the Scars") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Regenerate target creature. You gain life equal to that creature's toughness."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            RegenerateEffect(t),
+            Effects.GainLife(
+                DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.Toughness)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Carl Frank"
+        flavorText = "Elvish battle-magic has evolved two specialties: inflicting wounds that scar, " +
+            "and healing wounds without scarring. Politics determines the recipients of each."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg?1783942862"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NectarFaerie.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NectarFaerie.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Nectar Faerie
+ * {1}{B}
+ * Creature — Faerie Wizard
+ * 1/1
+ * Flying
+ * {B}, {T}: Target Faerie or Elf gains lifelink until end of turn.
+ *
+ * The target names no card type and no controller: it is any *permanent* that is a Faerie or an
+ * Elf, an opponent's included, and in Lorwyn that reaches the Kindred noncreature permanents
+ * (a Kindred Enchantment — Faerie is a Faerie) as well as creatures. So the filter is
+ * [GameObjectFilter.Permanent] with a [GameObjectFilter.withAnySubtype] union, not
+ * `GameObjectFilter.Creature` — one noun phrase, one filter, the way Goblin Wizard's
+ * "target Goblin" is written.
+ */
+val NectarFaerie = card("Nectar Faerie") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{B}, {T}: Target Faerie or Elf gains lifelink until end of turn. (Damage dealt by the " +
+        "creature also causes its controller to gain that much life.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val t = target(
+            "target Faerie or Elf",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.withAnySubtype(Subtype.FAERIE.value, Subtype.ELF.value)
+                )
+            )
+        )
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, t)
+        description = "{B}, {T}: Target Faerie or Elf gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Thomas Denmark"
+        flavorText = "\"The unpredictable fae are just as likely to provide a blight as a boon.\"\n" +
+            "—Desmera, perfect of Wren's Run"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg?1783942885"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/QuillSlingerBoggart.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/QuillSlingerBoggart.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Quill-Slinger Boggart
+ * {3}{B}
+ * Creature — Goblin Warrior
+ * 3/2
+ * Whenever a player casts a Kithkin spell, you may have target player lose 1 life.
+ *
+ * "A player" is every player, the Boggart's controller included, so this is
+ * [Triggers.anyPlayerCasts] — the same shape as Bog-Strider Ash and Elvish Handservant. The spell
+ * filter is [GameObjectFilter.Any] rather than `.Creature`: a Kithkin spell is any spell with the
+ * subtype, and Lorwyn prints Kindred noncreature ones (Militia's Pride is a Kithkin enchantment
+ * spell). The "you may" is `optional = true`, which the builder lowers to a MayEffect; the yes/no
+ * is asked as the ability goes on the stack, before targets are chosen, so declining never forces
+ * a pointless target.
+ */
+val QuillSlingerBoggart = card("Quill-Slinger Boggart") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever a player casts a Kithkin spell, you may have target player lose 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withSubtype(Subtype.KITHKIN))
+        optional = true
+        val p = target("target player", Targets.Player)
+        effect = Effects.LoseLife(1, p)
+        description = "Whenever a player casts a Kithkin spell, you may have target player lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Warren Mahy"
+        flavorText = "\"A good day in Goldmeadow is one in which I don't spend all evening picking " +
+            "quills out of my backside.\"\n—Calydd, kithkin farmer"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg?1783942885"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/RunedStalactite.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/RunedStalactite.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.IsAllCreatureTypes
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Runed Stalactite
+ * {1}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+1 and is every creature type.
+ * Equip {2}
+ *
+ * "Is every creature type" is [IsAllCreatureTypes], a Layer 4 type-setting static — it adds the
+ * types without granting changeling, which is the right distinction: the equipped creature becomes
+ * every type but the *Equipment* is not itself a changeling permanent, and nothing that counts
+ * changeling permanents should see it. Pointed at the attached creature it turns any body into a
+ * lord magnet for every tribe in the set.
+ */
+val RunedStalactite = card("Runed Stalactite") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and is every creature type.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = IsAllCreatureTypes(GroupFilter.attachedCreature())
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "260"
+        artist = "Jim Pavelec"
+        flavorText = "When a changeling adopts a form no other changeling has taken, a rune " +
+            "appears in the caverns of Velis Vel to mark the event."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg?1783942852"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TriclopeanSight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TriclopeanSight.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Triclopean Sight
+ * {1}{W}
+ * Enchantment — Aura
+ * Flash
+ * Enchant creature
+ * When this Aura enters, untap enchanted creature.
+ * Enchanted creature gets +1/+1 and has vigilance.
+ *
+ * Flash plus the untap is the trick: cast it on a tapped attacker or blocker and it stands back up,
+ * and the vigilance keeps it that way afterwards. The untap is a one-shot from the enters trigger,
+ * so it fires once on arrival — [EffectTarget.EnchantedCreature] resolves through the Aura's own
+ * attachment, which is already in place by the time the trigger resolves. The +1/+1 and the
+ * vigilance are the continuous half and stay scoped to [Filters.EnchantedCreature].
+ */
+val TriclopeanSight = card("Triclopean Sight") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "When this Aura enters, untap enchanted creature.\n" +
+        "Enchanted creature gets +1/+1 and has vigilance."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Untap(EffectTarget.EnchantedCreature)
+        description = "When this Aura enters, untap enchanted creature."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EnchantedCreature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Scott Hampton"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg?1783942908"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -3017,6 +3017,131 @@
     ]
 }
 
+// Harpoon Sniper
+{
+    "name": "Harpoon Sniper",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Merfolk Archer",
+    "oracleText": "{W}, {T}: This creature deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Merfolk"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ],
+                "descriptionOverride": "{W}, {T}: This creature deals X damage to target attacking or blocking creature, where X is the number of Merfolk you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Dominick Domingo",
+        "flavorText": "Made from whiskergill bones, merrow spinebows can fire bolts through tree trunks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c10ccaef-2a75-43d6-95f2-c3690ae5c87a.jpg?1783942914"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Heal the Scars
+{
+    "name": "Heal the Scars",
+    "manaCost": "{3}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Regenerate target creature. You gain life equal to that creature's toughness.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Toughness"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "artist": "Carl Frank",
+        "flavorText": "Elvish battle-magic has evolved two specialties: inflicting wounds that scar, and healing wounds without scarring. Politics determines the recipients of each.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b802a7fe-9c8b-4bc3-95d8-4a5dafcf2c75.jpg?1783942862"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hearthcage Giant
 {
     "name": "Hearthcage Giant",
@@ -5124,6 +5249,69 @@
     ]
 }
 
+// Nectar Faerie
+{
+    "name": "Nectar Faerie",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\n{B}, {T}: Target Faerie or Elf gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Faerie or Elf"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Faerie|Elf"
+                        },
+                        "id": "target Faerie or Elf"
+                    }
+                ],
+                "descriptionOverride": "{B}, {T}: Target Faerie or Elf gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas Denmark",
+        "flavorText": "\"The unpredictable fae are just as likely to provide a blight as a boon.\"\n—Desmera, perfect of Wren's Run",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d943b877-805d-4bc8-a3ae-abec00fa51a6.jpg?1783942885"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nightshade Stinger
 {
     "name": "Nightshade Stinger",
@@ -5445,6 +5633,68 @@
     ]
 }
 
+// Quill-Slinger Boggart
+{
+    "name": "Quill-Slinger Boggart",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Whenever a player casts a Kithkin spell, you may have target player lose 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Kithkin"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    },
+                    "descriptionOverride": "Whenever a player casts a Kithkin spell, you may have target player lose 1 life."
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "Whenever a player casts a Kithkin spell, you may have target player lose 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Warren Mahy",
+        "flavorText": "\"A good day in Goldmeadow is one in which I don't spend all evening picking quills out of my backside.\"\n—Calydd, kithkin farmer",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3a15a9d-46d7-4181-8131-50ba46a11c7b.jpg?1783942885"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Rootgrapple
 {
     "name": "Rootgrapple",
@@ -5504,6 +5754,62 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Runed Stalactite
+{
+    "name": "Runed Stalactite",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and is every creature type.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            "IsAllCreatureTypes"
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "260",
+        "artist": "Jim Pavelec",
+        "flavorText": "When a changeling adopts a form no other changeling has taken, a rune appears in the caverns of Velis Vel to mark the event.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9be88336-83c7-422d-8826-13ceb8db5534.jpg?1783942852"
+    },
+    "colorIdentityOverride": []
 }
 
 // Scarred Vinebreeder
@@ -6624,6 +6930,59 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Triclopean Sight
+{
+    "name": "Triclopean Sight",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nWhen this Aura enters, untap enchanted creature.\nEnchanted creature gets +1/+1 and has vigilance.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature",
+                    "tap": false
+                },
+                "descriptionOverride": "When this Aura enters, untap enchanted creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Scott Hampton",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/444b5d72-ac5b-43d2-b5dc-0cc4bf63e43d.jpg?1783942908"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Six unimplemented Lorwyn commons and uncommons, all composed from existing `Effects.*` / `Filters.*` / `Triggers.*` primitives — no new SDK vocabulary, so no card needed to leave the batch.

- **Heal the Scars** {3}{G} — `RegenerateEffect` plus `Effects.GainLife` on a `DynamicAmount.EntityProperty(EntityReference.Target, Toughness)`. Both clauses read the same target, so the life gain is measured on resolution rather than hard-coded.
- **Triclopean Sight** {1}{W} — flash Aura. The enters trigger is `Effects.Untap(EffectTarget.EnchantedCreature)`; the continuous half is `ModifyStats(+1/+1)` and `GrantKeyword(VIGILANCE)` scoped to `Filters.EnchantedCreature`.
- **Nectar Faerie** {1}{B} — `{B}, {T}`: `Effects.GrantKeyword(LIFELINK, …)` until end of turn. "Target Faerie or Elf" names no card type and no controller, so the filter is `GameObjectFilter.Permanent.withAnySubtype(FAERIE, ELF)` rather than `.Creature` — in Lorwyn that reaches the Kindred noncreature permanents too, the way Goblin Wizard's "target Goblin" is written.
- **Runed Stalactite** {1} — `ModifyStats(+1/+1, Filters.EquippedCreature)` plus `IsAllCreatureTypes(GroupFilter.attachedCreature())`, the Layer 4 type-setting static that adds every creature type *without* granting changeling, so nothing counting changeling permanents sees the Equipment itself. `equipAbility("{2}")`.
- **Harpoon Sniper** {2}{W} — `{W}, {T}`: `DealDamageEffect` for `DynamicAmounts.battlefield(Player.You, Permanent.withSubtype(MERFOLK)).count()` at a `TargetFilter.AttackingOrBlockingCreature`. Deliberately not `DynamicAmounts.creaturesWithSubtype`, which is `Player.Each` and would count an opponent's Merfolk too.
- **Quill-Slinger Boggart** {3}{B} — `Triggers.anyPlayerCasts(GameObjectFilter.Any.withSubtype(KITHKIN))` with `optional = true`, then `Effects.LoseLife(1, targetPlayer)`. "A player" is every player, the Boggart's controller included; the spell filter is `.Any` because Lorwyn prints Kindred noncreature Kithkin spells.

None of these introduce a new decision shape — targeting and the "you may" both route through existing client components — so there is no e2e test, and per the skill's rule no scenario test either (they add no engine vocabulary).

### Verification

- `just build` — compiles clean, 372 tests, one expected failure: `CardDefinitionSnapshotTest` on `snapshots/cards/LRW.json`.
- `just rebless-cards` — re-blessed and green. The diff is 359 pure insertions and only the six new cards move.
- `just assay-differential --set LRW` — 96/109 confirmed, 13 `DIVERGENT`. All 13 are pre-existing cards I did not touch (the Harbinger cycle, Boggart Birth Rite, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart, Scarred Vinebreeder, Wort). None of the six new cards is divergent.
- `just check-card-printing` — passes for all six. LRW is the earliest real printing of each, so each is a canonical; Runed Stalactite's later MMA/PLST printings are in unscaffolded sets.
- Field-by-field re-verified against Scryfall: mana cost, type line, P/T, rarity, collector number, artist, color identity, image URI and oracle text all match. Runed Stalactite's `oracleText` carries the equip reminder text, matching the printed card and the era's existing Equipment (No-Dachi, Vulshok Morningstar).

**Not run locally:** the final full `just build` after the re-bless. Both machine-global Gradle slots were held by another agent's `:rules-engine:test :mtg-sets:scenarioTest` run for the duration, and every queued attempt was terminated before acquiring one. The only file changed since the green `rebless-cards` run is the snapshot golden that run produced, so CI is the check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)