### PR TITLE
Add explicit hidden-world materialization

### DIFF
--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -176,6 +176,21 @@ Phase 8 starts with one shared determinization per search. More worlds compete d
 count, so raising K requires an arena result showing it buys more strength at the same wall-clock
 budget.
 
+For callers that already own an assignment, the generic engine boundary separate from Phase 8's
+sampling policy is `HiddenWorldMaterializer` in `rules-engine`. It accepts an explicit
+`EntityId → CardDefinition` assignment and a caller-selected RNG for future simulated game events.
+It preserves the opaque entity slots and ordered zones, rebuilds only definition-derived card
+components, and returns a typed unsupported result when an identity rewrite would cross in-flight
+references or runtime-bearing card state it cannot preserve safely. It has no viewer, deck model,
+or probability semantics: choosing candidate identities remains the caller's job. It also does
+not accept a `ClientGameState` or Gym observation; those are lossy views, while the materializer
+operates on a trusted complete engine-state substrate. The assignment map explicitly names the
+slots to rewrite; unmentioned slots remain unchanged because `GameState` itself cannot say which
+identities are epistemically unresolved. Callers that require hypothetical future randomness to be
+independent of an authoritative game must supply an independently derived `futureRng`; deliberately
+reusing the source state's RNG remains an explicit caller choice. Phase 8's existing
+`Determinizer` remains a separate AI policy path and is not migrated by this primitive.
+
 ---
 
 ## Scores are in raw evaluator units, everywhere above the leaf

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -469,6 +469,29 @@ combat state, attachments — leaving only the immutable identity (`CardComponen
   the immutable `GameState` — modifying a component means creating a new container, which means
   creating a new entity map, which means creating a new `GameState`.
 
+#### Hypothetical hidden worlds
+
+`GameState` is always a complete engine state; the masked client and Gym DTOs are not alternate
+`GameState` representations and cannot be expanded back into one. A simulation caller that has
+already chosen hypothetical identities for hidden hand or library slots can apply that explicit
+assignment through `HiddenWorldMaterializer` in `rules-engine/hidden`.
+
+The materializer preserves each slot's `EntityId`, owner, controller-component state, zone
+membership, zone ordering, and every unrelated part of the state. It rebuilds the slot's
+definition-derived components through `CardEntityFactory`, and requires the caller to provide the
+RNG for future events in the hypothetical world. It does not choose hidden slots, inspect
+visibility, infer a deck, or define a sampling distribution. Identity rewrites are refused with a
+typed unsupported result when stack objects, pending decisions, continuation frames, or runtime
+state on the assigned hidden object make substitution unsafe.
+
+References elsewhere in the state remain attached to the same opaque entity. Live relationships
+therefore observe the assigned identity, while frozen snapshots and turn-history records remain
+historical. This is a current-state coherence check, not replay/evidence validation. A caller that
+intends the result to represent a complete hidden-world hypothesis must name every semantically
+unresolved slot itself; `GameState` cannot detect an omission. When future-randomness separation
+matters, the caller must also derive an independent hypothetical future RNG. Unmentioned slots and
+an explicitly reused source RNG are preserved by request.
+
 ### 2.3 Rule 613: Base State vs. Projected State
 
 **Principle:** The engine explicitly separates stored state from derived state.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -1,0 +1,237 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+
+/**
+ * An explicit assignment of card definitions to unresolved hidden-zone entity slots.
+ *
+ * This request deliberately contains no sampling policy. The caller decides which slots are
+ * unresolved, which definitions occupy them, and which random stream future simulated game events
+ * use. Assigning definitions to the existing entity ids also assigns the ordered library: zone
+ * membership and entity order are preserved exactly. The keys must include every slot the caller
+ * considers unresolved; unmentioned slots are intentionally left unchanged because the complete
+ * [GameState] substrate cannot reveal a semantic omission.
+ */
+data class HiddenWorldMaterializationRequest(
+    val slotAssignments: Map<EntityId, CardDefinition>,
+    val futureRng: GameRng,
+)
+
+/** Why an explicit hidden-world assignment cannot safely be applied. */
+enum class UnsupportedHiddenWorldKind {
+    /** The request names a missing entity, an unknown source definition, or a non-hand/library slot. */
+    INVALID_ASSIGNMENT,
+
+    /** A stack, pending decision, or continuation caches identities that cannot be audited generically. */
+    IN_FLIGHT_REFERENCES,
+
+    /** The hidden object carries state beyond its printed-definition-derived components. */
+    RUNTIME_STATE,
+}
+
+data class UnsupportedHiddenWorld(
+    val kind: UnsupportedHiddenWorldKind,
+    val entityId: EntityId? = null,
+    val details: List<String> = emptyList(),
+)
+
+sealed interface HiddenWorldMaterializationResult {
+    data class Materialized(val state: GameState) : HiddenWorldMaterializationResult
+    data class Unsupported(val reason: UnsupportedHiddenWorld) : HiddenWorldMaterializationResult
+}
+
+/**
+ * Applies caller-supplied hidden card identities to a hypothetical engine state.
+ *
+ * This is the engine-coherence half of hidden-world construction, not a visibility oracle or a
+ * determinizer. It never chooses slots, reads their current identities as candidate assignments,
+ * checks deck composition, or assigns probabilities. A caller operating from incomplete
+ * information must name every unresolved slot itself. The source definition is inspected only to
+ * verify that the slot's component shape is factory-derived; it is never copied into an assignment.
+ *
+ * Supported slots are ordinary cards in hand or library. Their entity ids, owners, controller
+ * component, zone membership, and zone order are preserved while [CardEntityFactory] rebuilds
+ * every component derived from the requested definition. Individually revealed-to relationships
+ * are also preserved. An object with any other runtime state is refused rather than transplanting
+ * that state onto a different card.
+ *
+ * References stored elsewhere in the state keep pointing at the same entity. Live consumers
+ * therefore see the assigned current definition, while frozen historical snapshots remain frozen.
+ * The materializer validates current structural safety, not whether the assignment could have been
+ * reached through the state's recorded history.
+ *
+ * [HiddenWorldMaterializationRequest.slotAssignments] is also the caller's explicit declaration of
+ * which slots are unresolved. Unmentioned slots are deliberately preserved. Because [GameState]
+ * itself always contains complete identities, this utility cannot infer that a caller omitted a
+ * semantically hidden slot and is not an information-security boundary.
+ *
+ * [HiddenWorldMaterializationRequest.futureRng] is mandatory and is installed verbatim.
+ * Consequently a hypothetical world never inherits the source state's authoritative future random
+ * stream unless the caller explicitly asks for that exact generator. Search callers that require
+ * information separation must derive this generator from caller-owned randomness, not [GameState.rng].
+ */
+class HiddenWorldMaterializer(
+    private val cardRegistry: CardRegistry,
+) {
+    fun materialize(
+        state: GameState,
+        request: HiddenWorldMaterializationRequest,
+    ): HiddenWorldMaterializationResult {
+        if (request.slotAssignments.isNotEmpty() && hasInFlightReferences(state)) {
+            return unsupported(
+                kind = UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES,
+                details = buildList {
+                    if (state.stack.isNotEmpty()) add("stackDepth=${state.stack.size}")
+                    state.pendingDecision?.let { add(it::class.simpleName ?: "PendingDecision") }
+                    if (state.continuationStack.isNotEmpty()) {
+                        add("continuationDepth=${state.continuationStack.size}")
+                    }
+                },
+            )
+        }
+
+        var materialized = state
+
+        for ((entityId, replacementDefinition) in request.slotAssignments.entries.sortedBy { it.key.value }) {
+            val container = state.getEntity(entityId)
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity does not exist"),
+                )
+            val zones = state.zones.filterValues { entityId in it }
+            val occurrences = zones.values.sumOf { zone -> zone.count { it == entityId } }
+            if (occurrences != 1 || zones.keys.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf(
+                        if (occurrences == 0) "entity is not in a zone"
+                        else if (occurrences > 1) "entity occurs in zones $occurrences times"
+                        else "supported slots are HAND/LIBRARY; found ${zones.keys.single().zoneType.name}"
+                    ),
+                )
+            }
+            val zoneKey = zones.keys.single()
+
+            val ownerId = container.get<OwnerComponent>()?.playerId
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity has no owner"),
+                )
+            if (zoneKey.ownerId != ownerId) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("zone owner ${zoneKey.ownerId.value} differs from card owner ${ownerId.value}"),
+                )
+            }
+            val currentCard = container.get<CardComponent>()
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity has no card identity"),
+                )
+            if (currentCard.ownerId != ownerId) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("card identity owner differs from OwnerComponent"),
+                )
+            }
+            val currentDefinition = cardRegistry.getCard(currentCard.cardDefinitionId)
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("source definition is not registered: ${currentCard.cardDefinitionId}"),
+                )
+            val runtimeDifferences = runtimeDifferences(container, currentDefinition, ownerId)
+            if (runtimeDifferences.isNotEmpty()) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.RUNTIME_STATE,
+                    entityId,
+                    runtimeDifferences,
+                )
+            }
+            if (isDfcBackFace(replacementDefinition)) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("replacement HAND/LIBRARY identity is a DFC back face: ${replacementDefinition.name}"),
+                )
+            }
+            var replacement = CardEntityFactory.create(replacementDefinition, ownerId)
+            val replacementDefinitionId = replacement.require<CardComponent>().cardDefinitionId
+            if (cardRegistry.getCard(replacementDefinitionId) != replacementDefinition) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("replacement definition is not registered: $replacementDefinitionId"),
+                )
+            }
+            replacement = container.get<ControllerComponent>()
+                ?.let { replacement.with(it) }
+                ?: replacement.without<ControllerComponent>()
+            container.get<RevealedToComponent>()?.let { replacement = replacement.with(it) }
+            materialized = materialized.withEntity(entityId, replacement)
+        }
+
+        return HiddenWorldMaterializationResult.Materialized(
+            materialized.copy(rng = request.futureRng)
+        )
+    }
+
+    /**
+     * Compare against the factory output for the card currently occupying the slot. This keeps the
+     * safe set in lockstep with new definition-derived components without teaching the materializer
+     * a second hard-coded list. Every component present on the slot must match the factory value:
+     * a normally definition-derived component that has been changed at runtime is runtime state
+     * for this purpose. Missing factory components are safe to regenerate; zone transitions
+     * legitimately strip [com.wingedsheep.engine.state.components.identity.ControllerComponent].
+     */
+    private fun runtimeDifferences(
+        actual: ComponentContainer,
+        currentDefinition: CardDefinition,
+        ownerId: EntityId,
+    ): List<String> {
+        val expectedByType = CardEntityFactory.create(currentDefinition, ownerId)
+            .all()
+            .associateBy { it::class.java }
+        return actual.all()
+            .filterNot { it is CardComponent || it is RevealedToComponent }
+            .filter { component -> expectedByType[component::class.java] != component }
+            .map { component -> component::class.simpleName ?: component::class.java.name }
+            .sorted()
+    }
+
+    private fun isDfcBackFace(definition: CardDefinition): Boolean =
+        cardRegistry.getFrontFace(definition.name) != null
+
+    private fun hasInFlightReferences(state: GameState): Boolean =
+        state.stack.isNotEmpty() || state.pendingDecision != null || state.continuationStack.isNotEmpty()
+
+    private fun unsupported(
+        kind: UnsupportedHiddenWorldKind,
+        entityId: EntityId? = null,
+        details: List<String> = emptyList(),
+    ): HiddenWorldMaterializationResult.Unsupported =
+        HiddenWorldMaterializationResult.Unsupported(
+            UnsupportedHiddenWorld(kind, entityId, details)
+        )
+
+    private companion object {
+        val SUPPORTED_ZONES = setOf(Zone.HAND, Zone.LIBRARY)
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -1,0 +1,255 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.MadnessComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class HiddenWorldMaterializerTest : ScenarioTestBase() {
+
+    private val materializer = HiddenWorldMaterializer(cardRegistry)
+
+    init {
+        test("explicit assignments preserve slots and unrelated state while installing future RNG") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Forest")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Craw Wurm")
+                .withRngSeed(101L)
+                .build()
+            val hiddenHandId = game.state.getHand(game.player2Id).single()
+            val hiddenLibraryIds = game.state.getLibrary(game.player2Id)
+            val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
+            val source = game.state
+                .updateEntity(hiddenHandId) { it.with(RevealedToComponent.to(game.player1Id)) }
+                .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val futureRng = GameRng.seeded(202L)
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(
+                        hiddenHandId to cardRegistry.requireCard("Fiery Temper"),
+                        hiddenLibraryIds[0] to cardRegistry.requireCard("Mountain"),
+                        hiddenLibraryIds[1] to cardRegistry.requireCard("Island"),
+                    ),
+                    futureRng = futureRng,
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+            val world = result.state
+
+            world.rng shouldBe futureRng
+            source.rng shouldBe GameRng.seeded(101L)
+            world.entities.keys shouldBe source.entities.keys
+            world.zones shouldBe source.zones
+            world.lastCardDrawnThisTurnByPlayer shouldBe mapOf(game.player2Id to hiddenHandId)
+            world.getEntity(hiddenHandId)?.get<RevealedToComponent>() shouldBe
+                source.getEntity(hiddenHandId)?.get<RevealedToComponent>()
+            cardName(world, hiddenHandId) shouldBe "Fiery Temper"
+            cardName(world, hiddenLibraryIds[0]) shouldBe "Mountain"
+            cardName(world, hiddenLibraryIds[1]) shouldBe "Island"
+            world.getEntity(hiddenHandId)?.has<MadnessComponent>() shouldBe true
+
+            val restored = world.copy(
+                entities = world.entities + assignedIds.associateWith { source.entities.getValue(it) },
+                rng = source.rng,
+            )
+            withClue("only assigned entity containers and the future RNG may change") {
+                restored shouldBe source
+            }
+            withClue("materialization is purely functional") {
+                game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+            }
+        }
+
+        test("caller-generated assignments are reproducible and do not consume source randomness") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withRngSeed(303L)
+                .build()
+            val slots = game.state.getLibrary(game.player2Id)
+            val candidates = listOf("Plains", "Island", "Swamp", "Mountain")
+                .map(cardRegistry::requireCard)
+            val futureRng = GameRng.seeded(404L)
+
+            fun worldFor(assignmentSeed: Long): GameState {
+                val (definitions, _) = GameRng.seeded(assignmentSeed).shuffle(candidates)
+                val request = HiddenWorldMaterializationRequest(slots.zip(definitions).toMap(), futureRng)
+                return materializer.materialize(game.state, request)
+                    .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                    .state
+            }
+
+            worldFor(7L) shouldBe worldFor(7L)
+            val worlds = (7L..22L).map { seed ->
+                val world = worldFor(seed)
+                world.getLibrary(game.player2Id).map { cardName(world, it) }
+            }
+            worlds.distinct().size shouldNotBe 1
+            game.state.rng shouldBe GameRng.seeded(303L)
+            worlds.forEach { it.toSet() shouldBe setOf("Plains", "Island", "Swamp", "Mountain") }
+        }
+
+        test("a hidden card carrying battlefield last-known information is refused") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val source = ZoneTransitionService.moveToZone(
+                game.state,
+                bears,
+                Zone.HAND,
+            ).state
+            source.getEntity(bears)?.has<LastKnownPermanentComponent>() shouldBe true
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(bears to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(505L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe bears
+            result.reason.details shouldContain LastKnownPermanentComponent::class.simpleName
+            source.getEntity(bears)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+
+            val cleanAgain = ZoneTransitionService.moveToZone(source, bears, Zone.LIBRARY).state
+            cleanAgain.getEntity(bears)?.has<LastKnownPermanentComponent>() shouldBe false
+            cleanAgain.getEntity(bears)?.has<ControllerComponent>() shouldBe false
+            val cleanWorld = materializer.materialize(
+                cleanAgain,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(bears to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(506L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+            cleanWorld.getEntity(bears)?.has<ControllerComponent>() shouldBe false
+        }
+
+        test("a real stack state is refused instead of being guessed through") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Shock")
+                .withCardOnBattlefield(1, "Mountain")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+            val target = game.findPermanent("Hill Giant")!!
+            game.castSpell(1, "Shock", targetId = target).error shouldBe null
+            val source = game.state
+            source.stack.size shouldBe 1
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(606L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+            result.reason.details shouldContain "stackDepth=1"
+            source.getEntity(hiddenId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+        }
+
+        test("a DFC back face cannot be materialized directly into a hidden zone") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+
+            val result = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(
+                        hiddenId to cardRegistry.requireCard("Test DFC Back")
+                    ),
+                    futureRng = GameRng.seeded(650L),
+                ),
+            )
+
+            val unsupported =
+                result.shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            unsupported.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+            unsupported.reason.entityId shouldBe hiddenId
+            unsupported.reason.details shouldContain
+                "replacement HAND/LIBRARY identity is a DFC back face: Test DFC Back"
+        }
+
+        test("an unregistered replacement is a typed unsupported request") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+            val unregistered = card("Unregistered Hypothesis") {
+                manaCost = "{1}"
+                typeLine = "Sorcery"
+            }
+
+            val result = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to unregistered),
+                    futureRng = GameRng.seeded(707L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+            result.reason.entityId shouldBe hiddenId
+        }
+
+        test("a materialized world can continue through ordinary engine simulation") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player1Id).single()
+            val world = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to cardRegistry.requireCard("Forest")),
+                    futureRng = GameRng.seeded(808L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+
+            val simulated = actionProcessor.process(
+                world,
+                PlayLand(game.player1Id, hiddenId),
+            ).result
+
+            simulated.error shouldBe null
+            simulated.state.getZone(ZoneKey(game.player1Id, Zone.BATTLEFIELD)) shouldContain hiddenId
+            cardName(simulated.state, hiddenId) shouldBe "Forest"
+        }
+    }
+
+    private fun cardName(state: GameState, entityId: EntityId): String? =
+        state.getEntity(entityId)?.get<CardComponent>()?.name
+}


### PR DESCRIPTION
Adds a narrow rules-engine primitive for constructing hypothetical complete states from caller-supplied hidden-card assignments.

Argentum’s rules engine always operates on a complete `GameState`, even when an AI or simulation caller is reasoning from partial information. The existing AI determinizer handles one version of that problem inside the AI layer, but it also owns sampling policy and fallback behavior. There is currently no reusable engine-level contract for the narrower operation: “apply these hypothetical hidden identities to this state if doing so is structurally safe.”

`HiddenWorldMaterializer` adds that boundary.

A caller supplies:

- an explicit `EntityId -> CardDefinition` assignment for hand/library slots;
- a caller-selected RNG for future simulated game events.

The materializer does not choose those identities. It answers only whether the supplied assignment can be installed coherently into the engine state.

For example, a search caller can take a position with three unresolved opponent hand/library slots and construct one hypothetical world in which those slots contain Mountain, Shock, and Grizzly Bears, then another world with a different assignment, while using the ordinary rules engine to simulate both. The search or belief layer remains free to decide why those worlds were chosen and how much weight to give them.

The same separation applies to randomness. A caller that wants each hypothetical world to have an independent future shuffle/draw stream can supply a separately derived `futureRng`. A caller that deliberately wants to preserve the source stream can explicitly pass the source RNG instead. The materializer does not derive either policy implicitly.

For supported hand/library slots, materialization preserves:

- the existing `EntityId`;
- owner and controller-component state;
- zone membership;
- exact library ordering;
- per-card reveal state;
- unrelated game state.

Definition-derived components are rebuilt through `CardEntityFactory`.

Thus if `card-1001` is the second card in a library, assigning a different hypothetical definition does not replace or move `card-1001`. The opaque slot remains the same object from the perspective of existing entity references; only the current card definition and its definition-derived component state change.

Some hidden-zone objects cannot safely be treated as interchangeable. A card can retain runtime state from an earlier incarnation, or the engine can have an in-flight stack/decision/continuation that depends on current object relationships. In those cases the materializer returns a typed unsupported result rather than producing a superficially complete but internally inconsistent state.

One regression exercises a real battlefield-to-hand transition. The card retains `LastKnownPermanentComponent`; assigning a different hypothetical identity at that point would attach historical battlefield information to the wrong card, so materialization is refused. After a subsequent zone transition clears that runtime state, the same slot becomes materializable again.

The materializer likewise refuses identity rewrites while stack, pending-decision, or continuation state makes generic substitution unsafe.

There is also a DFC-specific validity check. `CardRegistry` intentionally registers back-face definitions so transform machinery can resolve them, but those definitions are not legal standalone card identities in hand or library. A request to materialize `Test DFC Back` directly into a hidden hand slot is therefore rejected as an invalid assignment rather than accepted merely because the definition is registered.

This primitive deliberately has no viewer, deck model, or probability semantics. It does not inspect visibility, infer which slots are unknown, constrain assignments to a deck, sample worlds, or assign probabilities. `GameState` itself contains complete identities, so the materializer also cannot detect that a caller has omitted a slot that is epistemically unresolved from that caller’s perspective. A caller intending to construct a complete hidden-world hypothesis must provide the appropriate assignments itself.

The existing Phase 8 AI `Determinizer` is not migrated by this change and retains its current sampling and fallback behavior. This PR establishes only the generic engine-state materialization seam.

Coverage includes:

- explicit hand/library assignments while preserving entity IDs and zone ordering;
- reconstruction of definition-derived components such as Madness;
- caller-controlled reproducible assignment generation;
- source-state and source-RNG immutability;
- preservation of unrelated tracker and reveal state;
- typed refusal of battlefield last-known runtime state;
- successful materialization after that runtime state is cleared;
- typed refusal during a real stack state;
- rejection of unregistered definitions;
- rejection of DFC back-face identities in hand/library;
- ordinary `ActionProcessor` execution from a successfully materialized world.

Verification:

- `just test-class HiddenWorldMaterializerTest`
- `just test-rules`
- `just test-ai`
- `just test-gym`
- `just test-gym-trainer`
- `git diff --check upstream/main..HEAD`