### PR TITLE
Review fixups for #2123: pin the reveal bookkeeping a rejected action must not apply

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
@@ -84,11 +84,21 @@ class ActionProcessor(
             return ProcessedAction(ExecutionResult.error(state, validationError))
         }
 
-        // Execute the action, then update which revealed/returned cards opponents may see
-        // (cards revealed into hand or bounced back to hand stay visible until a same-named
-        // card is played — see [RevealedInHandTracker]).
-        val result = com.wingedsheep.engine.mechanics.RevealedInHandTracker
-            .applyAfterAction(registry.execute(state, action))
+        val executed = registry.execute(state, action)
+
+        // Action handlers may compose several immutable intermediate states before a nested
+        // handler or resumed continuation rejects a later step. The public action contract is
+        // atomic on error: retain only the message and expose the exact entry state. In
+        // particular, do this before event-driven post-action bookkeeping so events from the
+        // rejected attempt cannot mutate the externally visible result.
+        val result = if (executed.error != null) {
+            ExecutionResult.error(state, executed.error)
+        } else {
+            // Cards revealed into hand or bounced back to hand stay visible until a same-named
+            // card is played — see [RevealedInHandTracker]. Paused actions are accepted in-flight
+            // actions, so they retain this existing bookkeeping just like completed successes.
+            com.wingedsheep.engine.mechanics.RevealedInHandTracker.applyAfterAction(executed)
+        }
         val undoPolicy = if (computeUndo) {
             UndoPolicyComputer.compute(action, state, result, services.cardRegistry)
         } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
