### PR TITLE
Always offer the evoke choice next to the printed cost

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -281,6 +281,15 @@ pick a "normal" cast out of `legalActions` with its own hand-maintained list of 
 exclude, so the three disagreed, and a card whose only cast was an adventure face or a kicker showed
 its printed cost with no sign that the printed cost wasn't the price.
 
+**Keyword alternative costs never come off the legal actions alone.** Impending (CR 702.176) and
+evoke (CR 702.74) both mean "you may cast this for [cost] rather than its mana cost", so the card has
+two live prices — but the enumerator emits only the casts the player can currently *afford*. The cost
+therefore rides on `ClientCard` (`impending`, `evoke`), and `keywordAlternativeCostFor(card)` turns it
+into the pair of buttons `buildActionOptions` always draws, graying out whichever side the server
+didn't enumerate. `shouldShowCastModal` reads the same helper, so drag-to-play opens the menu instead
+of firing the lone affordable cast: a Mulldrifter you can only afford to evoke must not evoke itself —
+and sacrifice itself — because you dragged it out of hand.
+
 Two rules for `playCostRange`: the **low** end applies each option's reduction floor, the **high** end
 deliberately doesn't (the top of the range is what a cast *asks* for before you spend anything on it);
 and only options that actually put the card into play count. Cycling, plotting and suspending are

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -698,7 +698,18 @@ data class ClientCard(
      * player can't currently pay for — and annotate it with a time-counter glyph. Null for cards
      * without impending.
      */
-    val impending: ClientImpending? = null
+    val impending: ClientImpending? = null,
+
+    /**
+     * Evoke alternative cost (CR 702.74), derived from the card's `KeywordAbility.Evoke`. Present
+     * on any card whose definition has evoke, regardless of zone, so the client can always offer
+     * the evoke cast option alongside the normal cast — graying out whichever the player can't
+     * currently pay for. Null for cards without evoke.
+     *
+     * A bare cost string rather than a DTO of its own: evoke carries no second value the way
+     * [ClientImpending] carries its time-counter count.
+     */
+    val evoke: String? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1523,7 +1523,14 @@ class ClientStateTransformer(
             impending = cardDef?.keywordAbilities
                 ?.filterIsInstance<KeywordAbility.Impending>()
                 ?.firstOrNull()
-                ?.let { ClientImpending(cost = it.cost.toString(), time = it.time) }
+                ?.let { ClientImpending(cost = it.cost.toString(), time = it.time) },
+            // Evoke (CR 702.74): same reason as impending — the alternative cost has to be on the
+            // card so the menu can offer both prices even when only one of them is affordable.
+            evoke = cardDef?.keywordAbilities
+                ?.filterIsInstance<KeywordAbility.Evoke>()
+                ?.firstOrNull()
+                ?.cost
+                ?.toString()
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EvokeClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EvokeClientViewTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The client view of an evoke card (CR 702.74) must carry its evoke cost, for the same reason
+ * impending does: the enumerator only offers the casts the player can currently *afford*, so a
+ * Mulldrifter on five lands arrives with an evoke cast and nothing else. Without the cost on the
+ * card, the menu can't draw the hard cast next to it, and the drag-to-play path silently fires the
+ * lone action — evoking (and sacrificing) a creature the player meant to hard-cast.
+ *
+ * Evoke is intrinsic to the card definition, so it rides on `ClientCard` in every zone.
+ */
+class EvokeClientViewTest : ScenarioTestBase() {
+
+    private val transformer = com.wingedsheep.engine.view.ClientStateTransformer(cardRegistry)
+    private val p1 = EntityId.of("player-1")
+
+    private fun clientCardInHand(name: String) = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, name)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+        .let { game ->
+            val cardId = game.state.getHand(p1).first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == name
+            }
+            transformer.transform(game.state, p1).cards[cardId]!!
+        }
+
+    init {
+        test("an evoke card in hand exposes its evoke cost") {
+            withClue("Mulldrifter has Evoke {2}{U} against a printed {4}{U}") {
+                clientCardInHand("Mulldrifter").evoke shouldBe "{2}{U}"
+            }
+        }
+
+        test("a single-pip evoke cost survives the round-trip verbatim") {
+            // Ingot Chewer's {R} against a printed {4}{R} — the widest gap the menu has to show as
+            // two prices side by side.
+            clientCardInHand("Ingot Chewer").evoke shouldBe "{R}"
+        }
+
+        test("a card without evoke exposes no evoke option") {
+            clientCardInHand("Grizzly Bears").evoke.shouldBeNull()
+        }
+    }
+}

