### PR TITLE
Complete the decision-response completeness checks

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -142,19 +142,26 @@ class DecisionResponder(
             return bestResponse
         }
 
-        // Multi-target: simulate the best target for each requirement independently
+        // Multi-target: simulate the best target for each requirement independently. Every probe
+        // still has to be a *complete* answer to the decision — `DecisionValidators.validateTargets`
+        // rejects a response that leaves a mandatory requirement out, and a rejected probe comes
+        // back as `SimulationResult.Illegal` carrying the unchanged state, so every candidate would
+        // score identically: the pick would collapse to "the first legal target", and the optional
+        // pick-vs-skip comparison below would tie and always skip. Varying one requirement against a
+        // fixed baseline for the others keeps the comparison meaningful.
+        val baseline = minimalCompleteSelection(decision)
         val selected = decision.targetRequirements.associate { req ->
             val targets = decision.legalTargets[req.index] ?: emptyList()
             if (targets.isEmpty()) {
                 req.index to emptyList()
             } else {
                 val best = pickBestBySimulation(state, targets.take(maxCandidates), playerId) { target ->
-                    TargetsResponse(decision.id, mapOf(req.index to listOf(target)))
+                    TargetsResponse(decision.id, baseline + (req.index to listOf(target)))
                 }
                 // For optional targets, compare best pick against skipping
                 if (req.minTargets == 0) {
-                    val pickResponse = TargetsResponse(decision.id, mapOf(req.index to listOf(best)))
-                    val skipResponse = TargetsResponse(decision.id, mapOf(req.index to emptyList()))
+                    val pickResponse = TargetsResponse(decision.id, baseline + (req.index to listOf(best)))
+                    val skipResponse = TargetsResponse(decision.id, baseline + (req.index to emptyList()))
                     val pickScore = evaluateResult(simulator.simulateDecision(state, pickResponse), playerId)
                     val skipScore = evaluateResult(simulator.simulateDecision(state, skipResponse), playerId)
                     if (skipScore >= pickScore) req.index to emptyList()
@@ -765,11 +772,22 @@ class DecisionResponder(
         } ?: candidates.first()
     }
 
-    private fun cancelOrFirst(decision: ChooseTargetsDecision): DecisionResponse {
-        if (decision.canCancel) return CancelDecisionResponse(decision.id)
-        val selected = decision.targetRequirements.associate { req ->
+    /**
+     * The cheapest *complete* answer to [decision]: every declared requirement filled to its
+     * minimum from the targets that are legal for it, optional ones left empty.
+     *
+     * Completeness is the point. `DecisionValidators.validateTargets` rejects a response that omits
+     * a mandatory requirement, so a partial map is not a weaker answer but an illegal one — which
+     * is why this doubles as the fixed background a per-requirement probe varies one slot against.
+     */
+    internal fun minimalCompleteSelection(decision: ChooseTargetsDecision): Map<Int, List<EntityId>> =
+        decision.targetRequirements.associate { req ->
             req.index to (decision.legalTargets[req.index] ?: emptyList()).take(req.minTargets)
         }
+
+    private fun cancelOrFirst(decision: ChooseTargetsDecision): DecisionResponse {
+        if (decision.canCancel) return CancelDecisionResponse(decision.id)
+        val selected = minimalCompleteSelection(decision)
         return TargetsResponse(decision.id, selected)
     }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/llm/decision/handlers/ChooseTargetsHandler.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/llm/decision/handlers/ChooseTargetsHandler.kt
@@ -90,7 +90,12 @@ class ChooseTargetsHandler : AiDecisionHandler<ChooseTargetsDecision> {
                         result[req.index] = listOf(validTargets[index])
                     }
                 }
-                if (result.isNotEmpty()) {
+                // Every requirement or none: a partial map is not a parse, it's an unanswerable
+                // response. `DecisionValidators.validateTargets` rejects a mandatory requirement
+                // left out, and the controller only falls back to the engine AI when parsing
+                // returns null — so a partial answer would be submitted, rejected, and never
+                // retried, wedging the game on a decision no one answers.
+                if (result.size == decision.targetRequirements.size) {
                     TargetsResponse(decisionId = decision.id, selectedTargets = result)
                 } else null
             }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/DecisionResponderTargetProbeTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/DecisionResponderTargetProbeTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * The multi-requirement target responder scores one requirement at a time by simulating a candidate
+ * response. Those probes have to be *complete* answers to the decision: `validateTargets` rejects a
+ * response that leaves a mandatory requirement out, a rejected probe comes back as
+ * `SimulationResult.Illegal` carrying the unchanged state, and every candidate then scores
+ * identically — the pick silently collapses to "the first legal target", and the optional
+ * pick-vs-skip comparison ties and always skips.
+ *
+ * So the property under test is the probe's *shape*, checked against the validator that judges it.
+ */
+class DecisionResponderTargetProbeTest : FunSpec({
+
+    val player = EntityId.of("player")
+    val creature = EntityId.of("creature")
+    val other = EntityId.of("other")
+
+    val responder = DecisionResponder(GameSimulator(CardRegistry()), AIPlayer.defaultEvaluator())
+
+    val decision = ChooseTargetsDecision(
+        id = "two-requirements",
+        playerId = player,
+        prompt = "Choose targets",
+        context = DecisionContext(phase = DecisionPhase.RESOLUTION),
+        targetRequirements = listOf(
+            TargetRequirementInfo(index = 0, description = "target creature"),
+            TargetRequirementInfo(index = 1, description = "up to one target creature", minTargets = 0),
+        ),
+        legalTargets = mapOf(0 to listOf(creature), 1 to listOf(other)),
+    )
+
+    test("a probe varying one requirement still answers the others") {
+        val baseline = responder.minimalCompleteSelection(decision)
+
+        // What the responder simulates for each candidate of requirement 1 — including the "pick
+        // nothing" probe that decides whether an optional slot is worth filling.
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, baseline + (1 to listOf(other))),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, baseline + (1 to emptyList())),
+        ).shouldBeNull()
+    }
+
+    test("varying a requirement on its own is not a submittable response") {
+        // The shape the probes used to have. It names only legal targets, so nothing about it is
+        // wrong except that requirement 0 goes unanswered.
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(1 to listOf(other))),
+        ).shouldNotBeNull()
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/llm/decision/handlers/ChooseTargetsHandlerCompletenessTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/llm/decision/handlers/ChooseTargetsHandlerCompletenessTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.ai.llm.decision.handlers
+
+import com.wingedsheep.ai.llm.AiResponseParser
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The LLM controller falls back to the engine AI when a handler's `parse` returns null. Anything it
+ * returns instead is submitted as-is — and `DecisionValidators.validateTargets` rejects a response
+ * that leaves a mandatory requirement out. A partial map is therefore not a best-effort answer but a
+ * decision nobody ever answers: rejected by the server, no fallback, no retry.
+ */
+class ChooseTargetsHandlerCompletenessTest : FunSpec({
+
+    val handler = ChooseTargetsHandler()
+    val parser = AiResponseParser()
+
+    val allCards = PortalSet.cards + PortalSet.basicLands
+    val driver = GameTestDriver().apply {
+        registerCards(allCards)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+    val state = ClientStateTransformer(driver.cardRegistry).transform(driver.state, driver.player1)
+
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+
+    fun decision(legalTargets: Map<Int, List<EntityId>>) = ChooseTargetsDecision(
+        id = "two-requirements",
+        playerId = driver.player1,
+        prompt = "Choose targets",
+        context = DecisionContext(phase = DecisionPhase.RESOLUTION),
+        targetRequirements = listOf(
+            TargetRequirementInfo(index = 0, description = "target creature"),
+            TargetRequirementInfo(index = 1, description = "target creature"),
+        ),
+        legalTargets = legalTargets,
+    )
+
+    test("a single letter answers both requirements when both can be answered") {
+        val decision = decision(mapOf(0 to listOf(first, second), 1 to listOf(first, second)))
+
+        val response = handler.parse("A", decision, state, parser) as TargetsResponse
+
+        response.selectedTargets shouldBe mapOf(0 to listOf(first), 1 to listOf(first))
+    }
+
+    test("a response that can only answer one of two requirements is not a parse") {
+        // Requirement 1 has no legal-target list to resolve a letter against, so the fallback can
+        // only fill requirement 0. Returning that half answer would wedge the decision; returning
+        // null hands it to the engine AI instead.
+        val decision = decision(mapOf(0 to listOf(first, second)))
+
+        handler.parse("A", decision, state, parser).shouldBeNull()
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -182,6 +182,8 @@ object DecisionValidators {
             return "Expected target selection response"
         }
 
+        // Legality and per-requirement duplicates are checked against what was actually submitted:
+        // a group the decision never declared still can't name a target that isn't legal for it.
         for ((reqIndex, selectedIds) in response.selectedTargets) {
             val legalForReq = decision.legalTargets[reqIndex] ?: emptyList()
             for (id in selectedIds) {
@@ -195,68 +197,65 @@ object DecisionValidators {
             if (selectedIds.size != selectedIds.toSet().size) {
                 return "The same target can't be chosen more than once for requirement $reqIndex"
             }
+        }
 
-            val req = decision.targetRequirements.find { it.index == reqIndex }
-            if (req != null) {
-                if (selectedIds.size < req.minTargets) {
-                    return "Not enough targets for requirement $reqIndex: need at least ${req.minTargets}"
+        // Every *declared* requirement is then checked against the group that answered it, so the
+        // counts and the aggregate restrictions are driven by the decision rather than by whatever
+        // the response happened to contain. An omitted group is an empty selection for its
+        // requirement, not a way to bypass its minimum — which is what lets an optional group
+        // (`minTargets == 0`) stay absent while a mandatory one can't.
+        for (req in decision.targetRequirements) {
+            val selectedIds = response.selectedTargets[req.index] ?: emptyList()
+            val reqIndex = req.index
+            if (selectedIds.size < req.minTargets) {
+                return "Not enough targets for requirement $reqIndex: need at least ${req.minTargets}"
+            }
+            if (selectedIds.size > req.maxTargets) {
+                return "Too many targets for requirement $reqIndex: maximum is ${req.maxTargets}"
+            }
+            // "... from a single graveyard" — every chosen card target must share an owner.
+            if (req.sameOwner && selectedIds.size > 1 && state != null) {
+                val owners = selectedIds.mapNotNull { id ->
+                    state.getEntity(id)?.get<OwnerComponent>()?.playerId
                 }
-                if (selectedIds.size > req.maxTargets) {
-                    return "Too many targets for requirement $reqIndex: maximum is ${req.maxTargets}"
-                }
-                // "... from a single graveyard" — every chosen card target must share an owner.
-                if (req.sameOwner && selectedIds.size > 1 && state != null) {
-                    val owners = selectedIds.mapNotNull { id ->
-                        state.getEntity(id)?.get<OwnerComponent>()?.playerId
-                    }
-                    if (owners.toSet().size > 1) {
-                        return "Targets for requirement $reqIndex must be from a single graveyard"
-                    }
-                }
-                // "... with total mana value N or less" — the summed mana value of the chosen card
-                // targets may not exceed the resolved cap (Fire Lord Sozin's "total mana value X or
-                // less"; the cap was baked to a concrete int at decision-build time). CR 601.2c.
-                val manaCap = req.totalManaValueAtMost
-                if (manaCap != null && state != null) {
-                    val totalManaValue = selectedIds.sumOf { id ->
-                        state.getEntity(id)?.get<CardComponent>()?.manaValue ?: 0
-                    }
-                    if (totalManaValue > manaCap) {
-                        return "Targets for requirement $reqIndex exceed total mana value $manaCap"
-                    }
-                }
-                // "... with different names" — no two chosen targets may share a name (Behold the
-                // Sinister Six!). TargetValidator is authoritative; this rejects it interactively too.
-                if (req.differentNames && selectedIds.size > 1 && state != null) {
-                    val names = selectedIds.map { id ->
-                        state.projectedState.getName(id) ?: state.getEntity(id)?.get<CardComponent>()?.name
-                    }
-                    if (names.size != names.toSet().size) {
-                        return "Targets for requirement $reqIndex must have different names"
-                    }
-                }
-                // "For each other player, ... up to one target creature that player controls" — no
-                // two chosen targets may share a controller (Kaya, Spirits' Justice). TargetValidator
-                // is authoritative; this rejects it interactively too.
-                if (req.differentControllers && selectedIds.size > 1 && state != null) {
-                    val controllers = selectedIds.map { id ->
-                        state.projectedState.getController(id)
-                            ?: state.getEntity(id)?.get<ControllerComponent>()?.playerId
-                    }
-                    if (controllers.size != controllers.toSet().size) {
-                        return "Targets for requirement $reqIndex must be controlled by different players"
-                    }
+                if (owners.toSet().size > 1) {
+                    return "Targets for requirement $reqIndex must be from a single graveyard"
                 }
             }
-        }
-
-        // Omitting a requirement is an empty selection for that group, not a way to bypass its
-        // minimum. Optional target groups may still be absent from the response.
-        val omittedRequired = decision.targetRequirements.firstOrNull { req ->
-            req.minTargets > 0 && req.index !in response.selectedTargets
-        }
-        if (omittedRequired != null) {
-            return "Not enough targets for requirement ${omittedRequired.index}: need at least ${omittedRequired.minTargets}"
+            // "... with total mana value N or less" — the summed mana value of the chosen card
+            // targets may not exceed the resolved cap (Fire Lord Sozin's "total mana value X or
+            // less"; the cap was baked to a concrete int at decision-build time). CR 601.2c.
+            val manaCap = req.totalManaValueAtMost
+            if (manaCap != null && state != null) {
+                val totalManaValue = selectedIds.sumOf { id ->
+                    state.getEntity(id)?.get<CardComponent>()?.manaValue ?: 0
+                }
+                if (totalManaValue > manaCap) {
+                    return "Targets for requirement $reqIndex exceed total mana value $manaCap"
+                }
+            }
+            // "... with different names" — no two chosen targets may share a name (Behold the
+            // Sinister Six!). TargetValidator is authoritative; this rejects it interactively too.
+            if (req.differentNames && selectedIds.size > 1 && state != null) {
+                val names = selectedIds.map { id ->
+                    state.projectedState.getName(id) ?: state.getEntity(id)?.get<CardComponent>()?.name
+                }
+                if (names.size != names.toSet().size) {
+                    return "Targets for requirement $reqIndex must have different names"
+                }
+            }
+            // "For each other player, ... up to one target creature that player controls" — no
+            // two chosen targets may share a controller (Kaya, Spirits' Justice). TargetValidator
+            // is authoritative; this rejects it interactively too.
+            if (req.differentControllers && selectedIds.size > 1 && state != null) {
+                val controllers = selectedIds.map { id ->
+                    state.projectedState.getController(id)
+                        ?: state.getEntity(id)?.get<ControllerComponent>()?.playerId
+                }
+                if (controllers.size != controllers.toSet().size) {
+                    return "Targets for requirement $reqIndex must be controlled by different players"
+                }
+            }
         }
         return null
     }
@@ -405,21 +404,32 @@ object DecisionValidators {
         if (response !is OrderedResponse) {
             return "Expected ordering response"
         }
-        if (response.orderedObjects.size != decision.objects.size ||
-            response.orderedObjects.toSet() != decision.objects.toSet()
-        ) {
+        if (!isSameCollection(response.orderedObjects, decision.objects)) {
             return "Ordered objects must contain exactly the same objects as the decision"
         }
         return null
     }
+
+    /**
+     * True when [submitted] holds exactly the objects in [expected] — same count, same contents.
+     *
+     * Both conditions are load-bearing, and set equality alone is not enough: it discards
+     * multiplicity, so a one-object ordering answered with `[first, first]` has the same set as
+     * `[first]`. Comparing sizes as well makes an ordering response a permutation of the decision's
+     * objects — every object, exactly once — while still allowing any legal reordering.
+     */
+    private fun isSameCollection(submitted: List<EntityId>, expected: List<EntityId>): Boolean =
+        submitted.size == expected.size && submitted.toSet() == expected.toSet()
 
     private fun validateSplitPiles(decision: SplitPilesDecision, response: DecisionResponse): String? {
         if (response !is PilesSplitResponse) {
             return "Expected pile split response"
         }
 
-        val allCards = response.piles.flatten().toSet()
-        if (allCards != decision.cards.toSet()) {
+        // Flattened rather than set-compared: a card can't be in two piles at once, so a split that
+        // duplicates one card and drops another has the same set as a legal one (the multiplicity
+        // hole [isSameCollection] closes for orderings).
+        if (!isSameCollection(response.piles.flatten(), decision.cards)) {
             return "Piles must contain exactly the same cards as the decision"
         }
         if (response.piles.size != decision.numberOfPiles) {
@@ -550,13 +560,9 @@ object DecisionValidators {
             return "Expected ordered response for library reorder"
         }
 
-        val expectedSet = decision.cards.toSet()
-        val responseSet = response.orderedObjects.toSet()
-        if (expectedSet != responseSet) {
-            return "Invalid reorder: response must contain the same cards"
-        }
-        if (response.orderedObjects.size != decision.cards.size) {
-            return "Invalid reorder: response must contain exactly ${decision.cards.size} cards"
+        if (!isSameCollection(response.orderedObjects, decision.cards)) {
+            return "Invalid reorder: response must contain exactly the ${decision.cards.size} cards " +
+                "of the decision, each once"
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -249,6 +249,15 @@ object DecisionValidators {
                 }
             }
         }
+
+        // Omitting a requirement is an empty selection for that group, not a way to bypass its
+        // minimum. Optional target groups may still be absent from the response.
+        val omittedRequired = decision.targetRequirements.firstOrNull { req ->
+            req.minTargets > 0 && req.index !in response.selectedTargets
+        }
+        if (omittedRequired != null) {
+            return "Not enough targets for requirement ${omittedRequired.index}: need at least ${omittedRequired.minTargets}"
+        }
         return null
     }
 
@@ -396,7 +405,9 @@ object DecisionValidators {
         if (response !is OrderedResponse) {
             return "Expected ordering response"
         }
-        if (response.orderedObjects.toSet() != decision.objects.toSet()) {
+        if (response.orderedObjects.size != decision.objects.size ||
+            response.orderedObjects.toSet() != decision.objects.toSet()
+        ) {
             return "Ordered objects must contain exactly the same objects as the decision"
         }
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -182,9 +182,14 @@ object DecisionValidators {
             return "Expected target selection response"
         }
 
-        // Legality and per-requirement duplicates are checked against what was actually submitted:
-        // a group the decision never declared still can't name a target that isn't legal for it.
+        // Legality and per-requirement duplicates are checked against what was actually submitted.
+        // A group keyed to a requirement the decision never declared is the mirror of an omitted
+        // one: the counts below iterate the *declared* requirements, so an undeclared group is
+        // never reached by them and an empty one would slip through unexamined.
         for ((reqIndex, selectedIds) in response.selectedTargets) {
+            if (decision.targetRequirements.none { it.index == reqIndex }) {
+                return "Unknown target requirement $reqIndex"
+            }
             val legalForReq = decision.legalTargets[reqIndex] ?: emptyList()
             for (id in selectedIds) {
                 if (id !in legalForReq) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
@@ -66,23 +66,46 @@ class DecisionValidatorsCompletenessTest : FunSpec({
         ).shouldNotBeNull()
     }
 
-    test("ordering response contains every object exactly once") {
+    test("a target group keyed to a requirement the decision never declared is rejected") {
+        // The mirror of an omitted group. The count checks walk the declared requirements, so an
+        // undeclared group is never reached by them — an empty one would otherwise pass unexamined.
+        val decision = targetDecision()
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(0 to listOf(first), 2 to emptyList())),
+        ).shouldNotBeNull()
+    }
+
+    test("ordering response is any permutation of the objects, each exactly once") {
         val decision = OrderObjectsDecision(
             id = "order",
             playerId = player,
             prompt = "Order",
             context = context,
-            objects = listOf(first),
+            objects = listOf(first, second),
         )
 
+        // Reordering is the whole point of the decision, so both orders have to be accepted.
         DecisionValidators.validate(
             decision,
-            OrderedResponse(decision.id, listOf(first)),
+            OrderedResponse(decision.id, listOf(first, second)),
         ).shouldBeNull()
 
         DecisionValidators.validate(
             decision,
+            OrderedResponse(decision.id, listOf(second, first)),
+        ).shouldBeNull()
+
+        // Repeating one object in place of another: same set, wrong contents.
+        DecisionValidators.validate(
+            decision,
             OrderedResponse(decision.id, listOf(first, first)),
+        ).shouldNotBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first)),
         ).shouldNotBeNull()
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
@@ -5,6 +5,9 @@ import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.OrderObjectsDecision
 import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.PilesSplitResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.TargetRequirementInfo
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.sdk.model.EntityId
@@ -12,6 +15,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 
+/**
+ * A response can be *structurally* incomplete without naming a single illegal object: a target group
+ * left out entirely, or a collection that repeats one object in place of another. Set comparisons
+ * can't see either — a set discards both absence-by-omission and multiplicity — so each of these
+ * validators has to count as well as compare.
+ */
 class DecisionValidatorsCompletenessTest : FunSpec({
 
     val player = EntityId.of("player")
@@ -19,18 +28,20 @@ class DecisionValidatorsCompletenessTest : FunSpec({
     val second = EntityId.of("second")
     val context = DecisionContext(phase = DecisionPhase.RESOLUTION)
 
+    fun targetDecision() = ChooseTargetsDecision(
+        id = "targets",
+        playerId = player,
+        prompt = "Choose targets",
+        context = context,
+        targetRequirements = listOf(
+            TargetRequirementInfo(index = 0, description = "mandatory"),
+            TargetRequirementInfo(index = 1, description = "optional", minTargets = 0),
+        ),
+        legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
+    )
+
     test("target response may omit an optional requirement but not a mandatory one") {
-        val decision = ChooseTargetsDecision(
-            id = "targets",
-            playerId = player,
-            prompt = "Choose targets",
-            context = context,
-            targetRequirements = listOf(
-                TargetRequirementInfo(index = 0, description = "mandatory"),
-                TargetRequirementInfo(index = 1, description = "optional", minTargets = 0),
-            ),
-            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
-        )
+        val decision = targetDecision()
 
         DecisionValidators.validate(
             decision,
@@ -40,6 +51,18 @@ class DecisionValidatorsCompletenessTest : FunSpec({
         DecisionValidators.validate(
             decision,
             TargetsResponse(decision.id, emptyMap()),
+        ).shouldNotBeNull()
+    }
+
+    test("a mandatory requirement is missing even when another group answers") {
+        // The sharper case than an empty response: the map is non-empty and every id in it is legal,
+        // so only checking what was submitted sees a well-formed answer. The mandatory group 0 is
+        // still unanswered.
+        val decision = targetDecision()
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(1 to listOf(second))),
         ).shouldNotBeNull()
     }
 
@@ -60,6 +83,51 @@ class DecisionValidatorsCompletenessTest : FunSpec({
         DecisionValidators.validate(
             decision,
             OrderedResponse(decision.id, listOf(first, first)),
+        ).shouldNotBeNull()
+    }
+
+    test("library reorder rejects a repeated card even when every card appears") {
+        val decision = ReorderLibraryDecision(
+            id = "reorder",
+            playerId = player,
+            prompt = "Reorder",
+            context = context,
+            cards = listOf(first, second),
+            cardInfo = emptyMap(),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(second, first)),
+        ).shouldBeNull()
+
+        // Every card of the decision is present, so the sets match; only the count says the
+        // response holds one of them twice.
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first, second, first)),
+        ).shouldNotBeNull()
+    }
+
+    test("pile split rejects a card put in two piles") {
+        // A card can't be in two piles at once, but the pile count and the flattened *set* are both
+        // right when it is — only counting the cards catches it.
+        val decision = SplitPilesDecision(
+            id = "piles",
+            playerId = player,
+            prompt = "Split",
+            context = context,
+            cards = listOf(first, second),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            PilesSplitResponse(decision.id, listOf(listOf(first), listOf(second))),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            PilesSplitResponse(decision.id, listOf(listOf(first, second), listOf(first))),
         ).shouldNotBeNull()
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidatorsCompletenessTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.handlers.actions.decision
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+class DecisionValidatorsCompletenessTest : FunSpec({
+
+    val player = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val context = DecisionContext(phase = DecisionPhase.RESOLUTION)
+
+    test("target response may omit an optional requirement but not a mandatory one") {
+        val decision = ChooseTargetsDecision(
+            id = "targets",
+            playerId = player,
+            prompt = "Choose targets",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "mandatory"),
+                TargetRequirementInfo(index = 1, description = "optional", minTargets = 0),
+            ),
+            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(0 to listOf(first))),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+        ).shouldNotBeNull()
+    }
+
+    test("ordering response contains every object exactly once") {
+        val decision = OrderObjectsDecision(
+            id = "order",
+            playerId = player,
+            prompt = "Order",
+            context = context,
+            objects = listOf(first),
+        )
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first)),
+        ).shouldBeNull()
+
+        DecisionValidators.validate(
+            decision,
+            OrderedResponse(decision.id, listOf(first, first)),
+        ).shouldNotBeNull()
+    }
+})


### PR DESCRIPTION
Carries #2141 (cherry-picked, authored by @huxinq) and fixes what a review of it turned up. Based on `main`, so it can go in on its own; #2141 can then be closed as included.

## What #2141 fixed

- `validateTargets` iterated `response.selectedTargets`, so a mandatory target requirement that was simply absent from the response was never visited. An omitted group is now an empty selection for minimum-count purposes — optional groups (`minTargets == 0`) may still be absent.
- `validateOrder` compared ordering membership as sets, which discards multiplicity, so a one-object decision accepted `[first, first]`. An ordering response must now be a permutation: equal size *and* equal contents.

## What this adds

**The AI's target probes are no longer incomplete responses.** `DecisionResponder.respondTargets` scored a multi-requirement decision one requirement at a time by simulating `mapOf(req.index to listOf(target))` — a response that, after the change above, leaves every other mandatory requirement unanswered. A rejected probe returns `SimulationResult.Illegal` carrying the *unchanged* state (`GameSimulator.kt:134`), so `scoreOrRankLast` gave every candidate the same score: `maxByOrNull` returned the first one, and the optional pick-vs-skip comparison tied — and `skipScore >= pickScore` resolves to skip. Multi-target spells would have silently stopped filling their optional slots. Probes now vary one requirement against a minimal complete baseline, which is the same map `cancelOrFirst` already built inline; that's now the shared `minimalCompleteSelection`.

**`validateSplitPiles` had the same multiplicity hole `validateOrder` just lost.** `response.piles.flatten().toSet() != decision.cards.toSet()` accepts `[[first, second], [first]]` against cards `[first, second]` — one card in two piles, which no split can produce. Both ordering validators and the pile validator now share one `isSameCollection` helper (equal size, equal contents), which is what `validateLibraryReorder` was already doing by hand.

**The LLM `ChooseTargetsHandler` no longer returns a half-parsed answer.** Its fallback branch returned whatever requirements it managed to resolve (`if (result.isNotEmpty())`). `LlmAiPlayerController` falls back to the engine AI only when `parse` returns *null*, so a partial map would be submitted, rejected by the validator, and never retried — the wedged-game shape `SimulationResult.kt:64-69` warns about, which `GameStallGuard` can't see because nothing is ever submitted. It's all requirements or null.

**`validateTargets` reads the requirements, not the response.** The per-requirement counts and aggregate restrictions now iterate `decision.targetRequirements` with `response.selectedTargets[req.index] ?: emptyList()`, so the omitted-group case falls out of the existing minimum check instead of being restated after the loop with a duplicate message. Legality and per-requirement duplicates still iterate the response, so a group the decision never declared still can't name an illegal target.

**A group the decision never declared is rejected too.** That is the mirror of an omitted group: because the counts iterate the declared requirements, an undeclared key is never reached by them, so an empty one passed unexamined (a non-empty one was caught only incidentally, by the legality check finding nothing legal under that key). `validateTargets` now rejects an unknown requirement index outright.

## Tests

`DecisionValidatorsCompletenessTest` (rules-engine) keeps #2141's two cases and adds four:

- a mandatory requirement omitted while an *optional* group answers — a non-empty, entirely-legal response that is still incomplete;
- a library reorder repeating one card while every card appears (equal sets, unequal counts);
- a pile split putting one card in two piles (equal sets, right pile count);
- a target group keyed to a requirement the decision never declared.

The ordering case now uses two objects rather than one: a single-object decision can't distinguish "any permutation is accepted" from "only the original order is accepted", which is exactly the property the size-plus-set check has to preserve.

`DecisionResponderTargetProbeTest` (ai) pins the probe *shape* against the validator that judges it: a probe built from the baseline is accepted, the old one-requirement shape is not.

`ChooseTargetsHandlerCompletenessTest` (ai) covers both halves of the parse: a single letter that can answer both requirements does, and one that can only answer one returns null.

## Verification

- `just test-rules` — green (engine tests + every card scenario)
- `just test-ai` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
