### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DroolingGroodion.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DroolingGroodion.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Drooling Groodion
+ * {3}{B}{B}{G}
+ * Creature — Beast
+ * 4/3
+ *
+ * {2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target
+ * creature gets -2/-2 until end of turn.
+ *
+ * Two independent target requirements, the second wrapped in [TargetOther] so it cannot be the same
+ * creature as the first (CR 601.2c "another"). The sacrifice is a *cost*, paid on activation, so the
+ * Groodion may eat itself — and the creature sacrificed can be one of the two targets, which will
+ * simply have left the battlefield by the time the ability resolves.
+ */
+val DroolingGroodion = card("Drooling Groodion") {
+    manaCost = "{3}{B}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 3
+    oracleText = "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. " +
+        "Another target creature gets -2/-2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}{G}"),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        val pumped = target("target creature", TargetCreature())
+        val weakened = target("another target creature", TargetOther(TargetCreature()))
+        effect = Effects.Composite(
+            listOf(
+                Effects.ModifyStats(2, 2, pumped),
+                Effects.ModifyStats(-2, -2, weakened)
+            )
+        )
+        description = "Target creature gets +2/+2 until end of turn. Another target creature gets " +
+            "-2/-2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "Kev Walker"
+        flavorText = "\"The Golgari expand, yes, but I refuse to call their tainted creations " +
+            "'growth.'\"\n—Veszka, Selesnya evangel"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg?1783943621"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GoblinFireFiend.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GoblinFireFiend.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MustBeBlocked
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin Fire Fiend
+ * {3}{R}
+ * Creature — Goblin Berserker
+ * 1/1
+ *
+ * Haste
+ * This creature must be blocked if able.
+ * {R}: This creature gets +1/+0 until end of turn.
+ *
+ * "Must be blocked if able" is the *at least one* form of [MustBeBlocked] (`allCreatures = false`),
+ * not the Lure-style "blocked by all creatures able to block it": per the printed ruling the
+ * defending player must assign **a** blocker, and is free to keep the rest back. `BlockPhaseManager`
+ * enforces it during the declare-blockers legality check.
+ */
+val GoblinFireFiend = card("Goblin Fire Fiend") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Berserker"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "This creature must be blocked if able.\n" +
+        "{R}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    staticAbility {
+        ability = MustBeBlocked()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg?1783943654"
+        ruling(
+            "2005-10-01",
+            "If Goblin Fire Fiend is attacking, the defending player must assign at least one " +
+                "blocker to it during the declare blockers step if that player controls any " +
+                "creatures that could block Goblin Fire Fiend."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/IndenturedOaf.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/IndenturedOaf.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Indentured Oaf
+ * {3}{R}
+ * Creature — Ogre Warrior
+ * 4/3
+ *
+ * Prevent all damage that this creature would deal to red creatures.
+ *
+ * A continuous [PreventDamage] replacement (CR 615) scoped on both sides: source is the Oaf itself
+ * ([SourceFilter.Self]) and the recipient is any red creature. The recipient filter is evaluated
+ * against projected state at the moment damage would be dealt, so a creature that has been made red
+ * — or has lost red — since blockers were declared is judged on its colour *then*, and the Oaf's own
+ * controller is not spared: the sentence says "red creatures", not "red creatures an opponent
+ * controls".
+ */
+val IndenturedOaf = card("Indentured Oaf") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Prevent all damage that this creature would deal to red creatures."
+
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Matching(GameObjectFilter.Creature.withColor(Color.RED)),
+                source = SourceFilter.Self
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Glenn Fabry"
+        flavorText = "All it knows is the difference between friend and food."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg?1783943651"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LightOfSanction.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LightOfSanction.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Light of Sanction
+ * {1}{W}{W}
+ * Enchantment
+ *
+ * Prevent all damage that would be dealt to creatures you control by sources you control.
+ *
+ * One [PreventDamage] replacement with both halves of the sentence filled in: recipients are
+ * [RecipientFilter.CreatureYouControl] and sources are [SourceFilter.YouControl]. Both "you"s are
+ * the enchantment's *current* controller, re-read per damage instance, so creatures that come under
+ * your control later are covered and creatures that leave it stop being.
+ *
+ * [SourceFilter.YouControl] deliberately covers more than permanents — a burn spell on the stack and
+ * an activated ability's source are checked by controller the same way — which is what makes this
+ * the "point my own sweepers at my own board" card it was printed to be. Players are not creatures,
+ * so it never protects you.
+ */
+val LightOfSanction = card("Light of Sanction") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Prevent all damage that would be dealt to creatures you control by sources you control."
+
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.CreatureYouControl,
+                source = SourceFilter.YouControl
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Michael Phillippi"
+        flavorText = "The Legion looks after its own."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg?1783943697"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SabertoothAlleyCat.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SabertoothAlleyCat.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MustAttack
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sabertooth Alley Cat
+ * {1}{R}{R}
+ * Creature — Cat
+ * 2/1
+ *
+ * This creature attacks each combat if able.
+ * {1}{R}: Creatures without defender can't block this creature this turn.
+ *
+ * The activated ability is written from the *attacker's* side. "Creatures without defender can't
+ * block this creature" and "this creature can't be blocked except by creatures with defender" name
+ * the same set of legal blockers — every creature either has defender or it doesn't — so this is
+ * [Effects.GrantCantBeBlockedExceptBy] with a `withKeyword(DEFENDER)` blocker filter rather than a
+ * group-wide [com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect], which would also stop
+ * those creatures blocking *other* attackers. It rides the same projected
+ * `cantBeBlockedExceptByFilters` channel the printed `CantBeBlockedExceptBy` static uses, and the
+ * filter is re-read at declare-blockers, so a creature that gains or loses defender after
+ * activation is judged on its state at that moment.
+ */
+val SabertoothAlleyCat = card("Sabertooth Alley Cat") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 2
+    toughness = 1
+    oracleText = "This creature attacks each combat if able.\n" +
+        "{1}{R}: Creatures without defender can't block this creature this turn."
+
+    staticAbility {
+        ability = MustAttack()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.GrantCantBeBlockedExceptBy(
+            EffectTarget.Self,
+            GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER)
+        )
+        description = "Creatures without defender can't block this creature this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Carl Critchlow"
+        flavorText = "It has eight lives' worth of hunger to satisfy."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg?1783943647"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2194,6 +2194,110 @@
     ]
 }
 