--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { attachmentStackLayout, hasMultipleCastingOptions, shouldShowCastModal } from './shared'
-import type { LegalActionInfo } from '../../../types'
+import type { ClientCard, LegalActionInfo } from '../../../types'
 import { entityId } from '../../../types'
 
 // --- Fixture builders -------------------------------------------------------
@@ -77,6 +77,33 @@ function playLandBackFace(): LegalActionInfo {
   }
 }
 
+/** A card with evoke (CR 702.74) — two real prices, only one of them ever enumerated. */
+const mulldrifter = {
+  name: 'Mulldrifter',
+  manaCost: '{4}{U}',
+  cardTypes: [],
+  evoke: '{2}{U}',
+} as unknown as ClientCard
+
+/** A card with impending (CR 702.176) — the same shape, with a time-counter count attached. */
+const overlord = {
+  name: 'Overlord of the Mistmoors',
+  manaCost: '{5}{W}{W}',
+  cardTypes: [],
+  impending: { cost: '{2}{W}{W}', time: 4 },
+} as unknown as ClientCard
+
+/** A card with neither, to prove the new branch doesn't widen to every cast. */
+const grizzlyBears = { name: 'Grizzly Bears', manaCost: '{1}{G}', cardTypes: [] } as unknown as ClientCard
+
+function evokeCast(): LegalActionInfo {
+  return {
+    actionType: 'CastWithAlternativeCost',
+    description: 'Evoke Mulldrifter ({2}{U})',
+    action: { type: 'CastSpell', playerId: PLAYER, cardId: CARD, useAlternativeCost: true, alternativeCostType: 'EVOKE' },
+  } as unknown as LegalActionInfo
+}
+
 describe('shouldShowCastModal', () => {
   it('does not open the menu when there are no legal actions', () => {
     expect(shouldShowCastModal([])).toBe(false)
@@ -131,6 +158,32 @@ describe('shouldShowCastModal', () => {
 
   it('opens the menu for a modal double-faced land — two land faces are two choices', () => {
     expect(shouldShowCastModal([playLand(), playLandBackFace()])).toBe(true)
+  })
+
+  // Evoke (CR 702.74) is the cycling case reached from the cast side: the card has two real
+  // prices, but the server enumerates only the affordable one. Dragging out a Mulldrifter you can
+  // only afford to evoke used to cast it for its evoke cost — and sacrifice it — unasked.
+  it('opens the menu for an evoke card whose only enumerated cast is the evoke one', () => {
+    expect(shouldShowCastModal([evokeCast()], mulldrifter)).toBe(true)
+  })
+
+  it('opens the menu for an evoke card whose only enumerated cast is the hard one', () => {
+    expect(shouldShowCastModal([castSpell()], mulldrifter)).toBe(true)
+  })
+
+  it('opens the menu for an impending card with a single enumerated cast', () => {
+    expect(shouldShowCastModal([castSpell()], overlord)).toBe(true)
+  })
+
+  // The keyword is a second *cast* price, not a second way to use the card in any zone: an evoke
+  // creature already on the battlefield offers its activated abilities, and those are not casts.
+  it('leaves a non-cast action alone even on an evoke card', () => {
+    expect(shouldShowCastModal([cycle()], mulldrifter)).toBe(true)
+    expect(shouldShowCastModal([playLand()], mulldrifter)).toBe(false)
+  })
+
+  it('does not open the menu for a plain card with no keyword alternative cost', () => {
+    expect(shouldShowCastModal([castSpell()], grizzlyBears)).toBe(false)
   })
 })
 

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -13,6 +13,7 @@ import {
 } from './battlefieldLayout'
 import type { ResponsiveSizes, BadgeSizes } from '../../../hooks/useResponsive'
 import { getScryfallFallbackUrl } from '../../../utils/cardImages'
+import { keywordAlternativeCostFor } from '../../../utils/actionOptions'
 import type { ClientCard, LegalActionInfo } from '../../../types'
 import { CounterType, CounterTypeDisplayNames } from '../../../types'
 import { Color } from '../../../types/enums'
@@ -321,13 +322,33 @@ export function hasMultipleCastingOptions(cardLegalActions: LegalActionInfo[]): 
  * cancel). (Whether the grayed-out button reads "Cast" or "Play land" is decided later, by
  * `ActionMenu.buildActionOptions`, from the card's types — it doesn't affect this decision.)
  *
+ * A keyword alternative cost (impending, evoke) is the same situation reached from the other side:
+ * the card always has two prices, but the server enumerates only the affordable one, so a single
+ * `CastSpell` action here can still be one of two buttons the menu is about to draw. Evoke is the
+ * case that makes it bite — dragging out a Mulldrifter you can only afford to evoke used to cast
+ * it for its evoke cost on the spot, sacrificing the creature with no choice offered.
+ *
  * @param cardLegalActions Legal actions for this specific card from the server
+ * @param cardInfo The card itself, when known — carries the keyword alternative costs that never
+ *   appear in `cardLegalActions` because the player can't currently pay for them
  */
-export function shouldShowCastModal(cardLegalActions: LegalActionInfo[]): boolean {
+export function shouldShowCastModal(
+  cardLegalActions: LegalActionInfo[],
+  cardInfo?: ClientCard | null
+): boolean {
   if (cardLegalActions.length === 0) return false
   // More than one legal action, or multiple casting variants (morph + normal cast, etc.).
   if (cardLegalActions.length > 1) return true
   if (hasMultipleCastingOptions(cardLegalActions)) return true
+  // Impending / evoke: the printed cost and the keyword cost are both real prices for this card,
+  // so any cast of it is a choice between two buttons — whichever one the server could afford.
+  if (
+    cardInfo &&
+    keywordAlternativeCostFor(cardInfo) &&
+    cardLegalActions.some((a) => a.action.type === 'CastSpell')
+  ) {
+    return true
+  }
   // A lone alternative play mode still implies a second (possibly-unaffordable) option the
   // menu surfaces as a grayed-out button: "Play land" for lands, "Cast" for everything else.
   return cardLegalActions.some(

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -612,10 +612,11 @@ function GameCardImpl({
   }), [legalActions, card.id])
   const playableAction = playableActions[0]
   // Open the action menu when the card has more than one way to be played — including cards
-  // whose only affordable option is an alternative cast (cycling/typecycling/plot), so the
-  // player still sees the grayed-out "Cast"/"Play land" and can choose deliberately or cancel
-  // instead of silently auto-firing the lone affordable action.
-  const shouldShowCastModal = computeShouldShowCastModal(playableActions)
+  // whose only affordable option is an alternative cast (cycling/typecycling/plot) or whose
+  // second price is a keyword alternative cost the server couldn't afford to enumerate
+  // (impending, evoke), so the player still sees the grayed-out sibling and can choose
+  // deliberately or cancel instead of silently auto-firing the lone affordable action.
+  const shouldShowCastModal = computeShouldShowCastModal(playableActions, card)
   const canDragToPlay = (inHand || enableDragToCast) && playableAction && !isInCombatMode && !isInTargetingMode
 
   // What it costs to play this card from a face-up zone (hand or, for Commander, the command zone).

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -597,6 +597,14 @@ export interface ClientCard {
     /** Number of time counters the permanent enters with (e.g. 4). */
     readonly time: number
   } | null
+
+  /**
+   * Evoke alternative cost (CR 702.74), present iff the card definition has evoke — e.g. "{2}{U}"
+   * for Mulldrifter. Same job as `impending`: the action menu offers the evoke cast next to the
+   * normal cast in both directions, graying out whichever the player can't pay for, so a card you
+   * can only afford to evoke never casts itself the moment you drag it out.
+   */
+  readonly evoke?: string | null
 }
 
 /** One face of a split-layout card (CR 709). */

--- a/web-client/src/utils/actionOptions.test.ts
+++ b/web-client/src/utils/actionOptions.test.ts
@@ -214,3 +214,86 @@ describe('playLadderOptions', () => {
     expect(playLadderOptions(options)).toEqual([])
   })
 })
+
+describe('buildActionOptions — keyword alternative costs (evoke, impending)', () => {
+  const mulldrifter = card('{4}{U}', { name: 'Mulldrifter', evoke: '{2}{U}' } as Partial<ClientCard>)
+
+  it('offers the evoke price next to the printed one when only evoke is affordable', () => {
+    // The server enumerates only the casts it can pay for, so an unaffordable hard cast arrives as
+    // nothing at all. Before this, that left one option and the drag-to-play path fired it — you
+    // evoked a Mulldrifter you meant to hard-cast, and sacrificed it, without being asked.
+    const options = buildActionOptions(mulldrifter, [
+      action({
+        action: { type: 'CastSpell', alternativeCostType: 'EVOKE' },
+        actionType: 'CastWithAlternativeCost',
+        description: 'Evoke Mulldrifter ({2}{U})',
+        manaCostString: '{2}{U}',
+      }),
+    ])
+    expect(options.map((o) => o.key)).toEqual(['cast', 'evoke'])
+    expect(options[0]).toMatchObject({ label: 'Cast Mulldrifter', manaCost: '{4}{U}', isAvailable: false, action: null })
+    expect(options[1]).toMatchObject({ label: 'Evoke Mulldrifter', manaCost: '{2}{U}', isAvailable: true })
+    expect(options[1]!.hint).toContain('sacrificed')
+  })
+
+  it('offers the evoke price grayed out when only the hard cast is affordable', () => {
+    // The other direction: seven lands and no evoke action enumerated (it is affordable too, but a
+    // server that omits it must not cost the player the choice).
+    const options = buildActionOptions(mulldrifter, [
+      action({ manaCostString: '{4}{U}' }),
+    ])
+    expect(options.map((o) => o.key)).toEqual(['cast', 'evoke'])
+    expect(options[0]).toMatchObject({ isAvailable: true })
+    expect(options[1]).toMatchObject({ label: 'Evoke Mulldrifter', manaCost: '{2}{U}', isAvailable: false, action: null })
+  })
+
+  it('wires both cast actions to their own option when the player can afford either', () => {
+    const options = buildActionOptions(mulldrifter, [
+      action({ manaCostString: '{4}{U}' }),
+      action({
+        action: { type: 'CastSpell', alternativeCostType: 'EVOKE' },
+        actionType: 'CastWithAlternativeCost',
+        description: 'Evoke Mulldrifter ({2}{U})',
+        manaCostString: '{2}{U}',
+      }),
+    ])
+    expect(options.map((o) => o.key)).toEqual(['cast', 'evoke'])
+    expect(options.every((o) => o.isAvailable && o.action !== null)).toBe(true)
+  })
+
+  it('still pairs impending with the printed cost, keeping its time-counter glyph', () => {
+    const overlord = card('{5}{W}{W}', {
+      name: 'Overlord of the Mistmoors',
+      impending: { cost: '{2}{W}{W}', time: 4 },
+    } as Partial<ClientCard>)
+    const options = buildActionOptions(overlord, [
+      action({
+        action: { type: 'CastSpell', alternativeCostType: 'IMPENDING' },
+        actionType: 'CastWithAlternativeCost',
+        description: 'Impending Overlord of the Mistmoors ({2}{W}{W})',
+        manaCostString: '{2}{W}{W}',
+      }),
+    ])
+    expect(options.map((o) => o.key)).toEqual(['cast', 'impending'])
+    expect(options[1]).toMatchObject({ label: 'Cast for Impending', manaCost: '{2}{W}{W}', impendingTime: 4 })
+  })
+
+  it('keeps any further cost variant the server offered alongside the pair', () => {
+    const options = buildActionOptions(mulldrifter, [
+      action({ manaCostString: '{4}{U}' }),
+      action({
+        action: { type: 'CastSpell', alternativeCostType: 'EVOKE' },
+        actionType: 'CastWithAlternativeCost',
+        description: 'Evoke Mulldrifter ({2}{U})',
+        manaCostString: '{2}{U}',
+      }),
+      action({
+        action: { type: 'CastSpell', alternativeCostType: 'GRANTED' },
+        actionType: 'CastWithAlternativeCost',
+        description: 'Cast Mulldrifter (Omniscience)',
+        manaCostString: '{0}',
+      }),
+    ])
+    expect(options.map((o) => o.key)).toEqual(['cast', 'evoke', 'cast-extra-0'])
+  })
+})

--- a/web-client/src/utils/actionOptions.ts
+++ b/web-client/src/utils/actionOptions.ts
@@ -198,6 +198,63 @@ function reductionHintFor(action: LegalActionInfo): { hint: string } | null {
 }
 
 /**
+ * A keyword alternative cost the *player* chooses when casting — impending (CR 702.176) and evoke
+ * (CR 702.74). Both read "you may cast this card by paying [cost] rather than paying its mana
+ * cost", which makes the printed cost and the keyword cost two live prices for the same card, not
+ * a price and a fallback.
+ *
+ * That is why the cost lives on [ClientCard] and not just in `legalActions`: the server enumerates
+ * only the casts it can *afford*, so the side the player can't pay for arrives as nothing at all.
+ * Building the button off the card lets the menu show both prices and gray out the unpayable one —
+ * and, just as importantly, stops the drag-to-play path from silently firing the lone affordable
+ * cast (see `shouldShowCastModal`). Evoking a Mulldrifter you meant to hard-cast is not a choice
+ * the player should make by accident.
+ */
+export interface KeywordAlternativeCost {
+  /** Option key, also the discriminator the tests and the menu identify the row by. */
+  readonly key: 'impending' | 'evoke'
+  /** Button label. */
+  readonly label: string
+  /** The alternative mana cost, e.g. "{2}{U}". */
+  readonly cost: string
+  /** `CastSpell.alternativeCostType` naming this cast on the server side. */
+  readonly alternativeCostType: string
+  /** One short line under the label saying what paying this cost does to you. */
+  readonly hint?: string
+  /** Impending only: time counters the permanent enters with, rendered as a glyph. */
+  readonly impendingTime?: number
+}
+
+/**
+ * The keyword alternative cost this card offers, or null when it has none. At most one: no printed
+ * card carries two of these keywords, and a second one would need its own row rather than a
+ * different shape of this one.
+ */
+export function keywordAlternativeCostFor(cardInfo: ClientCard): KeywordAlternativeCost | null {
+  if (cardInfo.impending) {
+    return {
+      key: 'impending',
+      label: 'Cast for Impending',
+      cost: cardInfo.impending.cost,
+      alternativeCostType: 'IMPENDING',
+      impendingTime: cardInfo.impending.time,
+    }
+  }
+  if (cardInfo.evoke) {
+    return {
+      key: 'evoke',
+      label: `Evoke ${cardInfo.name}`,
+      cost: cardInfo.evoke,
+      alternativeCostType: 'EVOKE',
+      // The sacrifice is the whole point of the cheaper price, and it is the half a player who
+      // dragged the card out to hard-cast it needs to see before clicking.
+      hint: 'evoke — sacrificed as it enters, keeping only its ETB',
+    }
+  }
+  return null
+}
+
+/**
  * Build all potential action options for a card from server-sent legal actions.
  * The server sends ALL potential actions with isAffordable flags.
  */
@@ -207,6 +264,8 @@ export function buildActionOptions(
 ): ActionOption[] {
   const options: ActionOption[] = []
   if (!cardInfo) return options
+
+  const keywordAltCost = keywordAlternativeCostFor(cardInfo)
 
   // Find each type of action - server sends all potential actions with isAffordable flag
   const castActions = legalActions.filter(
@@ -250,15 +309,15 @@ export function buildActionOptions(
         actionType: 'cast',
       })
     })
-  } else if (cardInfo.impending && castActions.length > 0) {
-    // 1a-bis. Impending (CR 702.176) — an alternative cost the player chooses, so always present
-    // BOTH the normal cast and the impending cast, graying out whichever can't be paid for. The
-    // impending option is marked with a time-counter glyph (the card enters with `time` time
-    // counters and isn't a creature until the last is removed). The server only emits the cast
-    // actions it can afford; we synthesize a disabled placeholder (action: null) for the other.
-    const impendingInfo = cardInfo.impending
-    const impendingCast = castActions.find(
-      (a) => (a.action as { alternativeCostType?: string }).alternativeCostType === 'IMPENDING'
+  } else if (keywordAltCost && castActions.length > 0) {
+    // 1a-bis. A keyword alternative cost the player chooses — impending (CR 702.176), evoke
+    // (CR 702.74). Both mean "you may cast this for <cost> rather than its mana cost", so the menu
+    // presents BOTH the normal cast and the alternative every time, graying out whichever can't be
+    // paid. The server only emits the cast actions it can afford, so whichever side it left out is
+    // synthesized here as a disabled placeholder (action: null) — the alternative's cost comes off
+    // the card rather than off a legal action for exactly that reason.
+    const altCast = castActions.find(
+      (a) => (a.action as { alternativeCostType?: string }).alternativeCostType === keywordAltCost.alternativeCostType
     ) ?? null
     const normalCast = castActions.find((a) => a.actionType === 'CastSpell') ?? null
 
@@ -282,30 +341,32 @@ export function buildActionOptions(
           }
     )
     options.push(
-      impendingCast
+      altCast
         ? {
-            key: 'impending',
-            label: 'Cast for Impending',
-            ...costFieldsFor(impendingCast, impendingInfo.cost),
-            isAvailable: impendingCast.isAffordable !== false,
-            action: impendingCast,
+            key: keywordAltCost.key,
+            label: keywordAltCost.label,
+            ...costFieldsFor(altCast, keywordAltCost.cost),
+            ...(keywordAltCost.hint ? { hint: keywordAltCost.hint } : {}),
+            isAvailable: altCast.isAffordable !== false,
+            action: altCast,
             actionType: 'cast',
-            impendingTime: impendingInfo.time,
+            ...(keywordAltCost.impendingTime !== undefined ? { impendingTime: keywordAltCost.impendingTime } : {}),
           }
         : {
-            key: 'impending',
-            label: 'Cast for Impending',
-            manaCost: impendingInfo.cost || null,
+            key: keywordAltCost.key,
+            label: keywordAltCost.label,
+            manaCost: keywordAltCost.cost || null,
+            ...(keywordAltCost.hint ? { hint: keywordAltCost.hint } : {}),
             isAvailable: false,
             action: null,
             actionType: 'cast',
-            impendingTime: impendingInfo.time,
+            ...(keywordAltCost.impendingTime !== undefined ? { impendingTime: keywordAltCost.impendingTime } : {}),
           }
     )
     // Any further cost variant the server offered (e.g. a gift promise per opponent — CR 702.174a)
     // has to survive this branch too, or picking impending's sibling silently drops the option.
     castActions
-      .filter((ca) => ca !== normalCast && ca !== impendingCast)
+      .filter((ca) => ca !== normalCast && ca !== altCast)
       .forEach((ca, index) => {
         options.push({
           key: `cast-extra-${index}`,


### PR DESCRIPTION
## The bug

Evoke (CR 702.74) means *"you may cast this card by paying [cost] rather than paying its mana cost"* — the printed cost and the evoke cost are two live prices for the same card.

`CastSpellEnumerator` only emits the casts the player can currently **afford**. So a Mulldrifter in hand on five lands arrives with exactly one legal action: the evoke cast. That gave the action menu a single option, and `shouldShowCastModal` returned `false` for it — so dragging the card out of hand **cast it for its evoke cost on the spot and sacrificed the creature**, with no choice offered and no way to cancel.

## The fix

Impending (CR 702.176) already solved this, as a hand-written branch in `buildActionOptions`. Evoke is the second user, so the pair generalizes:

- **`keywordAlternativeCostFor(card)`** (`utils/actionOptions.ts`) turns whichever keyword the card carries into the label, cost, hint and `alternativeCostType` the one branch needs. At most one per card.
- **`buildActionOptions`** always draws *both* buttons and grays out the one that can't be paid, synthesizing a disabled placeholder (`action: null`) for the side the server couldn't afford to enumerate. The alternative's cost has to come off the *card* rather than off a legal action for exactly that reason, so `ClientCard` gains `evoke` beside `impending`.
- **`shouldShowCastModal`** reads the same helper, which is what actually closes the drag-to-play path — in **both** directions: a card whose only enumerated cast is the hard one must still show the evoke button, grayed or not. This fixes impending's drag path too; it had the same hole.

The evoke button carries a hint line — *"evoke — sacrificed as it enters, keeping only its ETB"* — since the sacrifice is the whole point of the cheaper price and the half a player who meant to hard-cast needs to see before clicking.

## Files

| Layer | Change |
|---|---|
| `ClientDTO.kt` / `ClientStateTransformer.kt` | `ClientCard.evoke: String?` — the evoke cost, in every zone, intrinsic to the card definition |
| `types/gameState.ts` | matching `readonly evoke?: string \| null` |
| `utils/actionOptions.ts` | `KeywordAlternativeCost` + `keywordAlternativeCostFor`; the impending branch generalized to both keywords |
| `board/shared.ts` | `shouldShowCastModal(actions, cardInfo?)` — a keyword alt cost plus any `CastSpell` opens the menu |
| `card/GameCard.tsx` | passes `card` through |
| `docs/web-client-architecture.md` | the rule, in the "what does this cost?" section |

## Verification

- `npm run typecheck` — clean
- `npx vitest run` — **781 passed / 54 files**, including 5 new `buildActionOptions` cases (evoke-only, hard-cast-only, both affordable, impending regression, extra cost variant survives) and 5 new `shouldShowCastModal` cases
- `just test-class EvokeClientViewTest` — 3 new engine cases pass (Mulldrifter `{2}{U}`, Ingot Chewer `{R}`, Grizzly Bears null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)