@@ -88,9 +88,9 @@ class ActionProcessor(
 
         // Action handlers may compose several immutable intermediate states before a nested
         // handler or resumed continuation rejects a later step. The public action contract is
-        // atomic on error: retain only the message and expose the exact entry state. In
-        // particular, do this before event-driven post-action bookkeeping so events from the
-        // rejected attempt cannot mutate the externally visible result.
+        // atomic on error: retain only the message and hand back the entry state itself. A
+        // rejected attempt therefore skips event-driven post-action bookkeeping entirely — its
+        // events describe work that is being thrown away and must not reach the tracker.
         val result = if (executed.error != null) {
             ExecutionResult.error(state, executed.error)
         } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ExecutionResult.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ExecutionResult.kt
@@ -9,7 +9,12 @@ import kotlinx.serialization.Serializable
  * The engine operates as a reentrant state machine. Every operation returns one of:
  * - **Success**: error == null && pendingDecision == null
  * - **PausedForDecision**: pendingDecision != null (needs player input)
- * - **Error**: error != null (action was invalid, state unchanged)
+ * - **Error**: error != null (action was rejected, state unchanged)
+ *
+ * Nested engine steps also use `ExecutionResult` while composing an action and may have built
+ * intermediate immutable states before reporting an error. [ActionProcessor] is the public
+ * transaction boundary: a top-level error exposes the exact input state and retains only the error
+ * message, with no events, pending decision, or processed-trigger marker from the rejected attempt.
  *
  * Game-over is signaled via `state.gameOver` + a [GameEndedEvent] in `events`.
  */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
@@ -1,17 +1,23 @@
 package com.wingedsheep.engine.core
 
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 class ActionProcessorAtomicityTest : ScenarioTestBase() {
     init {
@@ -35,7 +41,9 @@ class ActionProcessorAtomicityTest : ScenarioTestBase() {
 
             result.error shouldBe "No valid target for life gain"
             assertSoftly {
-                result.state shouldBe preActionState
+                // Identity, not equality: the boundary hands back the caller's own state object,
+                // so nothing the rejected attempt built can survive in any field of it.
+                result.state shouldBeSameInstanceAs preActionState
                 result.state.lifeTotal(game.player2Id) shouldBe 20
                 result.state.pendingDecision shouldBe decision
                 result.state.continuationStack shouldBe preActionState.continuationStack
@@ -46,11 +54,53 @@ class ActionProcessorAtomicityTest : ScenarioTestBase() {
             }
         }
 
+        test("a rejected action drops the revealed-in-hand bookkeeping its events would have driven") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.ContextTarget(0)),
+                revealTopCardFirst = true
+            )
+            val preActionState = game.state
+            val libraryCardId = preActionState.getLibrary(game.player1Id).single()
+
+            val result = actionProcessor.process(
+                preActionState,
+                SubmitDecision(
+                    playerId = game.player1Id,
+                    response = DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
+                )
+            ).result
+
+            result.error shouldBe "No valid target for life gain"
+            assertSoftly {
+                // The rejected attempt revealed the card into hand and emitted a CardsRevealedEvent.
+                // Running [RevealedInHandTracker] over those events would stamp a RevealedToComponent
+                // onto a card that, in the state everyone actually sees, never left the library.
+                result.state.getLibrary(game.player1Id) shouldBe listOf(libraryCardId)
+                result.state.getHand(game.player1Id).shouldBeEmpty()
+                result.state.getEntity(libraryCardId)?.get<RevealedToComponent>() shouldBe null
+            }
+        }
+
+        test("a successful reveal into hand still records who saw the card") {
+            val (game, _) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.Controller),
+                revealTopCardFirst = true
+            )
+            val libraryCardId = game.state.getLibrary(game.player1Id).single()
+
+            val result = game.submitDecision(
+                DistributionResponse("divide-damage", linkedMapOf(game.player2Id to 1))
+            )
+
+            result.error shouldBe null
+            result.state.getHand(game.player1Id) shouldBe listOf(libraryCardId)
+            result.state.getEntity(libraryCardId)?.get<RevealedToComponent>().shouldNotBeNull()
+        }
+
         test("a successful nested continuation commits its state and events") {
             val (game, decision) = gameAwaitingDividedDamage(
                 then = Effects.GainLife(1, EffectTarget.Controller)
             )
-            val preActionState = game.state
 
             val result = game.submitDecision(
                 DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
@@ -71,7 +121,6 @@ class ActionProcessorAtomicityTest : ScenarioTestBase() {
             val (game, decision) = gameAwaitingDividedDamage(
                 then = MayEffect(Effects.GainLife(1, EffectTarget.Controller))
             )
-            val preActionState = game.state
 
             val result = game.submitDecision(
                 DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
@@ -89,22 +138,45 @@ class ActionProcessorAtomicityTest : ScenarioTestBase() {
         }
     }
 
+    /**
+     * A game paused on a divided-damage decision, with [then] queued behind it as a gated follow-up
+     * so that resuming the decision runs damage first and [then] afterwards — the shape where a
+     * later step of one submitted action can fail after earlier steps have already changed state.
+     *
+     * With [revealTopCardFirst], a second gate in between reveals the top card of player 1's library
+     * into their hand, so the attempt emits a `CardsRevealedEvent` before [then] runs.
+     */
     private fun gameAwaitingDividedDamage(
-        then: Effect
+        then: Effect,
+        revealTopCardFirst: Boolean = false
     ): Pair<ScenarioTestBase.TestGame, DistributeDecision> {
-        val game = scenario().withPlayers().build()
+        val builder = scenario().withPlayers()
+        if (revealTopCardFirst) builder.withCardInLibrary(1, "Forest")
+        val game = builder.build()
         val decisionId = "divide-damage"
+        val effectContext = EffectContext(
+            sourceId = null,
+            controllerId = game.player1Id,
+            targets = emptyList()
+        )
         val gatedFollowUp = GatedActionContinuation(
             decisionId = "evaluate-damage",
             then = then,
             otherwise = null,
             successCriterion = SuccessCriterion.Always,
             snapshot = GatedActionSnapshot(),
-            effectContext = EffectContext(
-                sourceId = null,
-                controllerId = game.player1Id,
-                targets = emptyList()
-            )
+            effectContext = effectContext
+        )
+        val revealGate = GatedActionContinuation(
+            decisionId = "reveal-top",
+            then = Patterns.Library.revealTopPutAllMatchingToHand(
+                count = DynamicAmount.Fixed(1),
+                filter = GameObjectFilter.Any
+            ),
+            otherwise = null,
+            successCriterion = SuccessCriterion.Always,
+            snapshot = GatedActionSnapshot(),
+            effectContext = effectContext
         )
         val damage = DistributeDamageContinuation(
             decisionId = decisionId,
@@ -123,6 +195,7 @@ class ActionProcessorAtomicityTest : ScenarioTestBase() {
         )
         game.state = game.state
             .pushContinuation(gatedFollowUp)
+            .let { if (revealTopCardFirst) it.pushContinuation(revealGate) else it }
             .pushContinuation(damage)
             .withPendingDecision(decision)
         return game to decision

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/ActionProcessorAtomicityTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ActionProcessorAtomicityTest : ScenarioTestBase() {
+    init {
+        test("a later nested continuation error rejects the whole submitted decision") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.ContextTarget(0))
+            )
+            val preActionState = game.state
+
+            val processed = actionProcessor.process(
+                preActionState,
+                SubmitDecision(
+                    playerId = game.player1Id,
+                    response = DistributionResponse(
+                        decisionId = decision.id,
+                        distribution = linkedMapOf(game.player2Id to 1)
+                    )
+                )
+            )
+            val result = processed.result
+
+            result.error shouldBe "No valid target for life gain"
+            assertSoftly {
+                result.state shouldBe preActionState
+                result.state.lifeTotal(game.player2Id) shouldBe 20
+                result.state.pendingDecision shouldBe decision
+                result.state.continuationStack shouldBe preActionState.continuationStack
+                result.events.shouldBeEmpty()
+                result.pendingDecision shouldBe null
+                result.triggersAlreadyProcessed shouldBe false
+                processed.undoPolicy shouldBe UndoCheckpointAction.PRESERVE
+            }
+        }
+
+        test("a successful nested continuation commits its state and events") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = Effects.GainLife(1, EffectTarget.Controller)
+            )
+            val preActionState = game.state
+
+            val result = game.submitDecision(
+                DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
+            )
+
+            result.error shouldBe null
+            result.pendingDecision shouldBe null
+            result.state.lifeTotal(game.player1Id) shouldBe 21
+            result.state.lifeTotal(game.player2Id) shouldBe 19
+            result.state.pendingDecision shouldBe null
+            result.state.continuationStack.shouldBeEmpty()
+            result.events.shouldNotBeEmpty()
+            result.events.filterIsInstance<LifeChangedEvent>().map { it.playerId to it.newLife } shouldBe
+                listOf(game.player2Id to 19, game.player1Id to 21)
+        }
+
+        test("a nested continuation that pauses keeps its in-flight state and events") {
+            val (game, decision) = gameAwaitingDividedDamage(
+                then = MayEffect(Effects.GainLife(1, EffectTarget.Controller))
+            )
+            val preActionState = game.state
+
+            val result = game.submitDecision(
+                DistributionResponse(decision.id, linkedMapOf(game.player2Id to 1))
+            )
+
+            result.error shouldBe null
+            result.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            result.state.lifeTotal(game.player1Id) shouldBe 20
+            result.state.lifeTotal(game.player2Id) shouldBe 19
+            result.state.pendingDecision shouldBe result.pendingDecision
+            result.state.continuationStack.shouldNotBeEmpty()
+            result.events.shouldNotBeEmpty()
+            result.events.filterIsInstance<LifeChangedEvent>().map { it.playerId to it.newLife } shouldBe
+                listOf(game.player2Id to 19)
+        }
+    }
+
+    private fun gameAwaitingDividedDamage(
+        then: Effect
+    ): Pair<ScenarioTestBase.TestGame, DistributeDecision> {
+        val game = scenario().withPlayers().build()
+        val decisionId = "divide-damage"
+        val gatedFollowUp = GatedActionContinuation(
+            decisionId = "evaluate-damage",
+            then = then,
+            otherwise = null,
+            successCriterion = SuccessCriterion.Always,
+            snapshot = GatedActionSnapshot(),
+            effectContext = EffectContext(
+                sourceId = null,
+                controllerId = game.player1Id,
+                targets = emptyList()
+            )
+        )
+        val damage = DistributeDamageContinuation(
+            decisionId = decisionId,
+            sourceId = null,
+            controllerId = game.player1Id,
+            targets = listOf(game.player2Id)
+        )
+        val decision = DistributeDecision(
+            id = decisionId,
+            playerId = game.player1Id,
+            prompt = "Divide 1 damage",
+            context = DecisionContext(),
+            totalAmount = 1,
+            targets = listOf(game.player2Id),
+            minPerTarget = 1
+        )
+        game.state = game.state
+            .pushContinuation(gatedFollowUp)
+            .pushContinuation(damage)
+            .withPendingDecision(decision)
+        return game to decision
+    }
+}


