### PR TITLE
Keep automatic decisions strictly forced

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
@@ -8,9 +8,7 @@ import com.wingedsheep.engine.core.ChooseNumberDecision
 import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.ColorChosenResponse
-import com.wingedsheep.engine.core.DamageAssignmentResponse
 import com.wingedsheep.engine.core.DecisionResponse
-import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
 import com.wingedsheep.engine.core.ModesChosenResponse
 import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.core.OptionChosenResponse
@@ -31,21 +29,30 @@ import com.wingedsheep.engine.core.TargetsResponse
  * ([com.wingedsheep.ai.engine.rollout.FastDecisionResponder], inside a playout) start here and only
  * fall through to their own policy when the choice is real.
  *
- * Extracted from `GameSimulator` in Phase 7 unchanged, rather than reimplemented: a playout that
- * answered a forced decision differently from the simulator would make rollout scores incomparable
- * with the static ones they replace, for no benefit.
+ * This helper is deliberately conservative. Defaults, solver suggestions, and decisions whose
+ * uniqueness depends on state stay with the caller's policy; surfacing a forced decision is cheaper
+ * than silently making a strategic choice here.
  */
 object TrivialDecisions {
 
     /** The forced response to [decision], or null when the choice is a real one. */
     fun responseFor(decision: PendingDecision): DecisionResponse? = when (decision) {
-        // Single target, single requirement → auto-select
+        // A single requirement has one mandatory target, with no cancellation or state-dependent
+        // cap. Cross-requirement distinctness is not represented on ChooseTargetsDecision, so a
+        // multi-requirement response cannot be proved unique here.
         is ChooseTargetsDecision -> {
-            val allSingle = decision.targetRequirements.all { req ->
-                val targets = decision.legalTargets[req.index] ?: emptyList()
-                targets.size == 1 && req.minTargets == 1 && req.maxTargets == 1
-            }
-            if (allSingle) {
+            val requirementIndices = decision.targetRequirements.map { it.index }
+            val allForced = !decision.canCancel &&
+                requirementIndices.size <= 1 &&
+                requirementIndices.size == requirementIndices.toSet().size &&
+                decision.targetRequirements.all { req ->
+                    val targets = decision.legalTargets[req.index] ?: emptyList()
+                    targets.size == 1 &&
+                        req.minTargets == 1 &&
+                        req.maxTargets == 1 &&
+                        req.totalManaValueAtMost == null
+                }
+            if (allForced) {
                 TargetsResponse(
                     decisionId = decision.id,
                     selectedTargets = decision.targetRequirements.associate { req ->
@@ -55,36 +62,39 @@ object TrivialDecisions {
             } else null
         }
 
-        // Forced card selection (min == max == options.size)
+        // The shared response contract intentionally permits repeated IDs for distributed counter
+        // removal. Without metadata distinguishing that use, only zero/one-option selections can
+        // prove uniqueness here; larger all-options selections stay policy-owned.
         is SelectCardsDecision -> {
-            if (decision.minSelections == decision.options.size &&
+            val hasStateDependentConstraints = decision.onePerCardType ||
+                decision.onePerColor ||
+                decision.onePerCardName ||
+                decision.onePerBasicLandType ||
+                decision.onePerPower ||
+                decision.maxTotalManaValue != null ||
+                decision.minTotalManaValue != null ||
+                decision.maxTotalPower != null ||
+                decision.conditionalMinimums.isNotEmpty()
+            if (decision.options.size <= 1 &&
+                !hasStateDependentConstraints &&
+                decision.minSelections == decision.options.size &&
                 decision.maxSelections == decision.options.size
             ) {
                 CardsSelectedResponse(decision.id, decision.options)
             } else null
         }
 
-        // Damage assignment with defaults
-        is AssignDamageDecision -> {
-            if (decision.defaultAssignments.isNotEmpty()) {
-                DamageAssignmentResponse(decision.id, decision.defaultAssignments)
-            } else null
-        }
+        // A default assignment is an initial policy choice, not proof that no other distribution is
+        // legal. The rollout responder may still confirm it as its own heuristic.
+        is AssignDamageDecision -> null
 
-        // Mana sources — auto-pay is trivial only when the solver actually found a
-        // solution. When autoPaySuggestion is empty (e.g. the only available mana
-        // requires sacrificing a Treasure), autoPay=true errors and the resumer
-        // would re-prompt the same decision; fall through so the pluggable
-        // resolver (DecisionResponder.respondManaSelection) handles it.
-        is SelectManaSourcesDecision -> {
-            if (decision.autoPaySuggestion.isNotEmpty()) {
-                ManaSourcesSelectedResponse(decision.id, autoPay = true)
-            } else null
-        }
+        // autoPaySuggestion is one solver-selected payment. Manual source choices, mana abilities
+        // with side effects, and (when offered) declining remain strategy-owned.
+        is SelectManaSourcesDecision -> null
 
-        // Single option
+        // Single option with no separate cancel response.
         is ChooseOptionDecision -> {
-            if (decision.options.size == 1) {
+            if (!decision.canCancel && decision.options.size == 1) {
                 OptionChosenResponse(decision.id, 0)
             } else null
         }
@@ -96,10 +106,11 @@ object TrivialDecisions {
             } else null
         }
 
-        // Single mode, min==max==1
+        // Exact one-mode contract. A broader maximum is left conservative because the current
+        // response contract does not independently describe repeatability.
         is ChooseModeDecision -> {
             val available = decision.modes.filter { it.available }
-            if (available.size == 1 && decision.minModes == 1) {
+            if (available.size == 1 && decision.minModes == 1 && decision.maxModes == 1) {
                 ModesChosenResponse(decision.id, listOf(available.first().index))
             } else null
         }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.cost.PaymentResult
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class GameSimulatorForcedDecisionTest : FunSpec({
+
+    fun simulateNumberDecision(minValue: Int, maxValue: Int): SimulationResult {
+        val testCard = card("Number Choice $minValue-$maxValue") {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                effect = Effects.ChooseNumberThen(
+                    then = Effects.GainLife(1),
+                    minValue = minValue,
+                    maxValue = maxValue,
+                )
+            }
+        }
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + testCard)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val cardId = driver.putCardInHand(caster, testCard.name)
+        driver.castSpell(caster, cardId).isSuccess.shouldBeTrue()
+
+        val priority = driver.state.priorityPlayerId!!
+        return GameSimulator(driver.cardRegistry).simulate(driver.state, PassPriority(priority))
+    }
+
+    test("simulator traverses a genuinely forced number decision") {
+        simulateNumberDecision(minValue = 4, maxValue = 4)
+            .shouldBeInstanceOf<SimulationResult.Terminal>()
+    }
+
+    test("simulator stops when the analogous number decision has a real choice") {
+        val result = simulateNumberDecision(minValue = 3, maxValue = 4)
+            .shouldBeInstanceOf<SimulationResult.NeedsDecision>()
+
+        result.decision.shouldBeInstanceOf<ChooseNumberDecision>()
+    }
+
+    test("simulator leaves a solver-suggested mana payment to strategy") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+
+        val payer = driver.player1
+        val source = driver.putCreatureOnBattlefield(payer, "Goblin Guide")
+        driver.putLandOnBattlefield(payer, "Forest")
+        driver.putLandOnBattlefield(payer, "Forest")
+
+        val payment = CostPaymentService(EngineServices(driver.cardRegistry)).pay(
+            state = driver.state,
+            payerId = payer,
+            cost = Costs.pay.Mana(ManaCost.parse("{G}")),
+            sourceId = source,
+        ).shouldBeInstanceOf<PaymentResult.Pending>()
+
+        val result = GameSimulator(driver.cardRegistry).simulateDecision(
+            payment.state,
+            YesNoResponse(payment.pendingDecision.id, choice = true),
+        ).shouldBeInstanceOf<SimulationResult.NeedsDecision>()
+
+        val manaDecision = result.decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        manaDecision.availableSources.size shouldBe 2
+        manaDecision.autoPaySuggestion.size shouldBe 1
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/TrivialDecisionsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/TrivialDecisionsTest.kt
@@ -1,0 +1,337 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
+import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseModeDecision
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DamageAssignmentResponse
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.ManaSourceOption
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.ModeOption
+import com.wingedsheep.engine.core.ModesChosenResponse
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SearchCardInfo
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class TrivialDecisionsTest : FunSpec({
+
+    val player = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val context = DecisionContext(phase = DecisionPhase.RESOLUTION)
+
+    test("structurally forced decisions produce validator-approved responses") {
+        val decisions = listOf(
+            ChooseTargetsDecision(
+                id = "targets",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                targetRequirements = listOf(
+                    TargetRequirementInfo(index = 0, description = "first target"),
+                ),
+                legalTargets = mapOf(0 to listOf(first)),
+            ),
+            SelectCardsDecision(
+                id = "cards",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                options = listOf(first),
+                minSelections = 1,
+                maxSelections = 1,
+            ),
+            ChooseOptionDecision(
+                id = "option",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                options = listOf("Only option"),
+            ),
+            ChooseColorDecision(
+                id = "color",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                availableColors = setOf(Color.BLUE),
+            ),
+            ChooseModeDecision(
+                id = "mode",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                modes = listOf(
+                    ModeOption(index = 4, text = "Only available"),
+                    ModeOption(index = 9, text = "Unavailable", available = false),
+                ),
+                minModes = 1,
+                maxModes = 1,
+            ),
+            ChooseNumberDecision(
+                id = "number",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                minValue = 3,
+                maxValue = 3,
+            ),
+            OrderObjectsDecision(
+                id = "order",
+                playerId = player,
+                prompt = "Order",
+                context = context,
+                objects = listOf(first),
+            ),
+            ReorderLibraryDecision(
+                id = "library-order",
+                playerId = player,
+                prompt = "Order",
+                context = context,
+                cards = listOf(first),
+                cardInfo = mapOf(first to SearchCardInfo("Card", "", "Land")),
+            ),
+        )
+
+        for (decision in decisions) {
+            val response = TrivialDecisions.responseFor(decision)
+            response.shouldNotBeNull()
+            DecisionValidators.validate(decision, response, GameState()) shouldBe null
+        }
+    }
+
+    test("a lone target is not forced when cancellation or declining is legal") {
+        val cancellable = ChooseTargetsDecision(
+            id = "target",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(TargetRequirementInfo(index = 0, description = "target")),
+            legalTargets = mapOf(0 to listOf(first)),
+            canCancel = true,
+        )
+        val targetResponse = TargetsResponse(cancellable.id, mapOf(0 to listOf(first)))
+        val cancelResponse = CancelDecisionResponse(cancellable.id)
+
+        DecisionValidators.validate(cancellable, targetResponse) shouldBe null
+        DecisionValidators.validate(cancellable, cancelResponse) shouldBe null
+        TrivialDecisions.responseFor(cancellable).shouldBeNull()
+
+        val optional = cancellable.copy(
+            id = "optional-target",
+            canCancel = false,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "up to one target", minTargets = 0),
+            ),
+        )
+        DecisionValidators.validate(optional, TargetsResponse(optional.id, emptyMap())) shouldBe null
+        TrivialDecisions.responseFor(optional).shouldBeNull()
+    }
+
+    test("a lone target with a state-dependent legality cap is not guessed without state") {
+        val decision = ChooseTargetsDecision(
+            id = "aggregate-target",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(
+                    index = 0,
+                    description = "target with limited total mana value",
+                    totalManaValueAtMost = 0,
+                ),
+            ),
+            legalTargets = mapOf(0 to listOf(first)),
+        )
+
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("singleton target groups remain nontrivial when cross-group independence is not represented") {
+        val decision = ChooseTargetsDecision(
+            id = "multiple-target-groups",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "first target"),
+                TargetRequirementInfo(index = 1, description = "another target"),
+            ),
+            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
+        )
+
+        // The original TargetRequirement objects may impose cross-slot distinctness (for example,
+        // TargetOther), but ChooseTargetsDecision exposes no such field to this state-free helper.
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("a lone option is not forced when the decision can be cancelled") {
+        val decision = ChooseOptionDecision(
+            id = "option",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            options = listOf("Only option"),
+            canCancel = true,
+        )
+
+        DecisionValidators.validate(decision, CancelDecisionResponse(decision.id)) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("one visible mode is not forced when the response contract permits another answer") {
+        val optional = ChooseModeDecision(
+            id = "mode",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            modes = listOf(ModeOption(index = 0, text = "Only available")),
+            minModes = 0,
+            maxModes = 1,
+        )
+        DecisionValidators.validate(optional, ModesChosenResponse(optional.id, emptyList())) shouldBe null
+        DecisionValidators.validate(optional, ModesChosenResponse(optional.id, listOf(0))) shouldBe null
+        TrivialDecisions.responseFor(optional).shouldBeNull()
+
+        val broaderMaximum = optional.copy(
+            id = "repeatable-mode-contract",
+            minModes = 1,
+            maxModes = 2,
+        )
+        // A wider maximum does not prove that the single available mode is repeatable,
+        // so the forced-only helper must not infer a unique response.
+        TrivialDecisions.responseFor(broaderMaximum).shouldBeNull()
+    }
+
+    test("selecting every card is not forced when order is a player choice") {
+        val decision = SelectCardsDecision(
+            id = "ordered-cards",
+            playerId = player,
+            prompt = "Choose an order",
+            context = context,
+            options = listOf(first, second),
+            minSelections = 2,
+            maxSelections = 2,
+            ordered = true,
+        )
+
+        DecisionValidators.validate(decision, CardsSelectedResponse(decision.id, listOf(first, second))) shouldBe null
+        DecisionValidators.validate(decision, CardsSelectedResponse(decision.id, listOf(second, first))) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("multi-card selection is not forced without explicit repeated-selection semantics") {
+        val decision = SelectCardsDecision(
+            id = "shared-card-selection",
+            playerId = player,
+            prompt = "Choose two",
+            context = context,
+            options = listOf(first, second),
+            minSelections = 2,
+            maxSelections = 2,
+        )
+
+        // The same pending-decision shape is used by distributed counter-removal costs,
+        // where repeated IDs carry multiplicity. The decision itself does not identify
+        // that use, so selecting each option once is not provably the unique response.
+        DecisionValidators.validate(
+            decision,
+            CardsSelectedResponse(decision.id, listOf(first, second)),
+        ) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<CardsSelectedResponse>()
+        rollout.selectedCards shouldBe listOf(first, second)
+    }
+
+    test("state-dependent card constraints are not guessed without state") {
+        val decision = SelectCardsDecision(
+            id = "constrained-cards",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            options = listOf(first),
+            minSelections = 1,
+            maxSelections = 1,
+            onePerCardType = true,
+        )
+
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("a default damage assignment is policy when another legal assignment exists") {
+        val blockerOne = EntityId.of("blocker-one")
+        val blockerTwo = EntityId.of("blocker-two")
+        val default = mapOf(blockerOne to 3)
+        val alternative = mapOf(blockerOne to 2, blockerTwo to 1)
+        val decision = AssignDamageDecision(
+            id = "damage",
+            playerId = player,
+            prompt = "Assign damage",
+            context = context,
+            attackerId = first,
+            availablePower = 3,
+            orderedTargets = listOf(blockerOne, blockerTwo),
+            defenderId = null,
+            minimumAssignments = mapOf(blockerOne to 2, blockerTwo to 2),
+            defaultAssignments = default,
+            hasTrample = false,
+            hasDeathtouch = false,
+        )
+
+        DecisionValidators.validate(decision, DamageAssignmentResponse(decision.id, default)) shouldBe null
+        DecisionValidators.validate(decision, DamageAssignmentResponse(decision.id, alternative)) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<DamageAssignmentResponse>()
+        rollout.assignments shouldBe default
+    }
+
+    test("an auto-pay suggestion remains rollout policy rather than forced infrastructure") {
+        val landOne = ManaSourceOption(first, "Island", setOf(Color.BLUE), producesColorless = false)
+        val landTwo = ManaSourceOption(second, "Island", setOf(Color.BLUE), producesColorless = false)
+        val decision = SelectManaSourcesDecision(
+            id = "mana",
+            playerId = player,
+            prompt = "Pay {U}",
+            context = context,
+            availableSources = listOf(landOne, landTwo),
+            requiredCost = "{U}",
+            autoPaySuggestion = listOf(first),
+            canDecline = true,
+        )
+        val auto = ManaSourcesSelectedResponse(decision.id, autoPay = true)
+        val manual = ManaSourcesSelectedResponse(decision.id, selectedSources = listOf(second))
+        val decline = ManaSourcesSelectedResponse(decision.id, declined = true)
+
+        DecisionValidators.validate(decision, auto) shouldBe null
+        DecisionValidators.validate(decision, manual) shouldBe null
+        DecisionValidators.validate(decision, decline) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<ManaSourcesSelectedResponse>()
+        rollout.autoPay shouldBe true
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -1156,13 +1156,17 @@ class TriggerProcessor(
                 )
             }
 
-            // Auto-select the lone legal player target instead of prompting (mirrors
+            // Auto-select the lone mandatory legal player target instead of prompting (mirrors
             // processTargetedTrigger's single-player-target shortcut).
             val soleReq = mode.targetRequirements.singleOrNull()
             val soleLegal = legalTargetsMap[0].orEmpty()
             val isPlayerTarget = soleReq is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
                 soleReq is com.wingedsheep.sdk.scripting.targets.TargetOpponent
-            if (isPlayerTarget && soleLegal.size == 1 && soleReq.count == 1) {
+            if (isPlayerTarget &&
+                soleLegal.size == 1 &&
+                soleReq.count == 1 &&
+                soleReq.effectiveMinCount == 1
+            ) {
                 targetsAccum = targetsAccum + listOf(listOf(createChosenTarget(state, soleLegal.first())))
                 ordinal++
                 continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -1735,12 +1735,16 @@ internal fun processChosenModeQueue(
         )
     }
 
-    // Auto-select single player target.
+    // Auto-select a single mandatory player target.
     if (head.targetRequirements.size == 1) {
         val req = head.targetRequirements[0]
         val targets = legalTargetsMap[0] ?: emptyList()
         val isPlayerTarget = req is TargetPlayer || req is TargetOpponent
-        if (isPlayerTarget && targets.size == 1 && req.count == 1) {
+        if (isPlayerTarget &&
+            targets.size == 1 &&
+            req.count == 1 &&
+            req.effectiveMinCount == 1
+        ) {
             val chosenTargets = listOf(entityIdToChosenTarget(state, targets[0]))
             val context = EffectContext(
                 sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
@@ -56,14 +56,14 @@ class SelectTargetPipelineExecutor(
             )
         }
 
-        if (legalTargets.size == 1) {
-            // Single legal target — auto-select
+        if (legalTargets.size == 1 && effect.requirement.effectiveMinCount == 1) {
+            // Single mandatory legal target — auto-select
             return EffectResult.success(state).copy(
                 updatedCollections = mapOf(effect.storeAs to legalTargets)
             )
         }
 
-        // Multiple legal targets — pause for player decision
+        // Multiple legal targets or an optional singleton — pause for player decision
         return createDecision(state, context, effect, legalTargets)
     }
 
@@ -80,7 +80,7 @@ class SelectTargetPipelineExecutor(
         val requirementInfo = TargetRequirementInfo(
             index = 0,
             description = effect.requirement.description,
-            minTargets = 1,
+            minTargets = effect.requirement.effectiveMinCount,
             maxTargets = 1
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -1004,7 +1004,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             tapForGenericPermanents = abilityWaterbendPermanents,
                             tapForGenericLabel = TapForGeneric.WATERBEND.label.takeIf { ability.hasWaterbend }
                         ))
-                    } else if (targetReqs.size == 1 && firstReqInfo.validTargets.size == 1 && firstReqInfo.validTargets.first() == entityId) {
+                    } else if (targetReqs.size == 1 &&
+                        firstReq.effectiveMinCount == 1 &&
+                        firstReqInfo.validTargets.size == 1 &&
+                        firstReqInfo.validTargets.first() == entityId
+                    ) {
                         // Self-targeting: only valid target is the source itself — auto-select and offer repeat
                         val autoSelectedTarget = ChosenTarget.Permanent(entityId)
                         result.add(LegalAction(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTargetForcednessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTargetForcednessTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ModalTargetForcednessTest : FunSpec({
+
+    fun mode(optional: Boolean) = Mode.withTarget(
+        effect = Effects.GainLife(1),
+        target = TargetOpponent(optional = optional),
+        description = if (optional) "Gain life with up to one target opponent" else "Gain life with target opponent",
+    )
+
+    fun processMode(optional: Boolean): Pair<GameTestDriver, ExecutionResult> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        val controller = driver.player1
+
+        val result = processChosenModeQueue(
+            services = EngineServices(driver.cardRegistry),
+            state = driver.state,
+            queue = listOf(mode(optional)),
+            controllerId = controller,
+            sourceId = null,
+            sourceName = "Test modal effect",
+            xValue = null,
+            triggeringEntityId = null,
+            allowCancelBackToModesList = null,
+            outerTargets = emptyList(),
+            outerNamedTargets = emptyMap(),
+            accumulatedEvents = emptyList(),
+            checkForMore = { state, events -> ExecutionResult.success(state, events) },
+        )
+        return driver to result
+    }
+
+    test("resolution-time modal target is surfaced when the lone opponent may be declined") {
+        val (driver, result) = processMode(optional = true)
+
+        result.isPaused.shouldBeTrue()
+        val decision = result.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+        decision.legalTargets.values.single() shouldBe listOf(driver.player2)
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+            result.state,
+        ).shouldBeNull()
+    }
+
+    test("resolution-time modal target still auto-selects the lone mandatory opponent") {
+        val (driver, result) = processMode(optional = false)
+
+        result.isPaused.shouldBeFalse()
+        result.isSuccess.shouldBeTrue()
+        result.state.lifeTotal(driver.player1) shouldBe driver.state.lifeTotal(driver.player1) + 1
+    }
+
+    fun triggeredModalCard(optional: Boolean) = card(
+        if (optional) "Optional Player Modal Trigger" else "Mandatory Player Modal Trigger"
+    ) {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = ModalEffect.chooseOne(
+                mode(optional),
+                Mode.noTarget(Effects.GainLife(2), "Gain 2 life"),
+            )
+        }
+    }
+
+    fun chooseFirstTriggeredMode(optional: Boolean): GameTestDriver {
+        val testCard = triggeredModalCard(optional)
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + testCard)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val controller = driver.activePlayer!!
+        val cardId = driver.putCardInHand(controller, testCard.name)
+        driver.castSpell(controller, cardId).isSuccess.shouldBeTrue()
+
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        val modeDecision = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        driver.submitDecision(controller, OptionChosenResponse(modeDecision.id, optionIndex = 0))
+        return driver
+    }
+
+    test("stack-time modal target is surfaced when the lone opponent may be declined") {
+        val driver = chooseFirstTriggeredMode(optional = true)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+            driver.state,
+        ).shouldBeNull()
+    }
+
+    test("stack-time modal target still auto-selects the lone mandatory opponent") {
+        val driver = chooseFirstTriggeredMode(optional = false)
+
+        driver.pendingDecision.shouldBeNull()
+        driver.state.stack.isNotEmpty().shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ForcedTargetEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ForcedTargetEnumerationTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class ForcedTargetEnumerationTest : FunSpec({
+
+    fun testCard(optional: Boolean) = card(
+        if (optional) "Optional Self Target" else "Mandatory Self Target"
+    ) {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Free
+            target("creature", TargetCreature(optional = optional))
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun sourceId(driver: com.wingedsheep.engine.legalactions.support.EnumerationTestDriver, name: String): EntityId =
+        driver.game.state.getBattlefield(driver.player1).single { id ->
+            driver.game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    test("optional self target remains an explicit zero-or-one choice") {
+        val card = testCard(optional = true)
+        val driver = setupP1(battlefield = listOf(card.name), extraSetCards = listOf(card))
+        val source = sourceId(driver, card.name)
+
+        val actions = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(source)
+        actions.shouldHaveSize(1)
+        val legalAction = actions.single()
+        val action = legalAction.action as ActivateAbility
+
+        action.targets shouldBe emptyList()
+        legalAction.requiresTargets shouldBe true
+        legalAction.minTargets shouldBe 0
+        legalAction.validTargets.shouldContainExactly(source)
+    }
+
+    test("mandatory self target still auto-selects its only legal target") {
+        val card = testCard(optional = false)
+        val driver = setupP1(battlefield = listOf(card.name), extraSetCards = listOf(card))
+        val source = sourceId(driver, card.name)
+
+        val actions = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(source)
+        actions.shouldHaveSize(1)
+        val legalAction = actions.single()
+        val action = legalAction.action as ActivateAbility
+
+        action.targets.shouldContainExactly(ChosenTarget.Permanent(source))
+        legalAction.requiresTargets shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelectTargetPipelineTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelectTargetPipelineTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -52,9 +53,29 @@ class SelectTargetPipelineTest : FunSpec({
         )
     )
 
+    val OptionalPipelineBolt = CardDefinition.sorcery(
+        name = "Optional Pipeline Bolt",
+        manaCost = ManaCost.parse("{R}"),
+        oracleText = "Choose up to one creature. Deal 3 damage to it.",
+        script = CardScript.spell(
+            effect = CompositeEffect(
+                listOf(
+                    SelectTargetEffect(
+                        requirement = TargetCreature(optional = true),
+                        storeAs = "chosen"
+                    ),
+                    DealDamageEffect(
+                        amount = 3,
+                        target = EffectTarget.PipelineTarget("chosen")
+                    )
+                )
+            )
+        )
+    )
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(PipelineBolt))
+        driver.registerCards(TestCards.all + listOf(PipelineBolt, OptionalPipelineBolt))
         return driver
     }
 
@@ -96,6 +117,27 @@ class SelectTargetPipelineTest : FunSpec({
         // With only one legal creature, SelectTargetEffect auto-selects.
         // DealDamageEffect deals 3 to the 2/2 Bear → it dies.
         driver.assertInGraveyard(opponent, "Grizzly Bears")
+    }
+
+    test("single legal target is still offered when selecting it is optional") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            startingLife = 20
+        )
+
+        val (caster, opponent) = setupForCast(driver)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val boltId = driver.putCardInHand(caster, "Optional Pipeline Bolt")
+        driver.castSpell(caster, boltId)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+
+        driver.submitTargetSelection(caster, emptyList())
+        driver.getCreatures(opponent).shouldContain(bear)
     }
 
     test("multiple legal targets presents decision and deals damage to chosen") {


### PR DESCRIPTION
Several engine and AI paths currently treat a decision as automatic when the decision object supplies a convenient default, suggestion, or singleton-looking option, even though the player can still legally make a different choice.

This PR tightens that boundary:

> An automatic decision response is produced only when the decision schema itself proves that there is exactly one legal, non-cancellable response.

Defaults and heuristics remain available to the AI/rollout policy, but they no longer masquerade as forced game actions.

The change covers both the shared AI `TrivialDecisions` helper and several rules-engine singleton-target shortcuts that were applying the same assumption independently.

## Why singleton/default does not necessarily mean forced

A few representative examples:

### Optional singleton target

Suppose an effect says:

```text
Choose up to one target creature.
```

and only one creature is currently a legal target.

There are still two legal responses:

```text
choose that creature
choose no target
```

The existence of exactly one legal object therefore does not make the target decision forced. The minimum target count matters.

This was relevant both to `TrivialDecisions` and to several rules-engine shortcuts that directly selected a singleton target.

### Mana auto-pay suggestion

Suppose a player needs to pay `{R}` and either of two untapped red mana sources can pay it.

A solver may produce:

```text
autoPaySuggestion = [source A]
```

but manually choosing:

```text
[source B]
```

can still be legal.

`autoPaySuggestion` therefore means "here is a payment the solver found", not "this is the only legal response".

Likewise, `autoPay = true` delegates the source choice to engine policy; it is not evidence that the decision itself was forced.

### Damage assignment default

`AssignDamageDecision.defaultAssignments` similarly records the engine's preferred/default assignment.

A default can be validator-approved while another assignment is also legal. In that case the default remains useful to rollout policy, but its presence cannot establish uniqueness for generic automatic resolution.

### Card selection

Consider a generic decision with two options and an exact selection count of two.

It is tempting to infer:

```text
options = [A, B]
choose exactly 2
=> forced response = [A, B]
```

but the response representation is also used by distributed counter-removal costs, where repeated IDs encode multiplicity. A response such as:

```text
[A, A]
```

can represent removing two counters from the same permanent.

The generic `SelectCardsDecision` does not identify enough of that originating semantic context for `TrivialDecisions` to prove that selecting each option once is the unique legal response.

The conservative answer is therefore to leave multi-option selections to policy.

## `TrivialDecisions`

`TrivialDecisions` is used by simulation and fast rollout resolution to bypass decisions that do not actually require policy input.

Some existing cases were broader than that contract.

### Target selection

A target decision is now treated as forced only when the helper can establish the complete response structurally:

- there is at most one target requirement;
- the decision cannot be cancelled;
- the requirement requires exactly one target (`minTargets == maxTargets == 1`);
- exactly one legal target exists;
- the requirement does not contain a state-dependent total-mana-value constraint.

For example:

```text
Choose target creature.
legal targets = [A]
```

is forced.

But:

```text
Choose up to one target creature.
legal targets = [A]
```

is not.

Multi-requirement target decisions are also left to policy even when each requirement independently appears to have one legal target. `ChooseTargetsDecision` contains the projected legal-target lists, but not enough of the original targeting semantics to prove that independently filling several requirement slots always yields the unique legal compound response.

### Card selection

Card selection is auto-resolved only for the structurally simple zero/one-option case with an exact selection count and no aggregate/state-dependent selection constraints.

Multi-option "select all" cases remain policy-owned for the reason illustrated above: the generic pending-decision schema does not establish uniqueness.

### Mode selection

A single available mode is automatic only when the decision requires exactly one mode:

```text
minModes = 1
maxModes = 1
```

A wider maximum is not treated as proof that the one available mode may or must be repeated. If the schema does not prove the complete response, the helper leaves the decision to policy.

### Options, colors, numbers and ordering

The remaining structurally provable cases stay automatic:

- one non-cancellable generic option;
- one available color;
- a number range with equal minimum and maximum;
- zero or one object to order.

For example:

```text
Choose a number from 3 to 3.
```

has exactly one possible response and remains automatic.

### Damage assignment

`AssignDamageDecision.defaultAssignments` is a default, not a uniqueness proof.

`TrivialDecisions` therefore no longer submits it automatically merely because it is populated.

`FastDecisionResponder` can still explicitly choose that default as rollout policy.

### Mana payment

`SelectManaSourcesDecision.autoPaySuggestion` is one solver-produced payment, not a uniqueness proof.

`TrivialDecisions` therefore no longer turns a non-empty suggestion into an automatic `autoPay = true` response.

Rollout policy can still use auto-pay where appropriate.

## Rules-engine singleton target shortcuts

The same distinction existed outside `TrivialDecisions`: several rules-engine paths selected a target automatically whenever target enumeration returned one object.

Those shortcuts now also require the target requirement to be mandatory.

The affected paths are:

- stack-time modal triggered-ability targeting in `TriggerProcessor`;
- resolution-time modal targeting in `ModalAndCloneContinuationResumer`;
- activated-ability target embedding in `ActivatedAbilityEnumerator`;
- mid-pipeline targeting in `SelectTargetPipelineExecutor`.

The key contrast is:

```text
"target creature"
one legal creature
=> automatic
```

versus:

```text
"up to one target creature"
one legal creature
=> still a player choice
```

Mandatory singleton targets continue to auto-resolve.

This matches the existing target model, where optional targeting has an effective minimum of zero: the presence of one legal object does not remove the legal empty selection.

## Policy ownership

This PR does not remove AI handling for decisions that stop being classified as forced.

`GameSimulator` still resolves genuinely forced decisions automatically and otherwise uses its configured strategic decision resolver.

`FastDecisionResponder` still owns cheap rollout heuristics for non-forced decisions, including:

- target selection;
- card selection;
- damage assignment;
- mana payment;
- modes and other policy choices.

For example, after this change:

```text
damage default exists
```

no longer means:

```text
automatic resolution must submit that default
```

but rollout policy remains free to say:

```text
for this cheap rollout, use the engine's default assignment
```

The distinction is therefore between **rules-implied automatic resolution** and **policy-selected resolution**, not between "handled" and "unhandled" decisions.

## Scope

This change deliberately does not attempt to make the generic forced-decision helper infer uniqueness from game state beyond what the pending-decision representation establishes.

It also does not move existing LLM, rollout, or degraded/fallback heuristics into the forced-decision layer.

The conservative rule is intentional: when the representation cannot prove that every legal response is identical, the decision remains policy-owned.

## Regression coverage

New and expanded tests cover both sides of the boundary.

`TrivialDecisionsTest` checks:

- mandatory versus optional singleton targets;
- cancellation;
- multiple target requirements;
- state-dependent target constraints;
- exact and non-exact mode counts;
- card-selection constraints;
- default damage assignments with competing legal responses;
- mana auto-pay suggestions with competing policy responses;
- genuinely forced option/color/number/ordering cases.

`GameSimulatorForcedDecisionTest` verifies that simulation:

- continues through structurally forced decisions;
- stops at real choices when no strategic resolver is installed;
- can continue through those choices when a resolver is supplied.

Rules-engine regression tests verify that:

- optional modal singleton targets remain player choices at stack time;
- optional modal singleton targets remain choices during resolution;
- optional singleton activated-ability targets are not embedded automatically;
- optional singleton pipeline targets raise a decision;
- corresponding mandatory singleton cases still auto-resolve.

## Verification

Focused:

- `just test-class TrivialDecisionsTest`
- `just test-class GameSimulatorForcedDecisionTest`
- `just test-class ModalTargetForcednessTest`
- `just test-class ForcedTargetEnumerationTest`
- `just test-class SelectTargetPipelineTest`

Broad:

- `just test-rules`
- `just test-ai`
- `git diff upstream/main...HEAD --check`