### PR TITLE
Add six Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AncientAmphitheater.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AncientAmphitheater.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ancient Amphitheater
+ * Land
+ *
+ * As this land enters, you may reveal a Giant card from your hand.
+ * If you don't, this land enters tapped.
+ * {T}: Add {R} or {W}.
+ *
+ * One of Lorwyn's five "tribal reveal" duals. Same two atoms as Shadows over Innistrad's
+ * shadowlands (see Game Trail):
+ *  - [OnEnterRunEffect] — the generic "as ~ enters, run [effect]" replacement wrapper.
+ *  - [Effects.MayRevealCardFromHand] — an optional reveal whose `otherwise` rider fires when the
+ *    player declines or holds no eligible card; here it taps the land.
+ *
+ * The only difference from the shadowlands is what the filter reads: a *creature type* on any card
+ * type rather than a land subtype. [GameObjectFilter.Any] with a subtype predicate is what makes
+ * that work — Lorwyn's Kindred cards (e.g. Crush Underfoot, a Kindred Instant — Giant) carry the
+ * creature type without being creatures, and they count for the reveal.
+ */
+val AncientAmphitheater = card("Ancient Amphitheater") {
+    typeLine = "Land"
+    colorIdentity = "RW"
+    oracleText = "As this land enters, you may reveal a Giant card from your hand. " +
+        "If you don't, this land enters tapped.\n{T}: Add {R} or {W}."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            Effects.MayRevealCardFromHand(
+                filter = GameObjectFilter.Any.withSubtype("Giant"),
+                otherwise = Effects.Tap(EffectTarget.Self),
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "266"
+        artist = "Rob Alexander"
+        flavorText = "The arbiter Galanda Feudkiller judges Lorwyn's squabbles from a lofty perspective."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg?1783942848"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AuntiesHovel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AuntiesHovel.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Auntie's Hovel
+ * Land
+ *
+ * As this land enters, you may reveal a Goblin card from your hand.
+ * If you don't, this land enters tapped.
+ * {T}: Add {B} or {R}.
+ *
+ * One of Lorwyn's five "tribal reveal" duals. Same two atoms as Shadows over Innistrad's
+ * shadowlands (see Game Trail):
+ *  - [OnEnterRunEffect] — the generic "as ~ enters, run [effect]" replacement wrapper.
+ *  - [Effects.MayRevealCardFromHand] — an optional reveal whose `otherwise` rider fires when the
+ *    player declines or holds no eligible card; here it taps the land.
+ *
+ * The only difference from the shadowlands is what the filter reads: a *creature type* on any card
+ * type rather than a land subtype. [GameObjectFilter.Any] with a subtype predicate is what makes
+ * that work — Lorwyn's Kindred cards (e.g. Crush Underfoot, a Kindred Instant — Giant) carry the
+ * creature type without being creatures, and they count for the reveal.
+ */
+val AuntiesHovel = card("Auntie's Hovel") {
+    typeLine = "Land"
+    colorIdentity = "BR"
+    oracleText = "As this land enters, you may reveal a Goblin card from your hand. " +
+        "If you don't, this land enters tapped.\n{T}: Add {B} or {R}."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            Effects.MayRevealCardFromHand(
+                filter = GameObjectFilter.Any.withSubtype("Goblin"),
+                otherwise = Effects.Tap(EffectTarget.Self),
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "267"
+        artist = "Wayne Reynolds"
+        flavorText = "The Stinkdrinker warren's hill of salvaged trinkets is large enough to cut a door in."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg?1783942848"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GiltLeafPalace.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GiltLeafPalace.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gilt-Leaf Palace
+ * Land
+ *
+ * As this land enters, you may reveal an Elf card from your hand.
+ * If you don't, this land enters tapped.
+ * {T}: Add {B} or {G}.
+ *
+ * One of Lorwyn's five "tribal reveal" duals. Same two atoms as Shadows over Innistrad's
+ * shadowlands (see Game Trail):
+ *  - [OnEnterRunEffect] — the generic "as ~ enters, run [effect]" replacement wrapper.
+ *  - [Effects.MayRevealCardFromHand] — an optional reveal whose `otherwise` rider fires when the
+ *    player declines or holds no eligible card; here it taps the land.
+ *
+ * The only difference from the shadowlands is what the filter reads: a *creature type* on any card
+ * type rather than a land subtype. [GameObjectFilter.Any] with a subtype predicate is what makes
+ * that work — Lorwyn's Kindred cards (e.g. Crush Underfoot, a Kindred Instant — Giant) carry the
+ * creature type without being creatures, and they count for the reveal.
+ */
+val GiltLeafPalace = card("Gilt-Leaf Palace") {
+    typeLine = "Land"
+    colorIdentity = "BG"
+    oracleText = "As this land enters, you may reveal an Elf card from your hand. " +
+        "If you don't, this land enters tapped.\n{T}: Add {B} or {G}."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            Effects.MayRevealCardFromHand(
+                filter = GameObjectFilter.Any.withSubtype("Elf"),
+                otherwise = Effects.Tap(EffectTarget.Self),
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "268"
+        artist = "Christopher Moeller"
+        flavorText = "Dawn's Light, greatest palace of Gilt-Leaf Wood, is built on tiers of wood and power."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg?1783942847"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SecludedGlen.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SecludedGlen.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Secluded Glen
+ * Land
+ *
+ * As this land enters, you may reveal a Faerie card from your hand.
+ * If you don't, this land enters tapped.
+ * {T}: Add {U} or {B}.
+ *
+ * One of Lorwyn's five "tribal reveal" duals. Same two atoms as Shadows over Innistrad's
+ * shadowlands (see Game Trail):
+ *  - [OnEnterRunEffect] — the generic "as ~ enters, run [effect]" replacement wrapper.
+ *  - [Effects.MayRevealCardFromHand] — an optional reveal whose `otherwise` rider fires when the
+ *    player declines or holds no eligible card; here it taps the land.
+ *
+ * The only difference from the shadowlands is what the filter reads: a *creature type* on any card
+ * type rather than a land subtype. [GameObjectFilter.Any] with a subtype predicate is what makes
+ * that work — Lorwyn's Kindred cards (e.g. Crush Underfoot, a Kindred Instant — Giant) carry the
+ * creature type without being creatures, and they count for the reveal.
+ */
+val SecludedGlen = card("Secluded Glen") {
+    typeLine = "Land"
+    colorIdentity = "UB"
+    oracleText = "As this land enters, you may reveal a Faerie card from your hand. " +
+        "If you don't, this land enters tapped.\n{T}: Add {U} or {B}."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            Effects.MayRevealCardFromHand(
+                filter = GameObjectFilter.Any.withSubtype("Faerie"),
+                otherwise = Effects.Tap(EffectTarget.Self),
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "271"
+        artist = "Terese Nielsen"
+        flavorText = "Protected by glamers and guile, Glen Elendra harbors the elusive Oona, queen of the fae."
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg?1783942847"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Thoughtseize.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Thoughtseize.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Thoughtseize
+ * {B}
+ * Sorcery
+ *
+ * Target player reveals their hand. You choose a nonland card from it. That player discards that
+ * card. You lose 2 life.
+ *
+ * The hand-strip half is Duress's shape exactly — reveal, gather the target's hand, the *caster*
+ * picks one, move it with [MoveType.Discard] so discard triggers see a real discard rather than a
+ * bare zone change. Two things differ from Duress and both matter:
+ *
+ *  - it targets any **player**, not just an opponent, so [Targets.Player] rather than TargetOpponent;
+ *  - the filter is `Nonland` only, so creatures are fair game.
+ *
+ * The life loss is a separate clause and is unconditional: per the 2020-08-07 ruling you lose 2
+ * even when the target's hand holds nothing to take, which is why it sits outside the
+ * gather/select/move chain rather than riding on the discard.
+ */
+val Thoughtseize = card("Thoughtseize") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player reveals their hand. You choose a nonland card from it. " +
+        "That player discards that card. You lose 2 life."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            listOf(
+                RevealHandEffect(player),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "revealedHand",
+                ),
+                SelectFromCollectionEffect(
+                    from = "revealedHand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "Choose a nonland card to discard",
+                    alwaysPrompt = true,
+                    showAllCards = true,
+                ),
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard,
+                ),
+                Effects.LoseLife(2, EffectTarget.PlayerRef(Player.You)),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "145"
+        artist = "Aleksi Briclot"
+        flavorText = "\"Any dream is a robust harvest. Still, I prefer the timeworn dreams, heavy " +
+            "with import, that haunt the obsessive mind.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg?1783942883"
+        ruling(
+            "2020-08-07",
+            "You lose 2 life even if the target player has no nonland cards in their hand to discard.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WanderwineHub.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WanderwineHub.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wanderwine Hub
+ * Land
+ *
+ * As this land enters, you may reveal a Merfolk card from your hand.
+ * If you don't, this land enters tapped.
+ * {T}: Add {W} or {U}.
+ *
+ * One of Lorwyn's five "tribal reveal" duals. Same two atoms as Shadows over Innistrad's
+ * shadowlands (see Game Trail):
+ *  - [OnEnterRunEffect] — the generic "as ~ enters, run [effect]" replacement wrapper.
+ *  - [Effects.MayRevealCardFromHand] — an optional reveal whose `otherwise` rider fires when the
+ *    player declines or holds no eligible card; here it taps the land.
+ *
+ * The only difference from the shadowlands is what the filter reads: a *creature type* on any card
+ * type rather than a land subtype. [GameObjectFilter.Any] with a subtype predicate is what makes
+ * that work — Lorwyn's Kindred cards (e.g. Crush Underfoot, a Kindred Instant — Giant) carry the
+ * creature type without being creatures, and they count for the reveal.
+ */
+val WanderwineHub = card("Wanderwine Hub") {
+    typeLine = "Land"
+    colorIdentity = "WU"
+    oracleText = "As this land enters, you may reveal a Merfolk card from your hand. " +
+        "If you don't, this land enters tapped.\n{T}: Add {W} or {U}."
+
+    replacementEffect(
+        OnEnterRunEffect(
+            Effects.MayRevealCardFromHand(
+                filter = GameObjectFilter.Any.withSubtype("Merfolk"),
+                otherwise = Effects.Tap(EffectTarget.Self),
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "280"
+        artist = "Warren Mahy"
+        flavorText = "Below the great river, a bustling hub channels the flow of merrow trade."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg?1783942845"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SecludedGlenScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SecludedGlenScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.Peppersmoke
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.Pestermite
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SecludedGlen
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Secluded Glen.
+ *
+ * Secluded Glen
+ * Land
+ * As this land enters, you may reveal a Faerie card from your hand. If you don't, this land
+ * enters tapped.
+ * {T}: Add {U} or {B}.
+ *
+ * Stands in for the whole Lorwyn cycle (Ancient Amphitheater, Auntie's Hovel, Gilt-Leaf Palace,
+ * Wanderwine Hub) — the five share one script and differ only in creature type and mana. What
+ * these tests pin down is the thing that is *not* shared with the SOI shadowlands the shape was
+ * borrowed from: the reveal filter reads a **creature type on any card type**, so Lorwyn's Kindred
+ * noncreature cards satisfy it. Peppersmoke is a Kindred Instant — Faerie and must count.
+ */
+class SecludedGlenScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SecludedGlen, Pestermite, Peppersmoke))
+        return driver
+    }
+
+    fun setup(driver: GameTestDriver) {
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("revealing a Faerie creature lets the land enter untapped") {
+        val driver = createDriver()
+        setup(driver)
+        val player = driver.activePlayer!!
+
+        val faerie = driver.putCardInHand(player, "Pestermite")
+        val glen = driver.putCardInHand(player, "Secluded Glen")
+
+        // The reveal is an as-enters replacement, so playing the land pauses on a decision.
+        driver.playLand(player, glen).isPaused shouldBe true
+
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldBe listOf(faerie)
+
+        driver.submitCardSelection(player, listOf(faerie)).isSuccess shouldBe true
+
+        driver.isTapped(glen) shouldBe false
+    }
+
+    test("a Kindred noncreature Faerie card counts for the reveal") {
+        val driver = createDriver()
+        setup(driver)
+        val player = driver.activePlayer!!
+
+        // Peppersmoke is a Kindred Instant — Faerie: it is not a creature, but it has the type.
+        val peppersmoke = driver.putCardInHand(player, "Peppersmoke")
+        val glen = driver.putCardInHand(player, "Secluded Glen")
+
+        driver.playLand(player, glen).isPaused shouldBe true
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldBe listOf(peppersmoke)
+
+        driver.submitCardSelection(player, listOf(peppersmoke)).isSuccess shouldBe true
+
+        driver.isTapped(glen) shouldBe false
+    }
+
+    test("declining the reveal taps the land even with a Faerie in hand") {
+        val driver = createDriver()
+        setup(driver)
+        val player = driver.activePlayer!!
+
+        driver.putCardInHand(player, "Pestermite")
+        val glen = driver.putCardInHand(player, "Secluded Glen")
+
+        driver.playLand(player, glen).isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        // An empty selection is the decline.
+        driver.submitCardSelection(player, emptyList()).isSuccess shouldBe true
+
+        driver.isTapped(glen) shouldBe true
+    }
+
+    test("no Faerie in hand skips the prompt and the land enters tapped") {
+        val driver = createDriver()
+        setup(driver)
+        val player = driver.activePlayer!!
+
+        val glen = driver.putCardInHand(player, "Secluded Glen")
+
+        driver.playLand(player, glen).isSuccess shouldBe true
+
+        driver.pendingDecision shouldBe null
+        driver.isTapped(glen) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtseizeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtseizeScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.Thoughtseize
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Thoughtseize.
+ *
+ * Thoughtseize
+ * {B}
+ * Sorcery
+ * Target player reveals their hand. You choose a nonland card from it. That player discards that
+ * card. You lose 2 life.
+ *
+ * The two things worth pinning: the caster (not the target) picks the card, and the life loss is
+ * unconditional — per the 2020-08-07 ruling you lose 2 even when there is nothing to take.
+ */
+class ThoughtseizeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Thoughtseize))
+        return driver
+    }
+
+    test("the caster chooses a nonland card and the target discards it, at the cost of 2 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val victim = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putLandOnBattlefield(caster, "Swamp")
+        val bear = driver.putCardInHand(victim, "Grizzly Bears")
+        driver.putCardInHand(victim, "Swamp")
+
+        val thoughtseize = driver.putCardInHand(caster, "Thoughtseize")
+        driver.castSpell(caster, thoughtseize, listOf(victim)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        // The *caster* chooses, and the land in the revealed hand is not a legal pick.
+        decision.playerId shouldBe caster
+
+        driver.submitCardSelection(caster, listOf(bear)).isSuccess shouldBe true
+
+        driver.getGraveyardCardNames(victim) shouldContain "Grizzly Bears"
+        driver.getLifeTotal(caster) shouldBe 18
+        driver.getLifeTotal(victim) shouldBe 20
+    }
+
+    test("an all-land hand yields nothing but the caster still loses 2 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val victim = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putLandOnBattlefield(caster, "Swamp")
+        driver.putCardInHand(victim, "Swamp")
+        driver.putCardInHand(victim, "Forest")
+        val victimHandSize = driver.getHandSize(victim)
+
+        val thoughtseize = driver.putCardInHand(caster, "Thoughtseize")
+        driver.castSpell(caster, thoughtseize, listOf(victim)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Nothing to take: the hand is untouched.
+        driver.getHandSize(victim) shouldBe victimHandSize
+        driver.getGraveyardCardNames(victim).any { it != "Swamp" && it != "Forest" } shouldBe false
+
+        driver.getLifeTotal(caster) shouldBe 18
+    }
+
+    test("Thoughtseize can target its own caster") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putLandOnBattlefield(caster, "Swamp")
+        val bear = driver.putCardInHand(caster, "Grizzly Bears")
+
+        val thoughtseize = driver.putCardInHand(caster, "Thoughtseize")
+        driver.castSpell(caster, thoughtseize, listOf(caster)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(caster, listOf(bear)).isSuccess shouldBe true
+
+        driver.getGraveyardCardNames(caster) shouldContain "Grizzly Bears"
+        driver.getLifeTotal(caster) shouldBe 18
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AncientAmphitheaterReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AncientAmphitheaterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancient Amphitheater reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val AncientAmphitheaterReprint = Printing(
+    oracleId = "7211221d-d4d8-4bbe-9d2a-b82e005bfe8a",
+    name = "Ancient Amphitheater",
+    setCode = "C15",
+    collectorNumber = "276",
+    scryfallId = "04a37397-1d93-45d6-a19d-e02245b5f2fe",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04a37397-1d93-45d6-a19d-e02245b5f2fe.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ThoughtseizeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/ThoughtseizeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thoughtseize reprint in THS. Canonical CardDefinition lives in its earliest set.
+ */
+val ThoughtseizeReprint = Printing(
+    oracleId = "edd8d1e8-be43-4c38-bb3a-83081fbaf0b5",
+    name = "Thoughtseize",
+    setCode = "THS",
+    collectorNumber = "107",
+    scryfallId = "65b7275a-5305-42e6-b5c3-8b88568b4e28",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65b7275a-5305-42e6-b5c3-8b88568b4e28.jpg",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -54,6 +54,118 @@
     ]
 }
 
+// Ancient Amphitheater
+{
+    "name": "Ancient Amphitheater",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, you may reveal a Giant card from your hand. If you don't, this land enters tapped.\n{T}: Add {R} or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "MayRevealCardFromHand",
+                    "filter": "Giant",
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "RARE",
+        "artist": "Rob Alexander",
+        "flavorText": "The arbiter Galanda Feudkiller judges Lorwyn's squabbles from a lofty perspective.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2ff3a82d-e794-4c3b-994d-b28b8eb7eac4.jpg?1783942848"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Auntie's Hovel
+{
+    "name": "Auntie's Hovel",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, you may reveal a Goblin card from your hand. If you don't, this land enters tapped.\n{T}: Add {B} or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "MayRevealCardFromHand",
+                    "filter": "Goblin",
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "flavorText": "The Stinkdrinker warren's hill of salvaged trinkets is large enough to cut a door in.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/098685c9-cd85-4279-a3b5-b495485bba35.jpg?1783942848"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Avian Changeling
 {
     "name": "Avian Changeling",
@@ -2568,6 +2680,62 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gilt-Leaf Palace
+{
+    "name": "Gilt-Leaf Palace",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, you may reveal an Elf card from your hand. If you don't, this land enters tapped.\n{T}: Add {B} or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "MayRevealCardFromHand",
+                    "filter": "Elf",
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "RARE",
+        "artist": "Christopher Moeller",
+        "flavorText": "Dawn's Light, greatest palace of Gilt-Leaf Wood, is built on tiers of wood and power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc4bbbb5-4218-4b2a-9ca2-de4d5f5dda19.jpg?1783942847"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -5919,6 +6087,62 @@
     ]
 }
 
+// Secluded Glen
+{
+    "name": "Secluded Glen",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, you may reveal a Faerie card from your hand. If you don't, this land enters tapped.\n{T}: Add {U} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "MayRevealCardFromHand",
+                    "filter": "Faerie",
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "RARE",
+        "artist": "Terese Nielsen",
+        "flavorText": "Protected by glamers and guile, Glen Elendra harbors the elusive Oona, queen of the fae.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e4afa65-7933-4a64-b50f-a9a9f832b112.jpg?1783942847"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Seedguide Ash
 {
     "name": "Seedguide Ash",
@@ -6862,6 +7086,102 @@
     ]
 }
 
+// Thoughtseize
+{
+    "name": "Thoughtseize",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RevealHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "revealedHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealedHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "You"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "flavorText": "\"Any dream is a robust harvest. Still, I prefer the timeworn dreams, heavy with import, that haunt the obsessive mind.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3df8c148-e87d-4043-9d8b-ec72bf8b6d5d.jpg?1783942883",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "You lose 2 life even if the target player has no nonland cards in their hand to discard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Treefolk Harbinger
 {
     "name": "Treefolk Harbinger",
@@ -7423,6 +7743,62 @@
         "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ea7b2c0-c641-478f-b8d9-17aa17fa1cbe.jpg?1783942849"
     },
     "colorIdentityOverride": []
+}
+
+// Wanderwine Hub
+{
+    "name": "Wanderwine Hub",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, you may reveal a Merfolk card from your hand. If you don't, this land enters tapped.\n{T}: Add {W} or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "OnEnterRunEffect",
+                "effect": {
+                    "type": "MayRevealCardFromHand",
+                    "filter": "Merfolk",
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "280",
+        "rarity": "RARE",
+        "artist": "Warren Mahy",
+        "flavorText": "Below the great river, a bustling hub channels the flow of merrow trade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccec69de-7203-4810-a8ec-8748705ee3a2.jpg?1783942845"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
 }
 
 // Warren Pilferers


### PR DESCRIPTION
Six Lorwyn cards, all composed from existing primitives — no new SDK vocabulary.

**The tribal-reveal dual cycle** (five cards, one shape): `OnEnterRunEffect` wrapping `Effects.MayRevealCardFromHand`, whose `otherwise` rider taps the land. That is exactly the Shadows over Innistrad shadowland shape (`Game Trail`); the one thing that differs is the filter — `GameObjectFilter.Any.withSubtype(...)` reads a **creature type on any card type** rather than a land subtype, so Lorwyn's Kindred noncreature cards count for the reveal.

- **Ancient Amphitheater** — Giant, `{R}`/`{W}`. Also adds the C15 `Printing` row.
- **Auntie's Hovel** — Goblin, `{B}`/`{R}`.
- **Gilt-Leaf Palace** — Elf, `{B}`/`{G}`.
- **Secluded Glen** — Faerie, `{U}`/`{B}`.
- **Wanderwine Hub** — Merfolk, `{W}`/`{U}`.

**Thoughtseize** — `RevealHandEffect` → `GatherCardsEffect` → `SelectFromCollectionEffect` (chooser: the caster) → `MoveCollectionEffect` with `MoveType.Discard`, i.e. Duress's chain, differing in that it targets any **player** rather than an opponent and filters on `Nonland` only. `Effects.LoseLife(2, You)` sits outside that chain because it is unconditional. Also adds the THS `Printing` row.

## Tests

Two scenario tests, one per card, for the two claims worth pinning:

- `SecludedGlenScenarioTest` — stands in for the cycle. Revealing a Faerie creature (Pestermite) leaves the land untapped; revealing **Peppersmoke**, a Kindred Instant — Faerie and not a creature, also leaves it untapped; declining taps it; holding no Faerie raises no prompt at all and taps it.
- `ThoughtseizeScenarioTest` — the caster (not the target) chooses; an all-land hand yields nothing but still costs 2 life (the 2020-08-07 ruling); the spell can target its own caster.

## Verification

- `just build` green.
- `just rebless-cards` — only the six added cards move in `LRW.json`, nothing else.
- `just check-card-printing` clean for all six; canonical is LRW for every one.
- Every field (mana cost, type line, oracle text, rarity, collector number, artist, flavor, image URI, colour identity) re-checked against Scryfall; all image URIs return HTTP 200.
- `just assay-differential --set LRW` — the six decline in the grammar, so Assay does not cover them; LRW's 13 divergences are all pre-existing (the harbinger family), unchanged by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)