### PR TITLE
Add 53 Assay-ready cards and the basic lands to Dragons of Tarkir

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/DragonsOfTarkirSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/DragonsOfTarkirSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.dtk
 
-import com.wingedsheep.mtg.sets.definitions.ktk.KhansOfTarkirSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -23,11 +22,14 @@ object DragonsOfTarkirSet : MtgSet {
     override val displayName = "Dragons of Tarkir"
     override val releaseDate = "2015-03-27"
     override val block = "Khans of Tarkir"
-    override val basicLandsFallback = KhansOfTarkirSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ArtfulManeuver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ArtfulManeuver.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Artful Maneuver
+ * {1}{W}
+ * Instant
+ *
+ * Target creature gets +2/+2 until end of turn.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Rebound has a real consumer — `StackResolver` reads [Keyword.REBOUND] off `cardDef.keywords`
+ * when the spell resolves — so the bare keyword is the whole of the second line and the pump
+ * arrives twice, a turn apart, from one [Effects.ModifyStats]. `until end of turn` is that
+ * facade's default duration, so it isn't spelled here.
+ */
+val ArtfulManeuver = card("Artful Maneuver") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg?1783938620"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/BloodChinRager.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/BloodChinRager.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blood-Chin Rager
+ * {1}{B}
+ * Creature — Human Warrior
+ * 2 / 2
+ *
+ * Whenever this creature attacks, Warrior creatures you control gain menace until end of turn. (They can't be blocked except by two or more creatures.)
+ *
+ * The printed noun is "Warrior **creatures**", so the group is the creature filter narrowed by
+ * subtype — `AllCreaturesYouControl.withSubtype("Warrior")` — not a bare permanent-with-subtype
+ * group. One sentence names its group once, so this is a single
+ * [Patterns.Group.grantKeywordToAll] pass (`ForEach` over the group, granting menace to each
+ * member) rather than a hand-rolled pipeline; the until-end-of-turn duration is that facade's
+ * default.
+ */
+val BloodChinRager = card("Blood-Chin Rager") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, Warrior creatures you control gain menace until end of turn. (They can't be blocked except by two or more creatures.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Group.grantKeywordToAll(
+            keyword = Keyword.MENACE,
+            filter = GroupFilter.AllCreaturesYouControl.withSubtype("Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Karl Kopinski"
+        flavorText = "Kolaghan blades rarely stay clean for long."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg?1783938600"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/BoltwingMarauder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/BoltwingMarauder.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boltwing Marauder
+ * {3}{B}{R}
+ * Creature — Dragon
+ * 5 / 4
+ *
+ * Flying
+ * Whenever another creature you control enters, target creature gets +2/+0 until end of turn.
+ *
+ * "**Another** creature you control" is the binding, not the filter: [Triggers.OtherCreatureEnters]
+ * is `Creature.youControl()` entering the battlefield under [com.wingedsheep.sdk.scripting.TriggerBinding.OTHER],
+ * so the Dragon's own arrival doesn't pump anything. The pump names its own target — "target
+ * creature", any creature on the battlefield, not just yours — so the ability declares its
+ * own [Targets.Creature] requirement rather than reusing the triggering permanent.
+ */
+val BoltwingMarauder = card("Boltwing Marauder") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever another creature you control enters, target creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Raymond Swanland"
+        flavorText = "When battling the Kolaghan, consider yourself lucky if lightning strikes the same place only twice."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg?1783938573"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ButchersGlee.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ButchersGlee.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Butcher's Glee
+ * {2}{B}
+ * Instant
+ *
+ * Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)
+ *
+ * Two printed sentences, so two elements at the top level: the pump-and-lifelink sentence is one
+ * nested [Effects.Composite] and "Regenerate it" is its sibling. Chaining with `then` would splice
+ * the inner composite's members into a flat three-element list and lose that arity. There is no
+ * `Effects.Regenerate` facade — [RegenerateEffect] is the shipped spelling (Death Ward, Reknit) —
+ * and "it" is the creature just pumped, so every effect points at the same bound handle.
+ */
+val ButchersGlee = card("Butcher's Glee") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Composite(
+                Effects.ModifyStats(3, 0, t),
+                Effects.GrantKeyword(Keyword.LIFELINK, t)
+            ),
+            RegenerateEffect(t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "90"
+        artist = "Jesper Ejsing"
+        flavorText = "The Crave made Kneecleaver think she was bigger than the dragon."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg?1783938601"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ChampionOfArashin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ChampionOfArashin.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Champion of Arashin
+ * {3}{W}
+ * Creature — Dog Warrior
+ * 3 / 2
+ *
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ *
+ * A single evergreen keyword and nothing else, so the whole card is one `keywords(...)` line —
+ * the reminder text is printed flavour that the engine reads straight off `Keyword.LIFELINK`.
+ */
+val ChampionOfArashin = card("Champion of Arashin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Joseph Meehan"
+        flavorText = "\"The blood of Dromoka and the blood of my veins are the same.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg?1783938619"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CoatWithVenom.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CoatWithVenom.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coat with Venom
+ * {B}
+ * Instant
+ *
+ * Target creature gets +1/+2 and gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)
+ *
+ * One sentence, two clauses joined by "and", so one [Effects.Composite] over the pump and the
+ * grant — both pointed at the same bound target. The printed noun is a bare "target creature",
+ * with no controller restriction, so [Targets.Creature] is the whole requirement.
+ */
+val CoatWithVenom = card("Coat with Venom") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+2 and gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 2, t),
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Johann Bodin"
+        flavorText = "\"Every Silumgar blade carries the blessing of our dragonlord.\"\n—Xathi the Infallible"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg?1783938600"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CollectedCompany.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CollectedCompany.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Collected Company
+ * {3}{G}
+ * Instant
+ *
+ * Look at the top six cards of your library. Put up to two creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order.
+ *
+ * Three printed sentences, one recipe: [Patterns.Library.lookAtTopAndTakeMatching] is exactly this
+ * shape — look at the top six privately, take *up to two* of the cards that match
+ * ([SelectionMode.ChooseUpTo] over creatures capped at mana value 3; the recipe shows every
+ * looked-at card and only the matching ones are selectable), put those onto the battlefield, and
+ * bottom the remainder. "In any order" is the caster's choice, so the rest go back under
+ * [CardOrder.ControllerChooses] — not [CardOrder.Random], which is the *other* printed wording
+ * (Cartographer's Survey).
+ */
+val CollectedCompany = card("Collected Company") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Look at the top six cards of your library. Put up to two creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndTakeMatching(
+            count = DynamicAmount.Fixed(6),
+            filter = GameObjectFilter.Creature.manaValueAtMost(3),
+            prompt = "Put up to two creature cards with mana value 3 or less from among them onto the battlefield",
+            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+            keepDestination = CardDestination.ToZone(Zone.BATTLEFIELD),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "177"
+        artist = "Franz Vohwinkel"
+        flavorText = "Many can stand where one would fall."
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg?1783938582"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CommuneWithLava.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CommuneWithLava.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Commune with Lava
+ * {X}{R}{R}
+ * Instant
+ *
+ * Exile the top X cards of your library. Until the end of your next turn, you may play those cards.
+ *
+ * The impulse-draw recipe with a dynamic count: [Patterns.Exile.impulse] gathers the top X, moves
+ * that same stored collection to exile, and grants play permission over it — one variable name
+ * threaded through all three steps, which is what makes "those cards" refer to the exact cards
+ * exiled. "Until the end of your next turn" is
+ * [MayPlayExpiry.UntilControllerStep] at the cleanup step with `includeCurrentTurn = false`, so the
+ * permission survives this turn even when the spell is cast on your own turn.
+ */
+val CommuneWithLava = card("Commune with Lava") {
+    manaCost = "{X}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Exile the top X cards of your library. Until the end of your next turn, you may play those cards."
+
+    spell {
+        effect = Patterns.Exile.impulse(
+            count = DynamicAmount.XValue,
+            expiry = MayPlayExpiry.UntilControllerStep(Step.CLEANUP, includeCurrentTurn = false)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Ryan Barger"
+        flavorText = "Atarka conquered Qadat, the Fire Rim, long ago, winning over its efreet with a promise to spread the glory of fire to all the world."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg?1783938591"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ConiferStrider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ConiferStrider.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Conifer Strider
+ * {3}{G}
+ * Creature — Elemental
+ * 5 / 1
+ *
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ *
+ * Hexproof is engine-live off the bare keyword — the targeting restriction lives in the
+ * legality check, so the card needs no script of its own.
+ */
+val ConiferStrider = card("Conifer Strider") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 5
+    toughness = 1
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "YW Tang"
+        flavorText = "Atarka's presence thaws the glaciers of Qal Sisma, forcing its elementals to migrate or adapt."
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg?1783938581"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CunningBreezedancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CunningBreezedancer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cunning Breezedancer
+ * {4}{W}{U}
+ * Creature — Dragon
+ * 4 / 4
+ *
+ * Flying
+ * Whenever you cast a noncreature spell, this creature gets +2/+2 until end of turn.
+ *
+ * A prowess-shaped trigger that is deliberately *not* prowess — the printed line is its own
+ * ability with a +2/+2 bonus, so it is a plain [Triggers.YouCastNoncreature] trigger. Writing
+ * `prowess()` would lower to the keyword plus a second +1/+1 trigger and double-count the pump.
+ * The pump is [EffectTarget.Self]; `Duration.EndOfTurn` is the facade default that spells
+ * "until end of turn".
+ */
+val CunningBreezedancer = card("Cunning Breezedancer") {
+    manaCost = "{4}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever you cast a noncreature spell, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Todd Lockwood"
+        flavorText = "\"That which is beautiful in form can also be deadly.\"\n—Ishai, Ojutai dragonspeaker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg?1783938573"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CustodianOfTheTrove.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/CustodianOfTheTrove.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Custodian of the Trove
+ * {3}
+ * Artifact Creature — Golem
+ * 2 / 5
+ *
+ * Defender
+ * This creature enters tapped.
+ *
+ * "Enters tapped" is a self-replacement (CR 614.1c), not an as-enters effect, so it is
+ * `replacementEffect(EntersTapped())` — the same spelling every tapped-land in the corpus uses.
+ * Defender is the plain keyword beside it.
+ */
+val CustodianOfTheTrove = card("Custodian of the Trove") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 2
+    toughness = 5
+    oracleText = "Defender\n" +
+        "This creature enters tapped."
+
+    keywords(Keyword.DEFENDER)
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "236"
+        artist = "Raoul Vitale"
+        flavorText = "Silumgar delights in repurposing the treasures of other clans to serve his own ravenous greed."
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg?1783938569"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonsOfTarkirBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonsOfTarkirBasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Dragons of Tarkir Basic Lands
+ *
+ * DTK prints three art variants of each basic land type (250-264).
+ */
+
+// =============================================================================
+// Plains (250, 251, 252)
+// =============================================================================
+
+val DragonsOfTarkirPlains250 = basicLand("Plains") {
+    collectorNumber = "250"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cdf91075-8d8d-43c3-8125-2469e2dcd132.jpg?1783938566"
+}
+
+val DragonsOfTarkirPlains251 = basicLand("Plains") {
+    collectorNumber = "251"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/2484c9db-44bc-411c-af43-bfe0e30f0ffa.jpg?1783938566"
+}
+
+val DragonsOfTarkirPlains252 = basicLand("Plains") {
+    collectorNumber = "252"
+    artist = "Florian de Gesincourt"
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/910f2bcd-8d37-417c-a969-86e04f1daf23.jpg?1783938566"
+}
+
+// =============================================================================
+// Island (253, 254, 255)
+// =============================================================================
+
+val DragonsOfTarkirIsland253 = basicLand("Island") {
+    collectorNumber = "253"
+    artist = "Florian de Gesincourt"
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8c2f901-7d7b-47ec-a3d4-96ddcbd9218c.jpg?1783938565"
+}
+
+val DragonsOfTarkirIsland254 = basicLand("Island") {
+    collectorNumber = "254"
+    artist = "Florian de Gesincourt"
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78732e7f-421d-43e8-8f43-341bb01e993e.jpg?1783938565"
+}
+
+val DragonsOfTarkirIsland255 = basicLand("Island") {
+    collectorNumber = "255"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/966ac118-6d94-4f3b-9873-7a2440ab92d9.jpg?1783938565"
+}
+
+// =============================================================================
+// Swamp (256, 257, 258)
+// =============================================================================
+
+val DragonsOfTarkirSwamp256 = basicLand("Swamp") {
+    collectorNumber = "256"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7f4498e-e753-418e-8db6-e11d2caac3b1.jpg?1783938564"
+}
+
+val DragonsOfTarkirSwamp257 = basicLand("Swamp") {
+    collectorNumber = "257"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d4873cb-43ce-47b4-9d91-a8495a244c85.jpg?1783938564"
+}
+
+val DragonsOfTarkirSwamp258 = basicLand("Swamp") {
+    collectorNumber = "258"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d846729-deec-436f-af5c-08faf53ec36f.jpg?1783938564"
+}
+
+// =============================================================================
+// Mountain (259, 260, 261)
+// =============================================================================
+
+val DragonsOfTarkirMountain259 = basicLand("Mountain") {
+    collectorNumber = "259"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54968fa2-36f1-4d21-89e7-a307d68cfccc.jpg?1783938565"
+}
+
+val DragonsOfTarkirMountain260 = basicLand("Mountain") {
+    collectorNumber = "260"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7f613b2-de5b-4592-8d14-5ad373537a21.jpg?1783938564"
+}
+
+val DragonsOfTarkirMountain261 = basicLand("Mountain") {
+    collectorNumber = "261"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c356eb7-ebf4-400d-95a7-7452382bc32f.jpg?1783938564"
+}
+
+// =============================================================================
+// Forest (262, 263, 264)
+// =============================================================================
+
+val DragonsOfTarkirForest262 = basicLand("Forest") {
+    collectorNumber = "262"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f341b39-ac40-436b-967c-568265354886.jpg?1783938563"
+}
+
+val DragonsOfTarkirForest263 = basicLand("Forest") {
+    collectorNumber = "263"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23c9425a-2093-40c1-b3a9-a882d80cf198.jpg?1783938564"
+}
+
+val DragonsOfTarkirForest264 = basicLand("Forest") {
+    collectorNumber = "264"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67becef5-cd70-4fe9-b8a3-1bff2ea04ab4.jpg?1783938563"
+}
+
+
+/**
+ * All Dragons of Tarkir basic land variants.
+ */
+val DragonsOfTarkirBasicLands = listOf(
+    DragonsOfTarkirPlains250, DragonsOfTarkirPlains251, DragonsOfTarkirPlains252,
+    DragonsOfTarkirIsland253, DragonsOfTarkirIsland254, DragonsOfTarkirIsland255,
+    DragonsOfTarkirSwamp256, DragonsOfTarkirSwamp257, DragonsOfTarkirSwamp258,
+    DragonsOfTarkirMountain259, DragonsOfTarkirMountain260, DragonsOfTarkirMountain261,
+    DragonsOfTarkirForest262, DragonsOfTarkirForest263, DragonsOfTarkirForest264
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DromokaDunecaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DromokaDunecaster.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dromoka Dunecaster
+ * {W}
+ * Creature — Human Wizard
+ * 0 / 2
+ *
+ * {1}{W}, {T}: Tap target creature without flying.
+ *
+ * The printed cost is two atoms in one line, so it is a [Costs.Composite] of the mana payment and
+ * the tap symbol. "Without flying" is a *targeting* restriction rather than anything the effect
+ * checks, so it lives on the target filter and is re-checked against projected state both on
+ * activation and on resolution (cf. Merfolk Seastalkers, Flood).
+ */
+val DromokaDunecaster = card("Dromoka Dunecaster") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    power = 0
+    toughness = 2
+    oracleText = "{1}{W}, {T}: Tap target creature without flying."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.withoutKeyword(Keyword.FLYING)))
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Mark Winters"
+        flavorText = "\"The dragonlords rule the tempests of the skies. Here in the wastes, the storms are mine to command.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg?1783938618"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/FateForgotten.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/FateForgotten.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fate Forgotten
+ * {2}{W}
+ * Instant
+ *
+ * Exile target artifact or enchantment.
+ *
+ * "Artifact or enchantment" is one target with an alternation inside its filter, not two targets —
+ * [Targets.ArtifactOrEnchantment] is that filter. Exile is a plain zone move, so no destruction or
+ * regeneration hooks apply.
+ */
+val FateForgotten = card("Fate Forgotten") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target artifact or enchantment."
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Cliff Childs"
+        flavorText = "When Sarkhan saved Ugin in Tarkir's past, it changed Tarkir's future. The Sultai no longer exist, having been supplanted by the dragonlord Silumgar and his clan."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg?1783938617"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Flatten.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Flatten.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flatten
+ * {3}{B}
+ * Instant
+ *
+ * Target creature gets -4/-4 until end of turn.
+ *
+ * A single clause, so a bare [Effects.ModifyStats] and no wrapping composite — the negative
+ * modifiers are the whole card, and "until end of turn" is the facade's default duration.
+ */
+val Flatten = card("Flatten") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-4 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-4, -4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Raoul Vitale"
+        flavorText = "Like their dragonlord, the Kolaghan take no trophies. They find true fulfillment only in the battle itself, in clash of steel and thunder of hooves."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg?1783938598"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/GlaringAegis.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/GlaringAegis.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Glaring Aegis
+ * {W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap target creature an opponent controls.
+ * Enchanted creature gets +1/+3.
+ *
+ * Three separate lines, three separate pieces. "Enchant creature" is the attachment requirement
+ * (`auraTarget`), which is chosen as the Aura *spell*'s target. The enters trigger is an ordinary
+ * self ETB triggered ability with a target of its own — the creature it taps has nothing to do
+ * with the creature it enchants. "Enchanted creature gets +1/+3" is a static ability whose
+ * affected set is [ModifyStats]'s default, the attached permanent.
+ */
+val GlaringAegis = card("Glaring Aegis") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap target creature an opponent controls.\n" +
+        "Enchanted creature gets +1/+3."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.CreatureOpponentControls))
+        effect = Effects.Tap(t)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Anthony Palumbo"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg?1783938616"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Glint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Glint.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glint
+ * {1}{U}
+ * Instant
+ *
+ * Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)
+ *
+ * "you control" is a controller predicate on the requirement, not a clause on the effect, so it
+ * rides [Targets.CreatureYouControl]. Hexproof is granted as a plain keyword —
+ * `Effects.GrantHexproof` exists for the player-targeting case, which this card never reaches.
+ */
+val Glint = card("Glint") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)"
+
+    spell {
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(0, 3, t),
+            Effects.GrantKeyword(Keyword.HEXPROOF, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Igor Kieryluk"
+        flavorText = "Rakshasa waste no opportunity to display their wealth and power, even in the midst of a sorcerous duel."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg?1783938608"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/GreatTeachersDecree.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/GreatTeachersDecree.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Great Teacher's Decree
+ * {3}{W}
+ * Sorcery
+ *
+ * Creatures you control get +2/+1 until end of turn.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * An untargeted group pump, so it is [Patterns.Group]'s `modifyStatsForAll` over
+ * [GroupFilter.AllCreaturesYouControl] rather than a target requirement — the printed noun is
+ * "creatures you control", the whole group, chosen fresh on each resolution. That matters for the
+ * second cast: rebound (engine-live via [Keyword.REBOUND] in `StackResolver`) re-resolves the card
+ * from exile on your next upkeep, and the group is recomputed then.
+ */
+val GreatTeachersDecree = card("Great Teacher's Decree") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +2/+1 until end of turn.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(2, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg?1783938616"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/HandOfSilumgar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/HandOfSilumgar.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hand of Silumgar
+ * {1}{B}
+ * Creature — Human Warrior
+ * 2 / 1
+ *
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * One evergreen keyword; the damage rule is applied by the engine's damage step, so the bare
+ * `Keyword.DEATHTOUCH` is the whole card.
+ */
+val HandOfSilumgar = card("Hand of Silumgar") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Lius Lasahido"
+        flavorText = "Silumgar trains those whom he favors in his magic, granting them the ability to spread his disdain across the land."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg?1783938597"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/HeraldOfDromoka.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/HeraldOfDromoka.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Herald of Dromoka
+ * {1}{W}
+ * Creature — Human Warrior
+ * 2 / 2
+ *
+ * Vigilance
+ * Other Warrior creatures you control have vigilance.
+ *
+ * A lord, so the second line is a [GrantKeyword] *static* ability, not a one-shot grant: the
+ * affected set is recomputed by the projection layer every time it runs. "Other" is the group's
+ * `excludeSelf`, and the printed noun is "Warrior creatures", so the group narrows the creature
+ * filter by subtype rather than matching permanents.
+ */
+val HeraldOfDromoka = card("Herald of Dromoka") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Other Warrior creatures you control have vigilance."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.VIGILANCE,
+            filter = GroupFilter.OtherCreaturesYouControl.withSubtype("Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Zack Stella"
+        flavorText = "The trumpeters of Arashin are ever alert in their watch over the Great Aerie."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg?1783938615"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghanForerunners.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghanForerunners.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kolaghan Forerunners
+ * {2}{R}
+ * Creature — Human Berserker
+ * * / 3
+ *
+ * Trample
+ * Kolaghan Forerunners's power is equal to the number of creatures you control.
+ * Dash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * The printed `*` power is characteristic-defining, so it is a power-only
+ * [com.wingedsheep.sdk.dsl.CardBuilder.dynamicPower] over
+ * [DynamicAmount.AggregateBattlefield] counting creatures you control — layer 7b, the power *is*
+ * the base value — while toughness stays the fixed 3. `dash` is a builder property rather than a
+ * [Keyword] constant, and setting it is what adds the `KeywordAbility.Dash` the cast enumerator
+ * reads. A dashed Forerunners counts itself, so it is never smaller than a 1/3.
+ */
+val KolaghanForerunners = card("Kolaghan Forerunners") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Berserker"
+    // power is characteristic-defining — see the CDA below
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Kolaghan Forerunners's power is equal to the number of creatures you control.\n" +
+        "Dash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    dynamicPower(
+        DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+    )
+
+    dash = "{2}{R}"
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "144"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg?1783938589"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghanSkirmisher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghanSkirmisher.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kolaghan Skirmisher
+ * {1}{B}
+ * Creature — Human Warrior
+ * 2 / 2
+ *
+ * Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * A vanilla 2/2 whose whole body is the dash cost. `dash` is a builder property rather than a
+ * `Keyword` constant, and setting it is what adds the `KeywordAbility.Dash` the cast enumerator
+ * reads — the alternative cost, the haste and the next-end-step bounce all come from that one line.
+ */
+val KolaghanSkirmisher = card("Kolaghan Skirmisher") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    dash = "{2}{B}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Anthony Palumbo"
+        flavorText = "Kolaghan's army rushes from kill to kill, desperate to avoid the dragon's wrath."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg?1783938597"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghansCommand.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/KolaghansCommand.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kolaghan's Command
+ * {1}{B}{R}
+ * Instant
+ *
+ * Choose two —
+ * • Return target creature card from your graveyard to your hand.
+ * • Target player discards a card.
+ * • Destroy target artifact.
+ * • Kolaghan's Command deals 2 damage to any target.
+ *
+ * "Choose two —" over four modes is `modal(chooseCount = 2)` — two *different* modes, since the
+ * card carries no "you may choose the same mode more than once" rider.
+ *
+ * Three of the four modes target, and each targets something different, so the targets are declared
+ * *inside* their modes (the block form of `mode`): only the chosen modes' requirements are asked
+ * for, which is what CR 601.2c means by choosing targets after choosing modes.
+ *
+ * The graveyard return writes the plain [Effects.ReturnToHand] with no `fromZone` guard: the
+ * requirement's own `zone = GRAVEYARD` is re-checked at resolution under CR 608.2b, so a card
+ * exiled in response is already an illegal target.
+ */
+val KolaghansCommand = card("Kolaghan's Command") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Instant"
+    oracleText = "Choose two —\n" +
+        "• Return target creature card from your graveyard to your hand.\n" +
+        "• Target player discards a card.\n" +
+        "• Destroy target artifact.\n" +
+        "• Kolaghan's Command deals 2 damage to any target."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Return target creature card from your graveyard to your hand") {
+                val creatureCard = target("creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+                effect = Effects.ReturnToHand(creatureCard)
+            }
+            mode("Target player discards a card") {
+                val player = target("target player", Targets.Player)
+                effect = Effects.Discard(1, player)
+            }
+            mode("Destroy target artifact") {
+                val artifact = target("target artifact", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+            mode("Kolaghan's Command deals 2 damage to any target") {
+                val victim = target("any target", Targets.Any)
+                effect = Effects.DealDamage(2, victim)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "224"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg?1783938571"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/LightningBerserker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/LightningBerserker.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning Berserker
+ * {R}
+ * Creature — Human Berserker
+ * 1 / 1
+ *
+ * {R}: This creature gets +1/+0 until end of turn.
+ * Dash {R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * Firebreathing on a Berserker: the pump is a plain mana-cost activated ability over
+ * [Effects.ModifyStats] aimed at [EffectTarget.Self], repeatable because nothing restricts it.
+ * `dash` is a builder property rather than a `Keyword` constant, and setting it is what adds the
+ * `KeywordAbility.Dash` the cast enumerator reads — a dashed Berserker gets haste, so every red
+ * mana left over that turn is another point of damage.
+ */
+val LightningBerserker = card("Lightning Berserker") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Berserker"
+    power = 1
+    toughness = 1
+    oracleText = "{R}: This creature gets +1/+0 until end of turn.\n" +
+        "Dash {R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    dash = "{R}"
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Joseph Meehan"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg?1783938588"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/NecromasterDragon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/NecromasterDragon.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Necromaster Dragon
+ * {3}{U}{B}
+ * Creature — Dragon
+ * 4 / 4
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, you may pay {2}. If you do, create a 2/2
+ * black Zombie creature token and each opponent mills two cards.
+ *
+ * "You may pay {2}. If you do, …" is [MayPayManaEffect] — one gate whose consequence runs only when
+ * the mana is actually paid, rather than an `optional` trigger wrapped around a payment. The
+ * consequence is a single sentence with two halves, so both live in one [Effects.Composite].
+ *
+ * The mill half says "each opponent", which is the *player* argument to the mill recipe and not a
+ * loop around it: `Patterns.Library.mill(2, EffectTarget.PlayerRef(Player.EachOpponent))` gathers
+ * and moves each opponent's top two in one pipeline. Wrapping it in a `ForEachPlayer` would say the
+ * same thing twice.
+ */
+val NecromasterDragon = card("Necromaster Dragon") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever this creature deals combat damage to a player, you may pay {2}. If you do, create a 2/2 black Zombie creature token and each opponent mills two cards."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = Effects.Composite(
+                Effects.CreateToken(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf("Zombie")
+                ),
+                Patterns.Library.mill(2, EffectTarget.PlayerRef(Player.EachOpponent))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg?1783938571"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisBreath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisBreath.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ojutai's Breath
+ * {2}{U}
+ * Instant
+ *
+ * Tap target creature. It doesn't untap during its controller's next untap step.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * The same two-step construction as Crippling Chill: [Effects.Tap], then the
+ * [AbilityFlag.DOESNT_UNTAP] grant held for [Duration.UntilAfterAffectedControllersNextUntap].
+ * That duration is keyed to the *affected* creature's controller, not this spell's — which is what
+ * "its controller's next untap step" says, and what makes the freeze land correctly when the
+ * creature belongs to someone whose untap step comes before yours.
+ *
+ * The second line is the bare [Keyword.REBOUND]; `StackResolver` reads it off `cardDef.keywords`.
+ */
+val OjutaisBreath = card("Ojutai's Breath") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Tap target creature. It doesn't untap during its controller's next untap step.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.Tap(t) then
+            Effects.GrantKeyword(
+                AbilityFlag.DOESNT_UNTAP,
+                t,
+                Duration.UntilAfterAffectedControllersNextUntap
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg?1783938604"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisCommand.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisCommand.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ojutai's Command
+ * {2}{W}{U}
+ * Instant
+ *
+ * Choose two —
+ * • Return target creature card with mana value 2 or less from your graveyard to the battlefield.
+ * • You gain 4 life.
+ * • Counter target creature spell.
+ * • Draw a card.
+ *
+ * "Choose two —" over four modes is `modal(chooseCount = 2)`; two of the four target, so those two
+ * declare their requirements inside their own `mode` block and the other two declare none.
+ *
+ * The reanimation mode keeps its `fromZone = GRAVEYARD` guard ([Effects.PutOntoBattlefieldFromGraveyard])
+ * even though it targets — the asymmetry with the graveyard-to-*hand* return next door is
+ * deliberate and empirical, and the facade's KDoc records why. The mana-value clause is a
+ * refinement of the existing [TargetFilter.CreatureInYourGraveyard] rather than a hand-rolled
+ * filter, which keeps the card-predicate order the same as every other "creature card with mana
+ * value N or less" in the corpus.
+ *
+ * "Counter target creature spell" is [Effects.CounterSpell] over a stack-zone creature filter; the
+ * effect itself carries no target because the requirement supplies it.
+ */
+val OjutaisCommand = card("Ojutai's Command") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Instant"
+    oracleText = "Choose two —\n" +
+        "• Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n" +
+        "• You gain 4 life.\n" +
+        "• Counter target creature spell.\n" +
+        "• Draw a card."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Return target creature card with mana value 2 or less from your graveyard to the battlefield") {
+                val creatureCard = target(
+                    "creature card with mana value 2 or less in your graveyard",
+                    TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(2))
+                )
+                effect = Effects.PutOntoBattlefieldFromGraveyard(creatureCard)
+            }
+            mode("You gain 4 life") {
+                effect = Effects.GainLife(4)
+            }
+            mode("Counter target creature spell") {
+                target = Targets.CreatureSpell
+                effect = Effects.CounterSpell()
+            }
+            mode("Draw a card") {
+                effect = Effects.DrawCards(1)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Willian Murai"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg?1783938571"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisSummons.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/OjutaisSummons.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ojutai's Summons
+ * {3}{U}{U}
+ * Sorcery
+ *
+ * Create a 2/2 blue Djinn Monk creature token with flying.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * The blue Trumpeting Herd: one [Effects.CreateToken] plus the bare [Keyword.REBOUND], and the two
+ * Djinn Monks arrive a turn apart because `StackResolver` re-casts the card from exile on your next
+ * upkeep. The token's art comes from the set's token sheet, so no `imageUri` is spelled here.
+ */
+val OjutaisSummons = card("Ojutai's Summons") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Create a 2/2 blue Djinn Monk creature token with flying.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Djinn", "Monk"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Jakub Kasper"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg?1783938605"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PalaceFamiliar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PalaceFamiliar.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Palace Familiar
+ * {1}{U}
+ * Creature — Bird
+ * 1 / 1
+ *
+ * Flying
+ * When this creature dies, draw a card.
+ *
+ * [Triggers.Dies] already carries the battlefield → graveyard zone change; the ability keeps the
+ * default battlefield `activeZones`, because a dies trigger is indexed from where the creature
+ * *was*, not from where the card ends up. The draw's controller is the default, so it is left
+ * unwritten.
+ */
+val PalaceFamiliar = card("Palace Familiar") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature dies, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Kev Walker"
+        flavorText = "\"The most profound secrets lie in the darkest places of the world. It can be prudent to make use of another set of eyes.\"\n—Sidisi, Silumgar vizier"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg?1783938605"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PitilessHorde.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PitilessHorde.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pitiless Horde
+ * {2}{B}
+ * Creature — Orc Berserker
+ * 5 / 3
+ *
+ * At the beginning of your upkeep, you lose 2 life.
+ * Dash {2}{B}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * The drawback is unconditional — no "unless", no sacrifice — so it is one [Triggers.YourUpkeep]
+ * trigger over [Effects.LoseLife] aimed at the controller. `dash` is a builder property rather than
+ * a `Keyword` constant, and setting it is what adds the `KeywordAbility.Dash` the cast enumerator
+ * reads; dashing is how you get the 5/3 body without ever reaching an upkeep with it around.
+ */
+val PitilessHorde = card("Pitiless Horde") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Orc Berserker"
+    power = 5
+    toughness = 3
+    oracleText = "At the beginning of your upkeep, you lose 2 life.\n" +
+        "Dash {2}{B}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.LoseLife(2, EffectTarget.Controller)
+        description = "At the beginning of your upkeep, you lose 2 life."
+    }
+
+    dash = "{2}{B}{B}"
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "Viktor Titov"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg?1783938595"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PressTheAdvantage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/PressTheAdvantage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Press the Advantage
+ * {2}{G}{G}
+ * Instant
+ *
+ * Up to two target creatures each get +2/+2 and gain trample until end of turn.
+ *
+ * "Up to two target creatures **each**" is a `count = 2` requirement, and a `target()` handle on a
+ * multi-target requirement resolves to nothing — the bound variable names the requirement, not one
+ * chosen target. The corpus shape is [ForEachTargetEffect] over `ContextTarget(0)`: the loop rebinds
+ * the context to one chosen target per iteration, so the pump and the grant both land on each
+ * creature. The declared requirement is therefore not captured; only its registration matters.
+ */
+val PressTheAdvantage = card("Press the Advantage") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Up to two target creatures each get +2/+2 and gain trample until end of turn."
+
+    spell {
+        target("target", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0)),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "196"
+        artist = "Marco Nelor"
+        flavorText = "\"Show your enemies as much mercy as they would show you.\"\n—Surrak, the Hunt Caller"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg?1783938578"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ProfoundJourney.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ProfoundJourney.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Profound Journey
+ * {5}{W}{W}
+ * Sorcery
+ *
+ * Return target permanent card from your graveyard to the battlefield.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * [TargetFilter.PermanentInYourGraveyard] carries both halves of the printed noun — a permanent
+ * card, owned by you, in the graveyard zone — and the move repeats that zone as `fromZone` so the
+ * effect fails closed if the card has already left the graveyard in response. Rebound is the bare
+ * [Keyword.REBOUND]; the second cast picks a fresh target on your next upkeep.
+ */
+val ProfoundJourney = card("Profound Journey") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target permanent card from your graveyard to the battlefield.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.PermanentInYourGraveyard))
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "30"
+        artist = "Tomasz Jedruszek"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg?1783938614"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/RecklessImp.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/RecklessImp.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Reckless Imp
+ * {2}{B}
+ * Creature — Imp
+ * 2 / 2
+ *
+ * Flying
+ * This creature can't block.
+ * Dash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * "This creature can't block" is the source-scoped [CantBlock] static ability — its default
+ * `GroupFilter.source()` is exactly the printed subject, so no filter is spelled. `dash` is a
+ * builder property rather than a [Keyword] constant, and setting it is what adds the
+ * `KeywordAbility.Dash` the cast enumerator reads; the blocking restriction costs a dashed Imp
+ * nothing, since it leaves before the opponent's combat anyway.
+ */
+val RecklessImp = card("Reckless Imp") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "This creature can't block.\n" +
+        "Dash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    dash = "{1}{B}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Torstein Nordstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg?1783938594"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Roast.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Roast.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Roast
+ * {1}{R}
+ * Sorcery
+ *
+ * Roast deals 5 damage to target creature without flying.
+ *
+ * "Without flying" is a restriction on legality, so it belongs to the *target filter* rather than
+ * to the damage effect — [GameObjectFilter.withoutKeyword] reads the projected keyword set, so a
+ * creature that has been granted flying by a continuous effect is not a legal target and one that
+ * loses flying becomes one.
+ */
+val Roast = card("Roast") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Roast deals 5 damage to target creature without flying."
+
+    spell {
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING)))
+        )
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Zoltan Boros"
+        flavorText = "\"Intruders in the lands of Atarka have but two choices: be consumed by fire, or be consumed by maw.\"\n—Ulnok, Atarka shaman"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg?1783938587"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/RuthlessDeathfang.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/RuthlessDeathfang.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ruthless Deathfang
+ * {4}{U}{B}
+ * Creature — Dragon
+ * 4 / 4
+ *
+ * Flying
+ * Whenever you sacrifice a creature, target opponent sacrifices a creature of their choice.
+ *
+ * The printed article is bare — "a creature", not "another creature" — so this is
+ * [Triggers.YouSacrificeA], the per-permanent template that *counts the Dragon sacrificing itself*
+ * ([com.wingedsheep.sdk.scripting.TriggerBinding.ANY]), and not [Triggers.YouSacrificeAnother].
+ * Per-permanent also means CR 603.2c multiplicity: sacrificing two creatures to one cost fires it
+ * twice, which is the whole point of the singular wording.
+ *
+ * "Sacrifices a creature of their choice" names the player who must sacrifice, so the effect is
+ * [Effects.Sacrifice] pointed at the target opponent — the chooser is the sacrificing player, which
+ * is what that facade already models. (The bare-imperative sibling `SacrificeOwn` would make *you*
+ * sacrifice instead.)
+ */
+val RuthlessDeathfang = card("Ruthless Deathfang") {
+    manaCost = "{4}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever you sacrifice a creature, target opponent sacrifices a creature of their choice."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Creature)
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Sacrifice(GameObjectFilter.Creature, 1, opponent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Filip Burburan"
+        flavorText = "\"Bring forth the dead, their skull-grins and rattle-bones. We will feast upon their wailing ghosts.\"\n—Silumgar, translated from Draconic"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg?1783938570"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SaltRoadQuartermasters.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SaltRoadQuartermasters.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Salt Road Quartermasters
+ * {2}{G}
+ * Creature — Human Soldier
+ * 1 / 1
+ *
+ * This creature enters with two +1/+1 counters on it.
+ * {2}{G}, Remove a +1/+1 counter from this creature: Put a +1/+1 counter on target creature.
+ *
+ * "Enters with" is a replacement effect, never an ETB trigger — the counters are there as it
+ * arrives, so nothing can respond in between. The activation is two cost atoms in one line: the
+ * mana and a self-scoped counter removal, which is what makes the ability self-limiting.
+ */
+val SaltRoadQuartermasters = card("Salt Road Quartermasters") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "This creature enters with two +1/+1 counters on it.\n" +
+        "{2}{G}, Remove a +1/+1 counter from this creature: Put a +1/+1 counter on target creature."
+
+    replacementEffect(EntersWithCounters(count = 2, selfOnly = true))
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{G}"),
+            Costs.RemoveCounterFromSelf(Counters.PLUS_ONE_PLUS_ONE)
+        )
+        val t = target("target", TargetCreature())
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "199"
+        artist = "Anthony Palumbo"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg?1783938577"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SarkhansTriumph.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SarkhansTriumph.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Sarkhan's Triumph
+ * {2}{R}
+ * Instant
+ *
+ * Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * The whole sentence is one recipe: [Patterns.Library.searchLibrary] gathers the matching cards,
+ * lets the caster take up to one (CR 701.23b — finding a card is never mandatory), moves it to hand
+ * revealed, shuffles, and emits the "a player searched their library" event. "Dragon creature card"
+ * is a creature *and* a subtype, so the filter carries both predicates.
+ */
+val SarkhansTriumph = card("Sarkhan's Triumph") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle."
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature.withSubtype("Dragon"),
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "154"
+        artist = "Chris Rahn"
+        flavorText = "Sarkhan gazed on the world around him, the dragons sweeping through its skies, and joy kindled like a fire in his soul."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg?1783938586"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ScionOfUgin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ScionOfUgin.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scion of Ugin
+ * {6}
+ * Creature — Dragon Spirit
+ * 4 / 4
+ *
+ * Flying
+ *
+ * A colorless flier — the empty `colorIdentity` is the card's own, not an omission: its mana
+ * cost is generic and it has no colour indicator.
+ */
+val ScionOfUgin = card("Scion of Ugin") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Creature — Dragon Spirit"
+    power = 4
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Cliff Childs"
+        flavorText = "For hundreds of years Ugin slept, encased in the cocoon of stone and magic Sarkhan had created using a shard of a Zendikari hedron. As Ugin lay dormant, his spectral guardians kept vigil."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg?1783938621"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ScreamreachBrawler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ScreamreachBrawler.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Screamreach Brawler
+ * {2}{R}
+ * Creature — Orc Berserker
+ * 2 / 3
+ *
+ * Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * Kolaghan Skirmisher's shape in red: the printed body is the dash cost alone. `dash` is a builder
+ * property rather than a `Keyword` constant, and setting it is what adds the `KeywordAbility.Dash`
+ * the cast enumerator reads — here the dash cost is cheaper than the mana cost, so the Orc is
+ * usually a one-turn 2/3 haste for {1}{R}.
+ */
+val ScreamreachBrawler = card("Screamreach Brawler") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Orc Berserker"
+    power = 2
+    toughness = 3
+    oracleText = "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    dash = "{1}{R}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Slawomir Maniak"
+        flavorText = "\"My dragonlord's lightning will dance upon your bones!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg?1783938586"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SecureTheWastes.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SecureTheWastes.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Secure the Wastes
+ * {X}{W}
+ * Instant
+ *
+ * Create X 1/1 white Warrior creature tokens.
+ *
+ * One token effect with a dynamic count rather than X repetitions of a fixed one: the
+ * [DynamicAmount.XValue] overload of `Effects.CreateToken` reads the announced X at resolution, so
+ * a cost-increase or a copied spell sees the value that was actually paid.
+ */
+val SecureTheWastes = card("Secure the Wastes") {
+    manaCost = "{X}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Create X 1/1 white Warrior creature tokens."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.XValue,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Scott Murphy"
+        flavorText = "\"The Shifting Wastes provide our clan eternal protection. It is our duty to return the favor.\"\n—Kadri, Dromoka warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg?1783938613"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ShapeTheSands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ShapeTheSands.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shape the Sands
+ * {G}
+ * Instant
+ *
+ * Target creature gets +0/+5 and gains reach until end of turn. (It can block creatures with flying.)
+ *
+ * The Dromoka answer to a flying dragon: one [Effects.Composite] over the toughness pump and the
+ * reach grant, both bound to the same target. Nothing restricts the target's controller, so the
+ * bare [Targets.Creature] requirement is correct — you can shore up an opponent's blocker if you
+ * ever want to.
+ */
+val ShapeTheSands = card("Shape the Sands") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +0/+5 and gains reach until end of turn. (It can block creatures with flying.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(0, 5, t),
+            Effects.GrantKeyword(Keyword.REACH, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Ryan Yee"
+        flavorText = "\"Dragons in flight seldom expect company.\"\n—Kadri, Dromoka warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg?1783938576"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SightBeyondSight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SightBeyondSight.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Sight Beyond Sight
+ * {3}{U}
+ * Sorcery
+ *
+ * Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Anticipate's pipeline with two cards instead of three: `lookAtTopAndKeep` gathers, offers the
+ * choice, and moves both halves. "The other" is a single card, so no ordering is printed and
+ * `restOrder` stays at its `Preserve` default — unlike Anticipate, whose "the rest … in any order"
+ * needs `CardOrder.ControllerChooses`. The two selection labels are derived from the destinations.
+ *
+ * The second line is the bare [Keyword.REBOUND], engine-live in `StackResolver`.
+ */
+val SightBeyondSight = card("Sight Beyond Sight") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 2,
+            keepCount = 1,
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Anastasia Ovchinnikova"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg?1783938604"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SkywiseTeachings.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SkywiseTeachings.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Skywise Teachings
+ * {3}{U}
+ * Enchantment
+ *
+ * Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, create a 2/2 blue Djinn
+ * Monk creature token with flying.
+ *
+ * "You may pay {1}{U}. If you do, ..." is [MayPayManaEffect] — a gate whose payment is the
+ * condition, so the token is only minted when the mana is actually paid. The token's art comes from
+ * the set's token sheet, so no `imageUri` is spelled here.
+ */
+val SkywiseTeachings = card("Skywise Teachings") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, create a 2/2 blue Djinn Monk creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}{U}"),
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf("Djinn", "Monk"),
+                keywords = setOf(Keyword.FLYING)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "79"
+        artist = "Filip Burburan"
+        flavorText = "Ojutai's words must be translated from Draconic before his students can benefit from their wisdom."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg?1783938602"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/StrongarmMonk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/StrongarmMonk.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Strongarm Monk
+ * {4}{W}
+ * Creature — Human Monk
+ * 3 / 3
+ *
+ * Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.
+ *
+ * A team pump rather than a self pump, so this is not prowess — a plain
+ * [Triggers.YouCastNoncreature] trigger over [Patterns.Group.modifyStatsForAll], which iterates the
+ * group and applies the +1/+1 per creature (the source included; the printed noun is "creatures you
+ * control", not "other creatures"). The `Duration.EndOfTurn` default spells "until end of turn".
+ */
+val StrongarmMonk = card("Strongarm Monk") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Viktor Titov"
+        flavorText = "\"His companions are wise to follow him, for his foes dare not stand in his way.\"\n—Zhiada, Dirgur protector"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg?1783938611"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/StudentOfOjutai.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/StudentOfOjutai.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Student of Ojutai
+ * {3}{W}
+ * Creature — Human Monk
+ * 2 / 4
+ *
+ * Whenever you cast a noncreature spell, you gain 2 life.
+ *
+ * The Monk shell without prowess: the printed line is a bare [Triggers.YouCastNoncreature] trigger
+ * whose effect is life gain, so `prowess()` would be wrong — it would add a +1/+1 trigger the card
+ * doesn't have. `Effects.GainLife` defaults to the controller, which is the printed "you".
+ */
+val StudentOfOjutai = card("Student of Ojutai") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever you cast a noncreature spell, you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Jason A. Engle"
+        flavorText = "\"Human enlightenment is a firefly that sparks in the night. Dragon enlightenment is a beacon that disperses all darkness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg?1783938611"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TerritorialRoc.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TerritorialRoc.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Territorial Roc
+ * {1}{W}
+ * Creature — Bird
+ * 1 / 3
+ *
+ * Flying
+ *
+ * Evasion only — one keyword, no script.
+ */
+val TerritorialRoc = card("Territorial Roc") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 3
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "YW Tang"
+        flavorText = "\"Such lesser creatures must be purged from the sky. What use do they have but to help channel the lightning of our mighty dragonlord?\"\n—Gvar Barzeel, Kolaghan warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg?1783938611"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TreadUpon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/TreadUpon.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tread Upon
+ * {1}{G}
+ * Instant
+ *
+ * Target creature gets +2/+2 and gains trample until end of turn.
+ *
+ * The single-target half of [PressTheAdvantage]: one [Effects.Composite] over the pump and the
+ * trample grant, both on the same bound target, with the facade's default until-end-of-turn
+ * duration.
+ */
+val TreadUpon = card("Tread Upon") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 and gains trample until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "211"
+        artist = "Efrem Palacios"
+        flavorText = "\"Boasting impenetrable defenses only draws the most tenacious of attackers.\"\n—Yikaro, Atarka warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg?1783938574"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/UkudCobra.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/UkudCobra.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ukud Cobra
+ * {3}{B}
+ * Creature — Snake
+ * 2 / 5
+ *
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * One evergreen keyword and nothing else.
+ */
+val UkudCobra = card("Ukud Cobra") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Snake"
+    power = 2
+    toughness = 5
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "123"
+        artist = "Johann Bodin"
+        flavorText = "\"The Silumgar hide behind the deadly wildlife of their swamps. They'd rather scheme in their jungle palaces than face us.\"\n—Khibat, Kolaghan warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg?1783938593"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/UpdraftElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/UpdraftElemental.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Updraft Elemental
+ * {2}{U}
+ * Creature — Elemental
+ * 1 / 4
+ *
+ * Flying
+ *
+ * Evasion only — one keyword, no script.
+ */
+val UpdraftElemental = card("Updraft Elemental") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    power = 1
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Raf Sarmento"
+        flavorText = "\"It slips through the smallest cracks in the mountain, emerging whole and unfettered. There is nowhere it cannot go, for what can hold back the air itself?\"\n—Chanyi, Ojutai monk"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg?1783938601"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Vandalize.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/Vandalize.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vandalize
+ * {4}{R}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Destroy target artifact.
+ * • Destroy target land.
+ *
+ * "Choose one or both" is a *count* over the two printed modes, not a third "do both" mode:
+ * `chooseCount = 2` with `minChooseCount = 1` (CR 700.2d), which the SDK renders back as
+ * "one or both". See Scour for Scrap for the same correction — an authored "do both" mode reports
+ * one chosen mode where the spell actually chose two, which is the Winterflame regression. Each
+ * mode declares its own target, so only the chosen modes' targets are chosen on announcement.
+ */
+val Vandalize = card("Vandalize") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target land."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Destroy target artifact") {
+                val artifact = target("target", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+            mode("Destroy target land") {
+                val land = target("target", Targets.Land)
+                effect = Effects.Destroy(land)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Ryan Barger"
+        flavorText = "\"As we have learned from Kolaghan, to ruin is to rule.\"\n—Shensu, Kolaghan rider"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg?1783938584"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VoidSquall.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VoidSquall.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Void Squall
+ * {4}{U}
+ * Sorcery
+ *
+ * Return target nonland permanent to its owner's hand.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * A plain bounce: [Effects.Move] to [Zone.HAND] already sends a permanent to its *owner's* hand,
+ * so no controller override is spelled. No `fromZone` guard either — the target is a permanent on
+ * the battlefield, which is where the requirement already looks. Rebound is the bare
+ * [Keyword.REBOUND], so the same spell bounces a second permanent on your next upkeep.
+ */
+val VoidSquall = card("Void Squall") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return target nonland permanent to its owner's hand.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "James Paick"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg?1783938601"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VolcanicRush.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VolcanicRush.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Volcanic Rush
+ * {4}{R}
+ * Instant
+ *
+ * Attacking creatures get +2/+0 and gain trample until end of turn.
+ *
+ * "Attacking creatures" is an unqualified group, not a target — every attacker on the battlefield,
+ * whoever controls it — so this is [Effects.ForEachInGroup] over [GroupFilter.AttackingCreatures]
+ * with [EffectTarget.Self] naming the current iteration's creature. The group is snapshotted before
+ * the first iteration, so a creature that leaves combat mid-resolution still gets its bonus.
+ */
+val VolcanicRush = card("Volcanic Rush") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +2/+0 and gain trample until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AttackingCreatures,
+            Effects.Composite(
+                Effects.ModifyStats(2, 0, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "166"
+        artist = "Ryan Barger"
+        flavorText = "\"The bravest warriors take the shortest path to victory, whatever that path may be.\"\n—Sakta, Atarka hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg?1783938584"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/YouthfulScholar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/YouthfulScholar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Youthful Scholar
+ * {3}{U}
+ * Creature — Human Wizard
+ * 2 / 2
+ *
+ * When this creature dies, draw two cards.
+ *
+ * [Triggers.Dies] is the whole card: the battlefield → graveyard zone change with the default
+ * battlefield `activeZones`, so the trigger is indexed while the creature is still on the
+ * battlefield. The draw goes to the controller, which is the default and therefore unwritten.
+ */
+val YouthfulScholar = card("Youthful Scholar") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature dies, draw two cards."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Cynthia Sheppard"
+        flavorText = "\"Too dumb, and you end up a sibsig. Too smart, and you end up a meal. Mediocrity is the key to a long life.\"\n—Mogai, Silumgar noble"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg?1783938601"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ZephyrScribe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ZephyrScribe.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Zephyr Scribe
+ * {2}{U}
+ * Creature — Human Monk
+ * 2 / 1
+ *
+ * {U}, {T}: Draw a card, then discard a card.
+ * Whenever you cast a noncreature spell, untap this creature.
+ *
+ * "Draw a card, then discard a card" is the loot recipe ([Patterns.Hand.loot], draw 1 then the
+ * gather/select/discard pipeline), and the untap trigger is a plain [Triggers.YouCastNoncreature] —
+ * not prowess, which would add a +1/+1 the card doesn't print. Together they let each noncreature
+ * spell refund the tap cost, so the ability can be activated once per spell.
+ */
+val ZephyrScribe = card("Zephyr Scribe") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 1
+    oracleText = "{U}, {T}: Draw a card, then discard a card.\n" +
+        "Whenever you cast a noncreature spell, untap this creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        effect = Patterns.Hand.loot()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Lius Lasahido"
+        flavorText = "\"Ojutai's rule has allowed Tarkir's monks to learn from the truly enlightened.\"\n—Sarkhan Vol"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg?1783938601"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GlintReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GlintReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glint reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val GlintReprint = Printing(
+    oracleId = "2fc07680-3ffb-4507-a1e1-b9580f5ce878",
+    name = "Glint",
+    setCode = "ANB",
+    collectorNumber = "28",
+    scryfallId = "0b9db535-6279-4b5e-87c3-15c1321b50c8",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b9db535-6279-4b5e-87c3-15c1321b50c8.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GlaringAegisReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GlaringAegisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glaring Aegis reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val GlaringAegisReprint = Printing(
+    oracleId = "0b0c98ba-3505-40aa-b0f2-e03c9790f51e",
+    name = "Glaring Aegis",
+    setCode = "M20",
+    collectorNumber = "18",
+    scryfallId = "daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/daa83dc2-4ec0-4e4f-8bfd-4f6d6df06a2d.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -125,6 +125,51 @@
     ]
 }
 
+// Artful Maneuver
+{
+    "name": "Artful Maneuver",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fcaf67e-ba97-4af9-8c47-dbca703cba35.jpg?1783938620"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Atarka Monument
 {
     "name": "Atarka Monument",
@@ -298,6 +343,329 @@
     ]
 }
 
+// Blood-Chin Rager
+{
+    "name": "Blood-Chin Rager",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever this creature attacks, Warrior creatures you control gain menace until end of turn. (They can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Warrior ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "MENACE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Karl Kopinski",
+        "flavorText": "Kolaghan blades rarely stay clean for long.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8e93684-a587-4510-b48b-ecf27ff695f4.jpg?1783938600"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Boltwing Marauder
+{
+    "name": "Boltwing Marauder",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever another creature you control enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "When battling the Kolaghan, consider yourself lucky if lightning strikes the same place only twice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aab8841f-5c6f-47fc-91c9-acf3c84b7313.jpg?1783938573"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Butcher's Glee
+{
+    "name": "Butcher's Glee",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 and gains lifelink until end of turn. Regenerate it. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "artist": "Jesper Ejsing",
+        "flavorText": "The Crave made Kneecleaver think she was bigger than the dragon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4e7919e-6190-4f3c-99f7-faa666d34f79.jpg?1783938601"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Champion of Arashin
+{
+    "name": "Champion of Arashin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dog Warrior",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Joseph Meehan",
+        "flavorText": "\"The blood of Dromoka and the blood of my veins are the same.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/5635c8f2-164c-4a13-965a-9432d07092ed.jpg?1783938619"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Coat with Venom
+{
+    "name": "Coat with Venom",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+2 and gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Johann Bodin",
+        "flavorText": "\"Every Silumgar blade carries the blessing of our dragonlord.\"\n—Xathi the Infallible",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cc8e012-7043-405c-b6cd-b3b38f8a8d54.jpg?1783938600"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Collected Company
+{
+    "name": "Collected Company",
+    "manaCost": "{3}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Look at the top six cards of your library. Put up to two creature cards with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 6
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "filter": "creature mv<=3",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "Put up to two creature cards with mana value 3 or less from among them onto the battlefield",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "Many can stand where one would fall.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg?1783938582"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Colossodon Yearling
 {
     "name": "Colossodon Yearling",
@@ -316,6 +684,161 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Commune with Lava
+{
+    "name": "Commune with Lava",
+    "manaCost": "{X}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Exile the top X cards of your library. Until the end of your next turn, you may play those cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": "XValue"
+                    },
+                    "storeAs": "impulseExiled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "impulseExiled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "impulseExiled",
+                    "expiry": {
+                        "type": "UntilControllerStep",
+                        "step": "CLEANUP",
+                        "includeCurrentTurn": false
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Ryan Barger",
+        "flavorText": "Atarka conquered Qadat, the Fire Rim, long ago, winning over its efreet with a promise to spread the glory of fire to all the world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/051141cb-562a-42a5-984b-a83ee8baca51.jpg?1783938591"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Conifer Strider
+{
+    "name": "Conifer Strider",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 1
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "YW Tang",
+        "flavorText": "Atarka's presence thaws the glaciers of Qal Sisma, forcing its elementals to migrate or adapt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72f07879-7893-46d9-9239-8d2625355881.jpg?1783938581"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Cunning Breezedancer
+{
+    "name": "Cunning Breezedancer",
+    "manaCost": "{4}{W}{U}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever you cast a noncreature spell, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Todd Lockwood",
+        "flavorText": "\"That which is beautiful in form can also be deadly.\"\n—Ishai, Ojutai dragonspeaker",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdbfe3b0-3b1d-4b0c-9d98-07f1cecce4b7.jpg?1783938573"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Custodian of the Trove
+{
+    "name": "Custodian of the Trove",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Defender\nThis creature enters tapped.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "artist": "Raoul Vitale",
+        "flavorText": "Silumgar delights in repurposing the treasures of other clans to serve his own ravenous greed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb14f061-9506-40fb-b10d-4bada38ca0f7.jpg?1783938569"
+    },
+    "colorIdentityOverride": []
 }
 
 // Defeat
@@ -490,6 +1013,71 @@
     ]
 }
 
+// Dromoka Dunecaster
+{
+    "name": "Dromoka Dunecaster",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}{W}, {T}: Tap target creature without flying.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Mark Winters",
+        "flavorText": "\"The dragonlords rule the tempests of the skies. Here in the wastes, the storms are mine to command.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc98e542-4bcc-43e1-9616-64ce40348a34.jpg?1783938618"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dromoka Warrior
 {
     "name": "Dromoka Warrior",
@@ -504,6 +1092,298 @@
         "artist": "Zack Stella",
         "flavorText": "Dromoka has regard for the humans who serve under her. In return for her protection, they obey with steadfast loyalty, acting as weapons for her and her scalelords against the other clans.",
         "imageUri": "https://cards.scryfall.io/normal/front/1/3/13ae001b-556f-4576-8cf4-0b8902997bb1.jpg?1562782782"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Fate Forgotten
+{
+    "name": "Fate Forgotten",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Cliff Childs",
+        "flavorText": "When Sarkhan saved Ugin in Tarkir's past, it changed Tarkir's future. The Sultai no longer exist, having been supplanted by the dragonlord Silumgar and his clan.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b2161d9-ad52-45a6-9be9-e7ff09ec8f5a.jpg?1783938617"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Flatten
+{
+    "name": "Flatten",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Raoul Vitale",
+        "flavorText": "Like their dragonlord, the Kolaghan take no trophies. They find true fulfillment only in the battle itself, in clash of steel and thunder of hooves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2acae67-5238-40bb-a173-6fc858264a6c.jpg?1783938598"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Glaring Aegis
+{
+    "name": "Glaring Aegis",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap target creature an opponent controls.\nEnchanted creature gets +1/+3.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Anthony Palumbo",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5f66474-05bb-4235-b8b4-c2e6452118fc.jpg?1783938616"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Glint
+{
+    "name": "Glint",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gets +0/+3 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Rakshasa waste no opportunity to display their wealth and power, even in the midst of a sorcerous duel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35fa105f-c76b-4fd0-9b83-34b46648e0d6.jpg?1783938608"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Great Teacher's Decree
+{
+    "name": "Great Teacher's Decree",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +2/+1 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5ce2761c-20ee-497a-8c05-947a1ac93e57.jpg?1783938616"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Hand of Silumgar
+{
+    "name": "Hand of Silumgar",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Lius Lasahido",
+        "flavorText": "Silumgar trains those whom he favors in his magic, granting them the ability to spread his disdain across the land.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/884cbc26-f164-47bd-878c-dd46652465d0.jpg?1783938597"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Herald of Dromoka
+{
+    "name": "Herald of Dromoka",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Vigilance\nOther Warrior creatures you control have vigilance.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature Warrior ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Zack Stella",
+        "flavorText": "The trumpeters of Arashin are ever alert in their watch over the Great Aerie.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8987b2af-66d6-4271-a139-37e544cdec62.jpg?1783938615"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -608,6 +1488,979 @@
     ]
 }
 
+// Kolaghan Forerunners
+{
+    "name": "Kolaghan Forerunners",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "Trample\nKolaghan Forerunners's power is equal to the number of creatures you control.\nDash {2}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{2}{R}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c56a8de-8ae8-4672-8119-9e6a1f4cf5cd.jpg?1783938589"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kolaghan Skirmisher
+{
+    "name": "Kolaghan Skirmisher",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Dash {2}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{2}{B}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Anthony Palumbo",
+        "flavorText": "Kolaghan's army rushes from kill to kill, desperate to avoid the dragon's wrath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ced0adca-d11c-41b6-aec4-4799946425d3.jpg?1783938597"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kolaghan's Command
+{
+    "name": "Kolaghan's Command",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose two —\n• Return target creature card from your graveyard to your hand.\n• Target player discards a card.\n• Destroy target artifact.\n• Kolaghan's Command deals 2 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature card in your graveyard"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "creature card in your graveyard"
+                        }
+                    ],
+                    "description": "Return target creature card from your graveyard to your hand"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Target player discards a card"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target artifact"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "id": "any target"
+                        }
+                    ],
+                    "description": "Kolaghan's Command deals 2 damage to any target"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c884e1e-fecb-4330-b3de-5fc2a60f7173.jpg?1783938571"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Lightning Berserker
+{
+    "name": "Lightning Berserker",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "{R}: This creature gets +1/+0 until end of turn.\nDash {R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{R}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Meehan",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/3285cb6f-a9c0-4195-b6b2-3f33a16eaa01.jpg?1783938588"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Necromaster Dragon
+{
+    "name": "Necromaster Dragon",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever this creature deals combat damage to a player, you may pay {2}. If you do, create a 2/2 black Zombie creature token and each opponent mills two cards.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CreateToken",
+                                "power": 2,
+                                "toughness": 2,
+                                "colors": [
+                                    "BLACK"
+                                ],
+                                "creatureTypes": [
+                                    "Zombie"
+                                ]
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            },
+                                            "player": "EachOpponent",
+                                            "isMill": true
+                                        },
+                                        "storeAs": "milled"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "milled",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": "EachOpponent"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/2574aaf5-8397-4a88-b047-1b4dbb176930.jpg?1783938571"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Ojutai's Breath
+{
+    "name": "Ojutai's Breath",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Tap target creature. It doesn't untap during its controller's next untap step.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DOESNT_UNTAP",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "duration": "UntilAfterAffectedControllersNextUntap"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af51e5a1-7d46-4dad-a25c-6767cbd03dff.jpg?1783938604"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ojutai's Command
+{
+    "name": "Ojutai's Command",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose two —\n• Return target creature card with mana value 2 or less from your graveyard to the battlefield.\n• You gain 4 life.\n• Counter target creature spell.\n• Draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature card with mana value 2 or less in your graveyard"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature mv<=2 own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "creature card with mana value 2 or less in your graveyard"
+                        }
+                    ],
+                    "description": "Return target creature card with mana value 2 or less from your graveyard to the battlefield"
+                },
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                },
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature",
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "description": "Counter target creature spell"
+                },
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "RARE",
+        "artist": "Willian Murai",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7a7f500-594d-4c7b-80e8-54ae1ada2444.jpg?1783938571"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ojutai's Summons
+{
+    "name": "Ojutai's Summons",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 2/2 blue Djinn Monk creature token with flying.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 2,
+            "toughness": 2,
+            "colors": [
+                "BLUE"
+            ],
+            "creatureTypes": [
+                "Djinn",
+                "Monk"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Jakub Kasper",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/6769341a-1331-456d-a2bb-cd7fffe7b51d.jpg?1783938605"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Palace Familiar
+{
+    "name": "Palace Familiar",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Kev Walker",
+        "flavorText": "\"The most profound secrets lie in the darkest places of the world. It can be prudent to make use of another set of eyes.\"\n—Sidisi, Silumgar vizier",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc0c17c9-54af-4dd4-8d4a-fd5a7b8c3c77.jpg?1783938605"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Pitiless Horde
+{
+    "name": "Pitiless Horde",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Orc Berserker",
+    "oracleText": "At the beginning of your upkeep, you lose 2 life.\nDash {2}{B}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{2}{B}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, you lose 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "Viktor Titov",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg?1783938595"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Press the Advantage
+{
+    "name": "Press the Advantage",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Up to two target creatures each get +2/+2 and gain trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Nelor",
+        "flavorText": "\"Show your enemies as much mercy as they would show you.\"\n—Surrak, the Hunt Caller",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09253b39-8b3e-4cb8-b054-0e1a49762387.jpg?1783938578"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Profound Journey
+{
+    "name": "Profound Journey",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target permanent card from your graveyard to the battlefield.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "RARE",
+        "artist": "Tomasz Jedruszek",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg?1783938614"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Reckless Imp
+{
+    "name": "Reckless Imp",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\nThis creature can't block.\nDash {1}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{1}{B}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Torstein Nordstrand",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74a44e0a-5fff-4fc0-a76d-1b097f1d4d5d.jpg?1783938594"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Roast
+{
+    "name": "Roast",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Roast deals 5 damage to target creature without flying.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotKeyword",
+                                "keyword": "FLYING"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Intruders in the lands of Atarka have but two choices: be consumed by fire, or be consumed by maw.\"\n—Ulnok, Atarka shaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1ba2e9a8-fcbb-4328-b475-36730182b765.jpg?1783938587"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ruthless Deathfang
+{
+    "name": "Ruthless Deathfang",
+    "manaCost": "{4}{U}{B}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever you sacrifice a creature, target opponent sacrifices a creature of their choice.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "creature",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "\"Bring forth the dead, their skull-grins and rattle-bones. We will feast upon their wailing ghosts.\"\n—Silumgar, translated from Draconic",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93d99f0d-f5d4-4480-ac5e-fe9ff808416e.jpg?1783938570"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Salt Road Quartermasters
+{
+    "name": "Salt Road Quartermasters",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature enters with two +1/+1 counters on it.\n{2}{G}, Remove a +1/+1 counter from this creature: Put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "+1/+1",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony Palumbo",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/4076bf6b-c8b1-49ef-8f23-afaf7a234e2d.jpg?1783938577"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sarkhan's Triumph
+{
+    "name": "Sarkhan's Triumph",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "creature Dragon"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "Sarkhan gazed on the world around him, the dragons sweeping through its skies, and joy kindled like a fire in his soul.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9a0ff4d-060e-41dc-8b79-1fa42838adf2.jpg?1783938586"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Savage Ventmaw
 {
     "name": "Savage Ventmaw",
@@ -659,6 +2512,88 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Scion of Ugin
+{
+    "name": "Scion of Ugin",
+    "manaCost": "{6}",
+    "typeLine": "Creature — Dragon Spirit",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "For hundreds of years Ugin slept, encased in the cocoon of stone and magic Sarkhan had created using a shard of a Zendikari hedron. As Ugin lay dormant, his spectral guardians kept vigil.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/302d62d6-8abf-4693-974c-bef6841b394f.jpg?1783938621"
+    },
+    "colorIdentityOverride": []
+}
+
+// Screamreach Brawler
+{
+    "name": "Screamreach Brawler",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Orc Berserker",
+    "oracleText": "Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{1}{R}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"My dragonlord's lightning will dance upon your bones!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bfab1c5-e267-43a9-ae16-f6b8ae531eef.jpg?1783938586"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Secure the Wastes
+{
+    "name": "Secure the Wastes",
+    "manaCost": "{X}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Create X 1/1 white Warrior creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": "XValue",
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Warrior"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "Scott Murphy",
+        "flavorText": "\"The Shifting Wastes provide our clan eternal protection. It is our duty to return the favor.\"\n—Kadri, Dromoka warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/915d2f5f-b228-4190-ade9-52e2a8056847.jpg?1783938613"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -809,6 +2744,294 @@
     ]
 }
 
+// Shape the Sands
+{
+    "name": "Shape the Sands",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +0/+5 and gains reach until end of turn. (It can block creatures with flying.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Ryan Yee",
+        "flavorText": "\"Dragons in flight seldom expect company.\"\n—Kadri, Dromoka warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0243dde4-29c9-4e47-9129-8e01296851cc.jpg?1783938576"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sight Beyond Sight
+{
+    "name": "Sight Beyond Sight",
+    "manaCost": "{3}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/def0df83-fe20-497f-b372-1d2e4d7c8df9.jpg?1783938604"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Skywise Teachings
+{
+    "name": "Skywise Teachings",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, create a 2/2 blue Djinn Monk creature token with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}{U}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 2,
+                        "toughness": 2,
+                        "colors": [
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Djinn",
+                            "Monk"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "Ojutai's words must be translated from Draconic before his students can benefit from their wisdom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87875281-12d1-45b9-b1a9-fe0ae7448ab8.jpg?1783938602"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Strongarm Monk
+{
+    "name": "Strongarm Monk",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Whenever you cast a noncreature spell, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Viktor Titov",
+        "flavorText": "\"His companions are wise to follow him, for his foes dare not stand in his way.\"\n—Zhiada, Dirgur protector",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f5f5ead-b9e0-44c0-893f-0e3ae01933d3.jpg?1783938611"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Student of Ojutai
+{
+    "name": "Student of Ojutai",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Whenever you cast a noncreature spell, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Human enlightenment is a firefly that sparks in the night. Dragon enlightenment is a beacon that disperses all darkness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d06616c-a0df-4d2d-8bfc-9f59060d323b.jpg?1783938611"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sunscorch Regent
 {
     "name": "Sunscorch Regent",
@@ -928,6 +3151,86 @@
     ]
 }
 
+// Territorial Roc
+{
+    "name": "Territorial Roc",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "YW Tang",
+        "flavorText": "\"Such lesser creatures must be purged from the sky. What use do they have but to help channel the lightning of our mighty dragonlord?\"\n—Gvar Barzeel, Kolaghan warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c83aa5e-b607-4c4f-a5f6-db61c93a1152.jpg?1783938611"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tread Upon
+{
+    "name": "Tread Upon",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "artist": "Efrem Palacios",
+        "flavorText": "\"Boasting impenetrable defenses only draws the most tenacious of attackers.\"\n—Yikaro, Atarka warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87f04d27-f38a-4be2-8eb6-7dd0d3a1ac6d.jpg?1783938574"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Twin Bolt
 {
     "name": "Twin Bolt",
@@ -953,6 +3256,123 @@
         "artist": "Svetlin Velinov",
         "flavorText": "\"Kolaghan archers are trained in Dakla, the way of the bow. They utilize their dragonlord's lightning to strike their target, no matter how small, how fast, or how far away.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bd58ec4-34a9-4fc2-b057-438492e2e06e.jpg?1562786902"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ukud Cobra
+{
+    "name": "Ukud Cobra",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "flavorText": "\"The Silumgar hide behind the deadly wildlife of their swamps. They'd rather scheme in their jungle palaces than face us.\"\n—Khibat, Kolaghan warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71d2f6ee-af76-48f0-898d-3a19698d2790.jpg?1783938593"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Updraft Elemental
+{
+    "name": "Updraft Elemental",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Raf Sarmento",
+        "flavorText": "\"It slips through the smallest cracks in the mountain, emerging whole and unfettered. There is nowhere it cannot go, for what can hold back the air itself?\"\n—Chanyi, Ojutai monk",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/9621c700-569d-4d07-847e-68b97113415f.jpg?1783938601"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vandalize
+{
+    "name": "Vandalize",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Destroy target artifact.\n• Destroy target land.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target land"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Ryan Barger",
+        "flavorText": "\"As we have learned from Kolaghan, to ruin is to rule.\"\n—Shensu, Kolaghan rider",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48b04f7a-4fd6-47d2-b378-99c7fb0c1809.jpg?1783938584"
     },
     "colorIdentityOverride": [
         "RED"
@@ -1016,6 +3436,95 @@
     "colorIdentityOverride": []
 }
 
+// Void Squall
+{
+    "name": "Void Squall",
+    "manaCost": "{4}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target nonland permanent to its owner's hand.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d8a7aee-6403-44ce-a119-66147aa311fd.jpg?1783938601"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Volcanic Rush
+{
+    "name": "Volcanic Rush",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +2/+0 and gain trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "artist": "Ryan Barger",
+        "flavorText": "\"The bravest warriors take the shortest path to victory, whatever that path may be.\"\n—Sakta, Atarka hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b808883-f630-4070-ab7e-d347e26a9564.jpg?1783938584"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Wandering Tombshell
 {
     "name": "Wandering Tombshell",
@@ -1033,5 +3542,153 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Youthful Scholar
+{
+    "name": "Youthful Scholar",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature dies, draw two cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "UNCOMMON",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "\"Too dumb, and you end up a sibsig. Too smart, and you end up a meal. Mediocrity is the key to a long life.\"\n—Mogai, Silumgar noble",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43ae8147-bf25-44f9-b75f-837b81ebe0de.jpg?1783938601"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Zephyr Scribe
+{
+    "name": "Zephyr Scribe",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "{U}, {T}: Draw a card, then discard a card.\nWhenever you cast a noncreature spell, untap this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Ojutai's rule has allowed Tarkir's monks to learn from the truly enlightened.\"\n—Sarkhan Vol",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d23ae0d2-0ca1-4095-8710-be5800e389cd.jpg?1783938601"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Dragons of Tarkir had not authored.

## The four-way split

`just assay-ready DTK --names --tail` on main:

> 217 missing: **58 Assay-ready**, 159 declined, 0 absent from the ledger

| Bucket | Count | Work |
|---|---|---|
| `original` | 53 | canonical authored here — DTK is the earliest real printing for every one |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override (15 art variants, 250–264) |
| `elsewhere` | 0 | — |
| `row-only` | 0 | — |
| `unscaffolded` | 0 | — |

**Reprint tail: 2 rows owed in 2 other scaffolded sets** — invisible to `check-card-printing` until
the canonical existed, so they land here: `ANB` Glint, `M20` Glaring Aegis. `generate-reprints.py
--since main` was scoped to this branch's 53 canonicals and reported *0 misplaced canonical, 0 stale
cache* after the printing caches were refreshed first.

`basicLandsFallback = KhansOfTarkirSet` is dropped in favour of DTK's own basics.

## Capability pre-flight

Every mechanic the list touches was traced to its `rules-engine` consumer before any card was
written. **All 11 are engine-live — nothing on the list is display-only**, so no card here renders a
keyword the engine ignores:

| Mechanic | Cards | Consumer |
|---|---|---|
| Rebound | 7 | `StackResolver.spellHasRebound` / `scheduleReboundRecast` (incl. the paused-resolution path) |
| Dash | 6 | `CastFromZoneEnumerator` (alt cost) + `DashedComponent`→`StateProjector` (haste) + `StackResolver` (end-step return) |
| Regenerate | 1 | `RegenerateExecutor` |
| Cast-noncreature trigger | 5 | `Triggers.YouCastNoncreature` |
| Modal choose-two / one-or-both | 3 | `ModalEffect` |
| Sacrifice trigger | 1 | `PermanentsSacrificedEvent` |
| Mill / may-pay-{2} | 1 | `Patterns.Library.mill`, `MayPayManaEffect` |
| Impulse exile with X | 1 | `GrantMayPlayFromExileEffect` |
| CDA power | 1 | Layer 7b `SetBasePowerToughnessDynamicStatic` |
| Doesn't-untap-next-untap | 1 | `Duration.UntilAfterAffectedControllersNextUntap` |
| Look-at-top / take-matching | 1 | `Patterns.Library.lookAtTopAndTakeMatching` |

## Authored to Assay's JSON

Every card was written against `oracle-assay compile "<name>"` output — the exact `CardDefinition`
model Assay's grammar builds — rather than against the oracle text. Metadata came from **DTK's own
Scryfall payload**, not from the compile: 14 of the 53 compiled tagged with a later printing's set
code (IMA, BBD, 2X2, AFC, E01, M20, MIC, MOC), which is the printing the Oracle bulk happened to
carry.

A mechanical check diffed every written file's `card()` name, `manaCost`, `typeLine`,
`colorIdentity`, P/T, `oracleText` and the fields **inside the `metadata { }` block** back against
the Scryfall brief: **0 discrepancies across all 53**.

## Decisions worth naming

- **`Effect.then` flattens.** `Effects.Composite(pump, lifelink) then RegenerateEffect(t)` emits a
  flat 3-element list, not the brief's `Composite[Composite[…], Regenerate]`. Butcher's Glee is
  written with explicit nesting — effect-list arity is what the differential compares.
- **Vandalize is `chooseCount = 2, minChooseCount = 1` over two modes**, not a third "do both" mode
  (the Winterflame regression flagged in `ScourForScrap.kt`).
- **Ruthless Deathfang reads "a creature", not "another"** → `Triggers.YouSacrificeA` (per-permanent,
  `binding: ANY`, counts the Dragon sacrificing itself), not `YouSacrificeAnother`.
- **The two Commands differ on the `fromZone` guard by design**: Ojutai's battlefield return keeps
  it, Kolaghan's targeted hand return drops it — the requirement's own `zone = GRAVEYARD` is
  rechecked at resolution under CR 608.2b.
- **Collected Company's "in any order" is `CardOrder.ControllerChooses`**, not `Random`.
- **Kolaghan Forerunners' `*` power is Layer 7b**, `dynamicPower(...)` with no `power` line — the
  power *is* the base value, not a 7c bonus.

## Verification

| Gate | Result |
|---|---|
| `just build` (via CI `test (content)` + `test (engine)`) | compiles — all 53 cards, the basic lands, both reprint rows |
| `just rebless-cards` | DTK golden **23 → 76 entries: +53, nothing removed**; no other set's golden moved |
| `just assay-differential` | **6108 compared / 6054 confirmed / 54 divergent** vs. a main baseline of 6055 / 6001 / 54 — all 53 cards entered the compared set and **all 53 confirmed. Zero new divergences.** |
| `just assay-ready DTK` on the branch | **58 → 0.** The 159 still-missing cards are all `LINE_DECLINED` (157) / `LINES_DO_NOT_FOLD` (2) — grammar work, not authoring work |
| `just check-card-printing` | canonical in the earliest real printing and all scaffolded reprints have rows, including both tail entries (ANB Glint, M20 Glaring Aegis) |
| `generate-reprints.py --since main` | 0 misplaced canonical, 0 stale cache (all 53 printing caches refreshed first) |

The differential is the one that matters here: 53 cards authored against `assay compile`'s JSON,
none of them disagreeing with it. The 54 divergences are the pre-existing corpus set, unchanged.

Also verified: all 53 `compile` outputs are full cards (no short/art-card name collisions), every
oracle text matches DTK's Scryfall payload exactly, and a mechanical field diff of every written
file's `card()` name / `manaCost` / `typeLine` / `colorIdentity` / P/T / `oracleText` and the fields
**inside the `metadata { }` block** against the Scryfall brief found **0 discrepancies across 53
cards**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
