### PR TITLE
Distinguish simulation limit exhaustion from completion

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -752,7 +752,7 @@ class CombatAdvisor(
     ): Double? {
         val blockAction = DeclareBlockers(playerId, blockerMap)
         val simResult = simulator.simulate(state, blockAction)
-        if (simResult is SimulationResult.Illegal) return null
+        if (simResult is SimulationResult.Illegal || simResult is SimulationResult.StoppedAtLimit) return null
 
         var current = simResult.state
 
@@ -761,7 +761,9 @@ class CombatAdvisor(
         while (iterations < 50 && !current.gameOver && current.pendingDecision == null) {
             iterations++
             val priorityPlayer = current.priorityPlayerId ?: break
-            current = simulator.simulate(current, PassPriority(priorityPlayer)).state
+            val transition = simulator.simulate(current, PassPriority(priorityPlayer))
+            if (transition is SimulationResult.StoppedAtLimit) return null
+            current = transition.state
             if (current.phase != Phase.COMBAT) break
         }
 
@@ -963,7 +965,7 @@ class CombatAdvisor(
     ): GameState? {
         val attackAction = DeclareAttackers(playerId, attackerMap)
         val simResult = simulator.simulate(state, attackAction)
-        if (simResult is SimulationResult.Illegal) return null
+        if (simResult is SimulationResult.Illegal || simResult is SimulationResult.StoppedAtLimit) return null
         var current = simResult.state
 
         // Drive through combat: pass priority, handle blockers, resolve damage.
@@ -978,13 +980,17 @@ class CombatAdvisor(
                 val blockAction = legalActions.find { it.actionType == "DeclareBlockers" }
                 if (blockAction != null) {
                     val blockerAction = chooseBlockers(current, blockAction, opponentId, useSimulation = false)
-                    current = simulator.simulate(current, blockerAction).state
+                    val transition = simulator.simulate(current, blockerAction)
+                    if (transition is SimulationResult.StoppedAtLimit) return null
+                    current = transition.state
                     needsBlockerCheck = false
                     continue
                 }
             }
 
-            current = simulator.simulate(current, PassPriority(priorityPlayer)).state
+            val transition = simulator.simulate(current, PassPriority(priorityPlayer))
+            if (transition is SimulationResult.StoppedAtLimit) return null
+            current = transition.state
             if (current.phase != Phase.COMBAT) break
         }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -745,6 +745,7 @@ class DecisionResponder(
     // ═════════════════════════════════════════════════════════════════════
 
     private fun evaluateResult(result: SimulationResult, playerId: EntityId): Double {
+        result.requireNoAutomaticResolutionStop("Decision-response evaluation")
         return evaluator.evaluate(result.state, result.state.projectedState, playerId)
     }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
@@ -16,31 +16,61 @@ import com.wingedsheep.sdk.model.EntityId
  * Because GameState is immutable, simulating an action is just calling process()
  * on the same state — no rollback or cleanup needed.
  */
-class GameSimulator(
+class GameSimulator private constructor(
     private val cardRegistry: CardRegistry,
-    private val processor: ActionProcessor = ActionProcessor(EngineServices(cardRegistry), computeUndo = false),
-    private val enumerator: LegalActionEnumerator = LegalActionEnumerator.create(cardRegistry),
-    /**
-     * Carry a simulation past the empty stack to the end of the combat damage step, when blockers
-     * are already declared.
-     *
-     * A quiet state is "the stack is empty", which inside combat is *before damage*. Three puzzles
-     * fail on exactly that gap — `instants-05` (Fog), `activate-05` (firebreathing) and their
-     * relatives all pay mana now for something that only materialises when damage is dealt, so the
-     * post-simulation board is strictly worse than passing and the AI passes. Phase 7 answers this
-     * with full playouts; this answers only the case where the answer is already determined, which
-     * is why it costs one step rather than two turns.
-     *
-     * **Scoped to blockers-already-declared on purpose.** From `DECLARE_ATTACKERS` the outcome
-     * still depends on how the defender blocks, and nothing here would declare those blocks — the
-     * simulation would either stall or silently score an unblocked alpha strike. Once blocks are
-     * in, the only thing between the current state and the damage is the damage.
-     *
-     * Off for [AiProfile.LEGACY_V0], which has to stay frozen, and off by default so a
-     * `GameSimulator` built anywhere else keeps its historical horizon.
-     */
-    private val resolveThroughCombatDamage: Boolean = false,
+    private val processor: ActionProcessor,
+    private val enumerator: LegalActionEnumerator,
+    private val resolveThroughCombatDamage: Boolean,
+    private val maxAutomaticTransitions: Int,
 ) {
+    constructor(
+        cardRegistry: CardRegistry,
+        processor: ActionProcessor = ActionProcessor(EngineServices(cardRegistry), computeUndo = false),
+        enumerator: LegalActionEnumerator = LegalActionEnumerator.create(cardRegistry),
+        /**
+         * Carry a simulation past the empty stack to the end of the combat damage step, when blockers
+         * are already declared.
+         *
+         * A quiet state is "the stack is empty", which inside combat is *before damage*. Three puzzles
+         * fail on exactly that gap — `instants-05` (Fog), `activate-05` (firebreathing) and their
+         * relatives all pay mana now for something that only materialises when damage is dealt, so the
+         * post-simulation board is strictly worse than passing and the AI passes. Phase 7 answers this
+         * with full playouts; this answers only the case where the answer is already determined, which
+         * is why it costs one step rather than two turns.
+         *
+         * **Scoped to blockers-already-declared on purpose.** From `DECLARE_ATTACKERS` the outcome
+         * still depends on how the defender blocks, and nothing here would declare those blocks — the
+         * simulation would either stall or silently score an unblocked alpha strike. Once blocks are
+         * in, the only thing between the current state and the damage is the damage.
+         *
+         * Off for [AiProfile.LEGACY_V0], which has to stay frozen, and off by default so a
+         * `GameSimulator` built anywhere else keeps its historical horizon.
+         */
+        resolveThroughCombatDamage: Boolean = false,
+    ) : this(
+        cardRegistry = cardRegistry,
+        processor = processor,
+        enumerator = enumerator,
+        resolveThroughCombatDamage = resolveThroughCombatDamage,
+        maxAutomaticTransitions = 100,
+    )
+
+    /** Test seam for deterministically reaching the automatic-transition guard. */
+    internal constructor(
+        cardRegistry: CardRegistry,
+        maxAutomaticTransitions: Int,
+    ) : this(
+        cardRegistry = cardRegistry,
+        processor = ActionProcessor(EngineServices(cardRegistry), computeUndo = false),
+        enumerator = LegalActionEnumerator.create(cardRegistry),
+        resolveThroughCombatDamage = false,
+        maxAutomaticTransitions = maxAutomaticTransitions,
+    )
+
+    init {
+        require(maxAutomaticTransitions > 0) { "maxAutomaticTransitions must be positive" }
+    }
+
     /**
      * Optional resolver for non-trivial decisions encountered during simulation.
      * Set after constructing the [DecisionResponder] to enable full spell resolution
@@ -61,7 +91,9 @@ class GameSimulator(
      * After executing the action, both players auto-pass priority until
      * the stack is empty (spells resolve) or a non-trivial decision is needed.
      * This ensures the evaluator sees the actual effect of casting a spell,
-     * not just "spell on stack, lands tapped".
+     * not just "spell on stack, lands tapped". If automatic resolution still has work after
+     * [maxAutomaticTransitions], the unfinished state is returned as
+     * [SimulationResult.StoppedAtLimit], never as successful completion.
      */
     fun simulate(state: GameState, action: GameAction): SimulationResult {
         val result = processor.process(state, action).result
@@ -113,12 +145,17 @@ class GameSimulator(
         var current = result
         var allEvents = result.events
         var iterations = 0
-        val maxIterations = 100
 
-        while (iterations < maxIterations) {
+        while (true) {
             val error = current.error
             if (error != null) {
                 return SimulationResult.Illegal(current.state, allEvents, error)
+            }
+
+            // Terminal means the simulator has reached its stopping boundary. A real game end is
+            // one such boundary and remains distinguishable through GameState.gameOver.
+            if (current.state.gameOver) {
+                return SimulationResult.Terminal(current.state, allEvents)
             }
 
             // Auto-resolve trivial decisions; use decisionResolver for non-trivial ones
@@ -126,6 +163,9 @@ class GameSimulator(
                 val decision = current.pendingDecision!!
                 val trivialResponse = trivialResponseFor(decision)
                 if (trivialResponse != null) {
+                    if (iterations >= maxAutomaticTransitions) {
+                        return stoppedAtLimit(current, allEvents, iterations)
+                    }
                     val submitAction = SubmitDecision(decision.playerId, trivialResponse)
                     current = processor.process(current.state, submitAction).result
                     allEvents = allEvents + current.events
@@ -136,6 +176,9 @@ class GameSimulator(
                 // inner simulations from DecisionResponder evaluating alternatives break here)
                 val resolver = decisionResolver
                 if (resolver != null && !isResolving) {
+                    if (iterations >= maxAutomaticTransitions) {
+                        return stoppedAtLimit(current, allEvents, iterations)
+                    }
                     try {
                         isResolving = true
                         val response = resolver(current.state, decision)
@@ -148,7 +191,7 @@ class GameSimulator(
                     }
                     continue
                 }
-                break
+                return SimulationResult.NeedsDecision(current.state, decision, allEvents)
             }
 
             // Stack is non-empty — auto-pass priority for whoever has it
@@ -157,6 +200,9 @@ class GameSimulator(
             val state = current.state
             val priorityPlayerId = state.priorityPlayerId
             if (state.stack.isNotEmpty() && priorityPlayerId != null && !state.gameOver) {
+                if (iterations >= maxAutomaticTransitions) {
+                    return stoppedAtLimit(current, allEvents, iterations)
+                }
                 val passAction = PassPriority(priorityPlayerId)
                 current = processor.process(state, passAction).result
                 allEvents = allEvents + current.events
@@ -168,26 +214,32 @@ class GameSimulator(
             // blockers already declared it is a *pre-damage* state, and the whole point of the
             // candidate may be the damage; pass priority to advance the step and look again.
             if (resolveThroughCombatDamage && isPreDamageCombatState(state)) {
-                if (priorityPlayerId == null || state.gameOver) break
+                if (priorityPlayerId == null || state.gameOver) {
+                    return SimulationResult.Terminal(state, allEvents)
+                }
+                if (iterations >= maxAutomaticTransitions) {
+                    return stoppedAtLimit(current, allEvents, iterations)
+                }
                 current = processor.process(state, PassPriority(priorityPlayerId)).result
                 allEvents = allEvents + current.events
                 iterations++
                 continue
             }
 
-            break
-        }
-
-        val finalError = current.error
-        return when {
-            finalError != null ->
-                SimulationResult.Illegal(current.state, allEvents, finalError)
-            current.isPaused ->
-                SimulationResult.NeedsDecision(current.state, current.pendingDecision!!, allEvents)
-            else ->
-                SimulationResult.Terminal(current.state, allEvents)
+            return SimulationResult.Terminal(state, allEvents)
         }
     }
+
+    private fun stoppedAtLimit(
+        current: ExecutionResult,
+        events: List<GameEvent>,
+        automaticTransitions: Int,
+    ): SimulationResult.StoppedAtLimit = SimulationResult.StoppedAtLimit(
+        state = current.state,
+        events = events,
+        automaticTransitions = automaticTransitions,
+        limit = maxAutomaticTransitions,
+    )
 
     /**
      * Returns a trivial response if there's exactly one legal choice, null otherwise.

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SimulationResult.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SimulationResult.kt
@@ -11,7 +11,10 @@ sealed interface SimulationResult {
     val state: GameState
     val events: List<GameEvent>
 
-    /** The action completed fully — no further input needed. */
+    /**
+     * The action reached the simulator's successful quiet/completed stopping boundary.
+     * This is simulation-terminal, not necessarily game-terminal; inspect [GameState.gameOver].
+     */
     data class Terminal(
         override val state: GameState,
         override val events: List<GameEvent>
@@ -30,4 +33,39 @@ sealed interface SimulationResult {
         override val events: List<GameEvent>,
         val reason: String
     ) : SimulationResult
+
+    /**
+     * Automatic resolution reached its bounded progress guard while another automatic transition
+     * remained. The retained state is unfinished and must not be scored as a completed candidate.
+     */
+    data class StoppedAtLimit(
+        override val state: GameState,
+        override val events: List<GameEvent>,
+        val automaticTransitions: Int,
+        val limit: Int,
+    ) : SimulationResult {
+        init {
+            require(limit > 0) { "limit must be positive" }
+            require(automaticTransitions >= limit) {
+                "automaticTransitions must have reached limit"
+            }
+        }
+    }
+}
+
+/** Raised when a consumer attempts to use an unfinished automatic-resolution state as an outcome. */
+class AutomaticResolutionLimitException(
+    val stopped: SimulationResult.StoppedAtLimit,
+    context: String,
+) : IllegalStateException(
+    "$context stopped after ${stopped.automaticTransitions}/${stopped.limit} automatic transitions; " +
+        "the retained simulation state is unfinished",
+)
+
+/** Refuse the one result whose state is diagnostic rather than suitable for evaluation. */
+fun SimulationResult.requireNoAutomaticResolutionStop(context: String): SimulationResult {
+    if (this is SimulationResult.StoppedAtLimit) {
+        throw AutomaticResolutionLimitException(this, context)
+    }
+    return this
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -203,8 +203,10 @@ class Strategist(
         val dropped = if (insightSink != null) mutableListOf<AiActionOption>() else null
         var searched = 0
         if (pass != null) {
+            val passSimulation = simulator.simulate(evaluationState, pass.action)
+                .requireNoAutomaticResolutionStop("Pass evaluation")
             leaves += pass
-            leafStates += simulator.simulate(evaluationState, pass.action).state
+            leafStates += passSimulation.state
         }
         for (action in affordable) {
             searched++
@@ -426,6 +428,7 @@ class Strategist(
     ): Pair<GameAction, SimulationResult> {
         val materialized = chooseCommittedTargets(state, action, playerId, budget)
         val simulation = simulator.simulate(state, materialized)
+            .requireNoAutomaticResolutionStop("Target materialization")
         // Ordered so the budget that already refines pays nothing at all here — no digest, no
         // second simulation. `chooseAction` digests the leaf it keeps either way.
         if (budget.allowances.refineTargetsBySimulation) return materialized to simulation
@@ -437,6 +440,7 @@ class Strategist(
         val refined = chooseCommittedTargets(state, action, playerId, budget, forceTargetRefinement = true)
         if (refined == materialized) return materialized to simulation
         return refined to simulator.simulate(state, refined)
+            .requireNoAutomaticResolutionStop("Refined target materialization")
     }
 
     /**
@@ -736,6 +740,7 @@ class Strategist(
                 val trial = chosenTargets.toMutableList()
                 trial[i] = TargetSelection.toChosenTarget(state, info, candidate, playerId)
                 val result = simulator.simulate(state, TargetSelection.applyTargets(baseAction, trial))
+                    .requireNoAutomaticResolutionStop("Target-choice evaluation")
                 // A target that resolves back into the position we are standing in is not a target
                 // choice, it is a no-op wearing one — Aphetto Alchemist untapping itself. Rank it
                 // below every real option, so `chooseAction` only ever drops the whole ability as

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/advisor/modules/BloomburrowAdvisorModule.kt
@@ -1,11 +1,12 @@
 package com.wingedsheep.ai.engine.advisor.modules
 
 import com.wingedsheep.ai.engine.advisor.*
-import com.wingedsheep.ai.engine.evaluation.BoardPresence
-import com.wingedsheep.engine.core.*
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.ai.engine.anyOpponent
+import com.wingedsheep.ai.engine.evaluation.BoardPresence
+import com.wingedsheep.ai.engine.requireNoAutomaticResolutionStop
+import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
@@ -106,7 +107,7 @@ private fun pickBestGiftMode(context: AdvisorDecisionContext, decision: ChooseMo
         val result = context.simulator.simulateDecision(
             context.state,
             ModesChosenResponse(decision.id, listOf(mode.index))
-        )
+        ).requireNoAutomaticResolutionStop("Gift-mode evaluation")
         val score = context.evaluator.evaluate(result.state, result.state.projectedState, context.playerId)
         // Apply gift penalty to mode 2 (gift mode is always index 1)
         val adjusted = if (mode.index == 1) score - penalty else score
@@ -756,6 +757,7 @@ object BiteSpellAdvisor : CardAdvisor {
                     mapOf(req0.index to listOf(mine), req1.index to listOf(theirs))
                 )
                 val result = context.simulator.simulateDecision(context.state, response)
+                    .requireNoAutomaticResolutionStop("Paired-target evaluation")
                 val score = context.evaluator.evaluate(
                     result.state, result.state.projectedState, context.playerId
                 )

--- a/ai/src/main/kotlin/com/wingedsheep/ai/training/DecisionRecordFactory.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/training/DecisionRecordFactory.kt
@@ -9,6 +9,10 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.TeamComponent
 import com.wingedsheep.sdk.model.EntityId
 
+/** Only a completed simulator boundary may become a quiet-state training observation. */
+internal fun completedEvaluationState(simulation: SimulationResult): GameState? =
+    (simulation as? SimulationResult.Terminal)?.state
+
 /** Optional offline collector. Production AI does not depend on or allocate this object. */
 class DecisionRecordFactory(registry: CardRegistry) {
     private val enumerator = LegalActionEnumerator.create(registry)
@@ -37,10 +41,10 @@ class DecisionRecordFactory(registry: CardRegistry) {
         val candidates = retained.map { legalAction ->
             val descriptor = TrainingRecordEncoding.action(legalAction.action)
             val simulation = simulator.simulate(state, legalAction.action)
-            require(simulation is SimulationResult.Terminal) {
+            val quiet = completedEvaluationState(simulation)
+            require(quiet != null) {
                 "Candidate is not fully specified or legal: ${descriptor.actionType} (${simulation::class.simpleName})"
             }
-            val quiet = simulation.state
             val observation = TrainingRecordEncoding.observation(quiet, actingPlayer)
             CandidateTrainingRecord(descriptor, observation, TrainingRecordEncoding.digest(observation))
         }
@@ -83,7 +87,13 @@ class DecisionRecordReplayer(registry: CardRegistry) {
         if (emitted.keys != record.candidates.map { it.descriptor.actionDigest }.toSet()) errors += "legal candidates differ"
         for (candidate in record.candidates) {
             val legal = emitted[candidate.descriptor.actionDigest] ?: continue
-            val quiet = simulator.simulate(reconstructedRoot, legal.action).state
+            val simulation = simulator.simulate(reconstructedRoot, legal.action)
+            val quiet = completedEvaluationState(simulation)
+            if (quiet == null) {
+                errors += "candidate did not reach a completed evaluation boundary: " +
+                    "${candidate.descriptor.actionDigest} (${simulation::class.simpleName})"
+                continue
+            }
             val digest = TrainingRecordEncoding.digest(TrainingRecordEncoding.observation(quiet, player))
             if (digest != candidate.quietStateDigest) errors += "quiet digest mismatch: ${candidate.descriptor.actionDigest}"
         }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AIPlayerTest.kt
@@ -130,6 +130,8 @@ class AIPlayerTest : FunSpec({
                 is SimulationResult.Terminal -> result.state.shouldNotBeNull()
                 is SimulationResult.NeedsDecision -> result.decision.shouldNotBeNull()
                 is SimulationResult.Illegal -> {}
+                is SimulationResult.StoppedAtLimit ->
+                    error("Ordinary legal-action simulation exhausted its automatic transition limit")
             }
         }
     }
@@ -284,6 +286,7 @@ class AIPlayerTest : FunSpec({
                 val pass = actions.find { it.actionType == "PassPriority" }
                 val passResult = if (pass != null) simulator.simulate(state, pass.action) else null
                 val passScore = if (passResult != null) {
+                    passResult.requireNoAutomaticResolutionStop("AIPlayerTest pass debug")
                     evaluator.evaluate(passResult.state, passResult.state.projectedState, p1)
                 } else 0.0
 
@@ -291,11 +294,13 @@ class AIPlayerTest : FunSpec({
                 println("Pass score: $passScore")
                 for (a in actions.filter { it.affordable && it.actionType != "PassPriority" && !it.isManaAbility }) {
                     val result = simulator.simulate(state, a.action)
+                    result.requireNoAutomaticResolutionStop("AIPlayerTest candidate debug")
                     val score = evaluator.evaluate(result.state, result.state.projectedState, p1)
                     val resultType = when (result) {
                         is SimulationResult.Terminal -> "Terminal(stack=${result.state.stack.size})"
                         is SimulationResult.NeedsDecision -> "NeedsDecision(${result.decision::class.simpleName})"
                         is SimulationResult.Illegal -> "Illegal(${result.reason})"
+                        is SimulationResult.StoppedAtLimit -> error("Limit stop passed the guard above")
                     }
                     println("  ${a.actionType}(${a.description}): score=$score, result=$resultType")
                 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val TwoModeSpell: CardDefinition = card("Test Two Mode Spell") {
+    manaCost = "{G}"
+    typeLine = "Sorcery"
+    spell {
+        modal(chooseCount = 1) {
+            mode("Draw a card", Effects.DrawCards(1))
+            mode("Gain 1 life", Effects.GainLife(1))
+        }
+    }
+}
+
+private data class BoltFixture(
+    val registry: CardRegistry,
+    val driver: GameTestDriver,
+    val caster: EntityId,
+    val opponent: EntityId,
+    val cast: CastSpell,
+)
+
+private fun boltFixture(opponentLife: Int = 20): BoltFixture {
+    val registry = CardRegistry().apply { register(TestCards.all) }
+    val driver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(Deck.of("Mountain" to 20), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+    val caster = driver.player1
+    val opponent = driver.player2
+    driver.setLifeTotal(opponent, opponentLife)
+    val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+    driver.giveMana(caster, Color.RED, 1)
+    return BoltFixture(
+        registry = registry,
+        driver = driver,
+        caster = caster,
+        opponent = opponent,
+        cast = CastSpell(
+            playerId = caster,
+            cardId = bolt,
+            targets = listOf(ChosenTarget.Player(opponent)),
+            paymentStrategy = PaymentStrategy.FromPool,
+        ),
+    )
+}
+
+class GameSimulatorTest : FunSpec({
+
+    test("automatic transition exhaustion is not successful simulation completion") {
+        val fixture = boltFixture()
+        val result = GameSimulator(fixture.registry, maxAutomaticTransitions = 1)
+            .simulate(fixture.driver.state, fixture.cast)
+
+        val stopped = result.shouldBeInstanceOf<SimulationResult.StoppedAtLimit>()
+        withClue("one automatic pass leaves Lightning Bolt unresolved on the stack") {
+            stopped.state.stack.shouldNotBeEmpty()
+            stopped.state.gameOver.shouldBeFalse()
+        }
+        stopped.automaticTransitions.shouldBeExactly(1)
+        stopped.limit.shouldBeExactly(1)
+        shouldThrow<AutomaticResolutionLimitException> {
+            stopped.requireNoAutomaticResolutionStop("Test evaluation")
+        }.message shouldContain "retained simulation state is unfinished"
+    }
+
+    test("ordinary quiet simulation is Terminal without ending the game") {
+        val fixture = boltFixture()
+
+        val terminal = GameSimulator(fixture.registry, maxAutomaticTransitions = 2)
+            .simulate(fixture.driver.state, fixture.cast)
+            .shouldBeInstanceOf<SimulationResult.Terminal>()
+
+        terminal.state.stack.isEmpty().shouldBeTrue()
+        terminal.state.gameOver.shouldBeFalse()
+    }
+
+    test("a genuine game end remains Terminal and is identified by gameOver") {
+        val fixture = boltFixture(opponentLife = 3)
+
+        val terminal = GameSimulator(fixture.registry, maxAutomaticTransitions = 2)
+            .simulate(fixture.driver.state, fixture.cast)
+            .shouldBeInstanceOf<SimulationResult.Terminal>()
+
+        terminal.state.gameOver.shouldBeTrue()
+        terminal.state.winnerId shouldBe fixture.caster
+    }
+
+    test("a genuine unresolved choice remains NeedsDecision") {
+        val registry = CardRegistry().apply { register(TestCards.all + TwoModeSpell) }
+        val driver = GameTestDriver().apply {
+            registerCards(TestCards.all + TwoModeSpell)
+            initMirrorMatch(Deck.of("Forest" to 20), startingLife = 20)
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+        val caster = driver.player1
+        val spell = driver.putCardInHand(caster, TwoModeSpell.name)
+        driver.giveMana(caster, Color.GREEN, 1)
+
+        GameSimulator(registry, maxAutomaticTransitions = 1).simulate(
+            driver.state,
+            CastSpell(caster, spell, paymentStrategy = PaymentStrategy.FromPool),
+        ).shouldBeInstanceOf<SimulationResult.NeedsDecision>()
+    }
+
+    test("an engine rejection remains Illegal") {
+        val fixture = boltFixture()
+
+        val illegal = GameSimulator(fixture.registry)
+            .simulate(fixture.driver.state, PassPriority(fixture.opponent))
+            .shouldBeInstanceOf<SimulationResult.Illegal>()
+
+        illegal.reason shouldContain "priority"
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/training/DecisionTrainingRecordTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/training/DecisionTrainingRecordTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.ai.training
 
+import com.wingedsheep.ai.engine.SimulationResult
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.GameInitializer
 import com.wingedsheep.engine.core.PlayerConfig
@@ -69,5 +70,19 @@ class DecisionTrainingRecordTest : FunSpec({
         a.others.single().visibleHand shouldHaveSize 0
         b.others.single().visibleHand shouldHaveSize 0
         a.others.single().handSize shouldBe b.others.single().handSize
+    }
+
+    test("training observations require a completed simulation boundary") {
+        val state = root(2)
+
+        completedEvaluationState(SimulationResult.Terminal(state, emptyList())) shouldBe state
+        completedEvaluationState(
+            SimulationResult.StoppedAtLimit(
+                state = state,
+                events = emptyList(),
+                automaticTransitions = 100,
+                limit = 100,
+            )
+        ) shouldBe null
     }
 })

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -1,8 +1,10 @@
 package com.wingedsheep.gym
 
+import com.wingedsheep.ai.engine.AutomaticResolutionLimitException
 import com.wingedsheep.ai.engine.DecisionResponder
 import com.wingedsheep.ai.engine.GameSimulator
 import com.wingedsheep.ai.engine.SimulationResult
+import com.wingedsheep.ai.engine.requireNoAutomaticResolutionStop
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.ai.engine.evaluation.CompositeBoardEvaluator
 import com.wingedsheep.ai.engine.evaluation.BoardPresence
@@ -173,6 +175,8 @@ class GameEnvironment private constructor(
      *               or a [SubmitDecision] when responding to a [pendingDecision].
      * @return [StepResult] with the new state, events, rewards, and termination flag.
      * @throws IllegalStateException if the game hasn't been started via [reset].
+     * @throws AutomaticResolutionLimitException if automatic resolution exhausts its progress
+     * guard; the environment is left at the pre-step state.
      */
     fun step(action: GameAction): StepResult {
         check(playerIds.isNotEmpty()) { "Call reset() before step()" }
@@ -181,7 +185,7 @@ class GameEnvironment private constructor(
             simulator.simulateDecision(state, action.response)
         } else {
             simulator.simulate(state, action)
-        }
+        }.requireNoAutomaticResolutionStop("Gym step")
 
         state = simResult.state
         events = events + simResult.events


### PR DESCRIPTION
`GameSimulator.resolveToQuietState` currently falls through to `SimulationResult.Terminal` when its 100-transition progress guard is exhausted, even if automatic resolution still has work remaining.

This can make an unfinished state look like a successfully completed simulation. A deterministic regression demonstrates the case with Lightning Bolt: after one permitted automatic transition the spell remains unresolved on the stack, but the previous implementation classified the state as `Terminal`.

Add `SimulationResult.StoppedAtLimit` for guard exhaustion and check the limit immediately before performing additional automatic work. Legitimate stopping conditions still take precedence: if the final permitted transition reaches quiet state, game end, a genuine decision, or an engine error, that result is returned normally.

`Terminal` retains its existing meaning as the simulator's successful quiet/completed boundary; actual game termination remains distinguishable through `state.gameOver`.

Consumers now avoid treating a limit-exhausted state as completed evaluation:

- strategic and decision evaluation fail visibly;
- combat evaluation discards the incomplete simulation;
- training capture/replay accept only completed `Terminal` states;
- Gym steps fail before mutating environment state;
- generic action expansion retains the typed result.

The existing public `GameSimulator` constructor shape is preserved; the configurable transition limit is an internal deterministic test seam.

Verification:

- `just test-class GameSimulatorTest`
- `just test-class DecisionTrainingRecordTest`
- `just test-ai`
- `just test-gym`
- `just test-gym-trainer`