### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BladesOfVelisVel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BladesOfVelisVel.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blades of Velis Vel
+ * {1}{R}
+ * Kindred Instant — Shapeshifter
+ *
+ * Changeling (This card is every creature type.)
+ * Up to two target creatures each get +2/+0 and gain all creature types until end of turn.
+ *
+ * "Up to two target creatures **each** get …" is a plural requirement, so the pump runs once per
+ * chosen target ([ForEachTargetEffect] over `ContextTarget(0)`) rather than once against the
+ * requirement as a whole. "Gains all creature types" is modelled by granting Changeling — the
+ * engine expands that keyword into every creature type (CR 702.73).
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val BladesOfVelisVel = card("Blades of Velis Vel") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Kindred Instant — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Up to two target creatures each get +2/+0 and gain all creature types until end of turn."
+
+    keywords(Keyword.CHANGELING)
+
+    spell {
+        target("target creature", Targets.UpToCreatures(2))
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.ModifyStats(2, 0, EffectTarget.ContextTarget(0)),
+                Effects.GrantKeyword(Keyword.CHANGELING, EffectTarget.ContextTarget(0)),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Ron Spencer"
+        flavorText = "\"The changing kind suffers as we do. We must join as one to quench our tyrants!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg?1783942882"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartShenanigans.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BoggartShenanigans.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Boggart Shenanigans
+ * {2}{R}
+ * Kindred Enchantment — Goblin
+ * Whenever another Goblin you control is put into a graveyard from the battlefield, you may have
+ * this enchantment deal 1 damage to target player or planeswalker.
+ *
+ * The bare tribal noun "Goblin" names every permanent with the subtype, so the filter is
+ * [GameObjectFilter.Permanent] rather than Creature — Boggart Shenanigans is itself a Goblin, and
+ * that is what the "another" ([TriggerBinding.OTHER]) is guarding against. "A graveyard", not
+ * "your graveyard": a Goblin you control but don't own still triggers this on the way to its own
+ * owner's graveyard, so the filter reads control and the destination is left unqualified.
+ *
+ * The target is chosen when the ability goes on the stack; the "you may" is asked at resolution.
+ */
+val BoggartShenanigans = card("Boggart Shenanigans") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Kindred Enchantment — Goblin"
+    oracleText = "Whenever another Goblin you control is put into a graveyard from the battlefield, you may have this enchantment deal 1 damage to target player or planeswalker."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Goblin").youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        optional = true
+        val t = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, t)
+        description = "you may have this enchantment deal 1 damage to target player or planeswalker."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Warren Mahy"
+        flavorText = "Boggarts revel in discovering new sensations, from the texture of an otter pellet to the squeak of a dying warren mate."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg?1783942879"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FaerieTauntings.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FaerieTauntings.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Faerie Tauntings
+ * {2}{B}
+ * Kindred Enchantment — Faerie
+ * Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life.
+ *
+ * "During an opponent's turn" is every turn that isn't yours — each other player is an opponent —
+ * so the trigger restriction is [Conditions.IsNotYourTurn], the same reading Glen Elendra
+ * Pranksters uses. The "may" is one decision for the whole ability, not one per opponent
+ * (ruling 2007-10-01), which is exactly what wrapping the single `EachOpponent` life loss in a
+ * [MayEffect] gives.
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val FaerieTauntings = card("Faerie Tauntings") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Kindred Enchantment — Faerie"
+    oracleText = "Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        triggerRestriction = Conditions.IsNotYourTurn
+        effect = MayEffect(Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)))
+        description = "Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Michael Sutfin"
+        flavorText = "Beneath the fae's constant pranks runs a subtler undercurrent of mockery: the influence of Oona, their hidden queen."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg?1783942890"
+        ruling(
+            "2007-10-01",
+            "You choose either to have each opponent lose 1 life or to have no opponent lose any life. " +
+                "You don't choose for each opponent individually."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/KithkinMourncaller.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/KithkinMourncaller.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Kithkin Mourncaller
+ * {2}{G}
+ * Creature — Kithkin Scout
+ * 2/2
+ * Whenever an attacking Kithkin or Elf is put into your graveyard from the battlefield, you may
+ * draw a card.
+ *
+ * No "another": Mourncaller is itself a Kithkin, so dying while attacking triggers its own ability
+ * ([TriggerBinding.ANY]). "Your graveyard" is ownership rather than control — a permanent always
+ * goes to its owner's graveyard (CR 400.3). The attacking check is answered from last-known
+ * information: the creature is removed from combat as it leaves the battlefield (CR 506.4), so the
+ * trigger gate reads the zone-change snapshot's `wasAttacking`.
+ */
+val KithkinMourncaller = card("Kithkin Mourncaller") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Kithkin Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever an attacking Kithkin or Elf is put into your graveyard from the battlefield, you may draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withAnySubtype("Kithkin", "Elf").attacking().ownedByYou(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        optional = true
+        effect = Effects.DrawCards(1)
+        description = "you may draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Dominick Domingo"
+        flavorText = "Eidren's hunts are dangerous affairs. All dread the inevitable recounting of those who died while flushing out his prey."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg?1783942861"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProwessOfTheFair.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProwessOfTheFair.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Prowess of the Fair
+ * {1}{B}
+ * Kindred Enchantment — Elf
+ * Whenever another nontoken Elf is put into your graveyard from the battlefield, you may create a
+ * 1/1 green Elf Warrior creature token.
+ *
+ * The filter is deliberately not creature-scoped: the bare tribal noun "Elf" names every permanent
+ * with the subtype, and Lorwyn's Kindred cards carry creature types onto noncreature permanents —
+ * Prowess of the Fair is itself an Elf, which is what the "another" is guarding against.
+ * "Another" is [TriggerBinding.OTHER], not a filter predicate; "your graveyard" is ownership
+ * rather than control, since a permanent always goes to its owner's graveyard (CR 400.3).
+ */
+val ProwessOfTheFair = card("Prowess of the Fair") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Kindred Enchantment — Elf"
+    oracleText = "Whenever another nontoken Elf is put into your graveyard from the battlefield, you may create a 1/1 green Elf Warrior creature token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Elf").nontoken().ownedByYou(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        optional = true
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf", "Warrior"),
+            imageUri = "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1783942838",
+        )
+        description = "you may create a 1/1 green Elf Warrior creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Jeremy Jarvis"
+        flavorText = "An elvish duel is a thing of beauty: the warriors' grace, the crash of steel, then the artful spray of blood."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg?1783942884"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KithkinMourncallerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KithkinMourncallerScenarioTest.kt
@@ -1,0 +1,185 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kithkin Mourncaller (LRW #224, {2}{G}, Creature — Kithkin Scout 2/2).
+ *
+ *   Whenever an attacking Kithkin or Elf is put into your graveyard from the battlefield, you may
+ *   draw a card.
+ *
+ * "Attacking" is only answerable from last-known information: a creature is removed from combat as
+ * it leaves the battlefield (CR 506.4), so by the time the trigger is gated its `AttackingComponent`
+ * is gone. These tests pin the LKI reading in both directions — the attacking death that triggers
+ * and the non-attacking death that must not — plus the declined "may", the subtype scoping, and
+ * Mourncaller's own death (there is no "another" on this card).
+ */
+class KithkinMourncallerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kithkin Mourncaller") {
+
+            test("an attacking Elf dying draws a card") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Llanowar Elves" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                // The 4/4 Angel eats the 1/1 Elf while it is attacking.
+                game.declareBlockers(mapOf("Serra Angel" to listOf("Llanowar Elves")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Llanowar Elves") shouldBe true
+                withClue("the attacking Elf's death should have drawn a card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("declining the may draws nothing") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Llanowar Elves" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Serra Angel" to listOf("Llanowar Elves")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Llanowar Elves") shouldBe true
+                game.handSize(1) shouldBe handBefore
+            }
+
+            test("a Kithkin or Elf that was not attacking does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(2, "Shock", game.findPermanent("Llanowar Elves")!!)
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Llanowar Elves") shouldBe true
+                withClue("the Elf was never attacking, so nothing should have triggered") {
+                    game.hasPendingDecision() shouldBe false
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("a non-Kithkin non-Elf attacker dying does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Serra Angel" to listOf("Grizzly Bears")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                withClue("a Bear is neither a Kithkin nor an Elf") {
+                    game.hasPendingDecision() shouldBe false
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("Mourncaller's own attacking death triggers it — there is no \"another\"") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Kithkin Mourncaller" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Serra Angel" to listOf("Kithkin Mourncaller")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Kithkin Mourncaller") shouldBe true
+                game.handSize(1) shouldBe handBefore + 1
+            }
+
+            test("an opponent's attacking Elf dying does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Kithkin Mourncaller")
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Llanowar Elves" to 1))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Serra Angel" to listOf("Llanowar Elves")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                game.isInGraveyard(2, "Llanowar Elves") shouldBe true
+                withClue("the Elf went to Bob's graveyard, not yours") {
+                    game.hasPendingDecision() shouldBe false
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ProwessOfTheFairReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/ProwessOfTheFairReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prowess of the Fair reprint in KHC. Canonical CardDefinition lives in its earliest set (LRW).
+ */
+val ProwessOfTheFairReprint = Printing(
+    oracleId = "31324235-8a2b-4ce4-b0d4-6d947489b930",
+    name = "Prowess of the Fair",
+    setCode = "KHC",
+    collectorNumber = "53",
+    scryfallId = "b870c742-e799-4276-bb3d-f2c288ce0db8",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b870c742-e799-4276-bb3d-f2c288ce0db8.jpg?1783928318",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -369,6 +369,71 @@
     ]
 }
 
+// Blades of Velis Vel
+{
+    "name": "Blades of Velis Vel",
+    "manaCost": "{1}{R}",
+    "typeLine": "Kindred Instant — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nUp to two target creatures each get +2/+0 and gain all creature types until end of turn.",
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "CHANGELING",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Ron Spencer",
+        "flavorText": "\"The changing kind suffers as we do. We must join as one to quench our tyrants!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a3ac629-a8c9-4b84-a8ea-b775d7913238.jpg?1783942882"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Blind-Spot Giant
 {
     "name": "Blind-Spot Giant",
@@ -699,6 +764,59 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Boggart Shenanigans
+{
+    "name": "Boggart Shenanigans",
+    "manaCost": "{2}{R}",
+    "typeLine": "Kindred Enchantment — Goblin",
+    "oracleText": "Whenever another Goblin you control is put into a graveyard from the battlefield, you may have this enchantment deal 1 damage to target player or planeswalker.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Goblin ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player or planeswalker"
+                        }
+                    },
+                    "descriptionOverride": "you may have this enchantment deal 1 damage to target player or planeswalker."
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayerOrPlaneswalker",
+                    "id": "target player or planeswalker"
+                },
+                "descriptionOverride": "you may have this enchantment deal 1 damage to target player or planeswalker."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "flavorText": "Boggarts revel in discovering new sensations, from the texture of an otter pellet to the squeak of a dying warren mate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b3c0ea9-270d-4738-9462-7f48fecb4bf4.jpg?1783942879"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2112,6 +2230,56 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Faerie Tauntings
+{
+    "name": "Faerie Tauntings",
+    "manaCost": "{2}{B}",
+    "typeLine": "Kindred Enchantment — Faerie",
+    "oracleText": "Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                },
+                "triggerRestriction": "IsNotYourTurn",
+                "descriptionOverride": "Whenever you cast a spell during an opponent's turn, you may have each opponent lose 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Sutfin",
+        "flavorText": "Beneath the fae's constant pranks runs a subtler undercurrent of mockery: the influence of Oona, their hidden queen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33727782-dafd-4a7c-96dd-6ffaf667cc6b.jpg?1783942890",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "You choose either to have each opponent lose 1 life or to have no opponent lose any life. You don't choose for each opponent individually."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4331,6 +4499,55 @@
     ]
 }
 
+// Kithkin Mourncaller
+{
+    "name": "Kithkin Mourncaller",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Kithkin Scout",
+    "oracleText": "Whenever an attacking Kithkin or Elf is put into your graveyard from the battlefield, you may draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Kithkin|Elf attacking own:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "descriptionOverride": "you may draw a card."
+                },
+                "descriptionOverride": "you may draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Dominick Domingo",
+        "flavorText": "Eidren's hunts are dangerous affairs. All dread the inevitable recounting of those who died while flushing out his prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a8b6f90-c609-4ffd-9136-9fd7a833ebb3.jpg?1783942861"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Knight of Meadowgrain
 {
     "name": "Knight of Meadowgrain",
@@ -5798,6 +6015,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Prowess of the Fair
+{
+    "name": "Prowess of the Fair",
+    "manaCost": "{1}{B}",
+    "typeLine": "Kindred Enchantment — Elf",
+    "oracleText": "Whenever another nontoken Elf is put into your graveyard from the battlefield, you may create a 1/1 green Elf Warrior creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Elf nontoken own:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Elf",
+                            "Warrior"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1783942838"
+                    },
+                    "descriptionOverride": "you may create a 1/1 green Elf Warrior creature token."
+                },
+                "descriptionOverride": "you may create a 1/1 green Elf Warrior creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Jeremy Jarvis",
+        "flavorText": "An elvish duel is a thing of beauty: the warriors' grace, the crash of steel, then the artful spray of blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/099badba-1c8a-4a74-80e9-133f2bafb94d.jpg?1783942884"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -2192,6 +2192,16 @@ class TriggerMatcher(
             if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEnchanted == true
             else hasAttachmentOfKind(state, event.entityId, equipment = false)
         }
+        // "Whenever an *attacking* creature is put into your graveyard from the battlefield"
+        // (Kithkin Mourncaller) is only answerable from the snapshot: the permanent is removed
+        // from combat as it leaves (CR 506.4), so its `AttackingComponent` is gone by gating time.
+        // `PredicateEvaluator` already falls back to `wasAttacking` for the resolution-time reading
+        // (Garna, Bloodfist of Keld); without this arm the trigger path would fail open and fire
+        // for every matching creature that dies, attacking or not.
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttacking -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasAttacking == true
+            else matchesStatePredicateForTrigger(predicate, state, event.entityId)
+        }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Or ->
             predicate.predicates.any { matchesStatePredicateForZoneChangeTrigger(it, state, event, sourceId) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.And ->


### PR DESCRIPTION
Five Lorwyn cards, all built on existing primitives except one engine fail-open fix.

- **Prowess of the Fair** ({1}{B} Kindred Enchantment — Elf) — `Triggers.leavesBattlefield` on a `Permanent.withSubtype("Elf").nontoken().ownedByYou()` filter with `TriggerBinding.OTHER`, `optional = true`, `Effects.CreateToken`. Includes the KHC `Printing` row.
- **Boggart Shenanigans** ({2}{R} Kindred Enchantment — Goblin) — same trigger shape scoped by control, plus `Targets.PlayerOrPlaneswalker` and `Effects.DealDamage`.
- **Kithkin Mourncaller** ({2}{G} Creature — Kithkin Scout 2/2) — the same trigger with `.withAnySubtype("Kithkin", "Elf").attacking()`. **Needed an engine fix** (below), and ships six scenario tests.
- **Blades of Velis Vel** ({1}{R} Kindred Instant — Shapeshifter) — `Targets.UpToCreatures(2)` + `ForEachTargetEffect` over `ContextTarget(0)`, pumping with `Effects.ModifyStats(2, 0)` and granting all creature types via `Effects.GrantKeyword(Keyword.CHANGELING)`.
- **Faerie Tauntings** ({2}{B} Kindred Enchantment — Faerie) — `Triggers.YouCastSpell` with `triggerRestriction = Conditions.IsNotYourTurn`, wrapping a single `EachOpponent` life loss in a `MayEffect`.

## Engine fix: `StatePredicate.IsAttacking` failed open on zone-change triggers

`TriggerMatcher.matchesStatePredicateForZoneChangeTrigger` had no `IsAttacking` arm, so it fell through to `matchesStatePredicateForTrigger`, where `IsAttacking` sits in the explicit fail-open `-> true` bucket. Any `.attacking()` inside a dies-trigger filter therefore matched **every** death, attacking or not — Kithkin Mourncaller is the first card in the corpus to put `.attacking()` in a `ZoneChangeEvent` filter, so nothing had caught it.

The gate now reads the battlefield-exit snapshot's `wasAttacking`, mirroring the `IsFaceDown` arm beside it. That is the same last-known reading `PredicateEvaluator` already does at resolution time for Garna, Bloodfist of Keld; a creature is removed from combat as it leaves the battlefield (CR 506.4), so the snapshot is the only source. The snapshot field already existed and was only reachable from the resolution path.

`KithkinMourncallerScenarioTest` pins both LKI directions (attacking death fires, non-attacking death does not), the declined "may", the subtype scoping, the ownership scoping, and Mourncaller's own attacking death (there is no "another" on this card).

## Dropped from the batch

**Turtleshell Changeling** — "{1}{U}: Switch this creature's power and toughness until end of turn." needs a new SDK effect + executor. The engine half already exists and is unreachable (`Sublayer.SWITCH` for CR 613.4e, `Modification.SwitchPowerToughness`, `SerializableModification.SwitchPowerToughness`, and the swap in `EffectApplicator`); only the SDK effect and a ~35-line executor are missing. New vocabulary, so it gets its own PR.

## Verification

- `just build` — green (after the expected `CardDefinitionSnapshotTest` diff; re-blessed, and only the five new cards moved in `LRW.json`).
- `just test-rules` — green (full engine suite + every card scenario, covering the `TriggerMatcher` change).
- `just test-class KithkinMourncallerScenarioTest` — 6/6.
- `just check-card-printing` — clean for all five; canonical sits in LRW for each.

The final `just build` re-run after adding the KHC `Printing` row was not executed at the user's request; `just rebless-cards` succeeded on that state and left `KHC.json` unchanged, so CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
