### PR TITLE
Add Brine Comber to Innistrad: Crimson Vow

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 263 / 273
+**Implemented:** 264 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -36,7 +36,7 @@
 - [x] Bramble Armor
 - [x] Bramble Wurm
 - [x] Bride's Gown
-- [ ] Brine Comber
+- [x] Brine Comber
 - [x] By Invitation Only
 - [x] Cartographer's Survey
 - [x] Catapult Fodder

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5792,6 +5792,19 @@ Triggers.youCastSpell(
   control" covers both halves of "King of the Oathbreakers or another Spirit you control becomes the
   target of a spell" because the source itself matches the filter. Pair with
   `Effects.PhaseOut(EffectTarget.TriggeringEntity)` to phase out the targeted permanent.
+- `BecomesTargetOfAuraSpell(binding = SELF)` — the bound permanent becomes the target of an **Aura
+  spell** (Brine Comber // Brinebound Gift). Where `spellsOnly` says only *that* a spell did the
+  targeting, this narrows *which kind*: it sets `BecomesTargetEvent.sourceFilter`, a
+  `GameObjectFilter?` matched against the **targeting** object rather than the targeted one, to
+  `Enchantment.withSubtype(Subtype.AURA)` — and keeps `spellsOnly = true`, which is not redundant
+  with it (an Aura already on the battlefield could target with an activated ability and match the
+  same card types). `binding` is a parameter because the card spells the same wording twice: SELF on
+  the front face ("this creature becomes the target"), `TriggerBinding.ATTACHED` on the back
+  ("enchanted creature becomes the target"), which reaches it through `AttachmentTriggerDetector`.
+  An Aura spell chooses its target as it is cast (CR 303.4a), so this never fires for the Aura a
+  permanent is already enchanted by — only for a new one being cast at it. `sourceFilter` is
+  general: any `EventPattern.BecomesTargetEvent` may carry one, and its `description` prints the
+  filter's subtype alone when it has one ("an Aura spell", not "an Aura enchantment spell").
 - `BecomesTargetOfAbility(filter = Any, byYou = false, includePlayerTargets = false)` — the exact mirror of
   `BecomesTargetOfSpell`: something becomes the target of an **ability** (activated *or* triggered),
   never a spell. Sets `BecomesTargetEvent(abilitiesOnly = true)`, reading the same `sourceIsSpell`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1611,6 +1611,8 @@ object Triggers {
     //     turnedFaceUp(binding = TriggerBinding.ATTACHED)
     // - "At the beginning of enchanted creature's controller's <step>":
     //     phase(step, Player.You, binding = TriggerBinding.ATTACHED)
+    // - "Enchanted creature becomes the target of an Aura spell":
+    //     BecomesTargetOfAuraSpell(binding = TriggerBinding.ATTACHED)
     // -------------------------------------------------------------------------
 
     // =========================================================================
@@ -2050,6 +2052,27 @@ object Triggers {
         event = BecomesTargetEvent(targetFilter = filter, spellsOnly = true),
         binding = TriggerBinding.ANY
     )
+
+    /**
+     * Whenever the bound permanent becomes the target of an **Aura spell** (Brine Comber's front
+     * face; its back face is the same wording bound to the enchanted creature, hence [binding]).
+     *
+     * "Aura spell" narrows the *targeting* object, not the targeted one, so it rides
+     * [BecomesTargetEvent.sourceFilter] rather than `targetFilter`. `spellsOnly` is part of the
+     * printed wording and not redundant with the filter: an Aura already on the battlefield could
+     * target with an activated ability and match the same card types.
+     *
+     * An Aura spell targets exactly once, as it is cast (CR 303.4a), so this never fires for the
+     * Aura the bound permanent is already enchanted by — only for a *new* one being cast at it.
+     */
+    fun BecomesTargetOfAuraSpell(binding: TriggerBinding = TriggerBinding.SELF): TriggerSpec =
+        TriggerSpec(
+            event = BecomesTargetEvent(
+                spellsOnly = true,
+                sourceFilter = GameObjectFilter.Enchantment.withSubtype(Subtype.AURA)
+            ),
+            binding = binding
+        )
 
     /**
      * Mirror of [BecomesTargetOfSpell]: whenever something becomes the target of an **ability**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1685,9 +1685,17 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * They are mutually exclusive: asking for both would match nothing, and throws — as does the
      * equally contradictory [byYou] + [byOpponent] pair.
      *
-     * Note that [spellsOnly] / [abilitiesOnly] narrow *what did the targeting*, while
-     * [includeSpellTargets] / [includePlayerTargets] widen *what got targeted*; the two axes are
-     * independent.
+     * [sourceFilter] is the finer-grained sibling of that pair: where [spellsOnly] says only *that*
+     * a spell did the targeting, [sourceFilter] says **which kind** of spell or ability did it —
+     * "becomes the target of an **Aura** spell" (Brine Comber). It is matched against the targeting
+     * object's card data, so it reads the spell's printed types off the stack; a targeted-by-ability
+     * event whose source is a permanent reads that permanent instead. Pair it with [spellsOnly] when
+     * the printed wording says "spell", since a permanent's *ability* would otherwise match the same
+     * card types (an Aura already on the battlefield targeting with an activated ability).
+     *
+     * Note that [spellsOnly] / [abilitiesOnly] / [sourceFilter] narrow *what did the targeting*,
+     * while [includeSpellTargets] / [includePlayerTargets] widen *what got targeted*; the two axes
+     * are independent.
      */
     @SerialName("BecomesTargetEvent")
     @Serializable
@@ -1699,7 +1707,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         val includeSpellTargets: Boolean = false,
         val spellsOnly: Boolean = false,
         val includePlayerTargets: Boolean = false,
-        val abilitiesOnly: Boolean = false
+        val abilitiesOnly: Boolean = false,
+        val sourceFilter: GameObjectFilter? = null
     ) : EventPattern {
         init {
             require(!(spellsOnly && abilitiesOnly)) {
@@ -1726,7 +1735,28 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
             } else {
                 append(describeObjectForEvent(targetFilter))
             }
+            // `sourceFilter` names the targeting object, so it supplies the noun the "of …"
+            // phrase would otherwise fill with the bare word "spell"/"ability": "becomes the
+            // target of an Aura spell". Its own article agrees with the filter's leading word.
+            //
+            // A subtype already implies its card type, and Magic drops the type word when one is
+            // present — "an Aura spell", never "an Aura enchantment spell". So the printed noun is
+            // the subtype alone whenever the filter carries one; the filter itself keeps both
+            // predicates, because matching still wants the card type.
+            val sourceNoun = sourceFilter?.let { f ->
+                val kind = when {
+                    spellsOnly -> "spell"
+                    abilitiesOnly -> "ability"
+                    else -> "spell or ability"
+                }
+                val subtype = f.cardPredicates
+                    .filterIsInstance<com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype>()
+                    .singleOrNull()
+                    ?.takeIf { f.controllerPredicate == null && f.statePredicates.isEmpty() && f.anyOf.isEmpty() }
+                "${f.indefiniteArticle} ${subtype?.description ?: f.description} $kind"
+            }
             when {
+                sourceNoun != null -> append(" becomes the target of $sourceNoun")
                 spellsOnly -> append(" becomes the target of a spell")
                 abilitiesOnly -> append(" becomes the target of an ability")
                 else -> append(" becomes the target of a spell or ability")
@@ -1738,7 +1768,9 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
 
         override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
             val newFilter = targetFilter.applyTextReplacement(replacer)
-            return if (newFilter !== targetFilter) copy(targetFilter = newFilter) else this
+            val newSourceFilter = sourceFilter?.applyTextReplacement(replacer)
+            return if (newFilter !== targetFilter || newSourceFilter !== sourceFilter)
+                copy(targetFilter = newFilter, sourceFilter = newSourceFilter) else this
         }
     }
 

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BrineComber.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BrineComber.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Brine Comber // Brinebound Gift (Innistrad: Crimson Vow #233 — the card's earliest printing)
+ * {1}{W}{U} · Creature — Spirit 1/1 // Enchantment — Aura
+ *
+ * Front — Brine Comber ({1}{W}{U}, Creature — Spirit, 1/1)
+ *   Whenever this creature enters or becomes the target of an Aura spell, create a 1/1 white
+ *   Spirit creature token with flying.
+ *   Disturb {W}{U}
+ *
+ * Back — Brinebound Gift (Enchantment — Aura, white-blue color indicator)
+ *   Enchant creature
+ *   Whenever this Aura enters or enchanted creature becomes the target of an Aura spell, create a
+ *   1/1 white Spirit creature token with flying.
+ *   If this Aura would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Implementation: each face's printed "enters **or** becomes the target" is two triggered
+ * abilities, the house shape for an or-joined trigger (Crow of Dark Tidings' enters/dies) — and
+ * here it is forced, because the back face's two halves don't even share a binding: the Aura's own
+ * ETB is SELF-bound while "enchanted creature becomes the target" is
+ * [TriggerBinding.ATTACHED]-bound. Both target halves use `Triggers.BecomesTargetOfAuraSpell`,
+ * which reads the *targeting* spell through `BecomesTargetEvent.sourceFilter`.
+ *
+ * An Aura spell chooses its target as it is cast (CR 303.4a), so neither half fires for the Aura
+ * that is already attached — only for a new Aura spell cast at the creature. Disturb (CR 702.146)
+ * puts the card on the stack back face up (CR 712.8c), so the disturb cast is itself an Aura spell
+ * that picks its host from `auraTarget`; that cast targets the creature, which means a *different*
+ * Brine Comber already on the battlefield sees it. The exile-instead clause is
+ * [RedirectZoneChange] with `selfOnly = true` so it functions from every zone (CR 614.12).
+ */
+private val SpiritTokenWithFlying = Effects.CreateToken(
+    power = 1,
+    toughness = 1,
+    colors = setOf(Color.WHITE),
+    creatureTypes = setOf("Spirit"),
+    keywords = setOf(Keyword.FLYING),
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1783924700"
+)
+
+private val BrineComberFront = card("Brine Comber") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature enters or becomes the target of an Aura spell, create a " +
+        "1/1 white Spirit creature token with flying.\n" +
+        "Disturb {W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = SpiritTokenWithFlying
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetOfAuraSpell()
+        effect = SpiritTokenWithFlying
+    }
+
+    disturb("{W}{U}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Olena Richards"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1783924801"
+    }
+}
+
+private val BrineboundGift = card("Brinebound Gift") {
+    manaCost = ""
+    colorIdentity = "WU"
+    colorIndicator = "WU"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Whenever this Aura enters or enchanted creature becomes the target of an Aura spell, " +
+        "create a 1/1 white Spirit creature token with flying.\n" +
+        "If this Aura would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = SpiritTokenWithFlying
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetOfAuraSpell(binding = TriggerBinding.ATTACHED)
+        effect = SpiritTokenWithFlying
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Olena Richards"
+        imageUri = "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1783924801"
+    }
+}
+
+val BrineComber: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = BrineComberFront,
+    backFace = BrineboundGift,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrineComberScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrineComberScenarioTest.kt
@@ -1,0 +1,183 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Brine Comber // Brinebound Gift (VOW #233) — {1}{W}{U} Creature — Spirit 1/1 // Enchantment — Aura
+ *
+ * Front:
+ *   Whenever this creature enters or becomes the target of an Aura spell, create a 1/1 white Spirit
+ *   creature token with flying.
+ *   Disturb {W}{U}
+ * Back (Brinebound Gift):
+ *   Enchant creature
+ *   Whenever this Aura enters or enchanted creature becomes the target of an Aura spell, create a
+ *   1/1 white Spirit creature token with flying.
+ *   If this Aura would be put into a graveyard from anywhere, exile it instead.
+ *
+ * The card is the first user of `BecomesTargetEvent.sourceFilter` — a filter on the *targeting*
+ * spell rather than the targeted permanent — on both the SELF binding (front) and the ATTACHED
+ * binding (back). The negative tests are the point of the pair: a non-Aura spell targeting the same
+ * permanent must not make a token, which is what proves the filter isn't a no-op.
+ */
+class BrineComberScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Brine Comber — front face") {
+
+            test("entering the battlefield creates a 1/1 white flying Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Brine Comber")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Brine Comber").error shouldBe null
+                game.resolveStack()
+
+                val tokens = game.findPermanents("Spirit Token")
+                tokens.size shouldBe 1
+                withClue("the token is a 1/1 with flying") {
+                    game.state.projectedState.getPower(tokens.first()) shouldBe 1
+                    game.state.projectedState.getToughness(tokens.first()) shouldBe 1
+                    game.state.projectedState.hasKeyword(tokens.first(), Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("becoming the target of an Aura spell creates a Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brine Comber", summoningSickness = false)
+                    .withCardInHand(1, "Pacifism")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val comber = game.findPermanent("Brine Comber")!!
+                withClue("direct battlefield placement fires no ETB trigger, so the board starts clean") {
+                    game.findPermanents("Spirit Token").size shouldBe 0
+                }
+
+                game.castSpell(1, "Pacifism", targetId = comber).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Aura spell targeting it made exactly one Spirit token") {
+                    game.findPermanents("Spirit Token").size shouldBe 1
+                }
+            }
+
+            test("becoming the target of a NON-Aura spell creates no token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brine Comber", summoningSickness = false)
+                    .withCardInHand(1, "Giant Growth")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val comber = game.findPermanent("Brine Comber")!!
+                game.castSpell(1, "Giant Growth", targetId = comber).error shouldBe null
+                game.resolveStack()
+
+                withClue("an instant is not an Aura spell — the trigger must stay silent") {
+                    game.findPermanents("Spirit Token").size shouldBe 0
+                }
+                withClue("the pump still happened, so the spell really did target it") {
+                    game.state.projectedState.getPower(comber) shouldBe 4
+                }
+            }
+        }
+
+        context("Brinebound Gift — back face") {
+
+            test("an Aura spell targeting the enchanted creature creates a Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Brinebound Gift", "Grizzly Bears")
+                    .withCardInHand(1, "Pacifism")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.findPermanents("Spirit Token").size shouldBe 0
+
+                game.castSpell(1, "Pacifism", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the ATTACHED-bound trigger fired for the host being targeted") {
+                    game.findPermanents("Spirit Token").size shouldBe 1
+                }
+            }
+
+            test("a NON-Aura spell targeting the enchanted creature creates no token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Brinebound Gift", "Grizzly Bears")
+                    .withCardInHand(1, "Giant Growth")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Giant Growth", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanents("Spirit Token").size shouldBe 0
+            }
+
+            test("disturb casts Brinebound Gift as an Aura whose own entry makes a Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInGraveyard(1, "Brine Comber")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val comberCard = game.state.getGraveyard(game.player1Id).first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = comberCard,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        useAlternativeCost = true,
+                        alternativeCostType = AlternativeCostType.DISTURB,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val aura = game.findPermanent("Brinebound Gift")
+                withClue("disturb resolves the back face as an Aura attached to the chosen creature") {
+                    aura shouldBe game.findPermanent("Brinebound Gift")
+                    game.state.getEntity(aura!!)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+                withClue("the Aura's own enters trigger made one Spirit token") {
+                    game.findPermanents("Spirit Token").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -2286,6 +2286,174 @@
     ]
 }
 
+// Brine Comber
+{
+    "name": "Brine Comber",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever this creature enters or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nDisturb {W}{U} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{W}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1783924700"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "spellsOnly": true,
+                    "sourceFilter": "enchantment Aura"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1783924700"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Brinebound Gift",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura",
+        "oracleText": "Enchant creature\nWhenever this Aura enters or enchanted creature becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying.\nIf this Aura would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Battlefield"
+                    },
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1783924700"
+                    }
+                },
+                {
+                    "id": "ability_4",
+                    "trigger": {
+                        "type": "BecomesTargetEvent",
+                        "spellsOnly": true,
+                        "sourceFilter": "enchantment Aura"
+                    },
+                    "binding": "ATTACHED",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bee4081-5d74-4cc2-ba2f-887bc8799513.jpg?1783924700"
+                    }
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        },
+        "metadata": {
+            "collectorNumber": "233",
+            "rarity": "UNCOMMON",
+            "artist": "Olena Richards",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1783924801"
+        },
+        "colorIdentityOverride": [
+            "WHITE",
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "WHITE",
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Olena Richards",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d233bc5-8a08-4d38-abd4-21a112141afd.jpg?1783924801"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // By Invitation Only
 {
     "name": "By Invitation Only",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.event
 
 import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
+import com.wingedsheep.engine.core.BecomesTargetEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
 import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.TransformedEvent
@@ -155,6 +156,9 @@ class AttachmentTriggerDetector(
             // "an ability of enchanted artifact … was activated" (Artifact Possession) — the
             // activated ability's source is the enchanted permanent.
             is AbilityActivatedEvent -> listOf(event.sourceId)
+            // "enchanted creature becomes the target of an Aura spell" (Brinebound Gift). The
+            // targeted object is the aura's host; the targeting source is checked by the matcher.
+            is BecomesTargetEvent -> listOf(event.targetEntityId)
             is ZoneChangeEvent -> {
                 if (event.fromZone == Zone.BATTLEFIELD) listOf(event.entityId) else emptyList()
             }
@@ -221,6 +225,16 @@ class AttachmentTriggerDetector(
             }
             is EventPattern.TurnFaceUpEvent -> {
                 event is TurnFaceUpEvent && event.entityId == attachedEntityId
+            }
+            // "Whenever enchanted creature becomes the target of an Aura spell" (Brinebound Gift).
+            // Identity with the host settles the binding, then the full SELF matcher runs every
+            // other axis (spellsOnly, sourceFilter, byYou, targetFilter) against the aura's own
+            // controller — reusing it rather than restating it keeps the two paths from drifting.
+            is EventPattern.BecomesTargetEvent -> {
+                event is BecomesTargetEvent && event.targetEntityId == attachedEntityId &&
+                    matcher.matchesBecomesTargetTrigger(
+                        trigger, TriggerBinding.ANY, event, auraId, auraControllerId, state
+                    )
             }
             // "When equipped creature transforms" (Neglected Heirloom). Identity with the attached
             // permanent plus the pattern's direction filter is the whole match — the same two checks

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1492,6 +1492,21 @@ class TriggerMatcher(
         if (trigger.spellsOnly && !event.sourceIsSpell) return false
         if (trigger.abilitiesOnly && event.sourceIsSpell) return false
 
+        // "becomes the target of an **Aura** spell" (Brine Comber) — narrow by the targeting
+        // object's own card data. The source is a spell on the stack (or the permanent whose
+        // ability targeted), so the same PredicateEvaluator call the targetFilter uses below reads
+        // it: projected types when it has a battlefield projection, base card data otherwise. A
+        // source with no card data (a spell that has already left the stack) fails closed.
+        val sourceFilter = trigger.sourceFilter
+        if (sourceFilter != null) {
+            val sourceContainer = state.getEntity(event.sourceEntityId) ?: return false
+            if (!sourceContainer.has<CardComponent>()) return false
+            val sourcePredicateContext = PredicateContext(controllerId = controllerId, sourceId = sourceId)
+            if (!PredicateEvaluator().matches(
+                    state, state.projectedState, event.sourceEntityId, sourceFilter, sourcePredicateContext
+                )) return false
+        }
+
         // Valiant: check if the targeting spell/ability is controlled by "you" (the trigger's controller)
         if (trigger.byYou && event.controllerId != controllerId) return false
 


### PR DESCRIPTION
## What

**Brine Comber // Brinebound Gift** (VOW #233, {1}{W}{U} Creature — Spirit 1/1 // Enchantment — Aura), plus the engine vocabulary it needs.

`Whenever this creature enters or becomes the target of an Aura spell, create a 1/1 white Spirit creature token with flying. / Disturb {W}{U}` — and the same wording again on the back face, bound to the enchanted creature.

VOW backlog: 263 → **264 / 273**.

## Why it isn't a plain card PR

"Becomes the target of an **Aura** spell" had no spelling in the SDK, and the ATTACHED half had no path through the engine at all:

- `EventPattern.BecomesTargetEvent` could say *that* a spell did the targeting (`spellsOnly`) but never **which kind** — `targetFilter` narrows what got targeted, not what did the targeting.
- `AttachmentTriggerDetector` had no `BecomesTargetEvent` branch, and `TriggerMatcher` bails on `TriggerBinding.ATTACHED` for that pattern with `return false`, so "enchanted creature becomes the target" was silently inert.

Three additive seams, in the first commit:

| Layer | Change |
|---|---|
| SDK | `BecomesTargetEvent.sourceFilter: GameObjectFilter?` — a filter on the *targeting* object; `null` default, so every existing card and serialized definition is unchanged |
| `TriggerMatcher` | evaluates it against `event.sourceEntityId` via the same `PredicateEvaluator` call `targetFilter` uses (reads a spell's card data off the stack); a source with no card data fails closed |
| `AttachmentTriggerDetector` | routes `BecomesTargetEvent` by its target entity, then delegates every other axis back to the SELF matcher so the two paths can't drift |

Facade: `Triggers.BecomesTargetOfAuraSpell(binding = SELF)`. The binding is a parameter rather than a second named constant — the file's own Aura/Equipment convention says no named ATTACHED constants. `spellsOnly` stays set alongside the filter and is **not** redundant with it: an Aura already on the battlefield could target with an activated ability and match the same card types.

One English detail worth a look: `description` prints the filter's subtype alone when it has one, because a subtype already implies its card type and Magic templates it that way — "an Aura spell", never "an Aura enchantment spell".

## Card notes

Each face's printed "enters **or** becomes the target" is two triggered abilities — the house shape for an or-joined trigger (Crow of Dark Tidings' enters/dies). On the back face it is *forced*: the Aura's own entry is SELF-bound while "enchanted creature becomes the target" is ATTACHED-bound, so the halves can't share one ability.

An Aura spell chooses its target as it is cast (CR 303.4a), so neither half fires for the Aura a permanent is already enchanted by — only for a new one cast at it. The exile-instead clause is `RedirectZoneChange(selfOnly = true)`, the disturb-Aura shape Spectral Binding already uses.

## Verification

- `BrineComberScenarioTest` — 6 tests, all passing. Both bindings, each with a **negative control**: a non-Aura spell targeting the same permanent must make no token, which is what proves the filter isn't a no-op. Plus the disturb cast that puts Brinebound Gift onto the battlefield in the first place.
- `just build` — green.
- `just check-card-printing "Brine Comber"` — canonical is VOW, the card's earliest real printing; `dbl` is a later draft-innovation set and isn't scaffolded.
- `just assay-differential --set VOW` — 70/70 confirmed, **0 divergent**. Brine Comber itself lands in `multi-face (out of scope)`, as every DFC does.
- Card snapshot re-blessed: `VOW.json` is the only golden that moved, and the diff is pure addition (168 lines added, 0 removed).

## Scope: why one card and not a handful

Every one of the 10 cards VOW has left needs new engine vocabulary — that is *why* they are the tail — so the skill's no-batch rule (a card needing new vocabulary gets its own PR, with tests for the primitive) applies to all of them. Brine Comber was picked as the cheapest and most self-contained. The named gap for each of the others, for whoever picks the next one up:

| Card | Gap |
|---|---|
| Cemetery Desecrator | `RemoveAnyNumberOfCountersEffect.maxTotal`/`minTotal` are `Int`; "remove X counters, where X is the exiled card's mana value" needs them as `DynamicAmount` |
| Olivia, Crimson Bride | `StateTriggerPoller` reads state triggers only off the printed `cardDef`, so a *granted* state-triggered ability ("It gains 'When you don't control a legendary Vampire, exile this creature'") never fires |
| Magma Pummeler | `PreventDamageByRemovingCounter` removes exactly one counter (the Unbreathing Horde shape); this needs "that many", plus an event a reflexive trigger can read for the damage bounce-back |
| Faithbound Judge, Jacob Hauken, Runo Stromkirk, Radiant Grace, Alluring Suitor, Kaya Geist Hunter | larger — judgment-counter loss condition, exile-face-down play permission, copy-token attack trigger, return-transformed-attached-to-a-player, mana that survives step end, token-doubling replacement on a planeswalker |

🤖 Generated with [Claude Code](https://claude.com/claude-code)