### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BlazingArchon.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BlazingArchon.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeAttackedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Blazing Archon
+ * {6}{W}{W}{W}
+ * Creature — Archon
+ * 5/6
+ *
+ * Flying
+ * Creatures can't attack you.
+ *
+ * The unqualified sentence is the base case of [CantBeAttackedBy] — the filter carries the whole
+ * restriction, so "creatures" with no qualifier is the bare [GameObjectFilter.Creature]. The
+ * engine consults the *defending* player's battlefield for this ability, which is why the Archon
+ * protects its controller rather than itself, and why it keeps working while it is tapped.
+ *
+ * It is deliberately an attack restriction and nothing more: per the ruling below a creature that
+ * can't attack you may still attack a planeswalker you control, which falls out for free because
+ * CR 508.1c is checked against the *player* being attacked.
+ */
+val BlazingArchon = card("Blazing Archon") {
+    manaCost = "{6}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Archon"
+    oracleText = "Flying\n" +
+        "Creatures can't attack you."
+    power = 5
+    toughness = 6
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBeAttackedBy(GameObjectFilter.Creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "\"Through the haze of battle I saw the glint of sun on golden mane, the sheen " +
+            "of glory clad in mail, and I dropped my sword and wept at the idiocy of war.\"\n" +
+            "—Dravin, Gruul deserter"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg?1783943707"
+        ruling(
+            "2014-02-01",
+            "Unless some effect explicitly says otherwise, a creature that can't attack you can " +
+                "still attack a planeswalker you control."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GolgariGermination.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GolgariGermination.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Golgari Germination
+ * {1}{B}{G}
+ * Enchantment
+ *
+ * Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token.
+ *
+ * The dies clause is `leavesBattlefield(… to = GRAVEYARD)` — a battlefield→graveyard move, not a
+ * graveyard-scoped trigger. The `nontoken()` predicate is what stops the Saprolings it makes from
+ * feeding it further; without it the enchantment would loop off its own tokens.
+ *
+ * [TriggerBinding.ANY] rather than OTHER, matching Ulvenwald Mysteries: a leaves-the-battlefield
+ * trigger looks back in time (CR 603.10a / 608.2g), so a creature dying *simultaneously* with the
+ * enchantment still triggers it, and if some effect has animated the enchantment its own death
+ * counts too.
+ *
+ * The token takes the set's own Saproling art, declared as a [
+ * com.wingedsheep.sdk.model.TokenPrinting] on `RavnicaCityOfGuildsSet` — Ravnica predates token
+ * *cards*, so there is no `trav` printing to point `imageUri` at.
+ */
+val GolgariGermination = card("Golgari Germination") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a nontoken creature you control dies, create a 1/1 green Saproling " +
+        "creature token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+        description = "Whenever a nontoken creature you control dies, create a 1/1 green " +
+            "Saproling creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Thomas M. Baxa"
+        flavorText = "The Golgari don't bury their dead. They plant them."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg?1783943620"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoxodonGatekeeper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoxodonGatekeeper.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+
+/**
+ * Loxodon Gatekeeper
+ * {2}{W}{W}
+ * Creature — Elephant Soldier
+ * 2/3
+ *
+ * Artifacts, creatures, and lands your opponents control enter tapped.
+ *
+ * Three separate [PermanentsEnterTapped] replacements rather than one union filter, following
+ * Thalia, Heretic Cathar: "artifact", "creature" and "land" are independent characteristic checks,
+ * so an artifact creature (or a land that has become a creature) matches more than one and simply
+ * enters tapped once. A union filter would need an `AnyOf` that says nothing extra here.
+ *
+ * `appliesTo` describes the *affected* permanent, not the Gatekeeper — this is the group
+ * counterpart of the self-only `EntersTapped`, consulted from the battlefield whenever some other
+ * permanent enters. The controller-relative `opponentControls()` predicate resolves against the
+ * Gatekeeper's own controller at entry time, so permanents entering *simultaneously* with the
+ * Gatekeeper are unaffected (the replacement does not exist until it is on the battlefield).
+ *
+ * Note the noun list stops at three types: enchantments and planeswalkers your opponents control
+ * are untouched, which is the whole reason this is not `GameObjectFilter.Permanent`.
+ */
+val LoxodonGatekeeper = card("Loxodon Gatekeeper") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Soldier"
+    oracleText = "Artifacts, creatures, and lands your opponents control enter tapped."
+    power = 2
+    toughness = 3
+
+    // Artifacts your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // Creatures your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // Lands your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Land.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Carl Critchlow"
+        flavorText = "The gatekeepers are so fastidious that even the winds must wait to pass."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg?1783943696"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoxodonHierarch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LoxodonHierarch.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Loxodon Hierarch
+ * {2}{G}{W}
+ * Creature — Elephant Cleric
+ * 4/4
+ *
+ * When this creature enters, you gain 4 life.
+ * {G}{W}, Sacrifice this creature: Regenerate each creature you control.
+ *
+ * "Regenerate each creature you control" is [Effects.ForEachInGroup] over the creatures you
+ * control with a body of `RegenerateEffect(EffectTarget.Self)` — `IterationSpace.Group` binds the
+ * current permanent as the body's `Self`, so the single-target regeneration facade applies once
+ * per creature. That composition is what the ruling below describes: each creature gets its own
+ * regeneration shield, spent independently and expiring at end of turn, rather than one shared
+ * shield for the board.
+ *
+ * The Hierarch never regenerates itself. `Costs.SacrificeSelf` is paid on activation, so it is
+ * already in the graveyard when the ability resolves and the group snapshot is taken.
+ */
+val LoxodonHierarch = card("Loxodon Hierarch") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elephant Cleric"
+    oracleText = "When this creature enters, you gain 4 life.\n" +
+        "{G}{W}, Sacrifice this creature: Regenerate each creature you control."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{W}"), Costs.SacrificeSelf)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            RegenerateEffect(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Kev Walker"
+        flavorText = "\"I have lived long, and I remember how this city once was. If my death " +
+            "serves to bring back the Ravnica in my memory, then so be it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg?1783943619"
+        ruling(
+            "2005-10-01",
+            "The second ability sets up individual regeneration shields for each creature you " +
+                "control. They are each used up as necessary during the turn and wear off when the " +
+                "turn ends."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StoneshakerShaman.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StoneshakerShaman.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stoneshaker Shaman
+ * {2}{R}
+ * Creature — Human Shaman
+ * 1/1
+ *
+ * At the beginning of each player's end step, that player sacrifices an untapped land of their
+ * choice.
+ *
+ * "Each player's end step" is [Triggers.EachEndStep] — a `StepEvent(END, Player.Each)`. Only the
+ * active player has an end step in a given turn, so this fires once per turn and
+ * [Player.TriggeringPlayer] is whoever's turn it is. The Shaman's controller is not spared: the
+ * sentence names the player whose step it is, not an opponent, which is what makes this a
+ * symmetric card.
+ *
+ * "Of their choice" is the ordinary [Effects.Sacrifice] semantics — the sacrificing player picks,
+ * not the Shaman's controller — and the `untapped()` predicate keeps a player who has tapped out
+ * for the turn from choosing a land they've already used. Per the ruling below, a player with no
+ * untapped land simply does nothing; `ForceSacrificeEffect` sacrifices as many as it can find
+ * rather than failing.
+ */
+val StoneshakerShaman = card("Stoneshaker Shaman") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "At the beginning of each player's end step, that player sacrifices an untapped " +
+        "land of their choice."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        effect = Effects.Sacrifice(
+            filter = GameObjectFilter.Land.untapped(),
+            count = 1,
+            target = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+        )
+        description = "At the beginning of each player's end step, that player sacrifices an " +
+            "untapped land of their choice."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Jeff Miracola"
+        flavorText = "There is no place in Ravnica for stagnation, no room for lands unfilled and " +
+            "untilled."
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg?1783943646"
+        ruling(
+            "2005-10-01",
+            "If the player doesn't have an untapped land as Stoneshaker Shaman's ability resolves, " +
+                "that player does nothing."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlazingArchonScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlazingArchonScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Blazing Archon (RAV #4) — {6}{W}{W}{W} Archon, 5/6.
+ *
+ * "Flying
+ *  Creatures can't attack you."
+ *
+ * `CantBeAttackedBy(GameObjectFilter.Creature)` is checked against the *defending* player's
+ * battlefield (CR 508.1c), so the two things worth proving are that the restriction protects the
+ * Archon's controller — including against creatures that would otherwise be unblockable by it —
+ * and that it stops being enforced the moment the Archon leaves.
+ */
+class BlazingArchonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blazing Archon attack restriction") {
+
+            test("an opponent's creature can't attack the Archon's controller") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blazing Archon")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Grizzly Bears" to 1))
+
+                withClue("Declaring an attack on the Archon's controller must be rejected") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("the restriction is gone once the Archon leaves the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Grizzly Bears" to 1))
+
+                withClue("Without the Archon the same attack is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgariGerminationScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgariGerminationScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GolgariGermination
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Golgari Germination (RAV #209) — {1}{B}{G} Enchantment
+ *
+ * "Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token."
+ *
+ * Two predicates carry the whole card and each gets a test: `youControl()` (an opponent's dying
+ * creature does nothing) and `nontoken()` (the Saprolings it makes don't feed it — without that
+ * predicate the enchantment would replace each dying token with a fresh one forever).
+ */
+class GolgariGerminationScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GolgariGermination))
+        return driver
+    }
+
+    fun startGame(driver: GameTestDriver) {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Doom Blade [victim] off injected mana and let the kill (and any trigger) resolve. */
+    fun doomBlade(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val blade = driver.putCardInHand(caster, "Doom Blade")
+        driver.giveMana(caster, Color.BLACK, 1)
+        driver.giveColorlessMana(caster, 1)
+        driver.castSpell(caster, blade, listOf(victim))
+        driver.bothPass()   // resolve Doom Blade
+        driver.bothPass()   // resolve the Germination trigger, if one went on the stack
+    }
+
+    /** Minted tokens are named "<name> Token", so match on the prefix. */
+    fun saprolings(driver: GameTestDriver, playerId: EntityId): List<EntityId> =
+        driver.getCreatures(playerId).filter {
+            driver.getCardName(it)?.startsWith("Saproling") == true
+        }
+
+    test("a nontoken creature you control dying makes a Saproling") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(you, "Golgari Germination")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        saprolings(driver, you).size shouldBe 0
+
+        doomBlade(driver, you, bears)
+
+        driver.findPermanent(you, "Grizzly Bears") shouldBe null
+        saprolings(driver, you).size shouldBe 1
+    }
+
+    test("an opponent's creature dying does nothing — the filter is `you control`") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putPermanentOnBattlefield(you, "Golgari Germination")
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        doomBlade(driver, you, theirBears)
+
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        saprolings(driver, you).size shouldBe 0
+        saprolings(driver, opponent).size shouldBe 0
+    }
+
+    test("the Saproling it makes doesn't feed it — `nontoken` closes the loop") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(you, "Golgari Germination")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        doomBlade(driver, you, bears)
+        saprolings(driver, you).size shouldBe 1
+
+        val saproling = saprolings(driver, you).single()
+        doomBlade(driver, you, saproling)
+
+        // The token died and was not replaced.
+        saprolings(driver, you).size shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonGatekeeperScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonGatekeeperScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.LoxodonGatekeeper
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Loxodon Gatekeeper (RAV #25) — {2}{W}{W} 2/3 Creature — Elephant Soldier
+ *
+ * "Artifacts, creatures, and lands your opponents control enter tapped."
+ *
+ * Three independent `PermanentsEnterTapped` replacements, so the test walks all three halves plus
+ * the two cases they must *not* touch: your own permanents, and an opponent's *enchantment* —
+ * the noun list stops at three types, which is the whole reason this isn't a `Permanent` filter.
+ *
+ * The permanents must be genuinely *cast* (or played, for the land): placing one on the battlefield
+ * directly bypasses the entry replacement the card is made of, so this uses `GameTestDriver` rather
+ * than a direct-placement scenario builder.
+ */
+class LoxodonGatekeeperScenarioTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    val trinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val charm = CardDefinition.enchantment(
+        name = "Test Charm",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LoxodonGatekeeper, bear, trinket, charm))
+        return driver
+    }
+
+    /** Cast [cardName] off injected mana and let it resolve. */
+    fun castAndResolve(driver: GameTestDriver, playerId: EntityId, cardName: String): EntityId {
+        val cardId = driver.putCardInHand(playerId, cardName)
+        driver.giveColorlessMana(playerId, 1)
+        driver.submitSuccess(
+            CastSpell(playerId = playerId, cardId = cardId, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+        return cardId
+    }
+
+    /** Advance turns until [playerId] is the active player, then stop in their precombat main. */
+    fun handTurnTo(driver: GameTestDriver, playerId: EntityId) {
+        while (driver.activePlayer != playerId) {
+            driver.passPriorityUntil(Step.END)
+            driver.bothPass()
+        }
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("an opponent's creature enters tapped; your own does not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Loxodon Gatekeeper")
+
+        // Yours is unaffected — the filter is `opponentControls()`.
+        val yourBear = castAndResolve(driver, you, "Test Bear")
+        driver.isTapped(yourBear) shouldBe false
+
+        handTurnTo(driver, opponent)
+        val theirBear = castAndResolve(driver, opponent, "Test Bear")
+        driver.isTapped(theirBear) shouldBe true
+    }
+
+    test("an opponent's artifact enters tapped") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Loxodon Gatekeeper")
+
+        handTurnTo(driver, opponent)
+        val theirTrinket = castAndResolve(driver, opponent, "Test Trinket")
+        driver.isTapped(theirTrinket) shouldBe true
+    }
+
+    test("an opponent's land enters tapped, basic or not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Loxodon Gatekeeper")
+
+        // Unlike Thalia's "nonbasic lands", the Gatekeeper's filter is every land — a basic
+        // Plains is caught too.
+        handTurnTo(driver, opponent)
+        val theirPlains = driver.putCardInHand(opponent, "Plains")
+        driver.submitSuccess(PlayLand(playerId = opponent, cardId = theirPlains))
+        driver.isTapped(theirPlains) shouldBe true
+    }
+
+    test("an opponent's enchantment is untouched — the noun list stops at three types") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Loxodon Gatekeeper")
+
+        handTurnTo(driver, opponent)
+        val theirCharm = castAndResolve(driver, opponent, "Test Charm")
+        driver.isTapped(theirCharm) shouldBe false
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonHierarchScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonHierarchScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.LoxodonHierarch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Loxodon Hierarch (RAV #214) — {2}{G}{W} 4/4 Creature — Elephant Cleric
+ *
+ * "When this creature enters, you gain 4 life.
+ *  {G}{W}, Sacrifice this creature: Regenerate each creature you control."
+ *
+ * The second ability is the corpus's first group regeneration — `ForEachInGroup` over the creatures
+ * you control with a `RegenerateEffect(EffectTarget.Self)` body. The tests prove the three things
+ * that composition has to get right:
+ *
+ *  - every creature you control gets its own shield, not just one of them;
+ *  - the shields are *individual* (per the RAV ruling), so spending one leaves the others up;
+ *  - the Hierarch itself doesn't come back — `Costs.SacrificeSelf` is paid on activation, so it is
+ *    already in the graveyard when the group snapshot is taken.
+ */
+class LoxodonHierarchScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LoxodonHierarch))
+        return driver
+    }
+
+    fun startGame(driver: GameTestDriver) {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("entering the battlefield gains its controller 4 life") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        val before = driver.getLifeTotal(you)
+
+        val hierarch = driver.putCardInHand(you, "Loxodon Hierarch")
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveColorlessMana(you, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = you, cardId = hierarch, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()   // resolve the Hierarch
+        driver.bothPass()   // resolve the enters-the-battlefield trigger
+
+        driver.getLifeTotal(you) shouldBe before + 4
+    }
+
+    test("the sacrifice ability regenerates every other creature you control") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        val hierarch = driver.putCreatureOnBattlefield(you, "Loxodon Hierarch")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val abilityId = driver.cardRegistry.requireCard("Loxodon Hierarch")
+            .activatedAbilities.first().id
+
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = hierarch,
+                abilityId = abilityId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        driver.bothPass()
+
+        // Sacrifice is an activation cost, so the Hierarch is gone before the effect resolves.
+        driver.findPermanent(you, "Loxodon Hierarch") shouldBe null
+
+        // The shield shows up as survival: Doom Blade destroys the Bears, regeneration saves it.
+        val doomBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, doomBlade, listOf(bears))
+        driver.bothPass()
+
+        driver.findPermanent(you, "Grizzly Bears") shouldBe bears
+        driver.isTapped(bears) shouldBe true
+    }
+
+    test("the shields are individual — using one leaves the other creature's intact") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        val hierarch = driver.putCreatureOnBattlefield(you, "Loxodon Hierarch")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val wall = driver.putCreatureOnBattlefield(you, "Wall of Wood")
+
+        val abilityId = driver.cardRegistry.requireCard("Loxodon Hierarch")
+            .activatedAbilities.first().id
+
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = hierarch,
+                abilityId = abilityId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        driver.bothPass()
+
+        // Spend the Bears' shield.
+        val firstBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, firstBlade, listOf(bears))
+        driver.bothPass()
+        driver.findPermanent(you, "Grizzly Bears") shouldBe bears
+
+        // The Wall's own shield is untouched by that.
+        val secondBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, secondBlade, listOf(wall))
+        driver.bothPass()
+        driver.findPermanent(you, "Wall of Wood") shouldBe wall
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneshakerShamanScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneshakerShamanScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.StoneshakerShaman
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stoneshaker Shaman (RAV #145) — {2}{R} 1/1 Creature — Human Shaman
+ *
+ * "At the beginning of each player's end step, that player sacrifices an untapped land of their
+ *  choice."
+ *
+ * Two things are easy to get wrong here and both are tested. The trigger is
+ * [com.wingedsheep.sdk.dsl.Triggers.EachEndStep], not `YourEndStep`, so it fires on the Shaman's
+ * controller's own turn too — this card is symmetric. And the sacrificing player is
+ * `Player.TriggeringPlayer` (whoever's end step it is), not the Shaman's controller, which the
+ * second test pins by putting the Shaman under the *non-active* player's control.
+ *
+ * The `untapped()` predicate is the third axis: per the RAV ruling, a player with no *untapped*
+ * land sacrifices nothing rather than being forced to give up a tapped one.
+ */
+class StoneshakerShamanScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(StoneshakerShaman))
+        return driver
+    }
+
+    fun startGame(driver: GameTestDriver) {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun graveyardSize(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.GRAVEYARD)).size
+
+    /**
+     * Run the current turn's end step: reach it, let the trigger resolve, and answer the
+     * sacrifice prompt if one was raised (a player with no untapped land is never asked).
+     */
+    fun runEndStep(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        if (driver.pendingDecision != null) {
+            driver.autoResolveDecision()
+        }
+    }
+
+    test("the active player sacrifices an untapped land at their own end step") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(you, "Stoneshaker Shaman")
+        driver.putLandOnBattlefield(you, "Mountain")
+        driver.putLandOnBattlefield(you, "Mountain")
+
+        val landsBefore = driver.getLands(you).size
+        val graveyardBefore = graveyardSize(driver, you)
+
+        runEndStep(driver)
+
+        driver.getLands(you).size shouldBe landsBefore - 1
+        graveyardSize(driver, you) shouldBe graveyardBefore + 1
+    }
+
+    test("the sacrificing player is whoever's end step it is, not the Shaman's controller") {
+        val driver = createDriver()
+        startGame(driver)
+        val active = driver.activePlayer!!
+        val other = driver.getOpponent(active)
+
+        // The Shaman belongs to the *non-active* player; the active player still pays.
+        driver.putCreatureOnBattlefield(other, "Stoneshaker Shaman")
+        driver.putLandOnBattlefield(active, "Mountain")
+        driver.putLandOnBattlefield(active, "Mountain")
+        driver.putLandOnBattlefield(other, "Mountain")
+
+        val activeLandsBefore = driver.getLands(active).size
+        val otherLandsBefore = driver.getLands(other).size
+
+        runEndStep(driver)
+
+        driver.getLands(active).size shouldBe activeLandsBefore - 1
+        driver.getLands(other).size shouldBe otherLandsBefore
+    }
+
+    test("a player whose lands are all tapped sacrifices nothing") {
+        val driver = createDriver()
+        startGame(driver)
+        val you = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(you, "Stoneshaker Shaman")
+        val onlyLand = driver.putLandOnBattlefield(you, "Mountain")
+        driver.tapPermanent(onlyLand)
+
+        val landsBefore = driver.getLands(you).size
+
+        runEndStep(driver)
+
+        driver.getLands(you).size shouldBe landsBefore
+        driver.findPermanent(you, "Mountain") shouldBe onlyLand
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BlazingArchonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BlazingArchonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blazing Archon reprint in Commander 2016. The canonical card definition lives in
+ * Ravnica: City of Guilds; this file contributes only the Commander 2016 presentation data.
+ */
+val BlazingArchonReprint = Printing(
+    oracleId = "82a70e4c-01ed-4280-80e4-86cb2bf6e63d",
+    name = "Blazing Archon",
+    setCode = "C16",
+    collectorNumber = "58",
+    scryfallId = "3c6cc01f-a14b-462d-9bfc-8f38d46a546a",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c6cc01f-a14b-462d-9bfc-8f38d46a546a.jpg?1783937079",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -211,6 +211,49 @@
     ]
 }
 