+// Drooling Groodion
+{
+    "name": "Drooling Groodion",
+    "manaCost": "{3}{B}{B}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    },
+                    {
+                        "type": "TargetOther",
+                        "baseRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "id": "another target creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"The Golgari expand, yes, but I refuse to call their tainted creations 'growth.'\"\n—Veszka, Selesnya evangel",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de33c222-0d74-4eb5-8794-39f3601eb8f4.jpg?1783943621"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Duskmantle, House of Shadow
 {
     "name": "Duskmantle, House of Shadow",
@@ -2924,6 +3028,65 @@
     ]
 }
 
+// Goblin Fire Fiend
+{
+    "name": "Goblin Fire Fiend",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Goblin Berserker",
+    "oracleText": "Haste\nThis creature must be blocked if able.\n{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "This creature gets +1/+0 until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            "MustBeBlockedStatic"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64d3b2d2-4ec2-495d-833d-7476cbfc80f6.jpg?1783943654",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If Goblin Fire Fiend is attacking, the defending player must assign at least one blocker to it during the declare blockers step if that player controls any creatures that could block Goblin Fire Fiend."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Golgari Germination
 {
     "name": "Golgari Germination",
@@ -3566,6 +3729,43 @@
     ]
 }
 
+// Indentured Oaf
+{
+    "name": "Indentured Oaf",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "oracleText": "Prevent all damage that this creature would deal to red creatures.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": "creature red"
+                    },
+                    "source": "SourceSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "UNCOMMON",
+        "artist": "Glenn Fabry",
+        "flavorText": "All it knows is the difference between friend and food.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af6e976c-3c0b-4ba5-b614-e1b576b57e86.jpg?1783943651"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Infectious Host
 {
     "name": "Infectious Host",
@@ -3810,6 +4010,36 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Light of Sanction
+{
+    "name": "Light of Sanction",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Prevent all damage that would be dealt to creatures you control by sources you control.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "CreatureYouControl",
+                    "source": "SourceYouControl"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Michael Phillippi",
+        "flavorText": "The Legion looks after its own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg?1783943697"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -5157,6 +5387,58 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sabertooth Alley Cat
+{
+    "name": "Sabertooth Alley Cat",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "This creature attacks each combat if able.\n{1}{R}: Creatures without defender can't block this creature this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantCantBeBlockedExceptBy",
+                    "target": "Self",
+                    "blockerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasKeyword",
+                                "keyword": "DEFENDER"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Creatures without defender can't block this creature this turn."
+            }
+        ],
+        "staticAbilities": [
+            "MustAttack"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Carl Critchlow",
+        "flavorText": "It has eight lives' worth of hunger to satisfy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9ec817c-c414-4a56-b455-748c6e5cac0d.jpg?1783943647"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Five Ravnica: City of Guilds cards, all built from existing SDK primitives. Combat restrictions and damage prevention, mostly red.

- **Goblin Fire Fiend** {3}{R} 1/1 — haste, `MustBeBlocked()` static ("must be blocked if able" — the *at least one* form, matching the printed ruling), plus a `{R}: ModifyStats(1, 0)` pump on `EffectTarget.Self`.
- **Sabertooth Alley Cat** {1}{R}{R} 2/1 — `MustAttack()` static, plus `Effects.GrantCantBeBlockedExceptBy(Self, Creature.withKeyword(DEFENDER))`. Written from the attacker's side: "creatures without defender can't block this creature" and "can't be blocked except by creatures with defender" name the same set of legal blockers, and the attacker-side form doesn't stop those creatures blocking *other* attackers the way a group-wide `CantBlockGroupEffect` would.
- **Indentured Oaf** {3}{R} 4/3 — a `PreventDamage` replacement scoped on both sides: `SourceFilter.Self` and `RecipientFilter.Matching(Creature.withColor(RED))`.
- **Light of Sanction** {1}{W}{W} — one `PreventDamage` replacement with `RecipientFilter.CreatureYouControl` + `SourceFilter.YouControl`. Both "you"s resolve to the enchantment's current controller, re-read per damage instance; `YouControl` covers spells and abilities on the stack, not just permanents.
- **Drooling Groodion** {3}{B}{B}{G} 4/3 — `Costs.Composite(Mana, Sacrifice(Creature))` with two target requirements, the second wrapped in `TargetOther` for the "another target creature" distinctness rule (CR 601.2c).

No new SDK vocabulary, so no per-card scenario tests — the cards are covered by the snapshot and lint nets.

## Verification

- `just build` — green after re-blessing; the only failure was `CardDefinitionSnapshotTest`, and the RAV golden diff is 282 pure insertions naming only these five cards.
- `just check-card-printing` — all five canonical in RAV, their earliest real expansion. Drooling Groodion's later printings (td2/ddm/mm2) aren't scaffolded, so no reprint rows are owed.
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)