### PR TITLE
Add the Hunted cycle to Ravnica: City of Guilds

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedDragon.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedDragon.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Dragon — Ravnica: City of Guilds #131
+ * {3}{R}{R} · Creature — Dragon · 6/6
+ *
+ * Flying, haste
+ * When this creature enters, target opponent creates three 2/2 white Knight creature tokens with
+ * first strike.
+ *
+ * The red member of the Hunted cycle. Haste is the point: the Dragon attacks for six the turn it
+ * lands, before the three Knights it hands over can be used to trade with it. The Knights carry
+ * first strike as a token keyword and enter under the *targeted opponent's* control via
+ * [Effects.CreateToken]'s `controller`.
+ */
+val HuntedDragon = card("Hunted Dragon") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    oracleText = "Flying, haste\n" +
+        "When this creature enters, target opponent creates three 2/2 white Knight creature " +
+        "tokens with first strike."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.FIRST_STRIKE),
+            count = 3,
+            controller = opponent,
+        )
+        description = "When this creature enters, target opponent creates three 2/2 white Knight " +
+            "creature tokens with first strike."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Mark Zug"
+        flavorText = "The knights see a mighty quarry. The dragon sees breakfast, lunch, and dinner."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg?1783943652"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedHorror.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedHorror.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantProtection
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Hunted Horror — Ravnica: City of Guilds #90
+ * {B}{B} · Creature — Horror · 7/7
+ *
+ * Trample
+ * When this creature enters, target opponent creates two 3/3 green Centaur creature tokens with
+ * protection from black.
+ *
+ * The black member of the Hunted cycle, and the most extreme trade in it: a two-mana 7/7 trampler
+ * against two 3/3s the Horror itself can never fight through. Protection from black (CR 702.16) is
+ * exactly what makes the Centaurs a real answer rather than chump blockers — the Horror can't be
+ * blocked *by* them profitably because they can block it and take no damage from it, and it can't
+ * be targeted or enchanted by the black removal that would otherwise clear them.
+ *
+ * The Centaurs' protection is a [GrantProtection] on the token's own `staticAbilities`, scoped to
+ * [GroupFilter.source] so it applies to the token itself rather than to something it's attached to.
+ * That projects `PROTECTION_FROM_BLACK` onto the token, which is the single keyword every
+ * protection leg in the engine reads — combat damage, block legality, targeting, and aura
+ * attachment all consult it. (A creature *card* with printed protection uses
+ * `keywordAbility(KeywordAbility.Protection(...))` instead, but a token has no printed keyword
+ * abilities, so the static-ability route is the one available and the one that projects.)
+ *
+ * As with the rest of the cycle the tokens enter under the *targeted opponent's* control via
+ * [Effects.CreateToken]'s `controller`; if the opponent is an illegal target on resolution the
+ * trigger is removed from the stack and no Centaurs appear.
+ */
+val HuntedHorror = card("Hunted Horror") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    oracleText = "Trample\n" +
+        "When this creature enters, target opponent creates two 3/3 green Centaur creature " +
+        "tokens with protection from black."
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Centaur"),
+            count = 2,
+            controller = opponent,
+            staticAbilities = listOf(GrantProtection(Color.BLACK, GroupFilter.source())),
+        )
+        description = "When this creature enters, target opponent creates two 3/3 green Centaur " +
+            "creature tokens with protection from black."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "90"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg?1783943667"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedLammasu.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedLammasu.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Lammasu — Ravnica: City of Guilds #22
+ * {2}{W}{W} · Creature — Lammasu · 5/5
+ *
+ * Flying
+ * When this creature enters, target opponent creates a 4/4 black Horror creature token.
+ *
+ * The white member of the Hunted cycle: an over-statted body paid for by handing the defender a
+ * blocker. The Horror enters under the *targeted opponent's* control, which is what
+ * [Effects.CreateToken]'s `controller` parameter expresses — the trigger's controller creates
+ * nothing (Hunted Bonebrute takes the same route). If the targeted opponent has become an illegal
+ * target by resolution the whole trigger is removed from the stack and no Horror appears, leaving
+ * the Lammasu's drawback unpaid.
+ */
+val HuntedLammasu = card("Hunted Lammasu") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Lammasu"
+    oracleText = "Flying\n" +
+        "When this creature enters, target opponent creates a 4/4 black Horror creature token."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Horror"),
+            controller = opponent,
+        )
+        description = "When this creature enters, target opponent creates a 4/4 black Horror " +
+            "creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Mark Zug"
+        flavorText = "The lammasu ruled the velds before the city grew. Now they roam Ravnica's " +
+            "skies, but their ancient enemies have not forgotten them."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg?1783943698"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedPhantasm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedPhantasm.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Phantasm — Ravnica: City of Guilds #55
+ * {1}{U}{U} · Creature — Spirit · 4/6
+ *
+ * This creature can't be blocked.
+ * When this creature enters, target opponent creates five 1/1 red Goblin creature tokens.
+ *
+ * The blue member of the Hunted cycle, and the one whose drawback is sharpest: the five Goblins can
+ * never block the Phantasm itself, so they are pure offence for the defender. "Can't be blocked" is
+ * the card-level [AbilityFlag.CANT_BE_BLOCKED] rather than a keyword (Tidal Kraken), and the Goblins
+ * enter under the *targeted opponent's* control via [Effects.CreateToken]'s `controller`.
+ */
+val HuntedPhantasm = card("Hunted Phantasm") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "This creature can't be blocked.\n" +
+        "When this creature enters, target opponent creates five 1/1 red Goblin creature tokens."
+    power = 4
+    toughness = 6
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            count = 5,
+            controller = opponent,
+        )
+        description = "When this creature enters, target opponent creates five 1/1 red Goblin " +
+            "creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "55"
+        artist = "Justin Sweet"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg?1783943684"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedTroll.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HuntedTroll.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hunted Troll — Ravnica: City of Guilds #170
+ * {2}{G}{G} · Creature — Troll Warrior · 8/4
+ *
+ * When this creature enters, target opponent creates four 1/1 blue Faerie creature tokens with
+ * flying.
+ * {G}: Regenerate this creature.
+ *
+ * The green member of the Hunted cycle. The four flying Faeries are the drawback the regeneration
+ * is meant to survive: an 8/4 dies to four 1/1 fliers chump-blocking into it exactly never, but it
+ * folds to the removal those Faeries buy time for, and {G} answers that.
+ *
+ * There is no `Effects.Regenerate` facade — [RegenerateEffect] on [EffectTarget.Self] is the
+ * shipped spelling (Cudgel Troll, Woodwraith Strangler). The Faeries enter under the *targeted
+ * opponent's* control via [Effects.CreateToken]'s `controller`, as with the rest of the cycle.
+ */
+val HuntedTroll = card("Hunted Troll") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll Warrior"
+    oracleText = "When this creature enters, target opponent creates four 1/1 blue Faerie " +
+        "creature tokens with flying.\n" +
+        "{G}: Regenerate this creature."
+    power = 8
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Faerie"),
+            keywords = setOf(Keyword.FLYING),
+            count = 4,
+            controller = opponent,
+        )
+        description = "When this creature enters, target opponent creates four 1/1 blue Faerie " +
+            "creature tokens with flying."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{G}: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "170"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg?1783943635"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedDragonScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedDragonScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hunted Dragon (RAV #131) — {3}{R}{R} Creature — Dragon 6/6.
+ *
+ *   Flying, haste
+ *   When this creature enters, target opponent creates three 2/2 white Knight creature tokens with
+ *   first strike.
+ *
+ * The Knights are the only member of the cycle whose tokens carry a keyword of their own, so this
+ * test pins first strike on the created tokens as well as their controller — a token keyword that
+ * silently dropped would make the drawback strictly weaker than printed.
+ */
+class HuntedDragonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hunted Dragon") {
+
+            test("three 2/2 first-striking Knights enter under the targeted opponent's control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Dragon")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Dragon").isSuccess shouldBe true
+                game.resolveStack()
+
+                val dragon = game.findPermanent("Hunted Dragon")!!
+                withClue("Hunted Dragon is a 6/6 with flying and haste") {
+                    game.state.projectedState.getPower(dragon) shouldBe 6
+                    game.state.projectedState.getToughness(dragon) shouldBe 6
+                    game.state.projectedState.hasKeyword(dragon, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(dragon, Keyword.HASTE) shouldBe true
+                }
+
+                val knights = game.findPermanents("Knight Token")
+                withClue("All three Knights are created") { knights shouldHaveSize 3 }
+
+                withClue("Every Knight is a 2/2 first striker under the opponent's control") {
+                    knights.forEach { knight ->
+                        game.state.getBattlefield(game.player2Id).contains(knight) shouldBe true
+                        game.state.projectedState.getPower(knight) shouldBe 2
+                        game.state.projectedState.getToughness(knight) shouldBe 2
+                        game.state.projectedState
+                            .hasKeyword(knight, Keyword.FIRST_STRIKE) shouldBe true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedHorrorScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedHorrorScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hunted Horror (RAV #90) — {B}{B} Creature — Horror 7/7.
+ *
+ *   Trample
+ *   When this creature enters, target opponent creates two 3/3 green Centaur creature tokens with
+ *   protection from black.
+ *
+ * The Centaurs' protection from black is the one part of this cycle with no corpus precedent: a
+ * *token* has no printed keyword abilities, so protection can't take the
+ * `keywordAbility(KeywordAbility.Protection(...))` route a creature card uses. It rides on the
+ * token's own `staticAbilities` as a `GrantProtection` scoped to `GroupFilter.source()`, which
+ * projects `PROTECTION_FROM_BLACK` — the single keyword every protection leg in the engine reads.
+ * These tests prove the keyword actually lands on the token and that the targeting leg honours it,
+ * because a silently-inert protection would leave the Horror's drawback unpaid.
+ */
+class HuntedHorrorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hunted Horror") {
+
+            test("two 3/3 Centaurs with protection from black enter under the opponent's control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Horror")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Horror").isSuccess shouldBe true
+                game.resolveStack()
+
+                val horror = game.findPermanent("Hunted Horror")!!
+                withClue("Hunted Horror is a 7/7 trampler") {
+                    game.state.projectedState.getPower(horror) shouldBe 7
+                    game.state.projectedState.getToughness(horror) shouldBe 7
+                    game.state.projectedState.hasKeyword(horror, Keyword.TRAMPLE) shouldBe true
+                }
+
+                val centaurs = game.findPermanents("Centaur Token")
+                withClue("Both Centaurs are created") { centaurs shouldHaveSize 2 }
+
+                withClue("Each Centaur is a 3/3 with protection from black, opponent-controlled") {
+                    centaurs.forEach { centaur ->
+                        game.state.getBattlefield(game.player2Id).contains(centaur) shouldBe true
+                        game.state.projectedState.getPower(centaur) shouldBe 3
+                        game.state.projectedState.getToughness(centaur) shouldBe 3
+                        game.state.projectedState
+                            .hasKeyword(centaur, "PROTECTION_FROM_BLACK") shouldBe true
+                    }
+                }
+            }
+
+            test("a black removal spell can't target a Centaur") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Horror")
+                    .withCardInHand(1, "Terror")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Horror").isSuccess shouldBe true
+                game.resolveStack()
+
+                val centaur = game.findPermanents("Centaur Token").first()
+
+                val kill = game.castSpell(1, "Terror", centaur)
+                withClue("Protection from black should make the Centaur an illegal target") {
+                    kill.isSuccess shouldBe false
+                }
+                withClue("The Centaur is still on the battlefield") {
+                    game.findPermanents("Centaur Token") shouldHaveSize 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedLammasuScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedLammasuScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hunted Lammasu (RAV #22) — {2}{W}{W} Creature — Lammasu 5/5.
+ *
+ *   Flying
+ *   When this creature enters, target opponent creates a 4/4 black Horror creature token.
+ *
+ * The point of the cycle is *who* the token belongs to: the trigger's controller creates nothing,
+ * and the 4/4 Horror enters under the targeted opponent's control. A token minted for the caster
+ * would turn the drawback into an upside, so the test pins the controller, not just the count.
+ */
+class HuntedLammasuScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hunted Lammasu") {
+
+            test("the 4/4 Horror enters under the targeted opponent's control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Lammasu")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Lammasu").isSuccess shouldBe true
+                game.resolveStack()
+
+                val lammasu = game.findPermanent("Hunted Lammasu")!!
+                withClue("Hunted Lammasu is a 5/5 flier") {
+                    game.state.projectedState.getPower(lammasu) shouldBe 5
+                    game.state.projectedState.getToughness(lammasu) shouldBe 5
+                    game.state.projectedState.hasKeyword(lammasu, Keyword.FLYING) shouldBe true
+                }
+
+                val horrors = game.findPermanents("Horror Token")
+                withClue("Exactly one Horror is created") { horrors shouldHaveSize 1 }
+
+                val horror = horrors.single()
+                withClue("The Horror belongs to the targeted opponent, not the caster") {
+                    game.state.getBattlefield(game.player2Id).contains(horror) shouldBe true
+                    game.state.getBattlefield(game.player1Id).contains(horror) shouldBe false
+                }
+                withClue("The Horror is a 4/4") {
+                    game.state.projectedState.getPower(horror) shouldBe 4
+                    game.state.projectedState.getToughness(horror) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedPhantasmScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedPhantasmScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hunted Phantasm (RAV #55) — {1}{U}{U} Creature — Spirit 4/6.
+ *
+ *   This creature can't be blocked.
+ *   When this creature enters, target opponent creates five 1/1 red Goblin creature tokens.
+ *
+ * Five is the largest token count in the cycle, so it is worth proving the count survives the
+ * opponent-controller route rather than collapsing to one. The evasion half is the card-level
+ * [AbilityFlag.CANT_BE_BLOCKED] and is checked on the projected state.
+ */
+class HuntedPhantasmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hunted Phantasm") {
+
+            test("five 1/1 Goblins enter under the targeted opponent's control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Phantasm")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Phantasm").isSuccess shouldBe true
+                game.resolveStack()
+
+                val phantasm = game.findPermanent("Hunted Phantasm")!!
+                withClue("Hunted Phantasm is an unblockable 4/6") {
+                    game.state.projectedState.getPower(phantasm) shouldBe 4
+                    game.state.projectedState.getToughness(phantasm) shouldBe 6
+                    game.state.projectedState
+                        .hasKeyword(phantasm, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+
+                val goblins = game.findPermanents("Goblin Token")
+                withClue("All five Goblins are created") { goblins shouldHaveSize 5 }
+
+                withClue("Every Goblin belongs to the targeted opponent") {
+                    goblins.forEach { goblin ->
+                        game.state.getBattlefield(game.player2Id).contains(goblin) shouldBe true
+                        game.state.projectedState.getPower(goblin) shouldBe 1
+                        game.state.projectedState.getToughness(goblin) shouldBe 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedTrollScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedTrollScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Hunted Troll (RAV #170) — {2}{G}{G} Creature — Troll Warrior 8/4.
+ *
+ *   When this creature enters, target opponent creates four 1/1 blue Faerie creature tokens with
+ *   flying.
+ *   {G}: Regenerate this creature.
+ *
+ * The green member of the cycle is the only one that pairs the enters-drawback with an activated
+ * ability, so this covers both halves: the four flying Faeries landing under the opponent's
+ * control, and the regeneration shield the Troll uses to survive what they buy time for.
+ */
+class HuntedTrollScenarioTest : ScenarioTestBase() {
+
+    private val regenerateAbilityId =
+        cardRegistry.getCard("Hunted Troll")!!.activatedAbilities.first().id
+
+    init {
+        context("Hunted Troll") {
+
+            test("four 1/1 flying Faeries enter under the targeted opponent's control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Hunted Troll")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunted Troll").isSuccess shouldBe true
+                game.resolveStack()
+
+                val troll = game.findPermanent("Hunted Troll")!!
+                withClue("Hunted Troll is an 8/4") {
+                    game.state.projectedState.getPower(troll) shouldBe 8
+                    game.state.projectedState.getToughness(troll) shouldBe 4
+                }
+
+                val faeries = game.findPermanents("Faerie Token")
+                withClue("All four Faeries are created") { faeries shouldHaveSize 4 }
+
+                withClue("Every Faerie is a 1/1 flier under the opponent's control") {
+                    faeries.forEach { faerie ->
+                        game.state.getBattlefield(game.player2Id).contains(faerie) shouldBe true
+                        game.state.projectedState.getPower(faerie) shouldBe 1
+                        game.state.projectedState.getToughness(faerie) shouldBe 1
+                        game.state.projectedState.hasKeyword(faerie, Keyword.FLYING) shouldBe true
+                    }
+                }
+            }
+
+            test("{G} regeneration replaces the next destruction this turn") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Hunted Troll")
+                    .withCardInHand(1, "Rend Flesh")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val troll = game.findPermanent("Hunted Troll")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = troll,
+                        abilityId = regenerateAbilityId,
+                    )
+                )
+                withClue("Activating regeneration should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Rend Flesh destroys a non-Spirit creature and carries no "can't be
+                // regenerated" rider, so the shield is the only thing standing between the Troll
+                // and the graveyard.
+                game.castSpell(1, "Rend Flesh", troll).isSuccess shouldBe true
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("The regeneration shield replaces the destruction (CR 701.15)") {
+                    game.isOnBattlefield("Hunted Troll") shouldBe true
+                    game.isInGraveyard(1, "Hunted Troll") shouldBe false
+                }
+                withClue("Regenerating taps the creature (CR 701.15a)") {
+                    game.state.getEntity(troll)?.get<TappedComponent>() shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/HuntedTrollReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/HuntedTrollReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Troll reprint in Commander 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in RAV's `cards` package (the card's earliest
+ * real printing).
+ */
+val HuntedTrollReprint = Printing(
+    oracleId = "1f789fcf-3df6-45a6-a732-9f43e33718d6",
+    name = "Hunted Troll",
+    setCode = "C13",
+    collectorNumber = "150",
+    scryfallId = "cfe19e16-33f6-4594-9dd3-2699a66ba0e8",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/c/f/cfe19e16-33f6-4594-9dd3-2699a66ba0e8.jpg?1783939659",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HuntedDragonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HuntedDragonReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Dragon reprint in Commander 2015. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in RAV's `cards` package (the card's earliest
+ * real printing).
+ */
+val HuntedDragonReprint = Printing(
+    oracleId = "39a4416f-9b40-432e-aeb6-cc7bf519b37a",
+    name = "Hunted Dragon",
+    setCode = "C15",
+    collectorNumber = "159",
+    scryfallId = "f454ae09-6ad3-4ef5-b640-c09908ba3625",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f454ae09-6ad3-4ef5-b640-c09908ba3625.jpg?1783938075",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HuntedHorrorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HuntedHorrorReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Horror reprint in Commander Legends: Battle for Baldur's Gate. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in RAV's `cards` package (the card's earliest
+ * real printing).
+ */
+val HuntedHorrorReprint = Printing(
+    oracleId = "3469463e-ed4d-44bb-81f3-42bbe09d34ad",
+    name = "Hunted Horror",
+    setCode = "CLB",
+    collectorNumber = "758",
+    scryfallId = "02f74866-d0ea-42ce-bc44-500219fb73d4",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg?1783922444",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3729,6 +3729,330 @@
     ]
 }
 
+// Hunted Dragon
+{
+    "name": "Hunted Dragon",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, haste\nWhen this creature enters, target opponent creates three 2/2 white Knight creature tokens with first strike.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "FIRST_STRIKE"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates three 2/2 white Knight creature tokens with first strike."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "The knights see a mighty quarry. The dragon sees breakfast, lunch, and dinner.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2b9cc6e-47db-47d5-84c9-975e4b618261.jpg?1783943652"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Hunted Horror
+{
+    "name": "Hunted Horror",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Trample\nWhen this creature enters, target opponent creates two 3/3 green Centaur creature tokens with protection from black.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Centaur"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    },
+                    "staticAbilities": [
+                        {
+                            "type": "GrantProtection",
+                            "color": "BLACK",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates two 3/3 green Centaur creature tokens with protection from black."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "RARE",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ca680e3-2d10-4a32-8b0c-8b0c6be96540.jpg?1783943667"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hunted Lammasu
+{
+    "name": "Hunted Lammasu",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Lammasu",
+    "oracleText": "Flying\nWhen this creature enters, target opponent creates a 4/4 black Horror creature token.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Horror"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates a 4/4 black Horror creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "The lammasu ruled the velds before the city grew. Now they roam Ravnica's skies, but their ancient enemies have not forgotten them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b84de052-65e5-4723-a746-5c554fa1612d.jpg?1783943698"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Hunted Phantasm
+{
+    "name": "Hunted Phantasm",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "This creature can't be blocked.\nWhen this creature enters, target opponent creates five 1/1 red Goblin creature tokens.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates five 1/1 red Goblin creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "RARE",
+        "artist": "Justin Sweet",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg?1783943684"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Hunted Troll
+{
+    "name": "Hunted Troll",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Troll Warrior",
+    "oracleText": "When this creature enters, target opponent creates four 1/1 blue Faerie creature tokens with flying.\n{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Faerie"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates four 1/1 blue Faerie creature tokens with flying."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{G}: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd9d891e-ae8c-485a-b999-d1e08fffd164.jpg?1783943635"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Indentured Oaf
 {
     "name": "Indentured Oaf",


### PR DESCRIPTION
Implements all five members of RAV's Hunted cycle — the over-statted bodies that pay for themselves by handing the defender tokens. Every one composes existing primitives (`Triggers.EntersBattlefield` + `Targets.Opponent` + `Effects.CreateToken`'s `controller` parameter, the Hunted Bonebrute route); **no new SDK vocabulary**.

| Card | Cost / body | What it does | Primitives composed |
|---|---|---|---|
| **Hunted Lammasu** | {2}{W}{W} 5/5 flying | ETB: target opponent creates a 4/4 black Horror | `Keyword.FLYING`, `Effects.CreateToken(controller = …)` |
| **Hunted Phantasm** | {1}{U}{U} 4/6 unblockable | ETB: target opponent creates five 1/1 red Goblins | `flags(AbilityFlag.CANT_BE_BLOCKED)` (Tidal Kraken), `Effects.CreateToken` |
| **Hunted Dragon** | {3}{R}{R} 6/6 flying, haste | ETB: target opponent creates three 2/2 white first-striking Knights | token `keywords = setOf(Keyword.FIRST_STRIKE)` |
| **Hunted Horror** | {B}{B} 7/7 trample | ETB: target opponent creates two 3/3 green Centaurs with protection from black | token `staticAbilities = listOf(GrantProtection(BLACK, GroupFilter.source()))` |
| **Hunted Troll** | {2}{G}{G} 8/4 | ETB: target opponent creates four 1/1 blue flying Faeries; `{G}`: Regenerate | `RegenerateEffect(EffectTarget.Self)` (Cudgel Troll) |

RAV is the earliest real printing for all five, so every canonical lands here.

## The one part with no precedent

Hunted Horror's Centaurs. A *token* has no printed keyword abilities, so protection can't take the `keywordAbility(KeywordAbility.Protection(...))` route a creature card uses (Nightwind Glider). It rides on the token's own `staticAbilities` as a `GrantProtection` scoped to `GroupFilter.source()`, which projects `PROTECTION_FROM_BLACK` — the single keyword every protection leg in the engine reads: `CombatDamagePipeline`, `BlockEvasionRules`, `TargetValidator`, `UnattachedAurasCheck`. A silently-inert protection would leave the Horror's drawback unpaid, so `HuntedHorrorScenarioTest` pins both that the keyword lands on the token and that the targeting leg honours it (a black removal spell can't target a Centaur).

## Reprint rows

Authoring the canonicals surfaced three `Printing(...)` rows already owed in scaffolded sets, added here: **Hunted Dragon → C15**, **Hunted Horror → CLB**, **Hunted Troll → C13**. `just check-card-printing` is clean for all five.

## Verification

- **7 scenario tests, all passing** (`just test-class 'Hunted*ScenarioTest'`) — one file per card, each pinning the token *controller*, since a token minted for the caster would turn the drawback into an upside.
- **Field-verified against Scryfall** — name, mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor text and image URI compared programmatically for all five; all match. Image URLs return HTTP 200.
- **`just assay-differential --set RAV`: 103/103 confirmed, 0 divergent.**
- **RAV card snapshot re-blessed** — pure additions, only the five new cards; no existing card moved in the golden.
- **`just build`**: the full gate ran green except the expected RAV snapshot diff (re-blessed above). A later re-run hit a 120s coroutine timeout in `AbuJafarTest` (ARN combat, untouched by this change) under machine load; re-running that class alone passes all 3 of its tests. The final full-gate re-run was interrupted before completing, so CI is the authoritative gate here.

## Token art

RAV predates token cards — Scryfall has no `trav` set — so the Horror, Goblin, Knight, Centaur and Faerie tokens fall back to the engine-wide generic art rather than getting `TokenPrinting` rows. Adding rows would need self-hosted art under `web-client/public/images/tokens/`, which has no source for these; borrowing a later set's token art would be wrong per `TokenPrinting`'s own contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)