### PR TITLE
Reject incomplete target and ordering responses

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -249,6 +249,15 @@ object DecisionValidators {
                 }
             }
         }
+
+        // Omitting a requirement is an empty selection for that group, not a way to bypass its
+        // minimum. Optional target groups may still be absent from the response.
+        val omittedRequired = decision.targetRequirements.firstOrNull { req ->
+            req.minTargets > 0 && req.index !in response.selectedTargets
+        }
+        if (omittedRequired != null) {
+            return "Not enough targets for requirement ${omittedRequired.index}: need at least ${omittedRequired.minTargets}"
+        }
         return null
     }
 
@@ -396,7 +405,9 @@ object DecisionValidators {
         if (response !is OrderedResponse) {
             return "Expected ordering response"
         }
-        if (response.orderedObjects.toSet() != decision.objects.toSet()) {
+        if (response.orderedObjects.size != decision.objects.size ||
+            response.orderedObjects.toSet() != decision.objects.toSet()
+        ) {
             return "Ordered objects must contain exactly the same objects as the decision"
         }
         return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.handlers.actions.decision
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+class DecisionValidatorsCompletenessTest : FunSpec({
+
+    val player = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val context = DecisionContext(phase = DecisionPhase.RESOLUTION)
+
+    test("target response may omit an optional requirement but not a mandatory one") {
+        val decision = ChooseTargetsDecision(
+            id = "targets",
+            playerId = player,
+            prompt = "Choose targets",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "mandatory"),
+                TargetRequirementInfo(index = 1, description = "optional", minTargets = 0),
+            ),
+            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(0 to listOf(first))),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+        ).shouldNotBeNull()
+    }
+
+    test("ordering response contains every object exactly once") {
+        val decision = OrderObjectsDecision(
+            id = "order",
+            playerId = player,
+            prompt = "Order",
+            context = context,
+            objects = listOf(first),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first)),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first, first)),
+        ).shouldNotBeNull()
+    }
+})


### PR DESCRIPTION
`DecisionValidators` currently accepts two response shapes that are structurally incomplete even though the corresponding pending decisions require complete answers:

1. A `TargetsResponse` can omit a mandatory target requirement entirely.
2. An `OrderedResponse` can repeat one object while omitting another.

Both cases can pass validation even though they do not satisfy the decision that was issued.

This PR makes those validators check completeness explicitly.

## Target responses

`validateTargets` currently iterates over `response.selectedTargets`.

That correctly validates every target group that is present in the response, including:

- whether the submitted targets are legal for that requirement;
- per-requirement duplicate targets;
- minimum and maximum target counts;
- aggregate restrictions such as total mana value;
- same-owner, different-name, and different-controller constraints.

However, a requirement that is absent from `selectedTargets` is never visited.

For example, given a decision equivalent to:

```text
requirement 0: choose exactly one target
requirement 1: choose up to one target
```

this is correctly accepted:

```text
{ 0: [target] }
```

because requirement 1 is optional.

But the empty response:

```text
{}
```

was also accepted, even though requirement 0 requires one target.

The validator now separately checks the declared target requirements for any mandatory group omitted from the response. An omitted group is therefore equivalent to an empty selection for minimum-count purposes.

- omitted optional requirement (`minTargets == 0`) → valid;
- omitted mandatory requirement (`minTargets > 0`) → invalid.

This does not require callers to include empty lists for optional target groups.

## Ordering responses

`validateOrder` previously checked ordering membership using set equality.

That proves the response contains no *different* objects, but set conversion discards multiplicity.

For a one-object decision containing:

```text
[first]
```

the malformed response:

```text
[first, first]
```

therefore had the same set and was accepted.

More generally, an ordering response should be a permutation of the objects in the pending decision: every expected object, exactly once.

The validator now requires both:

- equal cardinality; and
- equal object sets.

Together those conditions reject duplicates and omissions while preserving arbitrary legal reordering.

## Scope

This change is intentionally limited to response completeness.

It does not:

- change target legality rules;
- require optional target groups to be explicitly represented;
- change cross-requirement target semantics;
- change ordering semantics beyond requiring a true permutation;
- add generic duplicate-card rejection to `SelectCardsDecision`.

The last point is intentional: some existing selection-based costs use repeated entity IDs to represent multiplicity, so duplicate-card handling is not the same invariant as ordering completeness.

## Regression coverage

`DecisionValidatorsCompletenessTest` covers paired valid/invalid cases:

### Targets

- a mandatory target group supplied and an optional group omitted → accepted;
- the mandatory group omitted → rejected.

### Ordering

- every required object supplied exactly once → accepted;
- a duplicate object causing an incomplete ordering → rejected.

## Verification

- `just test-class DecisionValidatorsCompletenessTest`
- `just test-rules`