### PR TITLE
Show a disturb card's transformed side in your hand

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -178,6 +178,19 @@ data class LegalAction(
     // Source zone
     val sourceZone: String? = null,
 
+    /**
+     * True when taking this action puts the card on the stack **back face up** (CR 712.8c) — i.e.
+     * the spell the player is being offered is the card's *back* face, not the face the zone it
+     * sits in is showing. Disturb (CR 702.146a) is the only enumerated offer that does this today.
+     *
+     * Sent to the client because a face-down-in-its-zone offer is otherwise invisible: a disturb
+     * card sits in the graveyard printed front face up, so an offer rendered from the card's own
+     * characteristics shows the wrong name, art and text for the spell it would actually cast.
+     * The client must never re-derive this from the disturb keyword — which face a cast uses is a
+     * rules question, and [description] / [manaCostString] are already read off that face here.
+     */
+    val castsTransformed: Boolean = false,
+
     // Tap-creatures-for-total-power selection (shared by Crew N and Saddle N: the player taps
     // any number of eligible creatures whose combined power meets [tapForPowerRequired]).
     val tapForPower: Boolean = false,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1582,7 +1582,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         action = disturbAction,
                         affordable = false,
                         manaCostString = disturb.cost.toString(),
-                        sourceZone = "GRAVEYARD"
+                        sourceZone = "GRAVEYARD",
+                        // CR 712.8c: the spell is the back face, so the client renders the offer as it.
+                        castsTransformed = true
                     )
                 )
                 continue
@@ -1608,7 +1610,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         action = disturbAction,
                         affordable = false,
                         manaCostString = costString,
-                        sourceZone = "GRAVEYARD"
+                        sourceZone = "GRAVEYARD",
+                        // CR 712.8c: the spell is the back face, so the client renders the offer as it.
+                        castsTransformed = true
                     )
                 )
                 continue
@@ -1642,7 +1646,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         targetRequirements = if (targetInfos.size > 1) targetInfos else null,
                         manaCostString = costString,
                         autoTapPreview = autoTapPreview,
