### PR TITLE
Add 59 Assay-ready cards to Avacyn Restored

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/Thunderbolt.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/Thunderbolt.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.wth.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Thunderbolt
+ * {1}{R}
+ * Instant
+ *
+ * Choose one —
+ * - Thunderbolt deals 3 damage to target player or planeswalker.
+ * - Thunderbolt deals 4 damage to target creature with flying.
+ *
+ * An ordinary "choose one" — two modes, one pick, each carrying its own target. The second mode is
+ * narrowed to creatures *with flying*, which the target legality check reads off projected state,
+ * so a creature that lost flying this turn is no longer a legal choice.
+ */
+val Thunderbolt = card("Thunderbolt") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Thunderbolt deals 3 damage to target player or planeswalker.\n" +
+        "• Thunderbolt deals 4 damage to target creature with flying."
+
+    spell {
+        modal {
+            mode("Thunderbolt deals 3 damage to target player or planeswalker") {
+                val t = target("target", Targets.PlayerOrPlaneswalker)
+                effect = Effects.DealDamage(3, t)
+            }
+            mode("Thunderbolt deals 4 damage to target creature with flying") {
+                val flier = target(
+                    "target",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING)))
+                )
+                effect = Effects.DealDamage(4, flier)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Dylan Martens"
+        flavorText = "\"Most wizards consider a thunderbolt to be a proper retort.\"\n—Ertai, wizard adept"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg?1783946723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/AvacynRestoredSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/AvacynRestoredSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.avr
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -23,11 +22,15 @@ object AvacynRestoredSet : MtgSet {
     override val displayName = "Avacyn Restored"
     override val releaseDate = "2012-05-04"
     override val block = "Innistrad"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    /** Avacyn Restored's own basics: three arts each of the five types, collector numbers 230-244. */
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AlchemistsApprentice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AlchemistsApprentice.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alchemist's Apprentice
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1 / 1
+ *
+ * Sacrifice this creature: Draw a card.
+ */
+val AlchemistsApprentice = card("Alchemist's Apprentice") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: Draw a card."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "David Palumbo"
+        flavorText = "Side effects may include foul odors, scalding steam, and spontaneous nonexistence."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg?1783940724"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelOfGlorysRise.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelOfGlorysRise.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angel of Glory's Rise — Avacyn Restored #1
+ * {5}{W}{W} · Creature — Angel · 4/6
+ *
+ * Flying
+ * When this creature enters, exile all Zombies, then return all Human creature cards from your
+ * graveyard to the battlefield.
+ *
+ * The two halves are sequenced inside one [Effects.Composite] so the exile finishes before the
+ * reanimation begins — a Human Zombie is exiled by the first half and therefore never seen by the
+ * second, which is the printed ordering.
+ *
+ * "All Zombies" is a bare tribal noun, so it names *permanents* with the subtype (a Zombie
+ * artifact or land counts), not only creatures; "Human creature cards" is explicit about the card
+ * type and keeps [GameObjectFilter.Creature] as its base. The exile half is a per-permanent sweep
+ * ([Effects.ForEachInGroup] with `EffectTarget.Self` bound to each member); the return half is the
+ * gather → move pipeline the corpus writes for a mass graveyard return.
+ */
+val AngelOfGlorysRise = card("Angel of Glory's Rise") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 4
+    toughness = 6
+    oracleText = "Flying\n" +
+        "When this creature enters, exile all Zombies, then return all Human creature cards from your " +
+        "graveyard to the battlefield."
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Permanent.withSubtype("Zombie")),
+                Effects.Exile(EffectTarget.Self)
+            ),
+            Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        Zone.GRAVEYARD,
+                        Player.You,
+                        GameObjectFilter.Creature.withSubtype("Human")
+                    ),
+                    storeAs = "graveyard_lands",
+                ),
+                MoveCollectionEffect(
+                    from = "graveyard_lands",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "James Ryman"
+        flavorText = "\"Justice isn't done until undeath is undone.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg?1783940744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelsMercyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelsMercyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Mercy reprint in AVR. Canonical CardDefinition lives in its earliest set (M10).
+ */
+val AngelsMercyReprint = Printing(
+    oracleId = "6b232bb7-d372-4174-a049-5f8d620810e6",
+    name = "Angel's Mercy",
+    setCode = "AVR",
+    collectorNumber = "3",
+    scryfallId = "7a437999-26ae-49fa-8647-c8c2b4640702",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a437999-26ae-49fa-8647-c8c2b4640702.jpg?1783940744",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ArchwingDragon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ArchwingDragon.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Archwing Dragon
+ * {2}{R}{R}
+ * Creature — Dragon
+ * 4 / 4
+ *
+ * Flying, haste
+ * At the beginning of the end step, return this creature to its owner's hand.
+ *
+ * "The end step" carries no possessive, so the trigger is [Triggers.EachEndStep]
+ * (`StepEvent(Step.END, Player.Each)`) — the Dragon bounces at the end of *every* turn, not only
+ * its controller's.
+ */
+val ArchwingDragon = card("Archwing Dragon") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying, haste\n" +
+        "At the beginning of the end step, return this creature to its owner's hand."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "126"
+        artist = "Daarken"
+        flavorText = "Swifter than an angel, crueler than a demon, and relentless as a ghoul."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg?1783940691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AvacynRestoredBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AvacynRestoredBasicLands.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** Avacyn Restored's three art variants for each basic land type (collector numbers 230-244). */
+
+val Plains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f090db87-b7a9-4c88-a211-495b27ae37c9.jpg?1783940646"
+}
+
+val Plains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91348123-e2d0-4acb-ab4e-ec17652b7853.jpg?1783940646"
+}
+
+val Plains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "Eytan Zana"
+    imageUri = "https://cards.scryfall.io/normal/front/9/c/9ca16bd5-e261-4229-a92d-7cd55654dd11.jpg?1783940646"
+}
+
+val Island233 = basicLand("Island") {
+    collectorNumber = "233"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25934479-a47e-45b8-bc35-fc4b659b0d68.jpg?1783940646"
+}
+
+val Island234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22f920a5-74ea-4b94-8822-5867e6d5017a.jpg?1783940644"
+}
+
+val Island235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cf3685e-0ed3-4dc3-9033-8faa10b17c27.jpg?1783940645"
+}
+
+val Swamp236 = basicLand("Swamp") {
+    collectorNumber = "236"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/339c3f05-444c-4e0a-a556-fc09417ee984.jpg?1783940644"
+}
+
+val Swamp237 = basicLand("Swamp") {
+    collectorNumber = "237"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/26c57bee-2810-467c-8ed7-6cecb5cbc379.jpg?1783940645"
+}
+
+val Swamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06a570b2-bcab-4500-b790-252baaf1f6d8.jpg?1783940644"
+}
+
+val Mountain239 = basicLand("Mountain") {
+    collectorNumber = "239"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f53b7e7e-494b-4346-b18e-0e879bba7cec.jpg?1783940644"
+}
+
+val Mountain240 = basicLand("Mountain") {
+    collectorNumber = "240"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94b728a4-c3a9-408e-8333-8266a02c64fa.jpg?1783940644"
+}
+
+val Mountain241 = basicLand("Mountain") {
+    collectorNumber = "241"
+    artist = "Eytan Zana"
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e468809-d639-43f0-8834-16e921547dee.jpg?1783940644"
+}
+
+val Forest242 = basicLand("Forest") {
+    collectorNumber = "242"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/8097c9ce-8fe9-4150-9810-52f6c92c6099.jpg?1783940643"
+}
+
+val Forest243 = basicLand("Forest") {
+    collectorNumber = "243"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f104987-f678-4ba4-b7f5-69ae7fdc01a3.jpg?1783940644"
+}
+
+val Forest244 = basicLand("Forest") {
+    collectorNumber = "244"
+    artist = "Eytan Zana"
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/990f4974-fcef-46d1-8baa-6a215f7f3292.jpg?1783940642"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BannersRaised.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BannersRaised.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Banners Raised
+ * {R}
+ * Instant
+ *
+ * Creatures you control get +1/+0 until end of turn.
+ *
+ * A group pump — the Chorus of Woe shape. [Patterns.Group.modifyStatsForAll] iterates the group
+ * and applies the bonus to each member ([com.wingedsheep.sdk.scripting.targets.EffectTarget.Self]
+ * inside the iteration), so creatures that enter after resolution are correctly untouched.
+ */
+val BannersRaised = card("Banners Raised") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +1/+0 until end of turn."
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            1, 0,
+            GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Mike Bierek"
+        flavorText = "After the destruction of the Helvault, fearful mobs soon became fearless battalions."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg?1783940690"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BloodflowConnoisseur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BloodflowConnoisseur.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bloodflow Connoisseur
+ * {2}{B}
+ * Creature — Vampire
+ * 1 / 1
+ *
+ * Sacrifice a creature: Put a +1/+1 counter on this creature.
+ */
+val BloodflowConnoisseur = card("Bloodflow Connoisseur") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice a creature: Put a +1/+1 counter on this creature."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Slawomir Maniak"
+        flavorText = "\"Death not for survival but for vanity and pleasure? This is the decadence I sought to curb.\"\n—Sorin Markov"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg?1783940706"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BorderlandRangerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BorderlandRangerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borderland Ranger reprint in AVR. Canonical CardDefinition lives in its earliest set (M10).
+ */
+val BorderlandRangerReprint = Printing(
+    oracleId = "ffe25048-0bd4-49b5-aecb-2b1b57fb8d8b",
+    name = "Borderland Ranger",
+    setCode = "AVR",
+    collectorNumber = "169",
+    scryfallId = "8f067c26-c51d-44d0-a0af-106b5778f06a",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8f067c26-c51d-44d0-a0af-106b5778f06a.jpg?1783940672",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BuildersBlessing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BuildersBlessing.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Builder's Blessing
+ * {3}{W}
+ * Enchantment
+ *
+ * Untapped creatures you control get +0/+2.
+ *
+ * A lord whose group filter carries a *state* predicate: `untapped()` puts
+ * [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsUntapped] on the filter, so the
+ * bonus is re-read every projection — a creature loses the +0/+2 the moment it attacks or taps for
+ * an ability, and gets it back on untap. That live re-evaluation is why this is a static
+ * [ModifyStats] over a filter rather than a one-shot pump.
+ */
+val BuildersBlessing = card("Builder's Blessing") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Untapped creatures you control get +0/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            0, 2,
+            GroupFilter(GameObjectFilter.Creature.untapped().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "John Stanko"
+        flavorText = "\"Mix the mortar with holy wards, or blood will run in the streets.\"\n—Vadvar, Thraben stonewright"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg?1783940741"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CommandersAuthority.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CommandersAuthority.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Commander's Authority
+ * {4}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "At the beginning of your upkeep, create a 1/1 white Human creature token."
+ *
+ * The Cathar's Call shape. The quoted ability is granted *to* the enchanted creature through
+ * [GrantTriggeredAbility] (whose filter defaults to the attached creature), and the trigger is
+ * installed with [Triggers.YourUpkeep]'s own event and binding passed through verbatim — ANY, not
+ * ATTACHED. An ATTACHED-bound trigger is never indexed by the engine's trigger index, so keeping
+ * the spec's binding is what makes the card do anything at all.
+ *
+ * Granting the ability to the creature also lands "your upkeep" and the token's controller on the
+ * *creature's* controller rather than the Aura's, which is the printed reading: enchant an
+ * opponent's creature and they get the Humans.
+ */
+val CommandersAuthority = card("Commander's Authority") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"At the beginning of your upkeep, create a 1/1 white Human creature " +
+        "token.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            TriggeredAbility.create(
+                trigger = Triggers.YourUpkeep.event,
+                binding = Triggers.YourUpkeep.binding,
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Human")
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Johannes Voss"
+        flavorText = "\"Wear her symbol with honor, a sign of faith upheld and honest deeds bravely done.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg?1783940740"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CryptCreeperReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CryptCreeperReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crypt Creeper reprint in AVR. Canonical CardDefinition lives in its earliest set (ODY).
+ */
+val CryptCreeperReprint = Printing(
+    oracleId = "00b3971b-5bf7-4a3f-9607-6265f9af9098",
+    name = "Crypt Creeper",
+    setCode = "AVR",
+    collectorNumber = "91",
+    scryfallId = "0382cb94-0836-4e23-99b7-034faa363203",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/0382cb94-0836-4e23-99b7-034faa363203.jpg?1783940705",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Cursebreak.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Cursebreak.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cursebreak
+ * {1}{W}
+ * Instant
+ *
+ * Destroy target enchantment. You gain 2 life.
+ *
+ * Two printed sentences, so two members of one flat [Effects.Composite]: the destroy (which is a
+ * move to the graveyard `byDestruction`, so indestructible and regeneration are honoured) and the
+ * life gain, whose default target is already the controller.
+ */
+val Cursebreak = card("Cursebreak") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target enchantment. You gain 2 life."
+
+    spell {
+        val enchantment = target("target", Targets.Enchantment)
+        effect = Effects.Composite(
+            Effects.Destroy(enchantment),
+            Effects.GainLife(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Sam Wolfe Connelly"
+        flavorText = "No longer the village pariah. No longer taunted and shamed. Sigrun was finally free."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg?1783940738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DangerousWager.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DangerousWager.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dangerous Wager
+ * {1}{R}
+ * Instant
+ *
+ * Discard your hand, then draw two cards.
+ *
+ * The discard is [Patterns.Hand.discardHand]'s gather/move pair, kept as its own nested composite:
+ * `then` would splice that pair into the outer list and flatten the sentence's two clauses into
+ * three, so the two halves are joined with an explicit [Effects.Composite].
+ */
+val DangerousWager = card("Dangerous Wager") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Discard your hand, then draw two cards."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Hand.discardHand(),
+            Effects.DrawCards(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Drew Baker"
+        flavorText = "\"C'mon friend, take a turn tossing the knucklebones. What've you got to lose?\"\n—Tobias, trader of Erdwal"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg?1783940687"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DevoutChaplain.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DevoutChaplain.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Devout Chaplain
+ * {2}{W}
+ * Creature — Human Cleric
+ * 2 / 2
+ *
+ * {T}, Tap two untapped Humans you control: Exile target artifact or enchantment.
+ *
+ * "Two untapped Humans you control" is a bare tribal noun — any Human *permanent*, not only
+ * creatures. `excludeSelf = true` because the Chaplain is itself a Human and is already paying
+ * the `{T}` half of the cost, so it can't also be one of the two tapped Humans.
+ */
+val DevoutChaplain = card("Devout Chaplain") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{T}, Tap two untapped Humans you control: Exile target artifact or enchantment."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.TapPermanents(
+                count = 2,
+                filter = GameObjectFilter.Permanent.withSubtype(Subtype.HUMAN),
+                excludeSelf = true
+            )
+        )
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Lucas Graciano"
+        flavorText = "\"By Avacyn's decree, we shall cleanse these relics of their demonic past.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg?1783940736"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EntreatTheAngels.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EntreatTheAngels.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Entreat the Angels
+ * {X}{X}{W}{W}{W}
+ * Sorcery
+ *
+ * Create X 4/4 white Angel creature tokens with flying.
+ * Miracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)
+ *
+ * The dynamic-count [Effects.CreateToken] overload with `count = DynamicAmount.XValue`: X is read
+ * once at resolution (CR 613.4c) from whatever was announced — the `{X}{X}` of the printed cost, or
+ * the single `{X}` of the miracle cost when cast that way. Token art resolves from the set's own
+ * `tokenArt`, so no `imageUri` is authored here.
+ */
+val EntreatTheAngels = card("Entreat the Angels") {
+    manaCost = "{X}{X}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create X 4/4 white Angel creature tokens with flying.\n" +
+        "Miracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the " +
+        "first card you drew this turn.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.XValue,
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Angel"),
+            keywords = setOf(Keyword.FLYING),
+        )
+    }
+
+    keywordAbility(KeywordAbility.miracle("{X}{W}{W}"))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "20"
+        artist = "Todd Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg?1783940735"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EvernightShade.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EvernightShade.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Evernight Shade
+ * {3}{B}
+ * Creature — Shade
+ * 1 / 1
+ *
+ * {B}: This creature gets +1/+1 until end of turn.
+ * Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)
+ *
+ * The Shade pump is the family's canonical shape: a bare [Costs.Mana] atom and
+ * [Effects.ModifyStats] on [EffectTarget.Self] with the default until-end-of-turn duration.
+ * Undying is a printed [Keyword] the engine reads on its own.
+ */
+val EvernightShade = card("Evernight Shade") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shade"
+    power = 1
+    toughness = 1
+    oracleText = "{B}: This creature gets +1/+1 until end of turn.\n" +
+        "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the " +
+        "battlefield under its owner's control with a +1/+1 counter on it.)"
+
+    keywords(Keyword.UNDYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "101"
+        artist = "Nic Klein"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg?1783940698"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FalkenrathExterminator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FalkenrathExterminator.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Falkenrath Exterminator
+ * {1}{R}
+ * Creature — Vampire Archer
+ * 1 / 1
+ *
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ * {2}{R}: This creature deals damage to target creature equal to the number of +1/+1 counters on this creature.
+ *
+ * The damage amount is a live read of the Exterminator's own +1/+1 counters
+ * ([DynamicAmounts.countersOnSelf]), so a counter added or removed between activation and
+ * resolution changes how much damage is dealt.
+ */
+val FalkenrathExterminator = card("Falkenrath Exterminator") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire Archer"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\n" +
+        "{2}{R}: This creature deals damage to target creature equal to the number of +1/+1 counters on " +
+        "this creature."
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(
+            DynamicAmounts.countersOnSelf(CounterTypeFilter.PlusOnePlusOne),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg?1783940685"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FarbogExplorer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FarbogExplorer.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Farbog Explorer
+ * {2}{W}
+ * Creature — Human Scout
+ * 2 / 3
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ */
+val FarbogExplorer = card("Farbog Explorer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 3
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Scott Chou"
+        flavorText = "\"I'd slog through a thousand swamps to help one soul find rest.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg?1783940735"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FerventCathar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/FerventCathar.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fervent Cathar — Avacyn Restored #135
+ * {2}{R} · Creature — Human Knight · 2/1
+ *
+ * Haste
+ * When this creature enters, target creature can't block this turn.
+ *
+ * The enters trigger targets on announcement and applies [Effects.CantBlock] on resolution; the
+ * default [com.wingedsheep.sdk.scripting.Duration.EndOfTurn] is the printed "this turn", so no
+ * duration is written.
+ */
+val FerventCathar = card("Fervent Cathar") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "Haste\n" +
+        "When this creature enters, target creature can't block this turn."
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.CantBlock(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Steven Belledin"
+        flavorText = "\"I'll put my sword down only to die. And I don't plan on doing that today.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg?1783940685"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GeistSnatch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GeistSnatch.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Geist Snatch
+ * {2}{U}{U}
+ * Instant
+ *
+ * Counter target creature spell. Create a 1/1 blue Spirit creature token with flying.
+ *
+ * The token is created whether or not the countered spell is still on the stack, so the two
+ * sentences are siblings in one composite rather than a gated rider.
+ */
+val GeistSnatch = card("Geist Snatch") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell. Create a 1/1 blue Spirit creature token with flying."
+
+    spell {
+        target("target", Targets.CreatureSpell)
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf("Spirit"),
+                keywords = setOf(Keyword.FLYING),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Dan Murayama Scott"
+        flavorText = "Angels and demons aren't the only ones listening to your prayers."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg?1783940720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GhostlyTouch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GhostlyTouch.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ghostly Touch
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "Whenever this creature attacks, you may tap or untap target permanent."
+ *
+ * The Contaminated Bond shape: the quoted trigger is granted *to* the enchanted creature via
+ * [GrantTriggeredAbility] (default attached-creature filter) with [Triggers.Attacks]' own event and
+ * SELF binding passed through verbatim. An ATTACHED-bound attack trigger is not indexed by the
+ * engine, so installing it on the creature is what makes it fire; it also puts "you" on the
+ * creature's controller, which is the printed reading of a granted ability.
+ *
+ * "Tap or untap" is the Pestermite idiom — a [MayEffect] over a two-[Mode] [ModalEffect] with
+ * `countsAsModalSpell = false`, since the choice is made on resolution and is not CR 700.2
+ * modality. The permanent is targeted when the trigger goes on the stack; the direction is chosen
+ * afterwards, so an opponent responding by tapping it doesn't strand you on the dead half.
+ */
+val GhostlyTouch = card("Ghostly Touch") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"Whenever this creature attacks, you may tap or untap target " +
+        "permanent.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = MayEffect(
+                    ModalEffect(
+                        modes = listOf(
+                            Mode.noTarget(TapUntapEffect(EffectTarget.ContextTarget(0), tap = true)),
+                            Mode.noTarget(TapUntapEffect(EffectTarget.ContextTarget(0), tap = false))
+                        ),
+                        chooseCount = 1,
+                        countsAsModalSpell = false
+                    )
+                ),
+                targetRequirement = Targets.Permanent
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Jason Felix"
+        flavorText = "\"Geists wish to make themselves known. I'm merely the vessel for their efforts.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg?1783940718"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GraveExchange.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GraveExchange.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Grave Exchange
+ * {4}{B}{B}
+ * Sorcery
+ *
+ * Return target creature card from your graveyard to your hand. Target player sacrifices a creature of their choice.
+ *
+ * Two targets chosen as the spell goes on the stack, in printed order: the graveyard card first,
+ * the sacrificing player second. The return needs no `fromZone` guard — the target requirement's
+ * own `zone = GRAVEYARD` is re-checked at resolution under CR 608.2b.
+ */
+val GraveExchange = card("Grave Exchange") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to your hand. Target player sacrifices a " +
+        "creature of their choice."
+
+    spell {
+        val creatureCard = target("target", Targets.CreatureCardInYourGraveyard)
+        val victim = target("target 1", Targets.Player)
+        effect = Effects.Composite(
+            Effects.ReturnToHand(creatureCard),
+            Effects.Sacrifice(GameObjectFilter.Creature, target = victim),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Sam Wolfe Connelly"
+        flavorText = "\"It's a cold, dark journey either way.\"\n—Eruth of Lambholt"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg?1783940698"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HauntedGuardian.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HauntedGuardian.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Haunted Guardian
+ * {2}
+ * Artifact Creature — Construct
+ * 2 / 1
+ *
+ * Defender, first strike
+ *
+ * Both lines are printed [Keyword]s — nothing but `keywords(...)`.
+ */
+val HauntedGuardian = card("Haunted Guardian") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 1
+    oracleText = "Defender, first strike"
+
+    keywords(Keyword.DEFENDER, Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Daniel Ljunggren"
+        flavorText = "\"Drain the victim's blood, sell the corpse, and use the soul on guard duty. No muss, no fuss, no problems.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg?1783940652"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HeirsOfStromkirk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HeirsOfStromkirk.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Heirs of Stromkirk
+ * {2}{R}{R}
+ * Creature — Vampire
+ * 2 / 2
+ *
+ * Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that
+ * share a color with it.)
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * [Triggers.DealsCombatDamageToPlayer] is the SELF-bound combat-damage-to-a-player trigger; "it"
+ * is the Heirs themselves, so the counter lands on [EffectTarget.Self].
+ */
+val HeirsOfStromkirk = card("Heirs of Stromkirk") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 2
+    oracleText = "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that " +
+        "share a color with it.)\n" +
+        "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+
+    keywords(Keyword.INTIMIDATE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg?1783940684"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HoundOfGriselbrand.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HoundOfGriselbrand.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hound of Griselbrand
+ * {2}{R}{R}
+ * Creature — Elemental Dog
+ * 2 / 2
+ *
+ * Double strike
+ * Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)
+ *
+ * Both lines are printed [Keyword]s — a vanilla body with no script at all.
+ */
+val HoundOfGriselbrand = card("Hound of Griselbrand") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Dog"
+    power = 2
+    toughness = 2
+    oracleText = "Double strike\n" +
+        "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the " +
+        "battlefield under its owner's control with a +1/+1 counter on it.)"
+
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "141"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg?1783940682"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KessigMalcontents.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KessigMalcontents.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Kessig Malcontents — Avacyn Restored #142
+ * {2}{R} · Creature — Human Warrior · 3/1
+ *
+ * When this creature enters, it deals damage to target player or planeswalker equal to the number
+ * of Humans you control.
+ *
+ * "Humans" is a bare tribal noun, so the count is over *permanents* with the subtype, not only
+ * creatures — the Malcontents itself is one of them, since it is already on the battlefield when
+ * the trigger resolves. The amount is read at resolution by
+ * [DynamicAmounts.battlefield], so removal in response shrinks the damage.
+ */
+val KessigMalcontents = card("Kessig Malcontents") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, it deals damage to target player or planeswalker equal to the number " +
+        "of Humans you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype("Human")
+            ).count(),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "John Stanko"
+        flavorText = "Discontent is a powerful weapon in the hands of a mob."
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg?1783940682"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KruinStriker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KruinStriker.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kruin Striker
+ * {1}{R}
+ * Creature — Human Warrior
+ * 2 / 1
+ *
+ * Whenever another creature you control enters, this creature gets +1/+0 and gains trample until
+ * end of turn.
+ *
+ * [Triggers.OtherCreatureEnters] carries both halves of "another creature you control" — the
+ * `Creature.youControl()` filter and the OTHER binding that excludes the Striker itself. The two
+ * riders are one [Effects.Composite] on [EffectTarget.Self]; both default to
+ * [com.wingedsheep.sdk.scripting.Duration.EndOfTurn], which is the printed duration.
+ */
+val KruinStriker = card("Kruin Striker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever another creature you control enters, this creature gets +1/+0 and gains trample until " +
+        "end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Christopher Moeller"
+        flavorText = "Unhappy with the creation of the wolfir, Rorica broke with her order and led a crusade against the \"reformed werewolves.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg?1783940682"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LatchSeeker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LatchSeeker.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Latch Seeker
+ * {1}{U}{U}
+ * Creature — Spirit
+ * 3 / 1
+ *
+ * This creature can't be blocked.
+ *
+ * Unconditional unblockability is an [AbilityFlag] on the card itself (Triton Shorestalker shape),
+ * not a static ability.
+ */
+val LatchSeeker = card("Latch Seeker") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 1
+    oracleText = "This creature can't be blocked."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Vincent Proce"
+        flavorText = "It seeks a tomb that will hold it, a coffin that will give it rest."
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg?1783940717"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LeapOfFaith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LeapOfFaith.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+
+/**
+ * Leap of Faith
+ * {2}{W}
+ * Instant
+ *
+ * Target creature gains flying until end of turn. Prevent all damage that would be dealt to that creature this turn.
+ *
+ * "That creature" is the same target both halves act on. No `Effects.*` facade spells the plain
+ * "prevent all damage that would be dealt to target this turn" shield — every parameter is
+ * [PreventDamageEffect]'s own default except the recipient (Djeru's Resolve).
+ */
+val LeapOfFaith = card("Leap of Faith") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gains flying until end of turn. Prevent all damage that would be dealt to that " +
+        "creature this turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.FLYING, creature),
+            PreventDamageEffect(target = creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Gabor Szikszai"
+        flavorText = "The finest maneuvers take place in three dimensions."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg?1783940733"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LunarMystic.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/LunarMystic.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+
+/**
+ * Lunar Mystic
+ * {2}{U}{U}
+ * Creature — Human Wizard
+ * 2 / 2
+ *
+ * Whenever you cast an instant spell, you may pay {1}. If you do, draw a card.
+ *
+ * "You may pay {1}. If you do" is a [Gate.MayPay] — the payment and the draw are one resolution,
+ * not a reflexive trigger.
+ */
+val LunarMystic = card("Lunar Mystic") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast an instant spell, you may pay {1}. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Instant)
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayManaCostEffect(ManaCost.parse("{1}"))),
+            then = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "65"
+        artist = "Wesley Burt"
+        flavorText = "\"I'm pleased this world has learned the moon affects more than the tides.\"\n—Tamiyo, the Moon Sage"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg?1783940715"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MadProphet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MadProphet.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mad Prophet
+ * {3}{R}
+ * Creature — Human Shaman
+ * 2 / 2
+ *
+ * Haste
+ * {T}, Discard a card: Draw a card.
+ */
+val MadProphet = card("Mad Prophet") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "{T}, Discard a card: Draw a card."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Wayne Reynolds"
+        flavorText = "\"There's no heron in the moon! It's a shrew, a five-legged shrew, with a voice like whispering thunder!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg?1783940683"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MaliciousIntent.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MaliciousIntent.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Malicious Intent
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "{T}: Target creature can't block this turn."
+ *
+ * The Lavamancer's Skill shape: [GrantActivatedAbility] hands the quoted ability to the enchanted
+ * creature (the static's filter defaults to the attached creature), so the {T} is the *creature's*
+ * tap and only its controller can activate it. Enchanting an opponent's creature therefore gives
+ * them the ability, which is the printed reading — the Aura's usual home is a creature of your own
+ * that has already attacked, or one you can tap for free.
+ */
+val MaliciousIntent = card("Malicious Intent") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"{T}: Target creature can't block this turn.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.CantBlock(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(TargetCreature())
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Kev Walker"
+        flavorText = "As peace returned to Thraben, some cathars made the mistake of letting down their guard."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg?1783940679"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MassAppeal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MassAppeal.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Mass Appeal
+ * {2}{U}
+ * Sorcery
+ *
+ * Draw a card for each Human you control.
+ *
+ * "each Human" is a bare tribal noun, so it counts every *permanent* with the subtype — a Human
+ * artifact or enchantment is included — hence [GameObjectFilter.Permanent] rather than
+ * `Creature`. The "you control" half lives on the query's [Player.You], not in the filter.
+ */
+val MassAppeal = card("Mass Appeal") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw a card for each Human you control."
+
+    spell {
+        effect = Effects.DrawCards(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype("Human"),
+            ).count()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Christopher Moeller"
+        flavorText = "\"We have emerged triumphant from the darkness. Let our hard-won wisdom guide us to prosperity.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg?1783940716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MidnightDuelist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MidnightDuelist.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Midnight Duelist
+ * {W}
+ * Creature — Human Soldier
+ * 1 / 2
+ *
+ * Protection from Vampires
+ *
+ * [ProtectionScope.Subtype] holds a single subtype, so protection from a creature type is one
+ * `keywordAbility` per type (Elite Inquisitor shape).
+ */
+val MidnightDuelist = card("Midnight Duelist") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "Protection from Vampires"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Subtype("Vampire")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "Bud Cook"
+        flavorText = "Avacyn's return did not rid him of his desire for revenge."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg?1783940731"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MoonlightGeist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MoonlightGeist.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Moonlight Geist
+ * {2}{W}
+ * Creature — Spirit
+ * 2 / 1
+ *
+ * Flying
+ * {3}{W}: Prevent all combat damage that would be dealt to and dealt by this creature this turn.
+ *
+ * Urborg Phantom's activated fog-on-a-body: [Effects.PreventCombatDamageToAndBy] is the shield
+ * with `scope = CombatOnly` and `direction = Both` already baked in, so only the recipient
+ * ([EffectTarget.Self]) has to be named.
+ */
+val MoonlightGeist = card("Moonlight Geist") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{3}{W}: Prevent all combat damage that would be dealt to and dealt by this creature this turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        effect = Effects.PreventCombatDamageToAndBy(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Dan Murayama Scott"
+        flavorText = "Wails and whispers are the only weapons she has left."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg?1783940730"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NarstadScrapper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NarstadScrapper.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Narstad Scrapper
+ * {5}
+ * Artifact Creature — Construct
+ * 3 / 3
+ *
+ * {2}: This creature gets +1/+0 until end of turn.
+ *
+ * A bare mana-cost firebreathing-style pump: [Effects.ModifyStats] on [EffectTarget.Self], whose
+ * default duration is already until end of turn.
+ */
+val NarstadScrapper = card("Narstad Scrapper") {
+    manaCost = "{5}"
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 3
+    oracleText = "{2}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Steven Belledin"
+        flavorText = "\"Finally, the principles of corpse animation applied to bloodless materials!\"\n—Ludevic, necro-alchemist"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg?1783940654"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NaturalEnd.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NaturalEnd.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Natural End
+ * {2}{G}
+ * Instant
+ *
+ * Destroy target artifact or enchantment. You gain 3 life.
+ *
+ * Cursebreak's green sibling — one flat [Effects.Composite] of destroy-then-gain, with the target
+ * widened to [Targets.ArtifactOrEnchantment] (a single `Or` card predicate, not two).
+ */
+val NaturalEnd = card("Natural End") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment. You gain 3 life."
+
+    spell {
+        val permanent = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Composite(
+            Effects.Destroy(permanent),
+            Effects.GainLife(3),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Scott Chou"
+        flavorText = "The haunted blade shattered, and the geist drifted gratefully to the Blessed Sleep."
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg?1783940664"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Necrobite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Necrobite.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Necrobite
+ * {2}{B}
+ * Instant
+ *
+ * Target creature gains deathtouch until end of turn. Regenerate it. (The next time that creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)
+ *
+ * "It" is the same creature both halves act on, so there is one named target and both effects
+ * bind to it — Djeru's Resolve's shape with a regeneration shield instead of a damage one.
+ * [RegenerateEffect] has no `Effects` facade entry, so the class is imported directly.
+ */
+val Necrobite = card("Necrobite") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gains deathtouch until end of turn. Regenerate it. (The next time that creature " +
+        "would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on " +
+        "it.)"
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, creature),
+            RegenerateEffect(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Nils Hamm"
+        flavorText = "An undead snake doesn't bite in self-defense. It hungers as any zombie, never sated."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg?1783940692"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/PollutedDead.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/PollutedDead.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Polluted Dead — Avacyn Restored #116
+ * {4}{B} · Creature — Zombie · 3/3
+ *
+ * When this creature dies, destroy target land.
+ *
+ * [Triggers.Dies] is the battlefield → graveyard zone change with the default `SELF` binding; the
+ * trigger stays indexed on the battlefield (its `triggerZone` is untouched) and reads its
+ * last-known information off the zone-change event.
+ */
+val PollutedDead = card("Polluted Dead") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature dies, destroy target land."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target", Targets.Land)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Jason A. Engle"
+        flavorText = "After the zombie attack, crops withered on the vine, and the thriving village became a ghost town almost overnight."
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg?1783940692"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RiotRingleader.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RiotRingleader.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Riot Ringleader
+ * {2}{R}
+ * Creature — Human Warrior
+ * 2 / 2
+ *
+ * Whenever this creature attacks, Human creatures you control get +1/+0 until end of turn.
+ *
+ * [Triggers.Attacks] is SELF-bound, so only the Ringleader's own attack fires it. The pump is
+ * [Patterns.Group.modifyStatsForAll] over the Humans you control — a group iteration rather than a
+ * static lord, so the bonus is locked to the creatures present on resolution and expires at end of
+ * turn. The Ringleader is itself a Human, so it pumps too.
+ */
+val RiotRingleader = card("Riot Ringleader") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, Human creatures you control get +1/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Group.modifyStatsForAll(
+            1, 0,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Human").youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Gabor Szikszai"
+        flavorText = "\"So the vampires like hot blood, do they? Let's see how they handle ours.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg?1783940678"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RotcrownGhoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RotcrownGhoul.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rotcrown Ghoul — Avacyn Restored #72
+ * {4}{U} · Creature — Zombie · 3/3
+ *
+ * When this creature dies, target player mills five cards.
+ *
+ * The mill is the [Patterns.Library] gather → move pipeline pointed at the chosen player
+ * ([EffectTarget.ContextTarget]), not at the controller.
+ */
+val RotcrownGhoul = card("Rotcrown Ghoul") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature dies, target player mills five cards."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target("target", Targets.Player)
+        effect = Patterns.Library.mill(5, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Dave Kendall"
+        flavorText = "\"Don't look into its eyes. It's thinking things no dead thing should think.\"\n—Captain Eberhart"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg?1783940711"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScaldingDevil.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScaldingDevil.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scalding Devil
+ * {1}{R}
+ * Creature — Devil
+ * 1 / 1
+ *
+ * {2}{R}: This creature deals 1 damage to target player or planeswalker.
+ */
+val ScaldingDevil = card("Scalding Devil") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{R}: This creature deals 1 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        val victim = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Erica Yang"
+        flavorText = "Demons massacre. Devils annoy."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg?1783940677"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SearchlightGeist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SearchlightGeist.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Searchlight Geist
+ * {2}{B}
+ * Creature — Spirit
+ * 2 / 1
+ *
+ * Flying
+ * {3}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a
+ * creature is enough to destroy it.)
+ *
+ * [Effects.GrantKeyword] on [EffectTarget.Self]; its default duration is already until end of turn.
+ */
+val SearchlightGeist = card("Searchlight Geist") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{3}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a " +
+        "creature is enough to destroy it.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Steven Belledin"
+        flavorText = "It rises with the fall of darkness, seeking souls to extinguish."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg?1783940691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ShelteringWord.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ShelteringWord.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sheltering Word
+ * {1}{G}
+ * Instant
+ *
+ * Target creature you control gains hexproof until end of turn. You gain life equal to that creature's toughness. (A creature with hexproof can't be the target of spells or abilities your opponents control.)
+ *
+ * The grant is the plain [Effects.GrantKeyword] floating-keyword shape rather than
+ * `Effects.GrantHexproof` — the latter is the player-or-permanent evasion effect, a different
+ * model. "That creature's toughness" is read at resolution off the spell's own target with
+ * [DynamicAmounts.targetToughness].
+ */
+val ShelteringWord = card("Sheltering Word") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature you control gains hexproof until end of turn. You gain life equal to that " +
+        "creature's toughness. (A creature with hexproof can't be the target of spells or abilities your " +
+        "opponents control.)"
+
+    spell {
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.HEXPROOF, creature),
+            Effects.GainLife(DynamicAmounts.targetToughness())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Igor Kieryluk"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg?1783940662"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SnareTheSkies.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SnareTheSkies.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snare the Skies
+ * {G}
+ * Instant
+ *
+ * Target creature gets +1/+1 and gains reach until end of turn. (It can block creatures with flying.)
+ *
+ * One target, two clauses: the pump and the keyword grant both bind to it and both take the
+ * default until-end-of-turn duration.
+ */
+val SnareTheSkies = card("Snare the Skies") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+1 and gains reach until end of turn. (It can block creatures with " +
+        "flying.)"
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, creature),
+            Effects.GrantKeyword(Keyword.REACH, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Ryan Yee"
+        flavorText = "A hunter's precision and a durkvine's strength are a potent combination."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg?1783940662"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThrabenValiant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThrabenValiant.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thraben Valiant
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2 / 1
+ *
+ * Vigilance
+ */
+val ThrabenValiant = card("Thraben Valiant") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Vigilance"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Jason Chan"
+        flavorText = "\"Once more into Devil's Breach, soldiers. I want another devil tail for my collection.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg?1783940728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThunderboltReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThunderboltReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunderbolt reprint in AVR. Canonical CardDefinition lives in its earliest set (WTH).
+ */
+val ThunderboltReprint = Printing(
+    oracleId = "6ffae2fa-511a-45bf-93c4-5d53c85324f5",
+    name = "Thunderbolt",
+    setCode = "AVR",
+    collectorNumber = "159",
+    scryfallId = "5845a5bc-6b7d-4bbb-80b3-a0f877b95553",
+    artist = "Anthony Francisco",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/5845a5bc-6b7d-4bbb-80b3-a0f877b95553.jpg?1783940676",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThunderousWrath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ThunderousWrath.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thunderous Wrath
+ * {4}{R}{R}
+ * Instant
+ *
+ * Thunderous Wrath deals 5 damage to any target.
+ * Miracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)
+ *
+ * A plain [Effects.DealDamage] at an [Targets.Any] target — no `damageSource` override, so the
+ * engine attributes the damage to the resolving spell itself. Miracle is the standard
+ * [KeywordAbility.miracle] first-draw-of-turn alternative cost.
+ */
+val ThunderousWrath = card("Thunderous Wrath") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Thunderous Wrath deals 5 damage to any target.\n" +
+        "Miracle {R} (You may cast this card for its miracle cost when you draw it if it's the first " +
+        "card you drew this turn.)"
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(5, t)
+    }
+
+    keywordAbility(KeywordAbility.miracle("{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg?1783940675"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/TimberlandGuide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/TimberlandGuide.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timberland Guide — Avacyn Restored #197
+ * {1}{G} · Creature — Human Scout · 1/1
+ *
+ * When this creature enters, put a +1/+1 counter on target creature.
+ *
+ * The trigger's target may legally be the Guide itself, which is already on the battlefield when
+ * the ability is put on the stack.
+ */
+val TimberlandGuide = card("Timberland Guide") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Zoltan Boros"
+        flavorText = "\"Can you build a fire? Track a deer? Identify killer trees? Then you'll never survive Kessig without me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg?1783940665"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/UncannySpeed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/UncannySpeed.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Uncanny Speed
+ * {1}{R}
+ * Instant
+ *
+ * Target creature gets +3/+0 and gains haste until end of turn.
+ *
+ * Zealous Strike's red sibling — one [Effects.Composite] of [Effects.ModifyStats] and
+ * [Effects.GrantKeyword] over the same bound target, both until end of turn.
+ */
+val UncannySpeed = card("Uncanny Speed") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 and gains haste until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 0, t),
+            Effects.GrantKeyword(Keyword.HASTE, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Raymond Swanland"
+        flavorText = "\"To survive, we must embrace the savagery we knew in our race's infancy.\"\n—Edgar Markov"
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg?1783940673"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/UndeadExecutioner.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/UndeadExecutioner.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undead Executioner — Avacyn Restored #123
+ * {3}{B} · Creature — Zombie · 2/2
+ *
+ * When this creature dies, you may have target creature get -2/-2 until end of turn.
+ *
+ * The printed "you may" is the builder's `optional`, which lowers to a `Gate.MayDecide` around the
+ * pump — the target is still locked when the trigger goes on the stack (CR 603.3d) and only the
+ * yes/no waits for resolution.
+ */
+val UndeadExecutioner = card("Undead Executioner") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature dies, you may have target creature get -2/-2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        optional = true
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-2, -2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Dave Kendall"
+        flavorText = "Heartless killer in life, brainless killer in death."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg?1783940690"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Vanishment.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Vanishment.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Vanishment
+ * {4}{U}
+ * Instant
+ *
+ * Put target nonland permanent on top of its owner's library.
+ * Miracle {U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)
+ *
+ * [Effects.PutOnTopOfLibrary] is the plain move to the top of the library — "its owner's" is not a
+ * knob, since a permanent always leaves the battlefield for its owner's zone (CR 400.3). Set Adrift
+ * (KTK) is the same shape without the miracle cost.
+ */
+val Vanishment = card("Vanishment") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Put target nonland permanent on top of its owner's library.\n" +
+        "Miracle {U} (You may cast this card for its miracle cost when you draw it if it's the first " +
+        "card you drew this turn.)"
+
+    spell {
+        val permanent = target("target", Targets.NonlandPermanent)
+        effect = Effects.PutOnTopOfLibrary(permanent)
+    }
+
+    keywordAbility(KeywordAbility.miracle("{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg?1783940709"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VigilanteJustice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VigilanteJustice.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vigilante Justice
+ * {3}{R}
+ * Enchantment
+ *
+ * Whenever a Human you control enters, this enchantment deals 1 damage to any target.
+ *
+ * "A Human you control" is a bare tribal noun with no "creature" beside it, so the filter is
+ * [GameObjectFilter.Permanent] with the subtype — a Human artifact or a Human enchantment creature
+ * token both count. The binding is ANY rather than OTHER because the printed text says "a Human",
+ * not "another Human"; the enchantment itself can never be the permanent that entered, so the two
+ * differ only in principle here, but the principle is what the wording states.
+ */
+val VigilanteJustice = card("Vigilante Justice") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a Human you control enters, this enchantment deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Human").youControl(),
+            binding = TriggerBinding.ANY
+        )
+        target = Targets.Any
+        effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Steve Prescott"
+        flavorText = "It begins as a whisper and ends with the red roar of fire."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg?1783940673"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/WolfirAvenger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/WolfirAvenger.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wolfir Avenger
+ * {1}{G}{G}
+ * Creature — Wolf Warrior
+ * 3 / 3
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * {1}{G}: Regenerate this creature.
+ *
+ * Marrow Bats' shape with a mana price: [RegenerateEffect] on [EffectTarget.Self]. There is no
+ * `Effects.Regenerate` facade, so the effect class is imported directly.
+ */
+val WolfirAvenger = card("Wolfir Avenger") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "{1}{G}: Regenerate this creature."
+
+    keywords(Keyword.FLASH)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Daniel Ljunggren"
+        flavorText = "Released from a dark curse and bound to a higher calling."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg?1783940657"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ZealousStrike.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ZealousStrike.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zealous Strike
+ * {1}{W}
+ * Instant
+ *
+ * Target creature gets +2/+2 and gains first strike until end of turn.
+ *
+ * The ordinary combat trick: one [Effects.Composite] of [Effects.ModifyStats] and
+ * [Effects.GrantKeyword] over the same bound target, both taking the default
+ * `Duration.EndOfTurn`.
+ */
+val ZealousStrike = card("Zealous Strike") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 and gains first strike until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Bud Cook"
+        flavorText = "\"Cower, fiend. The night is yours no longer.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg?1783940724"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/NecrobiteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/NecrobiteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Necrobite reprint in BNG. Canonical CardDefinition lives in its earliest set.
+ */
+val NecrobiteReprint = Printing(
+    oracleId = "d2a3e219-08f3-4c05-b239-abf80a1c1c6b",
+    name = "Necrobite",
+    setCode = "BNG",
+    collectorNumber = "77",
+    scryfallId = "a0955932-8ca9-4896-882c-2969fe7c7818",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/a/0/a0955932-8ca9-4896-882c-2969fe7c7818.jpg",
+    releaseDate = "2014-02-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/EvernightShadeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/EvernightShadeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Evernight Shade reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val EvernightShadeReprint = Printing(
+    oracleId = "9af1b6c4-295f-41d2-b3a0-0863798330d4",
+    name = "Evernight Shade",
+    setCode = "C14",
+    collectorNumber = "144",
+    scryfallId = "96ab331f-41eb-40af-b02d-1df0c5760e85",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96ab331f-41eb-40af-b02d-1df0c5760e85.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/ThrabenValiantReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddl/cards/ThrabenValiantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddl.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thraben Valiant reprint in DDL. Canonical CardDefinition lives in its earliest set.
+ */
+val ThrabenValiantReprint = Printing(
+    oracleId = "dee0b358-b9da-49b9-a47f-7907cde6d8ee",
+    name = "Thraben Valiant",
+    setCode = "DDL",
+    collectorNumber = "6",
+    scryfallId = "a8a8282b-bba6-4815-80fe-7a37a1fec3c1",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a8a8282b-bba6-4815-80fe-7a37a1fec3c1.jpg",
+    releaseDate = "2013-09-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/AngelsMercy.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/AngelsMercy.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Mercy
+ * {2}{W}{W}
+ * Instant
+ *
+ * You gain 7 life.
+ */
+val AngelsMercy = card("Angel's Mercy") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "You gain 7 life."
+
+    spell {
+        effect = Effects.GainLife(7)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Andrew Robinson"
+        flavorText = "\"Until that day I cursed the angels, those uncaring lights in the sky. They rewarded my scorn with the gift of time, every year of which I've spent in devotion to their names.\"\n—Torian Sha, soul warden"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg?1783942405"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/BorderlandRanger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/BorderlandRanger.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Borderland Ranger — Magic 2010 #169
+ * {2}{G} · Creature — Human Scout Ranger · 2/2
+ *
+ * When this creature enters, you may search your library for a basic land card, reveal it, put it
+ * into your hand, then shuffle.
+ *
+ * `optional = true` lowers to the `Gate.MayDecide` the printed "you may" names, wrapping the
+ * [Patterns.Library] gather → choose-up-to → move pipeline. `shuffleAfter` is the facade default
+ * and supplies the printed "then shuffle"; failing to find is legal (CR 701.23b), which is why the
+ * selection is a choose-*up-to*.
+ */
+val BorderlandRanger = card("Borderland Ranger") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout Ranger"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you may search your library for a basic land card, reveal it, put it " +
+        "into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Only fools and bandits use roads.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg?1783942366"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AngelSMercyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AngelSMercyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Mercy reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelSMercyReprint = Printing(
+    oracleId = "6b232bb7-d372-4174-a049-5f8d620810e6",
+    name = "Angel's Mercy",
+    setCode = "M12",
+    collectorNumber = "4",
+    scryfallId = "4e2b0942-423a-4378-b8cd-022a6b608a2e",
+    artist = "Andrew Robinson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e2b0942-423a-4378-b8cd-022a6b608a2e.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/AngelSMercyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/AngelSMercyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Mercy reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelSMercyReprint = Printing(
+    oracleId = "6b232bb7-d372-4174-a049-5f8d620810e6",
+    name = "Angel's Mercy",
+    setCode = "M13",
+    collectorNumber = "3",
+    scryfallId = "43e6d650-4e96-43a3-8b94-7f044d3b2f82",
+    artist = "Andrew Robinson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/43e6d650-4e96-43a3-8b94-7f044d3b2f82.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/NecrobiteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/NecrobiteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Necrobite reprint in M15. Canonical CardDefinition lives in its earliest set.
+ */
+val NecrobiteReprint = Printing(
+    oracleId = "d2a3e219-08f3-4c05-b239-abf80a1c1c6b",
+    name = "Necrobite",
+    setCode = "M15",
+    collectorNumber = "105",
+    scryfallId = "06c5bca1-b0f0-4032-b2ed-71bdbaa41993",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06c5bca1-b0f0-4032-b2ed-71bdbaa41993.jpg",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MadProphetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MadProphetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mad Prophet reprint in SOI. Canonical CardDefinition lives in its earliest set.
+ */
+val MadProphetReprint = Printing(
+    oracleId = "91081181-aec6-47de-b8ef-241a2f4fe880",
+    name = "Mad Prophet",
+    setCode = "SOI",
+    collectorNumber = "171",
+    scryfallId = "8f498cb6-2be2-4cd0-b002-564a0f006a69",
+    artist = "Iain McCaig",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8f498cb6-2be2-4cd0-b002-564a0f006a69.jpg",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/NaturalEndReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/NaturalEndReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Natural End reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val NaturalEndReprint = Printing(
+    oracleId = "05b5c0fb-84b2-4a32-bf66-179c4dccb3df",
+    name = "Natural End",
+    setCode = "M20",
+    collectorNumber = "183",
+    scryfallId = "84dcd314-f4d2-461e-a66e-7b1d8f141879",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84dcd314-f4d2-461e-a66e-7b1d8f141879.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/TimberlandGuideReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/TimberlandGuideReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timberland Guide reprint in MID. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberlandGuideReprint = Printing(
+    oracleId = "bd8ba76f-d9e1-4c4d-83e1-6782fa3d01ba",
+    name = "Timberland Guide",
+    setCode = "MID",
+    collectorNumber = "202",
+    scryfallId = "6b215b6a-82e3-4ce8-b288-d7341761cad0",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b215b6a-82e3-4ce8-b288-d7341761cad0.jpg",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -50,6 +50,119 @@
     ]
 }
 
+// Alchemist's Apprentice
+{
+    "name": "Alchemist's Apprentice",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Sacrifice this creature: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "David Palumbo",
+        "flavorText": "Side effects may include foul odors, scalding steam, and spontaneous nonexistence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31abba67-1241-4fb3-88b5-4c4668ec5f25.jpg?1783940724"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Angel of Glory's Rise
+{
+    "name": "Angel of Glory's Rise",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nWhen this creature enters, exile all Zombies, then return all Human creature cards from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "permanent Zombie"
+                                }
+                            },
+                            "body": {
+                                "type": "MoveToZone",
+                                "target": "Self",
+                                "destination": "Exile"
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Graveyard",
+                                        "filter": "creature Human"
+                                    },
+                                    "storeAs": "graveyard_lands"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "graveyard_lands",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "James Ryman",
+        "flavorText": "\"Justice isn't done until undeath is undone.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a8be765-0949-491c-875c-0385fb83e4b9.jpg?1783940744"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Angel's Tomb
 {
     "name": "Angel's Tomb",
@@ -186,6 +299,50 @@
     ]
 }
 
+// Archwing Dragon
+{
+    "name": "Archwing Dragon",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, haste\nAt the beginning of the end step, return this creature to its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "flavorText": "Swifter than an angel, crueler than a demon, and relentless as a ghoul.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg?1783940691"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Avacyn, Angel of Hope
 {
     "name": "Avacyn, Angel of Hope",
@@ -222,6 +379,46 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Banners Raised
+{
+    "name": "Banners Raised",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +1/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Mike Bierek",
+        "flavorText": "After the destruction of the Helvault, fearful mobs soon became fearless battalions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7792df3-e2ab-4e60-abee-f24b72807107.jpg?1783940690"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -284,6 +481,77 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Bloodflow Connoisseur
+{
+    "name": "Bloodflow Connoisseur",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Sacrifice a creature: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"Death not for survival but for vanity and pleasure? This is the decadence I sought to curb.\"\n—Sorin Markov",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97485dbf-2f31-4ed2-a6cd-529ca22c9ac5.jpg?1783940706"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Builder's Blessing
+{
+    "name": "Builder's Blessing",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Untapped creatures you control get +0/+2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature untapped ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "John Stanko",
+        "flavorText": "\"Mix the mortar with holy wards, or blood will run in the streets.\"\n—Vadvar, Thraben stonewright",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2ad27af1-b482-40d5-9dbb-11201ffa0410.jpg?1783940741"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -556,6 +824,56 @@
     "colorIdentityOverride": []
 }
 
+// Commander's Authority
+{
+    "name": "Commander's Authority",
+    "manaCost": "{4}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"At the beginning of your upkeep, create a 1/1 white Human creature token.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Human"
+                        ]
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "flavorText": "\"Wear her symbol with honor, a sign of faith upheld and honest deeds bravely done.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08ef4383-11e7-4426-a04a-058570f46e47.jpg?1783940740"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Conjurer's Closet
 {
     "name": "Conjurer's Closet",
@@ -746,6 +1064,108 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Cursebreak
+{
+    "name": "Cursebreak",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target enchantment. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Sam Wolfe Connelly",
+        "flavorText": "No longer the village pariah. No longer taunted and shamed. Sigrun was finally free.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c71a0883-316c-4870-a029-25f16952fbc0.jpg?1783940738"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dangerous Wager
+{
+    "name": "Dangerous Wager",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Discard your hand, then draw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "discardedHand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discardedHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Drew Baker",
+        "flavorText": "\"C'mon friend, take a turn tossing the knucklebones. What've you got to lose?\"\n—Tobias, trader of Erdwal",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/636c4042-703f-4548-9a0f-cb550c468bf9.jpg?1783940687"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1102,6 +1522,67 @@
     ]
 }
 
+// Devout Chaplain
+{
+    "name": "Devout Chaplain",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}, Tap two untapped Humans you control: Exile target artifact or enchantment.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "count": 2,
+                                "filter": "permanent Human",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"By Avacyn's decree, we shall cleanse these relics of their demonic past.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84ceb7f1-14b7-4102-ade2-fbeb835d3804.jpg?1783940736"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Driver of the Dead
 {
     "name": "Driver of the Dead",
@@ -1222,6 +1703,198 @@
     ]
 }
 
+// Entreat the Angels
+{
+    "name": "Entreat the Angels",
+    "manaCost": "{X}{X}{W}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create X 4/4 white Angel creature tokens with flying.\nMiracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
+    "keywords": [
+        "MIRACLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Miracle",
+            "cost": "{X}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": "XValue",
+            "power": 4,
+            "toughness": 4,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Angel"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "MYTHIC",
+        "artist": "Todd Lockwood",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31292616-70e6-4d19-a883-e63ad860f50c.jpg?1783940735"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Evernight Shade
+{
+    "name": "Evernight Shade",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Shade",
+    "oracleText": "{B}: This creature gets +1/+1 until end of turn.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "UNDYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "UNCOMMON",
+        "artist": "Nic Klein",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1091fadf-97c4-4f87-8466-6a1246a72226.jpg?1783940698"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Falkenrath Exterminator
+{
+    "name": "Falkenrath Exterminator",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Vampire Archer",
+    "oracleText": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\n{2}{R}: This creature deals damage to target creature equal to the number of +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": "PlusOnePlusOne"
+                        }
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40e23909-7e08-4686-ae59-e18e7d4cfd3c.jpg?1783940685"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Farbog Explorer
+{
+    "name": "Farbog Explorer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Scott Chou",
+        "flavorText": "\"I'd slog through a thousand swamps to help one soul find rest.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/489c6a2f-38b4-4ff9-95f7-431384480ed9.jpg?1783940735"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Favorable Winds
 {
     "name": "Favorable Winds",
@@ -1246,6 +1919,104 @@
         "artist": "Winona Nelson",
         "flavorText": "Long thought to be extinct, flocks of gryffs reappeared with Avacyn's return.",
         "imageUri": "https://cards.scryfall.io/normal/front/4/c/4cbd57f1-9883-40a4-9b52-1649cee83815.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fervent Cathar
+{
+    "name": "Fervent Cathar",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Haste\nWhen this creature enters, target creature can't block this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Steven Belledin",
+        "flavorText": "\"I'll put my sword down only to die. And I don't plan on doing that today.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fceeb14-a22a-4ab6-9e6d-ba375b6865c0.jpg?1783940685"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Geist Snatch
+{
+    "name": "Geist Snatch",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature spell. Create a 1/1 blue Spirit creature token with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature",
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Angels and demons aren't the only ones listening to your prayers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6dac5db-ef96-4bd5-aabc-e5ae2b95c8c3.jpg?1783940720"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -1287,6 +2058,76 @@
         "artist": "Scott Chou",
         "flavorText": "\"There's no such thing as 'impenetrable.'\"",
         "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ghostly Touch
+{
+    "name": "Ghostly Touch",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, you may tap or untap target permanent.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Modal",
+                            "modes": [
+                                {
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "tap": false
+                                    }
+                                }
+                            ],
+                            "countsAsModalSpell": false
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        }
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "\"Geists wish to make themselves known. I'm merely the vessel for their efforts.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3ebae54a-47e0-4e82-8a29-b5d9354a748b.jpg?1783940718"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -1401,6 +2242,60 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Grave Exchange
+{
+    "name": "Grave Exchange",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to your hand. Target player sacrifices a creature of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target 1"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            },
+            {
+                "type": "TargetPlayer",
+                "id": "target 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Sam Wolfe Connelly",
+        "flavorText": "\"It's a cold, dark journey either way.\"\n—Eruth of Lambholt",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14f420c4-801b-48e7-a10b-de44a2417265.jpg?1783940698"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -1543,6 +2438,95 @@
     ]
 }
 
+// Haunted Guardian
+{
+    "name": "Haunted Guardian",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Defender, first strike",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEFENDER",
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "\"Drain the victim's blood, sell the corpse, and use the soul on guard duty. No muss, no fuss, no problems.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d97f8b8-bdb0-4d4b-b077-9affe2f9cd91.jpg?1783940652"
+    }
+}
+
+// Heirs of Stromkirk
+{
+    "name": "Heirs of Stromkirk",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "INTIMIDATE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Winona Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff89ad3b-b154-49e2-a0fd-135279512250.jpg?1783940684"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Hound of Griselbrand
+{
+    "name": "Hound of Griselbrand",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "Double strike\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "UNDYING"
+    ],
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg?1783940682"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Human Frailty
 {
     "name": "Human Frailty",
@@ -1624,6 +2608,55 @@
     ]
 }
 
+// Kessig Malcontents
+{
+    "name": "Kessig Malcontents",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "When this creature enters, it deals damage to target player or planeswalker equal to the number of Humans you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Human"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayerOrPlaneswalker",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "John Stanko",
+        "flavorText": "Discontent is a powerful weapon in the hands of a mob.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dce9a30f-a850-4826-a255-ce511d567b60.jpg?1783940682"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Killing Wave
 {
     "name": "Killing Wave",
@@ -1694,6 +2727,135 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Kruin Striker
+{
+    "name": "Kruin Striker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever another creature you control enters, this creature gets +1/+0 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Christopher Moeller",
+        "flavorText": "Unhappy with the creation of the wolfir, Rorica broke with her order and led a crusade against the \"reformed werewolves.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73e72249-84ea-4e9c-9f64-b67b02ffdf3a.jpg?1783940682"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Latch Seeker
+{
+    "name": "Latch Seeker",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Vincent Proce",
+        "flavorText": "It seeks a tomb that will hold it, a coffin that will give it rest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e4e7589-9cee-4d57-8648-ce733781bfb2.jpg?1783940717"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Leap of Faith
+{
+    "name": "Leap of Faith",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains flying until end of turn. Prevent all damage that would be dealt to that creature this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Gabor Szikszai",
+        "flavorText": "The finest maneuvers take place in three dimensions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7ba52aed-440c-4b32-8f25-0c5364441712.jpg?1783940733"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1838,6 +3000,61 @@
     ]
 }
 
+// Lunar Mystic
+{
+    "name": "Lunar Mystic",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Whenever you cast an instant spell, you may pay {1}. If you do, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsInstant"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "RARE",
+        "artist": "Wesley Burt",
+        "flavorText": "\"I'm pleased this world has learned the moon affects more than the tides.\"\n—Tamiyo, the Moon Sage",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f346d236-528c-4164-9995-74cdc56597a9.jpg?1783940715"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Maalfeld Twins
 {
     "name": "Maalfeld Twins",
@@ -1887,6 +3104,103 @@
     ]
 }
 
+// Mad Prophet
+{
+    "name": "Mad Prophet",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Haste\n{T}, Discard a card: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"There's no heron in the moon! It's a shrew, a five-legged shrew, with a voice like whispering thunder!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/172383d9-9135-4daa-a647-9d76435d3158.jpg?1783940683"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Malicious Intent
+{
+    "name": "Malicious Intent",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"{T}: Target creature can't block this turn.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Kev Walker",
+        "flavorText": "As peace returned to Thraben, some cathars made the mistake of letting down their guard.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1dda42d-55eb-46fc-89da-17cc5bfaa823.jpg?1783940679"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Marrow Bats
 {
     "name": "Marrow Bats",
@@ -1927,6 +3241,64 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Mass Appeal
+{
+    "name": "Mass Appeal",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw a card for each Human you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent Human"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"We have emerged triumphant from the darkness. Let our hard-won wisdom guide us to prosperity.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfe9ae51-fd2b-45ca-a780-725f51f897b2.jpg?1783940716"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Midnight Duelist
+{
+    "name": "Midnight Duelist",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Protection from Vampires",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Subtype",
+                "subtype": "Vampire"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "Bud Cook",
+        "flavorText": "Avacyn's return did not rid him of his desire for revenge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/2371bd0c-ca38-4a62-b525-bef4d1ca0646.jpg?1783940731"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1980,6 +3352,50 @@
     ]
 }
 
+// Moonlight Geist
+{
+    "name": "Moonlight Geist",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\n{3}{W}: Prevent all combat damage that would be dealt to and dealt by this creature this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": "Self",
+                    "scope": "CombatOnly",
+                    "direction": "Both"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Wails and whispers are the only weapons she has left.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4cf4c4cf-df35-4725-81ca-d62b70b8d0dd.jpg?1783940730"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Moorland Inquisitor
 {
     "name": "Moorland Inquisitor",
@@ -2017,6 +3433,147 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Narstad Scrapper
+{
+    "name": "Narstad Scrapper",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{2}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Steven Belledin",
+        "flavorText": "\"Finally, the principles of corpse animation applied to bloodless materials!\"\n—Ludevic, necro-alchemist",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f808ed9b-95ac-4069-bdca-b100bc816b5b.jpg?1783940654"
+    }
+}
+
+// Natural End
+{
+    "name": "Natural End",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Scott Chou",
+        "flavorText": "The haunted blade shattered, and the geist drifted gratefully to the Blessed Sleep.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95d25235-de1c-4b67-9712-24f0564bd2bf.jpg?1783940664"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Necrobite
+{
+    "name": "Necrobite",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains deathtouch until end of turn. Regenerate it. (The next time that creature would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Nils Hamm",
+        "flavorText": "An undead snake doesn't bite in self-defense. It hungers as any zombie, never sated.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52e59918-cf12-4d73-a4e0-31f38e792dc4.jpg?1783940692"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2111,6 +3668,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Polluted Dead
+{
+    "name": "Polluted Dead",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, destroy target land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Jason A. Engle",
+        "flavorText": "After the zombie attack, crops withered on the vine, and the thriving village became a ghost town almost overnight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/036c1954-37d3-4787-8df8-f2d0dd39058a.jpg?1783940692"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2449,6 +4055,178 @@
     ]
 }
 
+// Riot Ringleader
+{
+    "name": "Riot Ringleader",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever this creature attacks, Human creatures you control get +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Human ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Gabor Szikszai",
+        "flavorText": "\"So the vampires like hot blood, do they? Let's see how they handle ours.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c043f30b-548f-4c31-a415-0e59c2841dcf.jpg?1783940678"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rotcrown Ghoul
+{
+    "name": "Rotcrown Ghoul",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, target player mills five cards.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Dave Kendall",
+        "flavorText": "\"Don't look into its eyes. It's thinking things no dead thing should think.\"\n—Captain Eberhart",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f13b5ba6-0de1-4f5c-867b-57e2c10bde8e.jpg?1783940711"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Scalding Devil
+{
+    "name": "Scalding Devil",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "{2}{R}: This creature deals 1 damage to target player or planeswalker.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Erica Yang",
+        "flavorText": "Demons massacre. Devils annoy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbe49a97-dac8-4273-b4dc-45cdf8f5a6e0.jpg?1783940677"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Scrapskin Drake
 {
     "name": "Scrapskin Drake",
@@ -2556,6 +4334,49 @@
     "colorIdentityOverride": []
 }
 
+// Searchlight Geist
+{
+    "name": "Searchlight Geist",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\n{3}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Steven Belledin",
+        "flavorText": "It rises with the fall of darkness, seeking souls to extinguish.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0dc1a94-0193-464e-a481-730b34b57db5.jpg?1783940691"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Seraph Sanctuary
 {
     "name": "Seraph Sanctuary",
@@ -2641,6 +4462,54 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Sheltering Word
+{
+    "name": "Sheltering Word",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gains hexproof until end of turn. You gain life equal to that creature's toughness. (A creature with hexproof can't be the target of spells or abilities your opponents control.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Toughness"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Igor Kieryluk",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93cd9be4-1ce4-4a7c-b2a6-98d3fde0a92b.jpg?1783940662"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -2784,6 +4653,62 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Snare the Skies
+{
+    "name": "Snare the Skies",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+1 and gains reach until end of turn. (It can block creatures with flying.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Ryan Yee",
+        "flavorText": "A hunter's precision and a durkvine's strength are a potent combination.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28f75827-a144-4fe2-a713-4439ae7567eb.jpg?1783940662"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -3208,6 +5133,284 @@
     ]
 }
 
+// Thraben Valiant
+{
+    "name": "Thraben Valiant",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Jason Chan",
+        "flavorText": "\"Once more into Devil's Breach, soldiers. I want another devil tail for my collection.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20558f69-9240-49b9-9695-caf75ee2db1b.jpg?1783940728"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Thunderous Wrath
+{
+    "name": "Thunderous Wrath",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Thunderous Wrath deals 5 damage to any target.\nMiracle {R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
+    "keywords": [
+        "MIRACLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Miracle",
+            "cost": "{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Paquette",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/daa39826-7f89-41cb-a7fe-7f7be817d5cd.jpg?1783940675"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Timberland Guide
+{
+    "name": "Timberland Guide",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "When this creature enters, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Can you build a fire? Track a deer? Identify killer trees? Then you'll never survive Kessig without me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae80fefb-af78-4f98-8058-71b61e91842f.jpg?1783940665"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Uncanny Speed
+{
+    "name": "Uncanny Speed",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 and gains haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"To survive, we must embrace the savagery we knew in our race's infancy.\"\n—Edgar Markov",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d7b747e-446a-4c25-9834-0be8476dc22d.jpg?1783940673"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Undead Executioner
+{
+    "name": "Undead Executioner",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, you may have target creature get -2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Dave Kendall",
+        "flavorText": "Heartless killer in life, brainless killer in death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d330058-16af-4486-aa89-b6be759e35d4.jpg?1783940690"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vanishment
+{
+    "name": "Vanishment",
+    "manaCost": "{4}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Put target nonland permanent on top of its owner's library.\nMiracle {U} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
+    "keywords": [
+        "MIRACLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Miracle",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/dece40c1-790c-4471-a790-1d356b345603.jpg?1783940709"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vexing Devil
 {
     "name": "Vexing Devil",
@@ -3293,6 +5496,49 @@
     ]
 }
 
+// Vigilante Justice
+{
+    "name": "Vigilante Justice",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a Human you control enters, this enchantment deals 1 damage to any target.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Human ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": "AnyTarget"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "It begins as a whisper and ends with the red roar of fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9db329b-6248-4082-bfc8-5d2c0db43338.jpg?1783940673"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Voice of the Provinces
 {
     "name": "Voice of the Provinces",
@@ -3354,6 +5600,49 @@
         "artist": "Lucas Graciano",
         "flavorText": "\"Where'd the werewolves go? Maybe *that* got hungry.\"\n—Halana of Ulvenwald",
         "imageUri": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg?1783940659"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wolfir Avenger
+{
+    "name": "Wolfir Avenger",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Wolf Warrior",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\n{1}{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "Released from a dark curse and bound to a higher calling.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88cc00e5-9683-4ccc-a914-c422b76f6014.jpg?1783940657"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -3428,5 +5717,61 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Zealous Strike
+{
+    "name": "Zealous Strike",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains first strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Bud Cook",
+        "flavorText": "\"Cower, fiend. The night is yours no longer.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae8a01fb-dd47-44de-b528-8b7ca4b3388b.jpg?1783940724"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -1,3 +1,29 @@
+// Angel's Mercy
+{
+    "name": "Angel's Mercy",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "You gain 7 life.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 7
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Andrew Robinson",
+        "flavorText": "\"Until that day I cursed the angels, those uncaring lights in the sky. They rewarded my scorn with the gift of time, every year of which I've spent in devotion to their names.\"\n—Torian Sha, soul warden",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b911124-3646-4014-b574-13fee44bfad5.jpg?1783942405"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ant Queen
 {
     "name": "Ant Queen",
@@ -142,6 +168,79 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Borderland Ranger
+{
+    "name": "Borderland Ranger",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Scout Ranger",
+    "oracleText": "When this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Only fools and bandits use roads.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdd0f8c8-1a1f-4d9b-a6e1-3654f3995012.jpg?1783942366"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WTH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WTH.json
@@ -538,3 +538,70 @@
         "BLUE"
     ]
 }
+
+// Thunderbolt
+{
+    "name": "Thunderbolt",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Thunderbolt deals 3 damage to target player or planeswalker.\n• Thunderbolt deals 4 damage to target creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayerOrPlaneswalker",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Thunderbolt deals 3 damage to target player or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:flying"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Thunderbolt deals 4 damage to target creature with flying"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Dylan Martens",
+        "flavorText": "\"Most wizards consider a thunderbolt to be a proper retort.\"\n—Ertai, wizard adept",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0a4b641-2eb3-482b-91a1-236ebe2a7a41.jpg?1783946723"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Avacyn Restored had not authored.

**Assay-ready: 59 → 0**, re-run on this branch (`just assay-ready AVR`), not inferred. AVR's remaining 111 missing cards are all `LINE_DECLINED`/`LINES_DO_NOT_FOLD` — grammar work, not authoring work.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 50 | canonical authored here — AVR is the earliest real printing |
| `elsewhere` | 3 | canonical authored in the earlier set + a `Printing` row here |
| `row-only` | 1 | Crypt Creeper (canonical in ODY) — `Printing` row only |
| `basic` | 5 | 15 `basicLand(...)` vals, three arts each, collector numbers 230–244 |

`elsewhere`: Angel's Mercy → M10, Borderland Ranger → M10, Thunderbolt → WTH.

**Reprint tail: 9 more `Printing` rows in 9 other sets** (BNG, C14, DDL, M12, M13, M15, M20, MID, SOI) — invisible to `check-card-printing` until these canonicals existed, so they belong in this PR. `generate-reprints.py --since main` reported 0 misplaced canonicals and 0 stale cache entries.

AVR now has basics of its own, so `basicLandsFallback = PortalSet` is dropped in favour of a `basicLands` override.

## Method

Every card was authored to **`assay compile`'s JSON**, not to the oracle text, and every metadata field comes from a **live Scryfall payload for the canonical's own printing** (not from the compile's `setCode`/`imageUri`, which name whatever printing the Oracle bulk carried — it pointed at a *later* set for 14 of the 53). A mechanical check diffed all 53 written files' `manaCost` / `typeLine` / P/T / `rarity` / `collectorNumber` / `artist` / `imageUri` back against those payloads, scoped inside the `metadata { }` block: **53/53 exact, 0 mismatches**.

**Capability pre-flight**: all 23 mechanics the batch touches were traced to a real `rules-engine` consumer. None are in the display-only family (RAMPAGE/MODULAR/ANNIHILATOR/CASCADE/FLURRY/BUSHIDO). Miracle (full reveal-on-draw + cast window), undying, intimidate, swampwalk, protection-from-subtype, regenerate, flash and both prevention shapes all have live consumers.

Four hazards the pre-flight caught before they shipped:

- **`TriggerBinding.ATTACHED` never fires** — `event/TriggerIndex.kt:215-227` returns `emptyList()` for it (two whitelisted block-event exceptions aside). Commander's Authority and Ghostly Touch install their quoted trigger on the creature via `GrantTriggeredAbility` and pass the `TriggerSpec`'s own binding through verbatim (`ANY` for `YourUpkeep`, `SELF` for `Attacks`).
- **Archwing Dragon is `Triggers.EachEndStep`, not `YourEndStep`** — "the end step" with no possessive is `Player.Each`. Using `YourEndStep` would be a silent behavioural bug no snapshot test catches.
- **`RegenerateEffect` has no `Effects.*` facade** — the class is imported directly on Necrobite and Wolfir Avenger, deliberately.
- **A bare tribal noun means *permanents*** — Mass Appeal, Kessig Malcontents and Vigilante Justice all use `Permanent.withSubtype("Human")`, matching Assay's `IsPermanent` predicate and the rules.

## Verification

- `just build` — compiles clean; the only failure was `CardDefinitionSnapshotTest`, expected for new cards.
- `just rebless-cards` — a block-level diff of the AVR golden confirms **50 added, 0 removed, 0 pre-existing cards changed**; M10 and WTH gained only their one card each. (The raw line diff shows ~208 "deletions" — that is pure re-ordering as new cards interleave alphabetically.)
- `just assay-ready AVR` on the branch — **0**.
- Per the repo owner's instruction, the remaining suites (`just test`, `just assay-differential`) are left to CI on this PR rather than run locally. **Differential baseline before the change was 6055 compared / 6001 confirmed / 54 divergent** — classify the delta against that, not against zero.

## Findings this sweep surfaced but did not fix

1. **`blb/cards/BywayBarterer.kt` is a live differential divergence.** Its `Patterns.Hand.discardHand().then(Effects.DrawCards(2))` produces a flat `Composite[gather, move, draw]`, but Assay models "discard your hand, then draw two cards" as `Composite[Composite[gather, move], draw]` — `Effect.then` splices into an existing composite (`Effect.kt:61`, `HandPatterns.kt:437`). Dangerous Wager here uses `Effects.Composite(...)` and matches; Byway Barterer does not. Same shape as the known `then`-flattens-a-Composite family.
2. **`oracleText` is not derived, and omitting it is load-bearing.** `CardBuilder.oracleText` defaults to `""`, and `CardPredicate.HasNoAbilities` is literally `card.oracleText.isBlank()` (`AffectsFilterResolver.kt:813`, `CostCalculator.kt:1241`) — a card with a blank `oracleText` would wrongly satisfy "creatures with no abilities". It is also what `ClientStateTransformer` shows the player. All 53 cards here set it. **63 of AVR's 116 pre-existing card files do not**, and the same gap likely exists corpus-wide; worth a sweep of its own.
3. **Devout Chaplain carries one deliberate divergence.** Assay's JSON omits `excludeSelf` on `AtomTapPermanents` (i.e. `false`); the card passes `excludeSelf = true`, because the Chaplain is itself a Human and is already paying `{T}`, so it cannot be one of the two Humans tapped. The Kotlin is rules-correct; the parser has no rule for this yet.
4. **Builder's Blessing is the first card in the corpus** to put a `StatePredicate.IsUntapped` inside a **static** `ModifyStats` filter. The plumbing exists (`AffectsFilterResolver.kt:411`) but was previously unexercised in the layer system. It deserves a scenario test that taps a creature and asserts the +0/+2 falls off, then untaps and asserts it returns — not written here, and flagged as follow-up.
5. **`AttachmentTriggerDetector` has no block branch**, so an `ATTACHED`-bound *blocks* trigger is dead for the same reason as (1) above. Noted in `mrd/cards/ContaminatedBond.kt`'s KDoc; nothing in this PR depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
