### PR TITLE
Add 59 Assay-ready cards to Magic 2014

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/TradingPostReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/TradingPostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trading Post reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val TradingPostReprint = Printing(
+    oracleId = "63788566-e25a-44bb-bb55-197e1b93b3e8",
+    name = "Trading Post",
+    setCode = "C14",
+    collectorNumber = "279",
+    scryfallId = "1b65d800-c517-4a9d-b588-757235c26fe3",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b65d800-c517-4a9d-b588-757235c26fe3.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BloodBairnReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BloodBairnReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Bairn reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodBairnReprint = Printing(
+    oracleId = "33bea2f0-c5aa-44b5-8714-5f50f7f2bb05",
+    name = "Blood Bairn",
+    setCode = "C15",
+    collectorNumber = "117",
+    scryfallId = "c9a9991a-4ac1-4408-aa62-8796d92bbc70",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9a9991a-4ac1-4408-aa62-8796d92bbc70.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/TradingPostReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/TradingPostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trading Post reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val TradingPostReprint = Printing(
+    oracleId = "63788566-e25a-44bb-bb55-197e1b93b3e8",
+    name = "Trading Post",
+    setCode = "C16",
+    collectorNumber = "278",
+    scryfallId = "6e0e70b6-1f5c-4cca-95eb-51ce89d76064",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e0e70b6-1f5c-4cca-95eb-51ce89d76064.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/DeadlyRecluseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/DeadlyRecluseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Recluse reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadlyRecluseReprint = Printing(
+    oracleId = "6b941291-1802-4ced-9869-39fa43825550",
+    name = "Deadly Recluse",
+    setCode = "CMD",
+    collectorNumber = "149",
+    scryfallId = "61031a81-7cb7-48ec-b5b9-97197b6df23e",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61031a81-7cb7-48ec-b5b9-97197b6df23e.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/DawnstrikePaladinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/DawnstrikePaladinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawnstrike Paladin reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val DawnstrikePaladinReprint = Printing(
+    oracleId = "c2bfb230-6949-4d5e-8cac-9d7dafdc5e9a",
+    name = "Dawnstrike Paladin",
+    setCode = "DDL",
+    collectorNumber = "14",
+    scryfallId = "549ca818-f7bf-47a8-9005-18ddabd3c360",
+    artist = "Tyler Jacobson",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/549ca818-f7bf-47a8-9005-18ddabd3c360.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/DeadlyRecluseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/DeadlyRecluseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Recluse reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadlyRecluseReprint = Printing(
+    oracleId = "6b941291-1802-4ced-9869-39fa43825550",
+    name = "Deadly Recluse",
+    setCode = "DDL",
+    collectorNumber = "45",
+    scryfallId = "880ba2a5-2cca-406d-804b-3250c25027d3",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/880ba2a5-2cca-406d-804b-3250c25027d3.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/NephaliaSeakite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/NephaliaSeakite.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nephalia Seakite
+ * {3}{U}
+ * Creature — Bird
+ * 2 / 3
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Flying
+ *
+ * Canonical printing: Dark Ascension, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val NephaliaSeakite = card("Nephalia Seakite") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 3
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+            "Flying"
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Wayne England"
+        flavorText = "\"Keep one eye on the cliff road or you may fall to your death. Keep one eye on the sky or your death may fall on you.\"\n" +
+            "—Manfried Ulmach, Elgaud Master-at-Arms"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/Bramblecrush.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/Bramblecrush.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Bramblecrush
+ * {2}{G}{G}
+ * Sorcery
+ * Destroy target noncreature permanent.
+ *
+ * Canonical printing: Innistrad, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val Bramblecrush = card("Bramblecrush") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target noncreature permanent."
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.NoncreaturePermanent))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "172"
+        artist = "Drew Baker"
+        flavorText = "\"Civilization is fertilizer.\"\n" +
+            "—Garruk Wildspeaker"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/PitchburnDevils.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/PitchburnDevils.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pitchburn Devils
+ * {4}{R}
+ * Creature — Devil
+ * 3 / 3
+ * When this creature dies, it deals 3 damage to any target.
+ *
+ * Canonical printing: Innistrad, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val PitchburnDevils = card("Pitchburn Devils") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature dies, it deals 3 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val damaged = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, damaged)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Johann Bodin"
+        flavorText = "The ingenuity of goblins, the depravity of demons, and the smarts of sheep."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DeadlyRecluse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DeadlyRecluse.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Recluse
+ * {1}{G}
+ * Creature — Spider
+ * 1 / 2
+ * Reach (This creature can block creatures with flying.)
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * Canonical printing: Magic 2010, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val DeadlyRecluse = card("Deadly Recluse") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 1
+    toughness = 2
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+            "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+    keywords(Keyword.REACH, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/GriffinSentinel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/GriffinSentinel.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griffin Sentinel
+ * {2}{W}
+ * Creature — Griffin
+ * 1 / 3
+ * Flying
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ *
+ * Canonical printing: Magic 2010, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val GriffinSentinel = card("Griffin Sentinel") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+            "Vigilance (Attacking doesn't cause this creature to tap.)"
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Warren Mahy"
+        flavorText = "Once a griffin sentinel adopts a territory as its own, only death can force it to betray its post."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/HowlOfTheNightPackReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/HowlOfTheNightPackReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Howl of the Night Pack reprint in M10. Canonical CardDefinition lives in its earliest set.
+ */
+val HowlOfTheNightPackReprint = Printing(
+    oracleId = "868b758c-e21c-4079-a1fc-4c89af106f4b",
+    name = "Howl of the Night Pack",
+    setCode = "M10",
+    collectorNumber = "187",
+    scryfallId = "a37ba2c4-dd92-4b23-a830-5dbabc9a972b",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a37ba2c4-dd92-4b23-a830-5dbabc9a972b.jpg",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/PlanarCleansing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/PlanarCleansing.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Planar Cleansing
+ * {3}{W}{W}{W}
+ * Sorcery
+ * Destroy all nonland permanents.
+ *
+ * Canonical printing: Magic 2010, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ *
+ * "All nonland permanents" is the gather-then-move pipeline
+ * ([Patterns.Group.destroyAllPipeline]), not a per-permanent iteration: the group is named once
+ * and every member leaves together.
+ */
+val PlanarCleansing = card("Planar Cleansing") {
+    manaCost = "{3}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all nonland permanents."
+
+    spell {
+        effect = Patterns.Group.destroyAllPipeline(GameObjectFilter.NonlandPermanent)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Michael Komarck"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/TomeScour.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/TomeScour.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tome Scour
+ * {U}
+ * Sorcery
+ * Target player mills five cards.
+ *
+ * Canonical printing: Magic 2010, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ *
+ * [Patterns.Library.mill] is the gather-then-move pipeline; passing the bound target routes both
+ * halves at the targeted player rather than the controller.
+ */
+val TomeScour = card("Tome Scour") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Target player mills five cards."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(5, player)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Steven Belledin"
+        flavorText = "Genius is overrated, especially when it's someone else's."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/TomeScourReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/TomeScourReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tome Scour reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val TomeScourReprint = Printing(
+    oracleId = "446a9d7e-9c1a-4e83-8342-2ed5acae2eed",
+    name = "Tome Scour",
+    setCode = "M11",
+    collectorNumber = "76",
+    scryfallId = "6445f013-8b50-4ea3-9013-df85289c2605",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/6445f013-8b50-4ea3-9013-df85289c2605.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DarkFavor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DarkFavor.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dark Favor
+ * {1}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, you lose 1 life.
+ * Enchanted creature gets +3/+1.
+ *
+ * The black counterpart of Divine Favor, and the same shape: an `auraTarget` attachment
+ * restriction, an enters trigger, and a bare [ModifyStats] on the enchanted creature.
+ *
+ * Canonical printing: Magic 2012, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val DarkFavor = card("Dark Favor") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+            "When this Aura enters, you lose 1 life.\n" +
+            "Enchanted creature gets +3/+1."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.LoseLife(1, EffectTarget.Controller)
+    }
+
+    staticAbility {
+        ability = ModifyStats(+3, +1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Allen Williams"
+        flavorText = "When he began to curse what he held holy, his strength grew unrivaled."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GladecoverScout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GladecoverScout.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gladecover Scout
+ * {G}
+ * Creature — Elf Scout
+ * 1 / 1
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ *
+ * Canonical printing: Magic 2012, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val GladecoverScout = card("Gladecover Scout") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Allen Williams"
+        flavorText = "\"The forest is my cover and I hold it close. In such a tight embrace, there is no room for wickedness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GriffinSentinelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GriffinSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griffin Sentinel reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val GriffinSentinelReprint = Printing(
+    oracleId = "72df0b70-5c9f-44f3-96d5-81c95abc0065",
+    name = "Griffin Sentinel",
+    setCode = "M12",
+    collectorNumber = "21",
+    scryfallId = "3c8f2fea-2bc1-49fc-91c9-83698f43262f",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c8f2fea-2bc1-49fc-91c9-83698f43262f.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/Trollhide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/Trollhide.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trollhide
+ * {2}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +2 / +2 and has "{1}{G}: Regenerate this creature." (The next time the
+ * creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage
+ * on it.)
+ *
+ * Canonical printing: Magic 2012, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ *
+ * The +2 / +2 is a static [ModifyStats] on the attached creature; the quoted ability is a
+ * [GrantActivatedAbility] whose [EffectTarget.Self] resolves to the host creature (CR 113.7), so
+ * "{1}{G}: Regenerate this creature" regenerates the enchanted creature (Lunarch Mantle). There is
+ * no `Effects.Regenerate` facade — [RegenerateEffect] is the shipped spelling (Cudgel Troll).
+ */
+val Trollhide = card("Trollhide") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+            "Enchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{1}{G}"),
+                effect = RegenerateEffect(EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Steven Belledin"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WringFlesh.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WringFlesh.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wring Flesh
+ * {B}
+ * Instant
+ * Target creature gets -3/-1 until end of turn.
+ *
+ * Canonical printing: Magic 2012, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ */
+val WringFlesh = card("Wring Flesh") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-1 until end of turn."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, -1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Izzy"
+        flavorText = "\"Don't blame me. You're the one walking around with skin.\"\n" +
+            "—Zul Ashur, lich lord"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DarkFavorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DarkFavorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Favor reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val DarkFavorReprint = Printing(
+    oracleId = "c1f4a440-638a-4e3e-8a3e-af4a4a73ec91",
+    name = "Dark Favor",
+    setCode = "M13",
+    collectorNumber = "86",
+    scryfallId = "5aae919b-7da6-42b1-84b4-fbc2971dad1e",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5aae919b-7da6-42b1-84b4-fbc2971dad1e.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DeadlyRecluseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DeadlyRecluseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Recluse reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadlyRecluseReprint = Printing(
+    oracleId = "6b941291-1802-4ced-9869-39fa43825550",
+    name = "Deadly Recluse",
+    setCode = "M13",
+    collectorNumber = "165",
+    scryfallId = "a32a5f77-7c1f-4da4-9ae6-3947504a8dea",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a32a5f77-7c1f-4da4-9ae6-3947504a8dea.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PlanarCleansingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PlanarCleansingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Planar Cleansing reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val PlanarCleansingReprint = Printing(
+    oracleId = "a98c2d81-4add-4292-bbdd-e1b69ff936d4",
+    name = "Planar Cleansing",
+    setCode = "M13",
+    collectorNumber = "26",
+    scryfallId = "b5047b71-2359-4d9a-a168-a8eec43c5f1b",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5047b71-2359-4d9a-a168-a8eec43c5f1b.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/ShowOfValor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/ShowOfValor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Show of Valor
+ * {1}{W}
+ * Instant
+ * Target creature gets +2/+4 until end of turn.
+ *
+ * Canonical printing: Magic 2013, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ */
+val ShowOfValor = card("Show of Valor") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+4 until end of turn."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 4, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Anthony Palumbo"
+        flavorText = "\"Duty, honor, and valor are either in your heart or they are not. You will never know for certain until you are tested.\"\n" +
+            "—Ajani Goldmane"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TradingPost.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TradingPost.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Trading Post
+ * {4}
+ * Artifact
+ * {1}, {T}, Discard a card: You gain 4 life.
+ * {1}, {T}, Pay 1 life: Create a 0 / 1 white Goat creature token.
+ * {1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.
+ * {1}, {T}, Sacrifice an artifact: Draw a card.
+ *
+ * Canonical printing: Magic 2013, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ *
+ * Four separate activated abilities, each a [Costs.Composite] of `{1}`, the tap symbol, and one
+ * additional cost. Only the third targets; the Goat token's art comes from the set's `tokenArt`
+ * registry, never a baked `imageUri`.
+ */
+val TradingPost = card("Trading Post") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}, Discard a card: You gain 4 life.\n" +
+            "{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token.\n" +
+            "{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.\n" +
+            "{1}, {T}, Sacrifice an artifact: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.Discard())
+        effect = Effects.GainLife(4)
+        description = "{1}, {T}, Discard a card: You gain 4 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.PayLife(1))
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Goat")
+        )
+        description = "{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.Sacrifice(GameObjectFilter.Creature))
+        val artifact = target(
+            "target artifact card from your graveyard",
+            TargetObject(filter = TargetFilter.ArtifactInYourGraveyard)
+        )
+        effect = Effects.ReturnToHand(artifact)
+        description = "{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.Sacrifice(GameObjectFilter.Artifact))
+        effect = Effects.DrawCards(1)
+        description = "{1}, {T}, Sacrifice an artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "220"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/WildGuess.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/WildGuess.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Guess
+ * {R}{R}
+ * Sorcery
+ * As an additional cost to cast this spell, discard a card.
+ * Draw two cards.
+ *
+ * Canonical printing: Magic 2013, the card's earliest printing. Reprinted in M14 as a `Printing`
+ * row.
+ */
+val WildGuess = card("Wild Guess") {
+    manaCost = "{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, discard a card.\n" +
+            "Draw two cards."
+
+    additionalCost(Costs.additional.DiscardCards())
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Lucas Graciano"
+        flavorText = "No guts, no glory."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/Magic2014Set.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/Magic2014Set.kt
@@ -22,6 +22,10 @@ object Magic2014Set : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AdvocateOfTheBeast.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AdvocateOfTheBeast.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Advocate of the Beast
+ * {2}{G}
+ * Creature — Elf Shaman
+ * 2 / 3
+ * At the beginning of your end step, put a +1/+1 counter on target Beast creature you control.
+ */
+val AdvocateOfTheBeast = card("Advocate of the Beast") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 2
+    toughness = 3
+    oracleText = "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val beast = target(
+            "target Beast creature you control",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.withSubtype(Subtype.BEAST).youControl())
+            )
+        )
+        effect = Effects.AddCounters("+1/+1", 1, beast)
+        description = "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Jesper Ejsing"
+        flavorText = "\"I am neither their drover nor their leader. To these majestic beasts, I am simply their herdmate and nothing more.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BattleSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BattleSliver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Battle Sliver
+ * {4}{R}
+ * Creature — Sliver
+ * 3 / 3
+ * Sliver creatures you control get +2/+0.
+ */
+val BattleSliver = card("Battle Sliver") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 3
+    toughness = 3
+    oracleText = "Sliver creatures you control get +2/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "128"
+        artist = "Slawomir Maniak"
+        flavorText = "\"One emitted a strange series of buzzing clicks and guttural commands, then clawed arms emerged from all of them. Is there no limit to their adaptations?\"\n" +
+            "—Hastric, Thunian scout"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Blightcaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Blightcaster.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Blightcaster
+ * {3}{B}
+ * Creature — Human Wizard
+ * 2 / 3
+ * Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.
+ */
+val Blightcaster = card("Blightcaster") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        val victim = target("target", TargetCreature(filter = TargetFilter.Creature))
+        optional = true
+        effect = Effects.ModifyStats(-2, -2, victim)
+        description =
+            "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Winona Nelson"
+        flavorText = "\"Your flesh is unprepared for my gifts.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BloodBairn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BloodBairn.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blood Bairn
+ * {2}{B}
+ * Creature — Vampire
+ * 2 / 2
+ * Sacrifice another creature: This creature gets +2/+2 until end of turn.
+ */
+val BloodBairn = card("Blood Bairn") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 2
+    oracleText = "Sacrifice another creature: This creature gets +2/+2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.Creature)
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Sacrifice another creature: This creature gets +2/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Ryan Yee"
+        flavorText = "The travelers were warned to watch out for children on the road."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BlurSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BlurSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blur Sliver
+ * {2}{R}
+ * Creature — Sliver
+ * 2 / 2
+ * Sliver creatures you control have haste. (They can attack and {T} as soon as they come under your control.)
+ */
+val BlurSliver = card("Blur Sliver") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have haste. (They can attack and {T} as soon as they come under your control.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Daarken"
+        flavorText = "They move in a synchronized swarm, turning entire squads into heaps of bloody rags and bones in an instant."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BonescytheSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BonescytheSliver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bonescythe Sliver
+ * {3}{W}
+ * Creature — Sliver
+ * 2 / 2
+ * Sliver creatures you control have double strike. (They deal both first-strike and regular combat damage.)
+ */
+val BonescytheSliver = card("Bonescythe Sliver") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have double strike. (They deal both first-strike and regular combat damage.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.DOUBLE_STRIKE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Trevor Claxton"
+        flavorText = "\"Their appendages are sharper than our swords and quicker than our bows.\"\n" +
+            "—Hastric, Thunian scout"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BramblecrushReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BramblecrushReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bramblecrush reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val BramblecrushReprint = Printing(
+    oracleId = "367282d6-956b-470d-a131-d22beff610b0",
+    name = "Bramblecrush",
+    setCode = "M14",
+    collectorNumber = "165",
+    scryfallId = "2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f",
+    artist = "Drew Baker",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e1bd3ff-f3cd-4e9d-ae2e-2c51d0aaec7f.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BriarpackAlphaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BriarpackAlphaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Briarpack Alpha reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val BriarpackAlphaReprint = Printing(
+    oracleId = "5604c475-6e01-4e9d-b4e6-8e8d72874581",
+    name = "Briarpack Alpha",
+    setCode = "M14",
+    collectorNumber = "166",
+    scryfallId = "585c11e2-4c30-436c-9dbd-354b154f6def",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/585c11e2-4c30-436c-9dbd-354b154f6def.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CapashenKnightReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CapashenKnightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Capashen Knight reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val CapashenKnightReprint = Printing(
+    oracleId = "e295d207-128f-419a-866a-c9ac6248c199",
+    name = "Capashen Knight",
+    setCode = "M14",
+    collectorNumber = "11",
+    scryfallId = "78802af4-46b5-4bac-8cdf-5b77d0b19895",
+    artist = "Jasper Sandner",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78802af4-46b5-4bac-8cdf-5b77d0b19895.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CoralMerfolkReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CoralMerfolkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coral Merfolk reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val CoralMerfolkReprint = Printing(
+    oracleId = "4ed27607-21a8-4bc3-997e-6d2242313f6d",
+    name = "Coral Merfolk",
+    setCode = "M14",
+    collectorNumber = "49",
+    scryfallId = "09ef366b-26f5-473a-ab96-e668ed54d691",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/09ef366b-26f5-473a-ab96-e668ed54d691.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DarkFavorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DarkFavorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Favor reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val DarkFavorReprint = Printing(
+    oracleId = "c1f4a440-638a-4e3e-8a3e-af4a4a73ec91",
+    name = "Dark Favor",
+    setCode = "M14",
+    collectorNumber = "92",
+    scryfallId = "5c1591ae-07aa-4013-bc6d-4cafd09927f0",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c1591ae-07aa-4013-bc6d-4cafd09927f0.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DawnstrikePaladin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DawnstrikePaladin.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawnstrike Paladin
+ * {3}{W}{W}
+ * Creature — Human Knight
+ * 2 / 4
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ */
+val DawnstrikePaladin = card("Dawnstrike Paladin") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 4
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+            "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Tyler Jacobson"
+        flavorText = "She crushes darkness beneath her charger's hooves."
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DeadlyRecluseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DeadlyRecluseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Recluse reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadlyRecluseReprint = Printing(
+    oracleId = "6b941291-1802-4ced-9869-39fa43825550",
+    name = "Deadly Recluse",
+    setCode = "M14",
+    collectorNumber = "168",
+    scryfallId = "c82cc190-7ec0-4493-b3dc-dad0cbffa2f8",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c82cc190-7ec0-4493-b3dc-dad0cbffa2f8.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DeathgazeCockatrice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DeathgazeCockatrice.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deathgaze Cockatrice
+ * {2}{B}{B}
+ * Creature — Cockatrice
+ * 2 / 2
+ * Flying
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ */
+val DeathgazeCockatrice = card("Deathgaze Cockatrice") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Cockatrice"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+            "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Kev Walker"
+        flavorText = "\"Sometimes I come across a stone finger or foot and I know I'm in cockatrice territory.\"\n" +
+            "—Rulak, bog guide"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FireshriekerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FireshriekerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fireshrieker reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val FireshriekerReprint = Printing(
+    oracleId = "a02e1ca7-23c5-41e3-a744-72fc9e9dd8ba",
+    name = "Fireshrieker",
+    setCode = "M14",
+    collectorNumber = "210",
+    scryfallId = "9f653742-b92a-4cfa-b3b5-8d20aabdb5dd",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f653742-b92a-4cfa-b3b5-8d20aabdb5dd.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FogReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FogReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fog reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val FogReprint = Printing(
+    oracleId = "27e9db49-7af7-4bef-ad4c-bf5dfb92030d",
+    name = "Fog",
+    setCode = "M14",
+    collectorNumber = "171",
+    scryfallId = "8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b55d04f-c52f-4b94-b25c-f5c7d8c1c18e.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GaleriderSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GaleriderSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Galerider Sliver
+ * {U}
+ * Creature — Sliver
+ * 1 / 1
+ * Sliver creatures you control have flying.
+ */
+val GaleriderSliver = card("Galerider Sliver") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "Sliver creatures you control have flying."
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.FLYING,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "James Zapata"
+        flavorText = "Masters of adaptation, galeriders serve multiple purposes useful to the hive. When they're not patrolling their territories, their majestic wings serve to circulate cool air through the vast hive chambers."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GladecoverScoutReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GladecoverScoutReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gladecover Scout reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val GladecoverScoutReprint = Printing(
+    oracleId = "385c1208-bfea-44e2-b236-4f38bc90db9f",
+    name = "Gladecover Scout",
+    setCode = "M14",
+    collectorNumber = "176",
+    scryfallId = "e112d77d-f019-4709-b31a-b02952df0e35",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e112d77d-f019-4709-b31a-b02952df0e35.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GlimpseTheFuture.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GlimpseTheFuture.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glimpse the Future
+ * {2}{U}
+ * Sorcery
+ * Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+ */
+val GlimpseTheFuture = card("Glimpse the Future") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(count = 3, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Andrew Robinson"
+        flavorText = "\"No simple coin toss can solve this riddle. You must think and choose wisely.\"\n" +
+            "—Shai Fusan, archmage"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GriffinSentinelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GriffinSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griffin Sentinel reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val GriffinSentinelReprint = Printing(
+    oracleId = "72df0b70-5c9f-44f3-96d5-81c95abc0065",
+    name = "Griffin Sentinel",
+    setCode = "M14",
+    collectorNumber = "20",
+    scryfallId = "b40d6626-a85f-4116-9721-19e39b83cba0",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b40d6626-a85f-4116-9721-19e39b83cba0.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GroundshakerSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GroundshakerSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Groundshaker Sliver
+ * {6}{G}
+ * Creature — Sliver
+ * 5 / 5
+ * Sliver creatures you control have trample. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)
+ */
+val GroundshakerSliver = card("Groundshaker Sliver") {
+    manaCost = "{6}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 5
+    toughness = 5
+    oracleText = "Sliver creatures you control have trample. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.TRAMPLE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Chase Stone"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/HiveStirrings.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/HiveStirrings.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hive Stirrings
+ * {2}{W}
+ * Sorcery
+ * Create two 1/1 colorless Sliver creature tokens.
+ *
+ * The tokens are colorless, i.e. an empty `colors` set. Their art comes from the set's token
+ * registry, so no `imageUri` is baked into the token here.
+ */
+val HiveStirrings = card("Hive Stirrings") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 colorless Sliver creature tokens."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Sliver"),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Maciej Kuciara"
+        flavorText = "Sliver young are sorted into clutches according to their potential and their future role. Human scholars can only guess how those are determined."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/HowlOfTheNightPackReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/HowlOfTheNightPackReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Howl of the Night Pack reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val HowlOfTheNightPackReprint = Printing(
+    oracleId = "868b758c-e21c-4079-a1fc-4c89af106f4b",
+    name = "Howl of the Night Pack",
+    setCode = "M14",
+    collectorNumber = "178",
+    scryfallId = "20fc5ff1-b8bd-44d5-a659-17eeae06736a",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20fc5ff1-b8bd-44d5-a659-17eeae06736a.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/LiturgyOfBlood.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/LiturgyOfBlood.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Liturgy of Blood
+ * {3}{B}{B}
+ * Sorcery
+ * Destroy target creature. Add {B}{B}{B}.
+ */
+val LiturgyOfBlood = card("Liturgy of Blood") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Add {B}{B}{B}."
+
+    spell {
+        val victim = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.Destroy(victim),
+            Effects.AddMana(Color.BLACK, 3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Zack Stella"
+        flavorText = "\"You harbor such vast potential. It would be such a shame to let you die of old age.\"\n" +
+            "—Zul Ashur, lich lord"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Magic2014BasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Magic2014BasicLands.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** Magic 2014's four art variants for each basic land type (collector numbers 230–249). */
+
+val Magic2014Plains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/334ca29a-7fb3-426f-922b-5a2b905a5565.jpg?1783939891"
+}
+
+val Magic2014Plains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d8098d41-38dc-4f82-b65e-d3bc7d8e0fcc.jpg?1783939890"
+}
+
+val Magic2014Plains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "Nils Hamm"
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/241d9f61-b94d-4ba3-b709-791ec647a716.jpg?1783939890"
+}
+
+val Magic2014Plains233 = basicLand("Plains") {
+    collectorNumber = "233"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90742ab3-89fb-4ac1-9bf0-0e2d17252bff.jpg?1783939891"
+}
+
+val Magic2014Island234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94de0250-53a6-45c8-85a7-a473f271102e.jpg?1783939889"
+}
+
+val Magic2014Island235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d2814990-4c7a-44ae-8d76-157156aa79bb.jpg?1783939889"
+}
+
+val Magic2014Island236 = basicLand("Island") {
+    collectorNumber = "236"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78d37787-be3a-4ed3-94b8-e675f2beecf0.jpg?1783939888"
+}
+
+val Magic2014Island237 = basicLand("Island") {
+    collectorNumber = "237"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b59cd300-c4f3-4ba6-8018-134eaf6a399c.jpg?1783939888"
+}
+
+val Magic2014Swamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/4510090f-b42d-4df1-af71-64a77dfbc1b2.jpg?1783939887"
+}
+
+val Magic2014Swamp239 = basicLand("Swamp") {
+    collectorNumber = "239"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2cce9570-e5d7-44e5-bc93-6d03dd1a3794.jpg?1783939888"
+}
+
+val Magic2014Swamp240 = basicLand("Swamp") {
+    collectorNumber = "240"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3ce4394a-14c9-4a6e-898c-056108b16e09.jpg?1783939886"
+}
+
+val Magic2014Swamp241 = basicLand("Swamp") {
+    collectorNumber = "241"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/0/7/07504e2d-9d70-4957-bee6-abab92368a33.jpg?1783939887"
+}
+
+val Magic2014Mountain242 = basicLand("Mountain") {
+    collectorNumber = "242"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e82bb8b-2a95-4935-a728-6898f64ce39a.jpg?1783939886"
+}
+
+val Magic2014Mountain243 = basicLand("Mountain") {
+    collectorNumber = "243"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1ffc2e95-dd9b-4581-988f-850d9e240a30.jpg?1783939886"
+}
+
+val Magic2014Mountain244 = basicLand("Mountain") {
+    collectorNumber = "244"
+    artist = "Karl Kopinski"
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67057abf-749d-4512-968a-832c56324e13.jpg?1783939886"
+}
+
+val Magic2014Mountain245 = basicLand("Mountain") {
+    collectorNumber = "245"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15c28158-fb96-4006-bc65-425dba031395.jpg?1783939886"
+}
+
+val Magic2014Forest246 = basicLand("Forest") {
+    collectorNumber = "246"
+    artist = "Volkan Baǵa"
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b5277ee-f1e0-4777-9011-d7a23c855919.jpg?1783939885"
+}
+
+val Magic2014Forest247 = basicLand("Forest") {
+    collectorNumber = "247"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd98de13-d556-4cf3-99f3-d1c0db85cb3f.jpg?1783939885"
+}
+
+val Magic2014Forest248 = basicLand("Forest") {
+    collectorNumber = "248"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04db1116-3819-4a57-a001-dfa7578f0f12.jpg?1783939887"
+}
+
+val Magic2014Forest249 = basicLand("Forest") {
+    collectorNumber = "249"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10b3dce8-9c28-41f6-823f-a7d64dd9e33a.jpg?1783939886"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ManaweftSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ManaweftSliver.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Manaweft Sliver
+ * {1}{G}
+ * Creature — Sliver
+ * 1 / 1
+ * Sliver creatures you control have "{T}: Add one mana of any color."
+ */
+val ManaweftSliver = card("Manaweft Sliver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "Sliver creatures you control have \"{T}: Add one mana of any color.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddManaOfChoice(),
+                timing = TimingRule.ManaAbility,
+                isManaAbility = true
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Trevor Claxton"
+        flavorText = "\"I see in their interconnectedness a strange embodiment of the natural order.\"\n" +
+            "—Dionus, elvish archdruid"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MeganticSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MeganticSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Megantic Sliver
+ * {5}{G}
+ * Creature — Sliver
+ * 3 / 3
+ * Sliver creatures you control get +3/+3.
+ */
+val MeganticSliver = card("Megantic Sliver") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 3
+    toughness = 3
+    oracleText = "Sliver creatures you control get +3/+3."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 3,
+            toughnessBonus = 3,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "185"
+        artist = "Ryan Barger"
+        flavorText = "Even the thrums, the lowliest of slivers, become deadly in its presence."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MessengerDrake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MessengerDrake.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Messenger Drake
+ * {3}{U}{U}
+ * Creature — Drake
+ * 3 / 3
+ * Flying
+ * When this creature dies, draw a card.
+ */
+val MessengerDrake = card("Messenger Drake") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+            "When this creature dies, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+        description = "When this creature dies, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Yeong-Hao Han"
+        flavorText = "The more important the message, the larger the messenger."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/NephaliaSeakiteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/NephaliaSeakiteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nephalia Seakite reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val NephaliaSeakiteReprint = Printing(
+    oracleId = "379ef166-a29f-4715-8ce4-9d7d567e4e91",
+    name = "Nephalia Seakite",
+    setCode = "M14",
+    collectorNumber = "65",
+    scryfallId = "39714ec8-b43c-4d61-9e53-46ac62da2c9f",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39714ec8-b43c-4d61-9e53-46ac62da2c9f.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/OathOfTheAncientWood.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/OathOfTheAncientWood.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Oath of the Ancient Wood
+ * {2}{G}
+ * Enchantment
+ * Whenever this enchantment or another enchantment you control enters, you may put a +1/+1 counter on target creature.
+ */
+val OathOfTheAncientWood = card("Oath of the Ancient Wood") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever this enchantment or another enchantment you control enters, you may put a +1/+1 counter on target creature."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        val recipient = target("target", TargetCreature(filter = TargetFilter.Creature))
+        optional = true
+        effect = Effects.AddCounters("+1/+1", 1, recipient)
+        description = "Whenever this enchantment or another enchantment you control enters, " +
+            "you may put a +1/+1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "187"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Some gaze upon the forest and see trees. I see true power.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/OpportunityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/OpportunityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Opportunity reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val OpportunityReprint = Printing(
+    oracleId = "1f544a9f-c238-4858-be19-d6cd7d023dcc",
+    name = "Opportunity",
+    setCode = "M14",
+    collectorNumber = "66",
+    scryfallId = "e1b242f3-9398-4d65-a2c7-4de56ee58933",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1b242f3-9398-4d65-a2c7-4de56ee58933.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PitchburnDevilsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PitchburnDevilsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pitchburn Devils reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val PitchburnDevilsReprint = Printing(
+    oracleId = "86e2bbdd-a788-4f76-9ebb-ef48d9bc9dcf",
+    name = "Pitchburn Devils",
+    setCode = "M14",
+    collectorNumber = "149",
+    scryfallId = "f9e0a702-6984-4ccd-9ce8-4518c9b19e22",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9e0a702-6984-4ccd-9ce8-4518c9b19e22.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PlanarCleansingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PlanarCleansingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Planar Cleansing reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val PlanarCleansingReprint = Printing(
+    oracleId = "a98c2d81-4add-4292-bbdd-e1b69ff936d4",
+    name = "Planar Cleansing",
+    setCode = "M14",
+    collectorNumber = "29",
+    scryfallId = "99873316-4872-4500-a225-cf483e1ebaa9",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99873316-4872-4500-a225-cf483e1ebaa9.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PredatorySliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PredatorySliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Predatory Sliver
+ * {1}{G}
+ * Creature — Sliver
+ * 1 / 1
+ * Sliver creatures you control get +1/+1.
+ */
+val PredatorySliver = card("Predatory Sliver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "Sliver creatures you control get +1/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Mathias Kollros"
+        flavorText = "No matter how much the slivers change, their collective might remains."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RangerSGuileReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RangerSGuileReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ranger's Guile reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val RangerSGuileReprint = Printing(
+    oracleId = "694cb93a-bcc5-44b0-a76c-19ae4a4e5e0f",
+    name = "Ranger's Guile",
+    setCode = "M14",
+    collectorNumber = "191",
+    scryfallId = "24976e3a-9f34-4dce-8bb3-efecfdfff160",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24976e3a-9f34-4dce-8bb3-efecfdfff160.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SeacoastDrake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SeacoastDrake.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seacoast Drake
+ * {1}{U}
+ * Creature — Drake
+ * 1 / 3
+ * Flying
+ */
+val SeacoastDrake = card("Seacoast Drake") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 1
+    toughness = 3
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Scott Chou"
+        flavorText = "Seacoast drakes have been known to follow ships for hundreds of miles, waiting to snap up garbage, bait, and the occasional sailor."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SensoryDeprivationReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SensoryDeprivationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sensory Deprivation reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val SensoryDeprivationReprint = Printing(
+    oracleId = "0006faf6-7a61-426c-9034-579f2cfcfa83",
+    name = "Sensory Deprivation",
+    setCode = "M14",
+    collectorNumber = "71",
+    scryfallId = "7050735c-b232-47a6-a342-01795bfd0d46",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/7050735c-b232-47a6-a342-01795bfd0d46.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SentinelSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SentinelSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sentinel Sliver
+ * {1}{W}
+ * Creature — Sliver
+ * 2 / 2
+ * Sliver creatures you control have vigilance. (Attacking doesn't cause them to tap.)
+ */
+val SentinelSliver = card("Sentinel Sliver") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have vigilance. (Attacking doesn't cause them to tap.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.VIGILANCE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Maciej Kuciara"
+        flavorText = "Through its watchful gaze, all slivers may see."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShimmeringGrottoReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShimmeringGrottoReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shimmering Grotto reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val ShimmeringGrottoReprint = Printing(
+    oracleId = "bae49475-fe01-400b-8959-f0dde959577c",
+    name = "Shimmering Grotto",
+    setCode = "M14",
+    collectorNumber = "229",
+    scryfallId = "7fd26b14-a920-4b82-91b8-8de0e7d03f6e",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7fd26b14-a920-4b82-91b8-8de0e7d03f6e.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShowOfValorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShowOfValorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Show of Valor reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val ShowOfValorReprint = Printing(
+    oracleId = "9645c1cb-2305-4bc0-89d0-a50815e91573",
+    name = "Show of Valor",
+    setCode = "M14",
+    collectorNumber = "33",
+    scryfallId = "c07932c2-7b97-4abe-be2b-02fc04de780f",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c07932c2-7b97-4abe-be2b-02fc04de780f.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShrivelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ShrivelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shrivel reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val ShrivelReprint = Printing(
+    oracleId = "1be478ee-87f3-4265-94d7-08521703c888",
+    name = "Shrivel",
+    setCode = "M14",
+    collectorNumber = "116",
+    scryfallId = "47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47b2ffdd-f8a4-49e4-aab1-a8096ba2b7cb.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SteelformSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SteelformSliver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Steelform Sliver
+ * {2}{W}
+ * Creature — Sliver
+ * 2 / 2
+ * Sliver creatures you control get +0/+1.
+ */
+val SteelformSliver = card("Steelform Sliver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control get +0/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Chase Stone"
+        flavorText = "\"Though the slivers may sometimes resemble us, they are not human. Anyone who fights them must remember this.\"\n" +
+            "—Sarlena, paladin of the Northern Verge"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/StonehornChanter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/StonehornChanter.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stonehorn Chanter
+ * {5}{W}
+ * Creature — Rhino Cleric
+ * 4 / 4
+ * {5}{W}: This creature gains vigilance and lifelink until end of turn.
+ */
+val StonehornChanter = card("Stonehorn Chanter") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rhino Cleric"
+    power = 4
+    toughness = 4
+    oracleText = "{5}{W}: This creature gains vigilance and lifelink until end of turn. (Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{W}")
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self)
+        )
+        description = "{5}{W}: This creature gains vigilance and lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Raymond Swanland"
+        flavorText = "With the Stonehorn, piety and power are one."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/StrikingSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/StrikingSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Striking Sliver
+ * {R}
+ * Creature — Sliver
+ * 1 / 1
+ * Sliver creatures you control have first strike. (They deal combat damage before creatures without first strike.)
+ */
+val StrikingSliver = card("Striking Sliver") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "Sliver creatures you control have first strike. (They deal combat damage before creatures without first strike.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.FIRST_STRIKE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Maciej Kuciara"
+        flavorText = "You're too busy recoiling in fear to realize that it's already hit you."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SyphonSliver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SyphonSliver.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Syphon Sliver
+ * {2}{B}
+ * Creature — Sliver
+ * 2 / 2
+ * Sliver creatures you control have lifelink. (Damage dealt by a Sliver creature you control also causes you to gain that much life.)
+ */
+val SyphonSliver = card("Syphon Sliver") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "Sliver creatures you control have lifelink. (Damage dealt by a Sliver creature you control also causes you to gain that much life.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.LIFELINK,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SLIVER).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "Tyler Jacobson"
+        flavorText = "When the hive must feed, every appendage becomes an additional mouth."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TomeScourReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TomeScourReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tome Scour reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val TomeScourReprint = Printing(
+    oracleId = "446a9d7e-9c1a-4e83-8342-2ed5acae2eed",
+    name = "Tome Scour",
+    setCode = "M14",
+    collectorNumber = "75",
+    scryfallId = "aed4cfec-5cea-4987-890e-825b2802e9f9",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/aed4cfec-5cea-4987-890e-825b2802e9f9.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TradingPostReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TradingPostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trading Post reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val TradingPostReprint = Printing(
+    oracleId = "63788566-e25a-44bb-bb55-197e1b93b3e8",
+    name = "Trading Post",
+    setCode = "M14",
+    collectorNumber = "225",
+    scryfallId = "132c5358-c258-4b86-862a-2d140011dc3f",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/132c5358-c258-4b86-862a-2d140011dc3f.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TrollhideReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/TrollhideReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trollhide reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val TrollhideReprint = Printing(
+    oracleId = "397df813-c759-4246-8def-122c7ff82d88",
+    name = "Trollhide",
+    setCode = "M14",
+    collectorNumber = "197",
+    scryfallId = "08b9c400-dc8f-4fe6-a868-fdf0d247086a",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/08b9c400-dc8f-4fe6-a868-fdf0d247086a.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VampireWarlord.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VampireWarlord.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vampire Warlord
+ * {4}{B}
+ * Creature — Vampire Warrior
+ * 4 / 2
+ * Sacrifice another creature: Regenerate this creature. (The next time this creature would be
+ * destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)
+ */
+val VampireWarlord = card("Vampire Warlord") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warrior"
+    power = 4
+    toughness = 2
+    oracleText = "Sacrifice another creature: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.Creature)
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "Sacrifice another creature: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Wesley Burt"
+        flavorText = "\"How can you serve me? By dying.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VialOfPoison.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VialOfPoison.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Vial of Poison
+ * {1}
+ * Artifact
+ * {1}, Sacrifice this artifact: Target creature gains deathtouch until end of turn.
+ */
+val VialOfPoison = card("Vial of Poison") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        val recipient = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, recipient)
+        description = "{1}, Sacrifice this artifact: Target creature gains deathtouch until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Franz Vohwinkel"
+        flavorText = "There are worse ways to die, but not many."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VolcanicGeyserReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/VolcanicGeyserReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Geyser reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val VolcanicGeyserReprint = Printing(
+    oracleId = "846a4f9c-d955-403f-8a08-5c7c3d32e180",
+    name = "Volcanic Geyser",
+    setCode = "M14",
+    collectorNumber = "160",
+    scryfallId = "3d2b0fdb-2209-4b98-87e1-1eb870706cec",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d2b0fdb-2209-4b98-87e1-1eb870706cec.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WildGuessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WildGuessReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Guess reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val WildGuessReprint = Printing(
+    oracleId = "a05ab59e-680a-4050-aecb-56ee69dcd13f",
+    name = "Wild Guess",
+    setCode = "M14",
+    collectorNumber = "161",
+    scryfallId = "e7c4556f-652b-4df0-a501-d413d32e7a91",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7c4556f-652b-4df0-a501-d413d32e7a91.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WringFleshReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WringFleshReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wring Flesh reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val WringFleshReprint = Printing(
+    oracleId = "45bb536c-c173-4b6e-a5a8-354c74fd93a1",
+    name = "Wring Flesh",
+    setCode = "M14",
+    collectorNumber = "122",
+    scryfallId = "d6b77692-08aa-40b6-b21b-c29a2dc87709",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6b77692-08aa-40b6-b21b-c29a2dc87709.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/XathridNecromancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/XathridNecromancer.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Xathrid Necromancer
+ * {2}{B}
+ * Creature — Human Wizard
+ * 2 / 2
+ * Whenever this creature or another Human creature you control dies, create a tapped 2/2 black Zombie creature token.
+ */
+val XathridNecromancer = card("Xathrid Necromancer") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature or another Human creature you control dies, create a tapped 2/2 black Zombie creature token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            tapped = true
+        )
+        description = "Whenever this creature or another Human creature you control dies, " +
+            "create a tapped 2/2 black Zombie creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Maciej Kuciara"
+        flavorText = "\"My commands shall echo forever in their dusty skulls.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ZephyrCharge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ZephyrCharge.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Zephyr Charge
+ * {1}{U}
+ * Enchantment
+ * {1}{U}: Target creature gains flying until end of turn.
+ */
+val ZephyrCharge = card("Zephyr Charge") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "{1}{U}: Target creature gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Steve Prescott"
+        flavorText = "\"All armies prefer high ground to low and sunny places to dark.\"\n" +
+            "—Sun Tzu, *Art of War*, trans. Giles"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlightcasterReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlightcasterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blightcaster reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val BlightcasterReprint = Printing(
+    oracleId = "b40e2aae-3a1d-4bc2-bf67-e821ec800434",
+    name = "Blightcaster",
+    setCode = "ORI",
+    collectorNumber = "85",
+    scryfallId = "b8986163-6362-4c70-8ece-22ae22da5031",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8986163-6362-4c70-8ece-22ae22da5031.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Shrivel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Shrivel.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Shrivel
+ * {1}{B}
+ * Sorcery
+ * All creatures get -1/-1 until end of turn.
+ *
+ * Canonical printing: Rise of the Eldrazi, the card's earliest printing. Reprinted in M14 as a
+ * `Printing` row.
+ */
+val Shrivel = card("Shrivel") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "All creatures get -1/-1 until end of turn."
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(-1, -1, GroupFilter.AllCreatures)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Jung Park"
+        flavorText = "\"Have you ever killed insects nibbling at your crops? I think that's what the Eldrazi believe they're doing to us.\"\n" +
+            "—Sheyda, Ondu gamekeeper"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HowlOfTheNightPack.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HowlOfTheNightPack.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Howl of the Night Pack
+ * {6}{G}
+ * Sorcery
+ * Create a 2/2 green Wolf creature token for each Forest you control.
+ *
+ * One token-creation effect with a dynamic count, not a repeated one — the Forest tally is read
+ * once on resolution.
+ *
+ * Canonical printing: Shadowmoor, the card's earliest real printing. Reprinted in Magic 2014.
+ */
+val HowlOfTheNightPack = card("Howl of the Night Pack") {
+    manaCost = "{6}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a 2/2 green Wolf creature token for each Forest you control."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.landsWithSubtype(Subtype.FOREST),
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Lars Grant-West"
+        flavorText = "The murderous horrors of Raven's Run are legendary, but even that haunted place goes quiet when the night wolves howl."
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GriffinSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GriffinSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griffin Sentinel reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val GriffinSentinelReprint = Printing(
+    oracleId = "72df0b70-5c9f-44f3-96d5-81c95abc0065",
+    name = "Griffin Sentinel",
+    setCode = "M20",
+    collectorNumber = "21",
+    scryfallId = "cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb13aaa4-d40a-4fb2-9fd6-62bf76db6a13.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PlanarCleansingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PlanarCleansingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Planar Cleansing reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val PlanarCleansingReprint = Printing(
+    oracleId = "a98c2d81-4add-4292-bbdd-e1b69ff936d4",
+    name = "Planar Cleansing",
+    setCode = "M20",
+    collectorNumber = "33",
+    scryfallId = "5eddac86-947e-48c1-9f02-4634a7918c98",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ShowOfValorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ShowOfValorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Show of Valor reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val ShowOfValorReprint = Printing(
+    oracleId = "9645c1cb-2305-4bc0-89d0-a50815e91573",
+    name = "Show of Valor",
+    setCode = "M20",
+    collectorNumber = "311",
+    scryfallId = "1ab07387-a9f2-4325-804e-6383408644fd",
+    artist = "Micah Epstein",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1ab07387-a9f2-4325-804e-6383408644fd.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ZephyrChargeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ZephyrChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zephyr Charge reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val ZephyrChargeReprint = Printing(
+    oracleId = "576128ba-28aa-4ef9-9e72-8ca13f42c9b4",
+    name = "Zephyr Charge",
+    setCode = "M20",
+    collectorNumber = "82",
+    scryfallId = "da749962-25f2-4ddc-9e55-bf74d216284e",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/da749962-25f2-4ddc-9e55-bf74d216284e.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PitchburnDevilsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PitchburnDevilsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pitchburn Devils reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val PitchburnDevilsReprint = Printing(
+    oracleId = "86e2bbdd-a788-4f76-9ebb-ef48d9bc9dcf",
+    name = "Pitchburn Devils",
+    setCode = "M21",
+    collectorNumber = "156",
+    scryfallId = "fbd306cf-6625-4414-b9e5-4b909bb1bb13",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbd306cf-6625-4414-b9e5-4b909bb1bb13.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/TradingPostReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/TradingPostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trading Post reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val TradingPostReprint = Printing(
+    oracleId = "63788566-e25a-44bb-bb55-197e1b93b3e8",
+    name = "Trading Post",
+    setCode = "MSC",
+    collectorNumber = "224",
+    scryfallId = "03499a72-e865-46ff-bcb2-75e53e4b600e",
+    artist = "L.A. Draws",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03499a72-e865-46ff-bcb2-75e53e4b600e.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1414,6 +1414,31 @@
     ]
 }
 
+// Nephalia Seakite
+{
+    "name": "Nephalia Seakite",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Wayne England",
+        "flavorText": "\"Keep one eye on the cliff road or you may fall to your death. Keep one eye on the sky or your death may fall on you.\"\n—Manfried Ulmach, Elgaud Master-at-Arms",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/174a1d08-cd79-43d6-897f-3ee9a682d15e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Niblis of the Urn
 {
     "name": "Niblis of the Urn",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -657,6 +657,44 @@
     ]
 }
 
+// Bramblecrush
+{
+    "name": "Bramblecrush",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target noncreature permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "noncreature permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "UNCOMMON",
+        "artist": "Drew Baker",
+        "flavorText": "\"Civilization is fertilizer.\"\n—Garruk Wildspeaker",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60fa219e-5dba-4d49-9cae-40d254f140e4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bump in the Night
 {
     "name": "Bump in the Night",
@@ -4699,6 +4737,54 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d495d85-6458-44d5-b3b4-5e09569057e3.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Pitchburn Devils
+{
+    "name": "Pitchburn Devils",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "When this creature dies, it deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "artist": "Johann Bodin",
+        "flavorText": "The ingenuity of goblins, the depravity of demons, and the smarts of sheep.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d31d3de5-4028-457f-8eba-82e829061a40.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Purify the Grave

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -229,6 +229,30 @@
     ]
 }
 
+// Deadly Recluse
+{
+    "name": "Deadly Recluse",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "175",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6ab810f1-21d6-4a98-b77a-e455370aa6cc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Disentomb
 {
     "name": "Disentomb",
@@ -717,6 +741,31 @@
     ]
 }
 
+// Griffin Sentinel
+{
+    "name": "Griffin Sentinel",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\nVigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Warren Mahy",
+        "flavorText": "Once a griffin sentinel adopts a territory as its own, only death can force it to betray its post.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/6784b663-b117-45a2-bde4-72e080058ea7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Honor of the Pure
 {
     "name": "Honor of the Pure",
@@ -995,6 +1044,47 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Planar Cleansing
+{
+    "name": "Planar Cleansing",
+    "manaCost": "{3}{W}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all nonland permanents.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "nonland permanent"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Michael Komarck",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30ee0d57-e404-4599-9b6e-f8ab8a95f9fa.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1322,6 +1412,64 @@
     "colorIdentityOverride": [
         "GREEN",
         "WHITE"
+    ]
+}
+
+// Tome Scour
+{
+    "name": "Tome Scour",
+    "manaCost": "{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player mills five cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        },
+                        "isMill": true
+                    },
+                    "storeAs": "milled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "milled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Steven Belledin",
+        "flavorText": "Genius is overrated, especially when it's someone else's.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdbdf96b-e7c5-42e5-9a16-03daafde40af.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -296,6 +296,55 @@
     "colorIdentityOverride": []
 }
 
+// Dark Favor
+{
+    "name": "Dark Favor",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, you lose 1 life.\nEnchanted creature gets +3/+1.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Controller"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Allen Williams",
+        "flavorText": "When he began to curse what he held holy, his strength grew unrivaled.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a258a235-086e-429b-9ac1-3178f902658b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Devouring Swarm
 {
     "name": "Devouring Swarm",
@@ -449,6 +498,30 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Gladecover Scout
+{
+    "name": "Gladecover Scout",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Allen Williams",
+        "flavorText": "\"The forest is my cover and I hold it close. In such a tight embrace, there is no room for wickedness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26710d5c-01d1-498b-9f54-521dfd195843.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -805,6 +878,54 @@
     ]
 }
 
+// Trollhide
+{
+    "name": "Trollhide",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{1}{G}: Regenerate this creature.\" (The next time the creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{1}{G}"
+                        }
+                    },
+                    "effect": {
+                        "type": "Regenerate",
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Steven Belledin",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32c8d6ed-4764-433b-9617-363e46e5b250.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Warstorm Surge
 {
     "name": "Warstorm Surge",
@@ -860,5 +981,48 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Wring Flesh
+{
+    "name": "Wring Flesh",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -3/-1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -1
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Izzy",
+        "flavorText": "\"Don't blame me. You're the one walking around with skin.\"\n—Zul Ashur, lich lord",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/663df3e8-12e5-46cf-9da7-39961feaa7f9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -657,6 +657,49 @@
     ]
 }
 
+// Show of Valor
+{
+    "name": "Show of Valor",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Anthony Palumbo",
+        "flavorText": "\"Duty, honor, and valor are either in your heart or they are not. You will never know for certain until you are tested.\"\n—Ajani Goldmane",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abe4d19d-1c9f-4b05-bde2-a9290b52c28d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Talrand's Invocation
 {
     "name": "Talrand's Invocation",
@@ -812,6 +855,161 @@
     ]
 }
 
+// Trading Post
+{
+    "name": "Trading Post",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}, Discard a card: You gain 4 life.\n{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token.\n{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand.\n{1}, {T}, Sacrifice an artifact: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "{1}, {T}, Discard a card: You gain 4 life."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Goat"
+                    ]
+                },
+                "descriptionOverride": "{1}, {T}, Pay 1 life: Create a 0/1 white Goat creature token."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact card from your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{1}, {T}, Sacrifice a creature: Return target artifact card from your graveyard to your hand."
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{1}, {T}, Sacrifice an artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20604b28-d096-40f8-a30c-3bc89e708676.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Watercourser
 {
     "name": "Watercourser",
@@ -856,6 +1054,38 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wild Guess
+{
+    "name": "Wild Guess",
+    "manaCost": "{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Lucas Graciano",
+        "flavorText": "No guts, no glory.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4e513b8-25c2-4645-abcc-a6e9d5f51e09.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -22,6 +22,56 @@
     ]
 }
 
+// Advocate of the Beast
+{
+    "name": "Advocate of the Beast",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Beast creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Beast ctrl:you"
+                    },
+                    "id": "target Beast creature you control"
+                },
+                "descriptionOverride": "At the beginning of your end step, put a +1/+1 counter on target Beast creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"I am neither their drover nor their leader. To these majestic beasts, I am simply their herdmate and nothing more.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1320400-5aa8-48d6-be84-197b4559456f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Barrage of Expendables
 {
     "name": "Barrage of Expendables",
@@ -78,6 +128,220 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Battle Sliver
+{
+    "name": "Battle Sliver",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control get +2/+0.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "UNCOMMON",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"One emitted a strange series of buzzing clicks and guttural commands, then clawed arms emerged from all of them. Is there no limit to their adaptations?\"\n—Hastric, Thunian scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68490b8c-e9d1-4f5c-9001-750be0e0569f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blightcaster
+{
+    "name": "Blightcaster",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "descriptionOverride": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you cast an enchantment spell, you may have target creature get -2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"Your flesh is unprepared for my gifts.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61752b13-255a-44d0-9fb0-5ed5680b954e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blood Bairn
+{
+    "name": "Blood Bairn",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Sacrifice another creature: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Sacrifice another creature: This creature gets +2/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Ryan Yee",
+        "flavorText": "The travelers were warned to watch out for children on the road.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3fcbbd1-ee51-42a3-ad11-2fd41728c35d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blur Sliver
+{
+    "name": "Blur Sliver",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have haste. (They can attack and {T} as soon as they come under your control.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Daarken",
+        "flavorText": "They move in a synchronized swarm, turning entire squads into heaps of bloody rags and bones in an instant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63227937-86cc-45e0-9e9e-8c7ab80cbaef.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bonescythe Sliver
+{
+    "name": "Bonescythe Sliver",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have double strike. (They deal both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Trevor Claxton",
+        "flavorText": "\"Their appendages are sharper than our swords and quicker than our bows.\"\n—Hastric, Thunian scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a26bb68b-1830-470a-8cea-91edc7db0c57.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -168,6 +432,56 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Dawnstrike Paladin
+{
+    "name": "Dawnstrike Paladin",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Tyler Jacobson",
+        "flavorText": "She crushes darkness beneath her charger's hooves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93cf5fb3-bb41-4efa-9721-2c2d169b05cd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Deathgaze Cockatrice
+{
+    "name": "Deathgaze Cockatrice",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Cockatrice",
+    "oracleText": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Kev Walker",
+        "flavorText": "\"Sometimes I come across a stone finger or foot and I know I'm in cockatrice territory.\"\n—Rulak, bog guide",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f17b58c-9738-4cdb-a408-e1595c384b92.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -282,6 +596,106 @@
     "colorIdentityOverride": []
 }
 
+// Galerider Sliver
+{
+    "name": "Galerider Sliver",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "James Zapata",
+        "flavorText": "Masters of adaptation, galeriders serve multiple purposes useful to the hive. When they're not patrolling their territories, their majestic wings serve to circulate cool air through the vast hive chambers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/425f5d1b-9989-4fd1-88e2-6c3108aefa0b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Glimpse the Future
+{
+    "name": "Glimpse the Future",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put in graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Robinson",
+        "flavorText": "\"No simple coin toss can solve this riddle. You must think and choose wisely.\"\n—Shai Fusan, archmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4d875e9-713d-4ddb-ae0a-db8483366319.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Gnawing Zombie
 {
     "name": "Gnawing Zombie",
@@ -359,6 +773,69 @@
     ]
 }
 
+// Groundshaker Sliver
+{
+    "name": "Groundshaker Sliver",
+    "manaCost": "{6}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have trample. (A creature with trample can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Chase Stone",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/712f0ce4-9189-4c75-9c2b-d370bce89052.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hive Stirrings
+{
+    "name": "Hive Stirrings",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 1/1 colorless Sliver creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [],
+            "creatureTypes": [
+                "Sliver"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Maciej Kuciara",
+        "flavorText": "Sliver young are sorted into clutches according to their potential and their future role. Human scholars can only guess how those are determined.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4399e19-d05d-4bb3-9aff-c4133ddd2850.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kalonian Tusker
 {
     "name": "Kalonian Tusker",
@@ -377,6 +854,173 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Liturgy of Blood
+{
+    "name": "Liturgy of Blood",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. Add {B}{B}{B}.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "AddMana",
+                    "color": "BLACK",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "artist": "Zack Stella",
+        "flavorText": "\"You harbor such vast potential. It would be such a shame to let you die of old age.\"\n—Zul Ashur, lich lord",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/3532105d-c550-4c20-8465-a6a19169efbd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Manaweft Sliver
+{
+    "name": "Manaweft Sliver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have \"{T}: Add one mana of any color.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": "AddManaOfChoice",
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Trevor Claxton",
+        "flavorText": "\"I see in their interconnectedness a strange embodiment of the natural order.\"\n—Dionus, elvish archdruid",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe45433b-e124-44d7-9463-dada39310148.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Megantic Sliver
+{
+    "name": "Megantic Sliver",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control get +3/+3.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3,
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "RARE",
+        "artist": "Ryan Barger",
+        "flavorText": "Even the thrums, the lowliest of slivers, become deadly in its presence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/7745f6a9-400c-4200-9732-86c54247de46.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Messenger Drake
+{
+    "name": "Messenger Drake",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature dies, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "The more important the message, the larger the messenger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13dd3172-0b45-4dc8-adc6-9e0ba112e664.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -468,6 +1112,92 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Oath of the Ancient Wood
+{
+    "name": "Oath of the Ancient Wood",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever this enchantment or another enchantment you control enters, you may put a +1/+1 counter on target creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "descriptionOverride": "Whenever this enchantment or another enchantment you control enters, you may put a +1/+1 counter on target creature."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever this enchantment or another enchantment you control enters, you may put a +1/+1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "RARE",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Some gaze upon the forest and see trees. I see true power.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Predatory Sliver
+{
+    "name": "Predatory Sliver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Mathias Kollros",
+        "flavorText": "No matter how much the slivers change, their collective might remains.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2e37de8-66a1-4afa-aa6f-1151f849dfa8.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -649,6 +1379,62 @@
     ]
 }
 
+// Seacoast Drake
+{
+    "name": "Seacoast Drake",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Scott Chou",
+        "flavorText": "Seacoast drakes have been known to follow ships for hundreds of miles, waiting to snap up garbage, bait, and the occasional sailor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5333de10-a6d4-47ff-ab57-4edb49535739.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sentinel Sliver
+{
+    "name": "Sentinel Sliver",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have vigilance. (Attacking doesn't cause them to tap.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Maciej Kuciara",
+        "flavorText": "Through its watchful gaze, all slivers may see.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74c28560-e6ac-4be9-a253-22c4613b0d90.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sliver Construct
 {
     "name": "Sliver Construct",
@@ -748,6 +1534,157 @@
     ]
 }
 
+// Steelform Sliver
+{
+    "name": "Steelform Sliver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control get +0/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Chase Stone",
+        "flavorText": "\"Though the slivers may sometimes resemble us, they are not human. Anyone who fights them must remember this.\"\n—Sarlena, paladin of the Northern Verge",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c15d6329-ffb1-43fd-8558-60c8315f5b91.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Stonehorn Chanter
+{
+    "name": "Stonehorn Chanter",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Rhino Cleric",
+    "oracleText": "{5}{W}: This creature gains vigilance and lifelink until end of turn. (Attacking doesn't cause it to tap. Damage dealt by it also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{5}{W}: This creature gains vigilance and lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Swanland",
+        "flavorText": "With the Stonehorn, piety and power are one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd6ec61b-c039-4526-a359-a7947eeba5c3.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Striking Sliver
+{
+    "name": "Striking Sliver",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have first strike. (They deal combat damage before creatures without first strike.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Maciej Kuciara",
+        "flavorText": "You're too busy recoiling in fear to realize that it's already hit you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ee9254b-3d98-4477-a82e-1450cf3ee96e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Syphon Sliver
+{
+    "name": "Syphon Sliver",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "Sliver creatures you control have lifelink. (Damage dealt by a Sliver creature you control also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK",
+                "filter": {
+                    "baseFilter": "creature Sliver ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "Tyler Jacobson",
+        "flavorText": "When the hive must feed, every appendage becomes an additional mouth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85cb40e3-c3ed-4b3f-88ad-6f1305297c6f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Undead Minotaur
 {
     "name": "Undead Minotaur",
@@ -766,6 +1703,102 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Vampire Warlord
+{
+    "name": "Vampire Warlord",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire Warrior",
+    "oracleText": "Sacrifice another creature: Regenerate this creature. (The next time this creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Sacrifice another creature: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Wesley Burt",
+        "flavorText": "\"How can you serve me? By dying.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e07929b-450c-45b0-85e6-512ad280a122.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vial of Poison
+{
+    "name": "Vial of Poison",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Target creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}, Sacrifice this artifact: Target creature gains deathtouch until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "There are worse ways to die, but not many.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/7769159b-5a6a-45e5-b69b-8db2a6ef5418.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Woodborn Behemoth
@@ -842,6 +1875,55 @@
     ]
 }
 
+// Xathrid Necromancer
+{
+    "name": "Xathrid Necromancer",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Whenever this creature or another Human creature you control dies, create a tapped 2/2 black Zombie creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Human ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "tapped": true
+                },
+                "descriptionOverride": "Whenever this creature or another Human creature you control dies, create a tapped 2/2 black Zombie creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Maciej Kuciara",
+        "flavorText": "\"My commands shall echo forever in their dusty skulls.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26494f96-1d97-4435-a116-3ade1becaab4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Young Pyromancer
 {
     "name": "Young Pyromancer",
@@ -900,5 +1982,53 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Zephyr Charge
+{
+    "name": "Zephyr Charge",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}{U}: Target creature gains flying until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Steve Prescott",
+        "flavorText": "\"All armies prefer high ground to low and sunny places to dark.\"\n—Sun Tzu, *Art of War*, trans. Giles",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9ea2808-0dde-4065-ae7d-905aae98703f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -932,6 +932,46 @@
     ]
 }
 
+// Shrivel
+{
+    "name": "Shrivel",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "All creatures get -1/-1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Jung Park",
+        "flavorText": "\"Have you ever killed insects nibbling at your crops? I think that's what the Eldrazi believe they're doing to us.\"\n—Sheyda, Ondu gamekeeper",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a87c80a1-5818-45fd-9a37-a2ee3396626e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Wildheart Invoker
 {
     "name": "Wildheart Invoker",

--- a/mtg-sets/src/test/resources/snapshots/cards/SHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SHM.json
@@ -1550,6 +1550,42 @@
     }
 }
 
+// Howl of the Night Pack
+{
+    "name": "Howl of the Night Pack",
+    "manaCost": "{6}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 2/2 green Wolf creature token for each Forest you control.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land Forest"
+            },
+            "power": 2,
+            "toughness": 2,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Wolf"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "The murderous horrors of Raven's Run are legendary, but even that haunted place goes quiet when the night wolves howl.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/293f7768-6279-4f26-979f-ea4e48095ae5.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hungry Spriggan
 {
     "name": "Hungry Spriggan",


### PR DESCRIPTION
Sweeps Magic 2014's ⚡ Assay-ready list to zero — the cards Argentum Assay reads whole that the set had not authored.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 28 | canonical `card(...)` authored in M14 |
| `elsewhere` | 16 | canonical authored in its earliest real printing, + an M14 `Printing` row |
| `row-only` | 10 | canonical already in the corpus — M14 `Printing` row only |
| `basic` | 5 | 20 `basicLand(...)` art variants (230–249) + the `basicLands` override on `Magic2014Set` |
| `unscaffolded` | 0 | — |

**Reprint tail: 19 rows in 13 other sets.** Authoring the 16 `elsewhere` canonicals made `check-card-printing` able to see that their *other* scaffolded printings had no rows either, so those land here too: M20 ×4, M13 ×3, DDL ×2, and one each in C14, C15, C16, CMD, M10, M11, M12, M21, MSC, ORI.

91 files, +2757 lines. `generate-reprints.py --since main` was run scoped to this branch's canonicals and reported **0 misplaced canonicals, 0 stale cache**; its 35 rows matched the pre-computed tail exactly. All 54 printing caches were refreshed first (the silent-skip trap — a cache past its 30-day TTL is dropped without a word).

### Where the canonicals went
- **ISD** — Bramblecrush, Pitchburn Devils
- **DKA** — Nephalia Seakite
- **M10** — Deadly Recluse, Griffin Sentinel, Planar Cleansing, Tome Scour
- **M12** — Dark Favor, Gladecover Scout, Trollhide, Wring Flesh
- **M13** — Show of Valor, Trading Post, Wild Guess
- **ROE** — Shrivel
- **SHM** — Howl of the Night Pack

## Assay-ready count

**59 → 0**, measured by re-running `just assay-ready M14` on this branch, not inferred:

```
M14 — Magic 2014
  97 missing: 0 Assay-ready, 97 declined, 0 absent from the ledger
  declines: LINE_DECLINED 96, MULTI_FACE 1
  nothing Assay-ready — this set's tail is grammar work, not authoring work.
```

M14's remaining 97 missing cards are all grammar work, not authoring work.

## Method

Every card was authored to `oracle-assay compile`'s JSON rather than to the oracle text, via per-card briefs carrying the authoritative Scryfall metadata pre-filled into a `card(...)` skeleton plus the compile JSON as the model. Metadata was diffed back mechanically, scoped inside each file's `metadata { }` block (the naive first-match regex hits a `CreateToken` `imageUri` instead): **44/44 files match their briefs.**

### Capability pre-flight
Clean. Every keyword the batch touches is engine-live evergreen — flying, vigilance, lifelink, deathtouch, reach, hexproof, flash, haste, trample, first strike, double strike. No display-only keyword (cascade/modular/annihilator/vanishing class) appears, so no card in this batch renders a line the engine ignores. **No new SDK vocabulary**; every shape composes existing primitives with a corpus precedent:

| Shape | Precedent |
|---|---|
| Sliver lord — stat pump | `plc/cards/SinewSliver.kt` |
| Sliver lord — keyword grant | `tmp/cards/WingedSliver.kt` |
| Sliver lord — granted mana ability | `tsp/cards/GemhideSliver.kt` |
| Token creation | `isd/cards/MausoleumGuard.kt` |
| Aura with a stat buff + ETB | `m12/cards/DivineFavor.kt` |
| Aura granting a quoted activated ability | `emn/cards/LunarchMantle.kt` |

## Verification

| Gate | Result |
|---|---|
| `just assay-ready M14` on the branch | **59 → 0** — measured, not inferred |
| `just assay-differential` | **6099 compared / 6045 confirmed / 54 divergent** |
| `just rebless-cards` | 44 card blocks added, **0 pre-existing blocks changed, 0 lost** |
| `generate-reprints.py --since main` | 0 misplaced canonicals, 0 stale cache; row count matched the prediction |
| metadata diff vs. the briefs | 44/44 |
| CI — scenarios ×4, engine, server, tools, frontend, `FacadeBoundaryTest` | pass |

**The differential is the headline: zero new divergences.** Against the merge-base baseline of
6055 / 6001 / 54, this branch is 6099 / 6045 / 54 — **+44 compared, +44 confirmed, divergent
unchanged**. Every one of the 44 authored cards round-trips to the model Assay reads, and none of
them appears anywhere in the divergence report. The 54 are pre-existing and untouched by this PR.

Authoring to `compile`'s JSON instead of to the oracle text is what bought that; sweeps written
from the oracle text have historically landed real defects in the `staticAbilities`/filter layer
that no other gate inspects.

`CardDefinitionSnapshotTest` failed on the first CI run for the eight sets this PR adds cards to.
That was the expected intentional rebless, fixed in 8d4db005be and verified card-for-card rather
than by line count — the diff's 49 deletions are pure re-ordering, since the goldens are
name-sorted and new names shift existing blocks.

## Findings not fixed here

- **M14 declares no `tokenArt`.** Hive Stirrings mints a Sliver token and Xathrid Necromancer a Zombie; both fall through `TokenArtRegistry` to generic art. Trading Post's Goat (M13) and Howl of the Night Pack's Wolf (SHM) are in the same position. Fixing it means committing local image assets under `/images/tokens/`, which is `verify-set` territory rather than an Assay-ready sweep — flagged rather than done.
- **`imageUri` timestamp suffixes are inconsistent corpus-wide** (12,055 rows carry `?<ts>`, 7,000 do not). This batch copies whatever the Scryfall cache held, so it inherits both styles. Cosmetic, pre-existing, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