### PR DESCRIPTION
Stacked on #2123 — its commit is included here until that PR lands, after which this narrows to the single fixup commit.

Review of #2123 found the behaviour and the layer correct: `ActionProcessor` really is the only engine action boundary `game-server` drives (nothing outside `actionProcessor` references `ExecutionResult` in `game-server/src/main`), and every existing consumer already discarded `result.state` on error, so the change closes a contract hole rather than altering live play. This addresses the gaps that review turned up.

### The untested second behaviour change

#2123 doesn't only replace the result on the error path — it also stops running `RevealedInHandTracker.applyAfterAction` there. That is correct (the tracker is pure, and its output would be thrown away), but nothing asserted it: with the two branches reordered, every test in the file still passed.

`ActionProcessorAtomicityTest` now pushes a second gate that reveals the top card of the library into hand *before* the failing gate, so the rejected attempt really does emit a `CardsRevealedEvent`, and asserts the card is still in the library carrying no `RevealedToComponent`. Its succeeding twin asserts the same reveal *does* stamp the component when the action completes — so the negative test can only pass by the bookkeeping being dropped, not by the reveal never having happened.

Verified with a control: reverting `ActionProcessor.kt` to main's unconditional `applyAfterAction` fails both error tests and leaves both success tests green.

### Smaller things

- `result.state` is asserted by identity (`shouldBeSameInstanceAs`), not value. The guarantee is that the boundary hands back the caller's own object; value equality would also accept a rebuilt one.
- The comment claimed the normalization happens *before* the post-action bookkeeping. Nothing is reordered — the bookkeeping is skipped outright on the error path. Reworded.
- Dropped two `preActionState` locals that were assigned and never read.

### Left alone, worth a follow-up issue

When the same effect fails with no decision in between, `StackResolver.kt:2365-2366` folds the state and events and **drops the error** — the spell limps on to the graveyard. Only the resume path surfaces an error to the top, where it now cleanly rejects. That asymmetry predates #2123 and is out of scope here.

### Verification

- `just test-class ActionProcessorAtomicityTest` — 5/5
- `just test-rules` — green on #2123's head merged with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)