### PR TITLE
Add Cemetery Desecrator; carry the pipeline into a pre-chosen modal mode

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 264 / 273
+**Implemented:** 265 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -40,7 +40,7 @@
 - [x] By Invitation Only
 - [x] Cartographer's Survey
 - [x] Catapult Fodder
-- [ ] Cemetery Desecrator
+- [x] Cemetery Desecrator
 - [x] Cemetery Gatekeeper
 - [x] Cemetery Illuminator
 - [x] Cemetery Protector

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1916,7 +1916,9 @@ object Effects {
      * Used by Heartless Act's "Remove up to three counters from target creature".
      */
     fun RemoveCountersUpTo(maxCount: Int, target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
-        com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect(target, maxTotal = maxCount)
+        com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect(
+            target, maxTotal = DynamicAmount.Fixed(maxCount)
+        )
 
     /**
      * "Remove a counter from [target]" — the player picks *which kind*, but not *whether*. The
@@ -1932,6 +1934,18 @@ object Effects {
     fun RemoveCounterOfAnyKind(
         target: EffectTarget = EffectTarget.ContextTarget(0),
         count: Int = 1
+    ): Effect = RemoveCounterOfAnyKind(target, DynamicAmount.Fixed(count))
+
+    /**
+     * [RemoveCounterOfAnyKind] with a resolution-time count — "Remove X counters from target
+     * permanent, where X is …" (Cemetery Desecrator). Floor and ceiling are the same amount, so
+     * the player still picks only *which kinds* come off; the executor clamps the floor to what
+     * the permanent actually carries, which is how "remove X" degrades to "remove as many as it
+     * has" without a separate spelling.
+     */
+    fun RemoveCounterOfAnyKind(
+        target: EffectTarget,
+        count: DynamicAmount
     ): Effect = com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect(
         target, maxTotal = count, minTotal = count
     )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -145,6 +145,13 @@ data class RemoveCountersEffect(
  * "Remove up to three counters from target creature." (Heartless Act, [maxTotal] = 3.)
  * "Remove a counter from it." ([minTotal] = [maxTotal] = 1 — the kind is the player's choice, the
  * count is not.)
+ * "Remove X counters from target permanent, where X is the mana value of the exiled card."
+ * (Cemetery Desecrator, [minTotal] = [maxTotal] = `StoredCardManaValue`.)
+ *
+ * Both bounds are [DynamicAmount]s, matching the additive mirror [AddCountersUpToEffect.max]:
+ * the printed count is as often a resolution-time value ("X counters, where X is …") as a literal,
+ * and the two effects had no reason to spell the same thing differently. `DynamicAmount.Fixed`
+ * covers the literal case.
  *
  * The floor matters because a bare ceiling silently makes every such removal optional: "remove a
  * counter" modelled as `maxTotal = 1` alone lets the controller answer 0 to every prompt and still
@@ -161,26 +168,39 @@ data class RemoveCountersEffect(
  *
  * @property target The permanent to remove counters from.
  * @property maxTotal The total budget across all kinds, or null for no cap.
- * @property minTotal The total that must be removed across all kinds; 0 makes the removal optional.
+ * @property minTotal The total that must be removed across all kinds; a literal 0 makes the
+ *   removal optional. A *dynamic* floor is never treated as optional up front — it can only be
+ *   evaluated at resolution — so a card whose count may legitimately come out as 0 should say so
+ *   with `DynamicAmount.Fixed(0)` rather than a computed zero.
  */
 @SerialName("RemoveAnyNumberOfCounters")
 @Serializable
 data class RemoveAnyNumberOfCountersEffect(
     val target: EffectTarget = EffectTarget.ContextTarget(0),
-    val maxTotal: Int? = null,
-    val minTotal: Int = 0
+    val maxTotal: DynamicAmount? = null,
+    val minTotal: DynamicAmount = DynamicAmount.Fixed(0)
 ) : Effect {
     override val description: String = when {
-        minTotal > 0 && minTotal == maxTotal ->
-            "Remove $minTotal counter${if (minTotal != 1) "s" else ""} from ${target.description}"
-        minTotal > 0 && maxTotal != null ->
-            "Remove $minTotal to $maxTotal counters from ${target.description}"
-        minTotal > 0 ->
-            "Remove at least $minTotal counter${if (minTotal != 1) "s" else ""} from ${target.description}"
+        !isLiteralZero(minTotal) && minTotal == maxTotal ->
+            "Remove ${minTotal.description} ${counterWord(minTotal)} from ${target.description}"
+        !isLiteralZero(minTotal) && maxTotal != null ->
+            "Remove ${minTotal.description} to ${maxTotal.description} counters from ${target.description}"
+        !isLiteralZero(minTotal) ->
+            "Remove at least ${minTotal.description} ${counterWord(minTotal)} from ${target.description}"
         maxTotal != null ->
-            "Remove up to $maxTotal counter${if (maxTotal != 1) "s" else ""} from ${target.description}"
+            "Remove up to ${maxTotal.description} ${counterWord(maxTotal)} from ${target.description}"
         else ->
             "Remove any number of counters from ${target.description}"
+    }
+
+    private companion object {
+        /** Only a printed literal 0 makes a removal optional; a computed one isn't known yet. */
+        fun isLiteralZero(amount: DynamicAmount): Boolean =
+            amount is DynamicAmount.Fixed && amount.amount == 0
+
+        /** Singular only for a literal 1 — every dynamic count reads as a plural. */
+        fun counterWord(amount: DynamicAmount): String =
+            if (amount is DynamicAmount.Fixed && amount.amount == 1) "counter" else "counters"
     }
 }
 

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CemeteryDesecrator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CemeteryDesecrator.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cemetery Desecrator
+ * {4}{B}{B}
+ * Creature — Zombie
+ * 4/4
+ *
+ * Menace
+ * When this creature enters or dies, exile another card from a graveyard. When you do, choose one —
+ * • Remove X counters from target permanent, where X is the mana value of the exiled card.
+ * • Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value
+ *   of the exiled card.
+ *
+ * Shape notes:
+ *
+ *  - **"enters or dies" is two triggered abilities**, not one — the corpus convention (Reputable
+ *    Merchant, Thawbringer). They share [desecrate] because the payoff clause is identical.
+ *  - **"When you do" is CR 603.12**, a genuine second stack object, so the exile is the
+ *    [ReflexiveTriggerEffect]'s `action` and the modal is its `reflexiveEffect`. The exile is
+ *    *mandatory* ("exile another card from a graveyard", no "may"), hence `optional = false`;
+ *    `ReflexiveTriggerEffectExecutor.isActionFeasible` still suppresses the whole thing when every
+ *    graveyard is empty, which is what stops the modal firing off an exile that never happened.
+ *  - **The modal is chosen as the reflexive ability goes on the stack**, not on resolution — a
+ *    top-level `ModalEffect` on a triggered ability is caught by `TriggerProcessor` (CR 603.3c),
+ *    and the reflexive trigger is an ordinary triggered ability by the time it gets there. That is
+ *    the correct timing here: the opponent sees which mode was picked while it is still
+ *    respondable, and the mode's target only *becomes* a target at that moment (ward, "becomes the
+ *    target of" triggers).
+ *  - **"another"** excludes the Desecrator's own card, which matters only on the dies trigger —
+ *    by then it is sitting in a graveyard itself. Entity ids are stable across zone changes, so
+ *    `GameObjectFilter.Any.notSourceItself()` is exactly the printed word.
+ *  - **X** is `StoredCardManaValue("exiledCard")` in both modes, read off the pipeline collection
+ *    the action half stored; the reflexive trigger carries that pipeline forward
+ *    (`ReflexiveAbilityTriggeredEvent.carriedPipeline`). Mode 1 removing "X counters" is
+ *    [Effects.RemoveCounterOfAnyKind] with a dynamic count — the player picks which *kinds* come
+ *    off, never whether, and the executor clamps the floor to what the permanent actually carries
+ *    so a permanent with fewer than X counters simply loses all of them.
+ */
+private val desecrate: Effect = ReflexiveTriggerEffect(
+    optional = false,
+    action = Effects.Composite(
+        listOf(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.Each,
+                    filter = GameObjectFilter.Any.notSourceItself()
+                ),
+                storeAs = "graveyardCards"
+            ),
+            SelectFromCollectionEffect(
+                from = "graveyardCards",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "exiledCard",
+                prompt = "Exile another card from a graveyard",
+                showAllCards = true
+            ),
+            MoveCollectionEffect(
+                from = "exiledCard",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            )
+        )
+    ),
+    reflexiveEffect = ModalEffect.chooseOne(
+        Mode(
+            effect = Effects.RemoveCounterOfAnyKind(
+                target = EffectTarget.ContextTarget(0),
+                count = DynamicAmount.StoredCardManaValue("exiledCard")
+            ),
+            targetRequirements = listOf(
+                TargetObject(filter = TargetFilter.Permanent, id = "target permanent")
+            ),
+            description = "Remove X counters from target permanent, " +
+                "where X is the mana value of the exiled card"
+        ),
+        Mode(
+            effect = Effects.ModifyStats(
+                DynamicAmount.Multiply(DynamicAmount.StoredCardManaValue("exiledCard"), -1),
+                DynamicAmount.Multiply(DynamicAmount.StoredCardManaValue("exiledCard"), -1),
+                EffectTarget.ContextTarget(0)
+            ),
+            targetRequirements = listOf(
+                TargetObject(
+                    filter = TargetFilter.Creature.opponentControls(),
+                    id = "target creature an opponent controls"
+                )
+            ),
+            description = "Target creature an opponent controls gets -X/-X until end of turn, " +
+                "where X is the mana value of the exiled card"
+        )
+    ),
+    descriptionOverride = "Exile another card from a graveyard. When you do, choose one — " +
+        "remove X counters from target permanent, or target creature an opponent controls gets " +
+        "-X/-X until end of turn, where X is the mana value of the exiled card"
+)
+
+val CemeteryDesecrator = card("Cemetery Desecrator") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 4
+    toughness = 4
+    oracleText = "Menace\n" +
+        "When this creature enters or dies, exile another card from a graveyard. " +
+        "When you do, choose one —\n" +
+        "• Remove X counters from target permanent, where X is the mana value of the exiled card.\n" +
+        "• Target creature an opponent controls gets -X/-X until end of turn, where X is the " +
+        "mana value of the exiled card."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = desecrate
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = desecrate
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "100"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg?1783924869"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryDesecratorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryDesecratorScenarioTest.kt
@@ -1,0 +1,259 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cemetery Desecrator (VOW #100) — {4}{B}{B} 4/4 Zombie.
+ *
+ * "Menace
+ *  When this creature enters or dies, exile another card from a graveyard. When you do, choose one —
+ *  • Remove X counters from target permanent, where X is the mana value of the exiled card.
+ *  • Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value
+ *    of the exiled card."
+ *
+ * What these tests pin down, in the order the card's own wording raises the questions:
+ *
+ *  - **X is dynamic.** `RemoveAnyNumberOfCountersEffect`'s bounds used to be `Int`s, so "remove X
+ *    counters, where X is …" had no spelling at all. Both bounds are now `DynamicAmount`s and both
+ *    modes read the same `StoredCardManaValue("exiledCard")`, evaluated once at resolution.
+ *  - **The floor clamps to what is actually there.** "Remove X counters" from a permanent carrying
+ *    fewer than X takes all of them; it is not a fizzle and not a debt.
+ *  - **"another" is load-bearing on the dies half.** By the time the dies trigger resolves the
+ *    Desecrator's own card is sitting in a graveyard, and it is the one card the exile may not take.
+ *  - **CR 603.12 — no exile, no modal.** With nothing exilable the reflexive ability must not
+ *    trigger at all, rather than putting a mode question on the stack for an X of 0. That is the
+ *    check that needed `ReflexiveTriggerEffectExecutor.gatherableCount` to score a *multi-player*
+ *    gather ("a graveyard" is every player's); left unscored it failed open.
+ */
+class CemeteryDesecratorScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, type: CounterType, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(type, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun counts(driver: GameTestDriver, entityId: EntityId): Map<CounterType, Int> =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.counters ?: emptyMap()
+
+    /** Pass priority until the pending decision satisfies [matches], or give up. */
+    fun GameTestDriver.advanceUntil(what: String, matches: (PendingDecision?) -> Boolean): PendingDecision {
+        var safety = 0
+        while (!matches(pendingDecision) && safety++ < 12) bothPass()
+        return pendingDecision?.takeIf { matches(it) }
+            ?: error("expected $what, got ${pendingDecision?.let { it::class.simpleName }}: ${pendingDecision?.prompt}")
+    }
+
+    /** Settle every stack object and auto-resolvable step without demanding a decision appear. */
+    fun GameTestDriver.settle(times: Int = 8) {
+        repeat(times) { if (pendingDecision == null) bothPass() }
+    }
+
+    /**
+     * Put the Desecrator onto the battlefield by *casting* it, so the enters trigger really fires —
+     * direct placement fires no ETB triggers.
+     */
+    fun castDesecrator(driver: GameTestDriver) {
+        val you = driver.player1
+        val card = driver.putCardInHand(you, "Cemetery Desecrator")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveColorlessMana(you, 4)
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, card).error shouldBe null
+        driver.settle()
+    }
+
+    /**
+     * Answer the "exile another card from a graveyard" selection with [cardId]. Requires more than
+     * one exilable card — with exactly one the executor has nothing to ask and takes it silently.
+     */
+    fun exile(driver: GameTestDriver, cardId: EntityId) {
+        val select = driver.advanceUntil("the exile selection") { it is SelectCardsDecision }
+        driver.submitCardSelection(select.playerId, listOf(cardId))
+    }
+
+    /** Pick the mode whose label contains [needle], then settle onto whatever comes next. */
+    fun chooseMode(driver: GameTestDriver, needle: String) {
+        val modal = driver.advanceUntil("the mode choice") { it is ChooseOptionDecision } as ChooseOptionDecision
+        val index = modal.options.indexOfFirst { it.contains(needle, ignoreCase = true) }
+        check(index >= 0) { "no mode matching '$needle' in ${modal.options}" }
+        driver.submitDecision(modal.playerId, OptionChosenResponse(modal.id, index))
+    }
+
+    /** Answer every per-kind counter prompt with its maximum, so all X counters actually come off. */
+    fun takeAllOffered(driver: GameTestDriver) {
+        var safety = 0
+        while (safety++ < 10) {
+            val decision = driver.pendingDecision as? ChooseNumberDecision ?: return
+            driver.submitDecision(decision.playerId, NumberChosenResponse(decision.id, decision.maxValue))
+        }
+    }
+
+    /**
+     * A board with two cards in the opponent's graveyard — Centaur Courser ({2}{G}, mana value 3)
+     * and Lightning Bolt ({R}, mana value 1) — so the exile is a genuine choice rather than the
+     * one card there was. Returns the Courser's id.
+     */
+    fun stockGraveyard(driver: GameTestDriver): EntityId {
+        val courser = driver.putCardInGraveyard(driver.player2, "Centaur Courser")
+        driver.putCardInGraveyard(driver.player2, "Lightning Bolt")
+        return courser
+    }
+
+    test("mode 1 removes exactly the exiled card's mana value in counters") {
+        val driver = createDriver()
+        val foe = driver.player2
+
+        val courser = stockGraveyard(driver)
+        val counted = driver.putCreatureOnBattlefield(foe, "Savannah Lions")
+        addCounters(driver, counted, CounterType.PLUS_ONE_PLUS_ONE, 5)
+
+        castDesecrator(driver)
+        exile(driver, courser)
+        chooseMode(driver, "Remove X counters")
+
+        val targets = driver.advanceUntil("the mode's target") { it is ChooseTargetsDecision }
+        driver.submitTargetSelection(targets.playerId, listOf(counted))
+        driver.settle()
+        takeAllOffered(driver)
+        driver.settle()
+
+        // Courser is mana value 3, so three of the five counters come off.
+        counts(driver, counted)[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 2
+        (driver.getExileCardNames(driver.player1) + driver.getExileCardNames(foe))
+            .contains("Centaur Courser") shouldBe true
+    }
+
+    test("a permanent carrying fewer than X counters simply loses all of them") {
+        val driver = createDriver()
+        val foe = driver.player2
+
+        val courser = stockGraveyard(driver)
+        val counted = driver.putCreatureOnBattlefield(foe, "Savannah Lions")
+        addCounters(driver, counted, CounterType.PLUS_ONE_PLUS_ONE, 1)
+
+        castDesecrator(driver)
+        exile(driver, courser)
+        chooseMode(driver, "Remove X counters")
+
+        val targets = driver.advanceUntil("the mode's target") { it is ChooseTargetsDecision }
+        driver.submitTargetSelection(targets.playerId, listOf(counted))
+        driver.settle()
+        takeAllOffered(driver)
+        driver.settle()
+
+        (counts(driver, counted)[CounterType.PLUS_ONE_PLUS_ONE] ?: 0) shouldBe 0
+    }
+
+    test("mode 2 shrinks an opponent's creature by the exiled card's mana value") {
+        val driver = createDriver()
+        val foe = driver.player2
+
+        val courser = stockGraveyard(driver)
+        // Savannah Lions is a 2/1, so -3/-3 from a mana value 3 card kills it.
+        driver.putCreatureOnBattlefield(foe, "Savannah Lions")
+
+        castDesecrator(driver)
+        exile(driver, courser)
+        chooseMode(driver, "-X/-X")
+
+        val targets = driver.advanceUntil("the mode's target") { it is ChooseTargetsDecision }
+        val victim = driver.findPermanent(foe, "Savannah Lions")!!
+        driver.submitTargetSelection(targets.playerId, listOf(victim))
+        driver.settle()
+
+        driver.findPermanent(foe, "Savannah Lions") shouldBe null
+    }
+
+    test("the smaller exile gives the smaller X") {
+        val driver = createDriver()
+        val foe = driver.player2
+
+        stockGraveyard(driver)
+        val bolt = driver.getGraveyard(foe).first {
+            driver.state.getEntity(it)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?.name == "Lightning Bolt"
+        }
+        val counted = driver.putCreatureOnBattlefield(foe, "Savannah Lions")
+        addCounters(driver, counted, CounterType.PLUS_ONE_PLUS_ONE, 5)
+
+        castDesecrator(driver)
+        exile(driver, bolt) // {R} — mana value 1
+        chooseMode(driver, "Remove X counters")
+
+        val targets = driver.advanceUntil("the mode's target") { it is ChooseTargetsDecision }
+        driver.submitTargetSelection(targets.playerId, listOf(counted))
+        driver.settle()
+        takeAllOffered(driver)
+        driver.settle()
+
+        counts(driver, counted)[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 4
+    }
+
+    test("with every graveyard empty the reflexive ability never triggers") {
+        val driver = createDriver()
+        driver.putCreatureOnBattlefield(driver.player2, "Savannah Lions")
+
+        castDesecrator(driver)
+        driver.settle()
+
+        driver.getGraveyard(driver.player2).isEmpty() shouldBe true
+        // Nothing to exile, so CR 603.12's "when you do" never fires: no mode question at all.
+        (driver.pendingDecision is ChooseOptionDecision) shouldBe false
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+    }
+
+    test("the dies trigger may not exile the Desecrator's own card") {
+        val driver = createDriver()
+        val you = driver.player1
+        val foe = driver.player2
+
+        val desecrator = driver.putCreatureOnBattlefield(you, "Cemetery Desecrator")
+        val courser = stockGraveyard(driver)
+
+        driver.putCardInHand(you, "Doom Blade")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpellWithTargets(
+            you,
+            driver.findCardInHand(you, "Doom Blade")!!,
+            listOf(entityIdToChosenTarget(driver.state, desecrator))
+        ).error shouldBe null
+        driver.settle()
+
+        val select = driver.advanceUntil("the exile selection") { it is SelectCardsDecision }
+            as SelectCardsDecision
+        // The Desecrator is in a graveyard by now, and is the one card "another" excludes.
+        driver.getGraveyard(you).contains(desecrator) shouldBe true
+        select.options.contains(desecrator) shouldBe false
+        select.options.contains(courser) shouldBe true
+    }
+})

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryDesecratorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryDesecratorScenarioTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ChooseNumberDecision
 import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.CombatResolutionDecision
 import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.core.OptionChosenResponse
 import com.wingedsheep.engine.core.PendingDecision
@@ -236,23 +237,37 @@ class CemeteryDesecratorScenarioTest : FunSpec({
         val foe = driver.player2
 
         val desecrator = driver.putCreatureOnBattlefield(you, "Cemetery Desecrator")
+        driver.removeSummoningSickness(desecrator)
         val courser = stockGraveyard(driver)
 
-        driver.putCardInHand(you, "Doom Blade")
-        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
-        driver.giveMana(you, Color.BLACK, 1)
-        driver.giveColorlessMana(you, 1)
-        driver.castSpellWithTargets(
-            you,
-            driver.findCardInHand(you, "Doom Blade")!!,
-            listOf(entityIdToChosenTarget(driver.state, desecrator))
-        ).error shouldBe null
-        driver.settle()
+        // Killed in combat rather than by removal: the Desecrator is black, so Doom Blade — the
+        // only destroy effect in TestCards — can't legally target it. Two blockers because the
+        // Desecrator has menace (CR 702.110b), which is incidentally the keyword under test here.
+        val blockerA = driver.putCreatureOnBattlefield(foe, "Force of Nature")
+        val blockerB = driver.putCreatureOnBattlefield(foe, "Centaur Courser")
 
-        val select = driver.advanceUntil("the exile selection") { it is SelectCardsDecision }
-            as SelectCardsDecision
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(desecrator), foe).error shouldBe null
+        driver.bothPass()
+        driver.declareBlockers(
+            foe,
+            mapOf(blockerA to listOf(desecrator), blockerB to listOf(desecrator))
+        ).error shouldBe null
+        // Walk combat until the blocked 4/4 is actually dead — how many priority rounds and
+        // damage confirmations that takes is not this test's business.
+        var safety = 0
+        while (!driver.getGraveyard(you).contains(desecrator) && safety++ < 14) {
+            when (val d = driver.pendingDecision) {
+                null -> driver.bothPass()
+                is CombatResolutionDecision -> driver.confirmCombatDamage()
+                else -> error("unexpected decision before the Desecrator died: ${d::class.simpleName} ${d.prompt}")
+            }
+        }
+
         // The Desecrator is in a graveyard by now, and is the one card "another" excludes.
         driver.getGraveyard(you).contains(desecrator) shouldBe true
+        val select = driver.advanceUntil("the exile selection") { it is SelectCardsDecision }
+            as SelectCardsDecision
         select.options.contains(desecrator) shouldBe false
         select.options.contains(courser) shouldBe true
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -10838,8 +10838,14 @@
                                                     "type": "PipelineTarget",
                                                     "collectionName": "hydeCounterSource"
                                                 },
-                                                "maxTotal": 1,
-                                                "minTotal": 1
+                                                "maxTotal": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                },
+                                                "minTotal": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
                                             },
                                             "successCriterion": "SuccessCriterion.CountersRemoved"
                                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -10281,7 +10281,10 @@
                 {
                     "effect": {
                         "type": "RemoveAnyNumberOfCounters",
-                        "maxTotal": 3
+                        "maxTotal": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
                     },
                     "targetRequirements": [
                         {

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5143,8 +5143,14 @@
                     "action": {
                         "type": "RemoveAnyNumberOfCounters",
                         "target": "Self",
-                        "maxTotal": 1,
-                        "minTotal": 1
+                        "maxTotal": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "minTotal": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     },
                     "reflexiveEffect": {
                         "type": "MoveToZone",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -2704,6 +2704,273 @@
     ]
 }
 
+// Cemetery Desecrator
+{
+    "name": "Cemetery Desecrator",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Menace\nWhen this creature enters or dies, exile another card from a graveyard. When you do, choose one —\n• Remove X counters from target permanent, where X is the mana value of the exiled card.\n• Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "player": "Each",
+                                    "filter": {
+                                        "statePredicates": [
+                                            {
+                                                "type": "StateNot",
+                                                "predicate": "IsSource"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "graveyardCards"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "graveyardCards",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "exiledCard",
+                                "prompt": "Exile another card from a graveyard",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiledCard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            }
+                        ]
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "RemoveAnyNumberOfCounters",
+                                    "maxTotal": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "exiledCard"
+                                    },
+                                    "minTotal": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "exiledCard"
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "permanent"
+                                        },
+                                        "id": "target permanent"
+                                    }
+                                ],
+                                "description": "Remove X counters from target permanent, where X is the mana value of the exiled card"
+                            },
+                            {
+                                "effect": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "StoredCardManaValue",
+                                            "collectionName": "exiledCard"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "StoredCardManaValue",
+                                            "collectionName": "exiledCard"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "creature ctrl:opponent"
+                                        },
+                                        "id": "target creature an opponent controls"
+                                    }
+                                ],
+                                "description": "Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Exile another card from a graveyard. When you do, choose one — remove X counters from target permanent, or target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "player": "Each",
+                                    "filter": {
+                                        "statePredicates": [
+                                            {
+                                                "type": "StateNot",
+                                                "predicate": "IsSource"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "graveyardCards"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "graveyardCards",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "exiledCard",
+                                "prompt": "Exile another card from a graveyard",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiledCard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            }
+                        ]
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "RemoveAnyNumberOfCounters",
+                                    "maxTotal": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "exiledCard"
+                                    },
+                                    "minTotal": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "exiledCard"
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "permanent"
+                                        },
+                                        "id": "target permanent"
+                                    }
+                                ],
+                                "description": "Remove X counters from target permanent, where X is the mana value of the exiled card"
+                            },
+                            {
+                                "effect": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "StoredCardManaValue",
+                                            "collectionName": "exiledCard"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "StoredCardManaValue",
+                                            "collectionName": "exiledCard"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "creature ctrl:opponent"
+                                        },
+                                        "id": "target creature an opponent controls"
+                                    }
+                                ],
+                                "description": "Target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Exile another card from a graveyard. When you do, choose one — remove X counters from target permanent, or target creature an opponent controls gets -X/-X until end of turn, where X is the mana value of the exiled card"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "MYTHIC",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg?1783924869"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cemetery Gatekeeper
 {
     "name": "Cemetery Gatekeeper",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -128,6 +128,13 @@ data class ModalPreChosenContinuation(
     val sourceName: String?,
     val xValue: Int? = null,
     val triggeringEntityId: EntityId? = null,
+    /**
+     * The enclosing resolution's pipeline, so the modes still queued behind a paused one read the
+     * same stored collections/numbers the modes before them did. Without it a choose-two modal
+     * whose first mode pauses would run its second mode against an empty pipeline.
+     */
+    val pipeline: com.wingedsheep.engine.handlers.PipelineState =
+        com.wingedsheep.engine.handlers.PipelineState.EMPTY,
     val remainingEntries: List<PreTargetedEffectEntry>
 ) : ContinuationFrame
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -164,7 +164,8 @@ class CoreAutoResumerModule(
                 sourceId = continuation.sourceId,
                 sourceName = continuation.sourceName,
                 xValue = continuation.xValue,
-                triggeringEntityId = continuation.triggeringEntityId
+                triggeringEntityId = continuation.triggeringEntityId,
+                pipeline = continuation.pipeline
             )
             val result = com.wingedsheep.engine.handlers.effects.composite.processPreTargetedEffectQueue(
                 state = state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
@@ -207,7 +207,12 @@ class ModalEffectExecutor(
             sourceId = context.sourceId,
             sourceName = sourceName,
             xValue = context.xValue,
-            triggeringEntityId = context.triggeringEntityId
+            triggeringEntityId = context.triggeringEntityId,
+            // The resolution so far, carried into each mode. A mode's effect can read what an
+            // earlier step of the same resolution stored — Cemetery Desecrator's two modes both
+            // spell X as `StoredCardManaValue("exiledCard")`, the collection its reflexive
+            // trigger's action half filled. Dropping it made every such amount read 0.
+            pipeline = context.pipeline
         )
         return processPreTargetedEffectQueue(state, entries, baseCtx, effectExecutor, targetValidator, emptyList())
     }
@@ -257,7 +262,16 @@ internal data class PreTargetedEffectContext(
     val sourceId: com.wingedsheep.sdk.model.EntityId?,
     val sourceName: String?,
     val xValue: Int?,
-    val triggeringEntityId: com.wingedsheep.sdk.model.EntityId?
+    val triggeringEntityId: com.wingedsheep.sdk.model.EntityId?,
+    /**
+     * Pipeline state the enclosing resolution had already built — stored collections, numbers,
+     * chosen values — which each mode's own [EffectContext] inherits. Only the per-mode
+     * `namedTargets` are rebuilt on top of it, because those *are* per mode.
+     *
+     * Defaults to empty for the callers that genuinely have no enclosing pipeline (splice, CR
+     * 702.47b: each spliced card's text is its own resolution).
+     */
+    val pipeline: PipelineState = PipelineState.EMPTY
 )
 
 /**
@@ -319,8 +333,12 @@ internal fun processPreTargetedEffectQueue(
         controllerId = ctx.controllerId,
         xValue = ctx.xValue,
         targets = head.targets,
-        pipeline = PipelineState(
-            namedTargets = EffectContext.buildNamedTargets(head.targetRequirements, head.targets)
+        // The enclosing resolution's pipeline, with this mode's own named targets laid over it.
+        // A bare `PipelineState(namedTargets = …)` here dropped every stored collection, number
+        // and chosen value the resolution had accumulated before the modal.
+        pipeline = ctx.pipeline.copy(
+            namedTargets = ctx.pipeline.namedTargets +
+                EffectContext.buildNamedTargets(head.targetRequirements, head.targets)
         ),
         triggeringEntityId = ctx.triggeringEntityId
     )
@@ -336,6 +354,7 @@ internal fun processPreTargetedEffectQueue(
                 sourceName = ctx.sourceName,
                 xValue = ctx.xValue,
                 triggeringEntityId = ctx.triggeringEntityId,
+                pipeline = ctx.pipeline,
                 remainingEntries = tail
             )
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -227,7 +227,9 @@ class ReflexiveTriggerEffectExecutor(
         // action that can't pay it in full can't be performed at all.
         is com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect ->
             countersOn(state, context, action.target)
-                ?.let { it >= action.minTotal.coerceAtLeast(1) } ?: true
+                ?.let {
+                    it >= amountEvaluator.evaluate(state, action.minTotal, context).coerceAtLeast(1)
+                } ?: true
         is com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect ->
             countersOn(state, context, action.target, kind = action.counterType)
                 ?.let { it >= action.count } ?: true
@@ -351,8 +353,15 @@ class ReflexiveTriggerEffectExecutor(
 
     /**
      * How many cards a [GatherCardsEffect] would collect right now, or null when the source isn't a
-     * plain single-player zone read (target-driven and multi-player sources are left unscored, so
-     * the enclosing feasibility check fails open).
+     * zone read at all (target-driven sources are left unscored, so the enclosing feasibility check
+     * fails open).
+     *
+     * Multi-player references fan out exactly as
+     * [com.wingedsheep.engine.handlers.effects.library.GatherCardsExecutor] fans them out, so
+     * "exile another card from **a** graveyard" (Cemetery Desecrator — `Player.Each`) is scored
+     * rather than failing open. Left unscored it would arm CR 603.12's "when you do" on a table
+     * where every graveyard is empty: the pipeline gathers nothing, selects nothing, and still
+     * reports success.
      */
     private fun gatherableCount(
         state: GameState,
@@ -360,13 +369,26 @@ class ReflexiveTriggerEffectExecutor(
         context: EffectContext
     ): Int? {
         val source = gather.source as? CardSource.FromZone ?: return null
-        val playerId = TargetResolutionUtils.resolvePlayerRef(source.player, context, state) ?: return null
-        val cards = state.getZone(ZoneKey(playerId, source.zone))
+        val playerIds = gatherPlayers(source.player, context, state) ?: return null
+        val cards = playerIds.flatMap { state.getZone(ZoneKey(it, source.zone)) }
         if (source.filter == GameObjectFilter.Any) return cards.size
         val predicateContext = PredicateContext.fromEffectContext(context)
         return cards.count { cardId ->
             predicateEvaluator.matches(state, state.projectedState, cardId, source.filter, predicateContext)
         }
+    }
+
+    /** Mirrors `GatherCardsExecutor.resolvePlayers` — the zone owners a gather would read. */
+    private fun gatherPlayers(
+        player: com.wingedsheep.sdk.scripting.references.Player,
+        context: EffectContext,
+        state: GameState
+    ): List<EntityId>? = when (player) {
+        is com.wingedsheep.sdk.scripting.references.Player.Each,
+        is com.wingedsheep.sdk.scripting.references.Player.ActivePlayerFirst -> state.turnOrder
+        is com.wingedsheep.sdk.scripting.references.Player.EachOpponent ->
+            state.turnOrder.filter { it != context.controllerId }
+        else -> TargetResolutionUtils.resolvePlayerRef(player, context, state)?.let { listOf(it) }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersExecutor.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.effects.permanent.counters
 
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
@@ -17,11 +18,18 @@ import kotlin.reflect.KClass
  * with `minTotal` set too, its mandatory form "Remove a counter from it" (Leatherhead, Swamp
  * Stalker), where the player picks the kind but not whether.
  *
+ * Both bounds are [com.wingedsheep.sdk.scripting.values.DynamicAmount]s and are evaluated here,
+ * once, against the state the effect resolves in — "Remove X counters from target permanent, where
+ * X is the mana value of the exiled card" (Cemetery Desecrator). The walk downstream only ever
+ * sees the two resulting numbers.
+ *
  * The prompt-per-kind walk itself — the budget cap, the floor, and the forced steps that are
  * applied rather than asked — lives in [RemoveAnyNumberOfCountersFlow], shared with the
  * continuation resumer that carries it on after each answer.
  */
-class RemoveAnyNumberOfCountersExecutor : EffectExecutor<RemoveAnyNumberOfCountersEffect> {
+class RemoveAnyNumberOfCountersExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<RemoveAnyNumberOfCountersEffect> {
 
     override val effectType: KClass<RemoveAnyNumberOfCountersEffect> = RemoveAnyNumberOfCountersEffect::class
 
@@ -30,7 +38,7 @@ class RemoveAnyNumberOfCountersExecutor : EffectExecutor<RemoveAnyNumberOfCounte
         effect: RemoveAnyNumberOfCountersEffect,
         context: EffectContext
     ): EffectResult {
-        val maxTotal = effect.maxTotal
+        val maxTotal = effect.maxTotal?.let { amountEvaluator.evaluate(state, it, context) }
         if (maxTotal != null && maxTotal <= 0) return EffectResult.success(state, emptyList())
 
         val targetId = context.resolveTarget(effect.target)
@@ -52,7 +60,7 @@ class RemoveAnyNumberOfCountersExecutor : EffectExecutor<RemoveAnyNumberOfCounte
         // The floor can't exceed the budget or what's actually there — a permanent carrying one
         // counter satisfies "remove a counter" by losing it, and can't be asked for more.
         val available = counters.counters.values.sum()
-        val floor = effect.minTotal
+        val floor = amountEvaluator.evaluate(state, effect.minTotal, context)
             .coerceAtMost(maxTotal ?: Int.MAX_VALUE)
             .coerceAtMost(available)
             .coerceAtLeast(0)


### PR DESCRIPTION
Cemetery Desecrator (VOW #100), `{4}{B}{B}` 4/4 Zombie. VOW 264/273 → 265/273.

One card, not the usual handful: every one of VOW's remaining nine needs *different* new engine
vocabulary — that is why they are the tail — so the no-batch rule applies to each of them.

## The bug worth reading

`processPreTargetedEffectQueue` built each modal mode's `EffectContext` with a **fresh**
`PipelineState` holding only that mode's named targets, discarding every stored collection, stored
number and chosen value the enclosing resolution had accumulated. Any amount a mode reads from the
pipeline evaluated to 0 — and *silently*, because `RemoveAnyNumberOfCountersExecutor` treats a
non-positive budget as "nothing to do" and `ModifyStats` of -0/-0 is a legal no-op. A mode that
should have removed three counters removed none and reported success.

Cemetery Desecrator is the first card to notice, because both its modes spell X as
`StoredCardManaValue("exiledCard")` — the collection its reflexive trigger's action half filled.
The path is shared by **every** pre-chosen modal, spells (cast-time picker) and triggered abilities
(CR 603.3c) alike, so this was never specific to reflexive triggers.

`PreTargetedEffectContext` and `ModalPreChosenContinuation` now carry the pipeline, and the per-mode
context lays its own `namedTargets` *over* it instead of replacing it. The continuation needs it
too: a choose-two modal whose first mode pauses would otherwise resume its second against an empty
pipeline. Splice keeps the empty default — CR 702.47b makes each spliced card's text its own
resolution.

## Other engine changes

**`RemoveAnyNumberOfCountersEffect`'s bounds become `DynamicAmount`s.** `maxTotal`/`minTotal` were
`Int?`/`Int`, so "Remove X counters from target permanent, where X is the mana value of the exiled
card" had no spelling at all. Its additive mirror `AddCountersUpToEffect.max` has always been a
`DynamicAmount`; the two had no reason to spell the same thing differently. Evaluated once, at
resolution; the executor's existing clamp to what the permanent actually carries means "remove X"
degrades to "remove as many as it has" with no second spelling. `Effects.RemoveCounterOfAnyKind`
gains a `DynamicAmount` overload alongside the `Int` one, mirroring `AddCountersUpTo`.

**`ReflexiveTriggerEffectExecutor.gatherableCount` now scores a multi-player gather.** "Exile
another card from **a** graveyard" reads every player's graveyard (`Player.Each`), a shape the
feasibility check left unscored — so it failed open: with every graveyard empty the pipeline
gathered nothing, selected nothing, reported success, and armed CR 603.12's "when you do" anyway.
Now mirrors `GatherCardsExecutor.resolvePlayers`.

## The card

- **"enters or dies" is two triggered abilities**, per the corpus convention (Reputable Merchant,
  Thawbringer); they share one payoff effect.
- **"When you do" is CR 603.12** — the exile is the `ReflexiveTriggerEffect`'s `action`
  (`optional = false`; the printed text has no "may"), the modal is its `reflexiveEffect`.
- **The modal is chosen as the reflexive ability goes on the stack**, not on resolution: a top-level
  `ModalEffect` on a triggered ability is caught by `TriggerProcessor` (CR 603.3c), and a reflexive
  trigger is an ordinary triggered ability by then. Correct here — the opponent sees the mode while
  it is still respondable, and the target only *becomes* a target at that moment.
- **"another"** is `GameObjectFilter.Any.notSourceItself()`, load-bearing only on the dies half,
  where the Desecrator's own card is already in a graveyard. Entity ids are stable across zones.

## Verification

- `CemeteryDesecratorScenarioTest` — **6/6**. Covers both modes, the floor clamping to a permanent
  carrying fewer than X counters, a smaller exile giving a smaller X, the no-exile/no-modal case,
  and "another" excluding the Desecrator's own card on the dies half.
- `just build` — green. (One flaky `FreeForAllLobbyTest` timing case — a 15s `eventually` on AI
  lobby deck dealing — failed on a loaded run and passes in isolation and on the clean re-run.)
- `just assay-differential --set VOW` — 70/70 confirmed, **0 divergent**.
- `just check-card-printing "Cemetery Desecrator"` — canonical in its earliest real printing.
- Card snapshot goldens re-blessed: VOW gains the card; TLA/TMT/MSH move only because
  `maxTotal`/`minTotal` now serialize as `{"type":"Fixed","amount":N}`.

Two harness details in the dies test are the card's own rules working: it needs **two** blockers
(menace, CR 702.110b), and Doom Blade can't kill it because it is black.

🤖 Generated with [Claude Code](https://claude.com/claude-code)