+// Blazing Archon
+{
+    "name": "Blazing Archon",
+    "manaCost": "{6}{W}{W}{W}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nCreatures can't attack you.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeAttackedBy",
+                "attackerFilter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "\"Through the haze of battle I saw the glint of sun on golden mane, the sheen of glory clad in mail, and I dropped my sword and wept at the idiocy of war.\"\n—Dravin, Gruul deserter",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd0bc05b-ec48-41fd-a97a-ffb0d5a2dee0.jpg?1783943707",
+        "rulings": [
+            {
+                "date": "2014-02-01",
+                "text": "Unless some effect explicitly says otherwise, a creature that can't attack you can still attack a planeswalker you control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Blockbuster
 {
     "name": "Blockbuster",
@@ -2881,6 +2924,51 @@
     ]
 }
 
+// Golgari Germination
+{
+    "name": "Golgari Germination",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "Whenever a nontoken creature you control dies, create a 1/1 green Saproling creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "The Golgari don't bury their dead. They plant them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24a1db16-d936-4f92-9611-327a988ce04c.jpg?1783943620"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Golgari Guildmage
 {
     "name": "Golgari Guildmage",
@@ -3863,6 +3951,134 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Loxodon Gatekeeper
+{
+    "name": "Loxodon Gatekeeper",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "oracleText": "Artifacts, creatures, and lands your opponents control enter tapped.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            },
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            },
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Carl Critchlow",
+        "flavorText": "The gatekeepers are so fastidious that even the winds must wait to pass.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg?1783943696"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Loxodon Hierarch
+{
+    "name": "Loxodon Hierarch",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Creature — Elephant Cleric",
+    "oracleText": "When this creature enters, you gain 4 life.\n{G}{W}, Sacrifice this creature: Regenerate each creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Regenerate",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "\"I have lived long, and I remember how this city once was. If my death serves to bring back the Ravnica in my memory, then so be it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1d3ccca-8040-4a5f-9f2b-6fdb1a033234.jpg?1783943619",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The second ability sets up individual regeneration shields for each creature you control. They are each used up as necessary during the turn and wear off when the turn ends."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -5860,6 +6076,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Stoneshaker Shaman
+{
+    "name": "Stoneshaker Shaman",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "At the beginning of each player's end step, that player sacrifices an untapped land of their choice.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "land untapped",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "At the beginning of each player's end step, that player sacrifices an untapped land of their choice."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "There is no place in Ravnica for stagnation, no room for lands unfilled and untilled.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17a0edb0-697a-4e0b-872b-f3c15c19cbda.jpg?1783943646",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If the player doesn't have an untapped land as Stoneshaker Shaman's ability resolves, that player does nothing."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Five Ravnica: City of Guilds cards, all canonical in RAV (verified earliest real-expansion printing via `check-card-printing`) and all built from existing SDK primitives — no new engine vocabulary.

| Card | What it does | Composes |
|---|---|---|
| **Blazing Archon** {6}{W}{W}{W} 5/6 | Flying; creatures can't attack you | `CantBeAttackedBy(GameObjectFilter.Creature)` — the unqualified sentence is the filter's base case |
| **Loxodon Gatekeeper** {2}{W}{W} 2/3 | Artifacts, creatures and lands your opponents control enter tapped | 3× `PermanentsEnterTapped` with `opponentControls()`, the Thalia, Heretic Cathar shape |
| **Loxodon Hierarch** {2}{G}{W} 4/4 | ETB gain 4 life; {G}{W}, Sac: regenerate each creature you control | `Triggers.EntersBattlefield` + `Effects.GainLife`; `Effects.ForEachInGroup` over `Creature.youControl()` with a `RegenerateEffect(Self)` body |
| **Golgari Germination** {1}{B}{G} | Nontoken creature you control dies → 1/1 Saproling | `Triggers.leavesBattlefield(to = GRAVEYARD)` + `nontoken()`, the Ulvenwald Mysteries shape |
| **Stoneshaker Shaman** {2}{R} 1/1 | Each player's end step: that player sacrifices an untapped land | `Triggers.EachEndStep` + `Effects.Sacrifice(Land.untapped(), Player.TriggeringPlayer)`, the Braids shape |

Also adds the **Commander 2016 `Printing` row for Blazing Archon** that `check-card-printing` reported missing for that scaffolded reprint set.

### Notes worth a reviewer's eye

- **Loxodon Hierarch is the corpus's first group regeneration.** `IterationSpace.Group` binds the current permanent as the body's `Self`, so the single-target `RegenerateEffect` facade applies once per creature — which is what the 2005 ruling describes (individual shields, spent independently, expiring at end of turn) rather than one shared shield. `Costs.SacrificeSelf` is paid on activation, so the Hierarch is already in the graveyard when the group snapshot is taken and never regenerates itself. Tested all three ways.
- **Loxodon Gatekeeper is three replacements, not one union filter.** "Artifact", "creature" and "land" are independent characteristic checks; an artifact creature matches more than one and simply enters tapped once. The noun list stopping at three types is the reason this isn't `GameObjectFilter.Permanent`, and the test pins that an opponent's enchantment is untouched.
- **Golgari Germination's `nontoken()` is load-bearing** — without it the Saprolings it mints would feed it forever. There's a test for exactly that loop.
- **Stoneshaker Shaman's two easy-to-swap axes** both have tests: the trigger is `EachEndStep` not `YourEndStep` (the card is symmetric), and the sacrificing player is `Player.TriggeringPlayer`, not the Shaman's controller — pinned by putting the Shaman under the *non-active* player's control.

### Dropped from the batch

**Hunted Lammasu** was in the original shortlist. Its ETB makes a 4/4 black Horror token, and RAV self-hosts its token art (it predates token *cards*, so there's no `trav` set to sync) with only a Saproling declared. That's an art-asset job rather than card implementation, so it was swapped for Loxodon Gatekeeper.

### Verification

- All five cards field-verified against Scryfall (name, mana cost, type line, P/T, rarity, collector number, artist, flavor, colour identity, image URI) and oracle text read line-by-line against the script.
- 15 scenario-test cases across five files, all passing locally (`just test-class` per card).
- `just check-card-printing` clean for all five.
- `CardDefinitionSnapshotTest` re-blessed; the golden diff is insertions-only and contains exactly these five cards.

### Pre-existing failure, disclosed

`just build` also reports **`:oracle-assay:test` → `AmountsTest > "life keeps its numeral and declines the clause the damage verbs read"`** failing. This is **not** from this branch: `:oracle-assay` depends only on `mtg-sdk`, and this change touches `mtg-sets` alone. The test expects a decline but now gets an `Accepted` carrying `GainLifeEffect(AggregateBattlefield(COUNT creatures))`. `main`'s HEAD commit is "Update AmountsTest for the life amount's second spelling", so it looks like in-flight work there. Flagging rather than touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)