-                        sourceZone = "GRAVEYARD"
+                        sourceZone = "GRAVEYARD",
+                        // CR 712.8c: the spell is the back face, so the client renders the offer as it.
+                        castsTransformed = true
                     )
                 )
             } else {
@@ -1653,7 +1659,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         action = disturbAction,
                         manaCostString = costString,
                         autoTapPreview = autoTapPreview,
-                        sourceZone = "GRAVEYARD"
+                        sourceZone = "GRAVEYARD",
+                        // CR 712.8c: the spell is the back face, so the client renders the offer as it.
+                        castsTransformed = true
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -625,6 +625,19 @@ data class ClientCard(
     val backFaceImageUri: String? = null,
 
     /**
+     * Back face's printed power / toughness, and its printed keywords.
+     *
+     * The siblings of [backFaceName] / [backFaceTypeLine] / [backFaceOracleText], and they exist
+     * for the same reason: a client showing the back face — a hover flip, or the disturb offer a
+     * graveyard card is rendered as (CR 712.8c) — otherwise pairs the back's art and text with the
+     * *front's* stats and keyword chips. Printed values, not projected ones: the back face of a
+     * card outside the battlefield has no projection entry of its own.
+     */
+    val backFacePower: Int? = null,
+    val backFaceToughness: Int? = null,
+    val backFaceKeywords: Set<Keyword> = emptySet(),
+
+    /**
      * For planeswalkers on the battlefield: every loyalty ability on the card, in declaration
      * order. Lets the client show the full menu with unavailable abilities grayed out instead of
      * hiding them. Null for non-planeswalkers and for planeswalkers outside the battlefield.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1500,6 +1500,11 @@ class ClientStateTransformer(
             backFaceTypeLine = dfcBackFace(container, cardDef)?.typeLine?.toString() ?: modalBackFace?.typeLine?.toString(),
             backFaceOracleText = dfcBackFace(container, cardDef)?.oracleText ?: modalBackFace?.oracleText,
             backFaceImageUri = cardComponent.backFaceImageUri ?: dfcBackFace(container, cardDef)?.metadata?.imageUri ?: modalBackFace?.imageUri,
+            // A modal DFC's spell back lives in `cardFaces` and carries no P/T of its own, so only
+            // the transform back face (a permanent) contributes stats; keywords come from either.
+            backFacePower = dfcBackFace(container, cardDef)?.creatureStats?.basePower,
+            backFaceToughness = dfcBackFace(container, cardDef)?.creatureStats?.baseToughness,
+            backFaceKeywords = dfcBackFace(container, cardDef)?.keywords ?: modalBackFace?.keywords ?: emptySet(),
             planeswalkerAbilities = buildPlaneswalkerAbilities(cardDef, zoneKey),
             isRoom = cardDef?.isRoom == true,
             // `cardDef` already tracks the *displayed* face of a DFC (dfcBackFace resolves the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -139,6 +139,7 @@ class LegalActionEnricher(
             availableManaSources = if (shouldExposeManaSources(action)) manaSourceInfos else null,
             eligibleRestrictedMana = eligibleRestrictedMana,
             sourceZone = action.sourceZone,
+            castsTransformed = action.castsTransformed,
             tapForPower = action.tapForPower,
             tapForPowerRequired = action.tapForPowerRequired,
             tapForPowerCreatures = action.tapForPowerCreatures?.map { it.toDto() },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -170,6 +170,14 @@ data class LegalActionInfo(
      */
     val availableManaColors: List<String>? = null,
     val sourceZone: String? = null,
+    /**
+     * True when this cast puts the card on the stack **back face up** (CR 712.8c) — disturb
+     * (CR 702.146a) today. The card sits in its zone printed *front* face up, so a client that
+     * renders the offer from the card's own name/art/text shows the wrong spell; it must swap in
+     * the `backFace*` fields of [ClientCard] instead. Mirrors
+     * [com.wingedsheep.engine.legalactions.LegalAction.castsTransformed].
+     */
+    val castsTransformed: Boolean = false,
     val blockerMaxBlockCounts: Map<EntityId, Int>? = null,
     val mandatoryBlockerAssignments: Map<EntityId, List<EntityId>>? = null,
     val maxRepeatableActivations: Int? = null,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbKeywordTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.view.CastProvenance
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.ClientEvent
 import com.wingedsheep.engine.view.ClientEventTransformer
 import com.wingedsheep.engine.support.GameTestDriver
@@ -31,6 +32,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -125,6 +127,48 @@ class DisturbKeywordTest : FunSpec({
         LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, playerId)
             .mapNotNull { it.action as? CastSpell }
             .filter { it.alternativeCostType == AlternativeCostType.DISTURB }
+
+    // The client renders a disturb card's graveyard offer in the player's hand as a "ghost" card.
+    // A card in the graveyard is printed FRONT face up, so without these two facts the ghost shows
+    // the wrong spell entirely — Test Geist's 1/1 Human instead of the 2/2 flying Spirit that would
+    // actually go on the stack (CR 712.8c).
+    test("the disturb offer is flagged as casting transformed, so the client can render the back face") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+
+        driver.putCardInGraveyard(player, "Test Geist")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(player, Color.WHITE, 2)
+
+        val actions = LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, player)
+        val offer = actions.firstOrNull {
+            (it.action as? CastSpell)?.alternativeCostType == AlternativeCostType.DISTURB
+        }
+        offer.shouldNotBeNull()
+        offer.castsTransformed.shouldBeTrue()
+
+        // Every other cast the same player is offered is its own printed face.
+        actions.filter { it !== offer }.forAll { it.castsTransformed shouldBe false }
+    }
+
+    test("a disturb card in the graveyard carries its back face's stats and keywords to the client") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+
+        val geist = driver.putCardInGraveyard(player, "Test Geist")
+        val view = ClientStateTransformer(driver.cardRegistry).transform(driver.state, player).cards.getValue(geist)
+
+        // The card itself is still the front face — it is lying in the graveyard face up.
+        view.name shouldBe "Test Geist"
+        view.power shouldBe 1
+        // ...and everything the client needs to draw the offer's face rides alongside it.
+        view.backFaceName shouldBe "Test Geist Spirit"
+        view.backFacePower shouldBe 2
+        view.backFaceToughness shouldBe 2
+        view.backFaceKeywords shouldContain Keyword.FLYING
+    }
 
     test("disturb is offered only from the graveyard, never from hand (CR 702.146a)") {
         val driver = createDriver()

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -12,6 +12,7 @@ import { useHasHover } from '@/hooks/useHasHover.ts'
 import { ManaCost, AbilityText } from '../../ui/ManaSymbols'
 import { buildActionOptions, playCostRange, playLadderOptions } from '@/utils/actionOptions.ts'
 import { parseManaCost, totalManaNeeded } from '@/utils/manaCost.ts'
+import { castOfferFace } from '@/utils/castFace.ts'
 
 /**
  * Game board card preview — wraps the shared HoverCardPreview with
@@ -27,7 +28,14 @@ export function CardPreview() {
 
   // All hooks must be called before any early return
   const cardActions = useCardLegalActions(hoveredCardId)
-  const card = hoveredCardId && gameState ? gameState.cards[hoveredCardId] ?? null : null
+  // Preview the face the card would be *cast* as, so a disturb card in the graveyard previews as
+  // the spirit it becomes (CR 712.8c) — matching the ghost card offered in hand. Press F still
+  // flips to the printed front, which `castOfferFace` leaves in the back-face slots.
+  const rawCard = hoveredCardId && gameState ? gameState.cards[hoveredCardId] ?? null : null
+  const card = useMemo(
+    () => (rawCard ? castOfferFace(rawCard, cardActions) : null),
+    [rawCard, cardActions]
+  )
 
   // Check if hovered card is in the player's hand
   const isInHand = useMemo(() => {

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -19,6 +19,7 @@ import {
   groupCards,
 } from './cardGrouping'
 import { teamLabel } from './teamLabel'
+import { castOfferFace } from '@/utils/castFace'
 
 /**
  * Select the game state (works for both normal play and spectating).
@@ -935,6 +936,10 @@ export function useGroupedZoneCards(zoneId: ZoneId): readonly GroupedCard[] {
  * Future Sight-like effects, and exile cards playable via Mind's Desire-like effects.
  * These are shown as translucent cards appended to the player's hand for discoverability.
  * Excludes simple mana abilities and unaffordable actions (same filtering as useHasLegalActions).
+ *
+ * A ghost is an *offer*, not the card as its zone holds it: a disturb card (CR 702.146a) is cast
+ * back face up (CR 712.8c), so it joins the hand as the spirit it becomes rather than the creature
+ * lying in the graveyard. {@link castOfferFace} does that swap wherever the server flags it.
  */
 export function useGhostCards(playerId: EntityId | null): readonly ClientCard[] {
   const gameState = useGameStore(selectGameState)
@@ -992,10 +997,12 @@ export function useGhostCards(playerId: EntityId | null): readonly ClientCard[] 
       }
     }
 
-    // Return deduplicated ClientCard objects
+    // Return deduplicated ClientCard objects, each shown as the face it would be cast as
+    const actionsByCard = getLegalActionsIndex(legalActions).byCard
     return Array.from(ghostCardIds)
       .map((id) => gameState.cards[id])
       .filter((card): card is ClientCard => card != null)
+      .map((card) => castOfferFace(card, actionsByCard.get(card.id) ?? EMPTY_ACTIONS))
   }, [gameState, legalActions, playerId])
 }
 

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -231,6 +231,14 @@ export interface ClientCard {
   readonly backFaceOracleText?: string | null
   /** Back face image URI for DFCs. */
   readonly backFaceImageUri?: string | null
+  /**
+   * Back face printed power / toughness and keywords — the siblings of `backFaceName` and
+   * friends, so a view showing the back face doesn't pair its art and text with the front's
+   * stats and keyword chips.
+   */
+  readonly backFacePower?: number | null
+  readonly backFaceToughness?: number | null
+  readonly backFaceKeywords?: readonly Keyword[]
 
   /** Combat state (if in combat) */
   readonly isAttacking: boolean

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -968,6 +968,13 @@ export interface LegalActionInfo {
   readonly availableManaColors?: readonly string[]
   /** Source zone if this action is from a non-hand zone (e.g., "LIBRARY" for Future Sight) */
   readonly sourceZone?: string
+  /**
+   * True when this cast puts the card on the stack **back face up** (CR 712.8c) — a disturb cast
+   * (CR 702.146a). The card is sitting in its zone printed *front* face up, so the offer must be
+   * rendered from the card's `backFace*` fields, not from its own name/art/text. Server-decided:
+   * which face a cast uses is a rules question, never one the client derives from a keyword.
+   */
+  readonly castsTransformed?: boolean
   /** Max block counts for blockers that can block more than one attacker */
   readonly blockerMaxBlockCounts?: Readonly<Record<EntityId, number>>
   /** Pre-computed mandatory blocker→attacker assignments from Provoke / MustBeBlockedByAll */

--- a/web-client/src/utils/castFace.test.ts
+++ b/web-client/src/utils/castFace.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { ClientCard, LegalActionInfo } from '@/types'
+import { Keyword } from '@/types'
+import { castOfferFace } from './castFace'
+
+/** Lunarch Veteran // Luminous Phantom, as the server sends it while it sits in the graveyard. */
+const veteran = (extra: Partial<ClientCard> = {}): ClientCard =>
+  ({
+    id: 'c1',
+    name: 'Lunarch Veteran',
+    manaCost: '{W}',
+    typeLine: 'Creature — Human Cleric',
+    oracleText: 'Whenever another creature enters, you gain 1 life.',
+    imageUri: 'front.jpg',
+    power: 1,
+    toughness: 1,
+    basePower: 1,
+    baseToughness: 1,
+    keywords: [],
+    isDoubleFaced: true,
+    currentFace: 'FRONT',
+    backFaceName: 'Luminous Phantom',
+    backFaceTypeLine: 'Creature — Spirit Cleric',
+    backFaceOracleText: 'Whenever another creature dies, you gain 1 life.',
+    backFaceImageUri: 'back.jpg',
+    backFacePower: 1,
+    backFaceToughness: 1,
+    backFaceKeywords: [Keyword.FLYING],
+    ...extra,
+  }) as unknown as ClientCard
+
+const disturbOffer: LegalActionInfo = {
+  action: { type: 'CastSpell', cardId: 'c1' },
+  actionType: 'CastWithDisturb',
+  description: 'Cast Luminous Phantom (Disturb)',
+  manaCostString: '{2}{W}',
+  sourceZone: 'GRAVEYARD',
+  castsTransformed: true,
+} as unknown as LegalActionInfo
+
+const flashbackOffer: LegalActionInfo = {
+  action: { type: 'CastSpell', cardId: 'c1' },
+  actionType: 'CastWithFlashback',
+  description: 'Cast Lunarch Veteran (Flashback)',
+  sourceZone: 'GRAVEYARD',
+} as unknown as LegalActionInfo
+
+describe('castOfferFace', () => {
+  it('shows the back face when the server says the cast is transformed (CR 712.8c)', () => {
+    const shown = castOfferFace(veteran(), [disturbOffer])
+    expect(shown.name).toBe('Luminous Phantom')
+    expect(shown.typeLine).toBe('Creature — Spirit Cleric')
+    expect(shown.oracleText).toContain('dies')
+    expect(shown.imageUri).toBe('back.jpg')
+    expect(shown.currentFace).toBe('BACK')
+    expect(shown.keywords).toEqual([Keyword.FLYING])
+  })
+
+  it('leaves the card alone when no offer casts it transformed', () => {
+    const card = veteran()
+    expect(castOfferFace(card, [flashbackOffer])).toBe(card)
+    expect(castOfferFace(card, [])).toBe(card)
+  })
+
+  it('leaves the card alone when the offer belongs to a different card', () => {
+    const card = veteran()
+    const elsewhere = { ...disturbOffer, action: { type: 'CastSpell', cardId: 'c2' } } as LegalActionInfo
+    expect(castOfferFace(card, [elsewhere])).toBe(card)
+  })
+
+  it('leaves a single-faced card alone even if something flags the cast', () => {
+    const single = veteran({ backFaceName: null, backFaceImageUri: null })
+    expect(castOfferFace(single, [disturbOffer])).toBe(single)
+  })
+
+  // The swap has to be reversible or pressing F on the hover preview flips to the face already
+  // on screen — the printed front has to end up in the back-face slots.
+  it('puts the printed front face into the back-face slots so the preview can still flip to it', () => {
+    const shown = castOfferFace(veteran(), [disturbOffer])
+    expect(shown.backFaceName).toBe('Lunarch Veteran')
+    expect(shown.backFaceTypeLine).toBe('Creature — Human Cleric')
+    expect(shown.backFaceImageUri).toBe('front.jpg')
+    expect(shown.backFaceKeywords).toEqual([])
+    expect(shown.isDoubleFaced).toBe(true)
+  })
+
+  // The back face's printed stats travel with it; showing them against the front's `basePower`
+  // would paint the preview's "buffed" box on a card nothing has modified.
+  it('carries the back face stats into both the current and the base P/T', () => {
+    const shown = castOfferFace(veteran({ backFacePower: 2, backFaceToughness: 3 }), [disturbOffer])
+    expect([shown.power, shown.toughness]).toEqual([2, 3])
+    expect([shown.basePower, shown.baseToughness]).toEqual([2, 3])
+  })
+
+  // A disturb spell's mana value is still calculated from the front face's mana cost, and the
+  // price of the offer itself rides on the legal action.
+  it('keeps the front face mana cost', () => {
+    expect(castOfferFace(veteran(), [disturbOffer]).manaCost).toBe('{W}')
+  })
+})

--- a/web-client/src/utils/castFace.ts
+++ b/web-client/src/utils/castFace.ts
@@ -1,0 +1,61 @@
+import type { ClientCard, LegalActionInfo } from '@/types'
+
+/**
+ * Rendering a card as the face it would actually be *cast* as, rather than the face its zone is
+ * showing.
+ *
+ * Almost always those are the same card and this is the identity function. Disturb (CR 702.146a)
+ * is the exception: the card lies in the graveyard printed front face up, but casting it puts the
+ * **back** face on the stack (CR 712.8c). So the ghost card offered in hand — and the hover
+ * preview behind it — would otherwise show Lunarch Veteran while the spell on offer is Luminous
+ * Phantom: a different name, a different creature, and different rules text.
+ *
+ * Which offers do this is the server's call ({@link LegalActionInfo.castsTransformed}); this file
+ * only decides what a swapped face looks like on screen.
+ */
+
+/**
+ * [card] as the face [actions] would cast it as.
+ *
+ * Returns [card] itself when no action on it casts transformed, or when the card carries no back
+ * face to swap in — so callers can apply it unconditionally.
+ *
+ * The face's own characteristics move with it — name, type line, text, art, printed P/T and
+ * keywords — so the preview never pairs the back's art with the front's stats. `manaCost` stays
+ * the front's on purpose: a disturbed spell's mana value is still calculated from the front
+ * face's mana cost, and what it costs *to cast* comes from the offer's own `manaCostString`.
+ * `cardTypes` / `subtypes` keep the front's values, since the server sends no back-face copy of
+ * them and their readers (combat, the battlefield overlays) never draw a graveyard card.
+ *
+ * The back-face slots are filled with the front face's values, so pressing F on the hover preview
+ * still flips back to the printed front.
+ */
+export function castOfferFace(card: ClientCard, actions: readonly LegalActionInfo[]): ClientCard {
+  if (!card.backFaceName) return card
+  const castsTransformed = actions.some(
+    (a) => a.castsTransformed === true && a.action.type === 'CastSpell' && a.action.cardId === card.id
+  )
+  if (!castsTransformed) return card
+  return {
+    ...card,
+    name: card.backFaceName,
+    typeLine: card.backFaceTypeLine ?? card.typeLine,
+    oracleText: card.backFaceOracleText ?? card.oracleText,
+    imageUri: card.backFaceImageUri ?? null,
+    isLandscapeFace: card.backFaceIsLandscape ?? false,
+    currentFace: 'BACK',
+    power: card.backFacePower ?? null,
+    toughness: card.backFaceToughness ?? null,
+    basePower: card.backFacePower ?? null,
+    baseToughness: card.backFaceToughness ?? null,
+    keywords: card.backFaceKeywords ?? [],
+    backFaceName: card.name,
+    backFaceTypeLine: card.typeLine,
+    backFaceOracleText: card.oracleText,
+    backFaceImageUri: card.imageUri ?? null,
+    backFaceIsLandscape: card.isLandscapeFace ?? false,
+    backFacePower: card.power,
+    backFaceToughness: card.toughness,
+    backFaceKeywords: card.keywords,
+  }
+}


### PR DESCRIPTION
## What

A graveyard card you can cast is offered in the hand as a translucent "ghost" card. For a **disturb** card (CR 702.146a) that ghost showed the wrong spell: the card lies in the graveyard printed **front** face up, but casting it puts the **back** face on the stack (CR 712.8c) — so the hand offered *Lunarch Veteran* while the spell on the table was *Luminous Phantom*, a different creature with different rules text.

The offer now renders as the face it would actually cast, in the hand and in the hover preview behind it.

## How

**Server decides which face.** `LegalAction.castsTransformed` (and its `LegalActionInfo` mirror) says "taking this action puts the card on the stack back face up". Set by `enumerateDisturb`, which already reads the offer's name, timing, targets and cost off that face. The client never derives it from the keyword — which face a cast uses is a rules question.

**Client swaps display fields in one pure helper.** `web-client/src/utils/castFace.ts` → `castOfferFace(card, actions)`, applied in `useGhostCards` (the hand) and `CardPreview` (the hover panel). Identity function unless the server flagged the offer.

**Back-face stats travel with the face.** New `backFacePower` / `backFaceToughness` / `backFaceKeywords` on `ClientCard` — the siblings of the `backFaceName` / `backFaceTypeLine` / `backFaceOracleText` the DTO already carried — so the preview never pairs the back's art with the front's stats and keyword chips.

Deliberately unchanged:
- `manaCost` stays the front face's. A disturbed spell's mana value is still calculated from the front face's mana cost (CR 712.8e), and the price of the cast rides on the action's own `manaCostString`.
- `cardTypes` / `subtypes` stay the front's — no back-face copy is sent, and their readers (combat, battlefield overlays) never draw a graveyard card.
- The graveyard pile itself. The card in it is face up; that is what it shows.
- The printed front lands in the back-face slots, so pressing **F** on the preview still flips to it.

## Tests

- `DisturbKeywordTest` — the offer is flagged `castsTransformed` (and no other cast is); a graveyard disturb card carries its back face's P/T and keywords to the client while still reporting the front face as its own.
- `web-client/src/utils/castFace.test.ts` — 7 cases: the swap, the three no-op paths (no such offer, another card's offer, single-faced card), reversibility for the F-flip, stats into both current and base P/T, front mana cost kept.

## Verification

Run locally before the remote:
- `just test-class DisturbKeywordTest` — 11 passed
- `just test-rules` — BUILD SUCCESSFUL
- `web-client`: `npx vitest run` (54 files / 771 tests passed), `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)