### PR TITLE
Unify card identity visibility

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -117,15 +117,10 @@ class Determinizer(
         viewerId: EntityId,
     ): List<EntityId> {
         val handKey = ZoneKey(opponentId, Zone.HAND)
-        val handHidden = !visibility.isZoneVisibleTo(state, handKey, viewerId)
-        val candidates = buildList {
-            addAll(state.getLibrary(opponentId))
-            if (handHidden) addAll(state.getHand(opponentId))
-        }
-        val visibleTop = state.getLibrary(opponentId).firstOrNull()?.takeIf {
-            visibility.revealsTopOfLibraryPublicly(state, opponentId) ||
-                (opponentId == viewerId && visibility.hasLookAtTopOfLibrary(state, viewerId))
-        }
+        val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
+        val library = state.getLibrary(opponentId)
+        val hand = state.getHand(opponentId)
+        val candidates = library + hand
         val referencedByStack = state.stack.flatMapTo(mutableSetOf()) { stackId ->
             state.getEntity(stackId)?.get<TargetsComponent>()?.targets.orEmpty().mapNotNull {
                 when (it) {
@@ -137,13 +132,13 @@ class Determinizer(
             }
         }
         return candidates.filter { id ->
-            id != visibleTop &&
+            val zoneKey = if (id in library) libraryKey else handKey
+            !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&
                 id !in referencedByStack &&
                 // Continuation frames carry entity references in several different shapes.
                 // Quiet search roots normally have none; pinning while one exists is the safe
                 // fallback until those shapes share a common reference visitor.
                 state.continuationStack.isEmpty() &&
-                !visibility.isCardRevealedTo(state, id, viewerId) &&
                 isSafeToRewrite(state.getEntity(id))
         }
     }

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -165,12 +165,13 @@ every candidate. Sampling before the one-ply simulation matters because pending 
 by that simulation can inspect hidden zones too. Sharing the world is essential: independently
 sampling candidates would make hidden-information variance look like move quality.
 
-`Visibility` in `rules-engine/view` is the common oracle for both client masking and AI
-determinization. The determinizer rewrites identities, never entities: entity IDs, zone membership,
-pending decisions, targets and continuations remain intact. Individually revealed cards and cards
-carrying runtime state are pinned. With a known decklist it samples from `decklist − seen`;
-otherwise it permutes the existing hidden multiset. That fallback removes exact hand and
-library-order knowledge, but remains “cheating-lite” because it knows which cards exist unseen.
+`Visibility` in `rules-engine/view` is the common identity oracle for client masking, Gym
+observations, and AI determinization. The determinizer rewrites identities, never entities: entity
+IDs, zone membership, pending decisions, targets and continuations remain intact. Individually
+revealed cards and cards carrying runtime state are pinned. With a known decklist it samples from
+`decklist − seen`; otherwise it permutes the existing hidden multiset. That fallback removes exact
+hand and library-order knowledge, but remains “cheating-lite” because it knows which cards exist
+unseen.
 
 Phase 8 starts with one shared determinization per search. More worlds compete directly with rollout
 count, so raising K requires an arena result showing it buys more strength at the same wall-clock

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1193,20 +1193,24 @@ The server's responsibilities are strictly limited to:
 
 ### 3.2 State Masking (Fog of War)
 
-Hidden-zone visibility is centralized in `rules-engine/view/Visibility`. Both
-`ClientStateTransformer` and the engine AI's determinizer consume it, so a reveal effect cannot be
-visible to the client while remaining hidden from the AI (or vice versa). Consumers must not
-reimplement hand, library, teammate, turn-control, or individually-revealed-card rules.
+Card-identity visibility is centralized in `rules-engine/view/Visibility`.
+`ClientStateTransformer`, server decision presentation, the engine AI's determinizer, and Gym
+observations consume it, so a reveal effect cannot be visible to one perspective consumer while
+remaining hidden from another.
+Consumers must not reimplement hand, library, teammate, turn-control, individual-reveal,
+top-of-library, or face-down identity rules. They remain free to encode the shared answer
+differently: for example, the client retains opaque library slots while Gym reports a size plus the
+known subset.
 
 **Principle:** Each player sees a filtered view of the game state.
 
 In Magic, players cannot see each other's hands or libraries. The `ClientStateTransformer` produces a
 per-player view of the state that hides private information:
 
-- **Libraries:** Always hidden — only the count is visible
+- **Libraries:** The zone remains hidden, but an explicitly known top/individual card may have details
 - **Opponent's hand:** Only the count is visible, not the card identities
-- **Face-down cards:** Show as generic "Card back" to all players (even the controller cannot see
-  the identity in the masked view — only when they choose to interact)
+- **Face-down cards:** Show public face-down characteristics while the underlying identity is shown
+  only to a player entitled to look at it
 - **Revealed cards:** `RevealedToComponent` overrides hiding for cards that have been explicitly revealed
 - **Revealed / returned hand cards:** A card revealed *into* a hand, or returned to a hand from a public
   zone (battlefield, graveyard, the stack), stays visible to opponents until its owner *plays* a card with

--- a/docs/gym-self-play-testing.md
+++ b/docs/gym-self-play-testing.md
@@ -64,8 +64,9 @@ Key config fields:
   `{"type":"RandomSealed","setCode":"BLB","boosterCount":8}` (needs the set's basic-land variants
   registered).
 - **`revealAll: true`** — set this for self-play. Normally observations hide the opponent's hand and
-  libraries; since one agent is playing *both* seats, you want to see everything. (Never use it for
-  real RL self-play — it leaks information.)
+  libraries except for identities the current perspective is entitled to know; since one agent is
+  playing *both* seats, you want to see everything. (Never use it for real RL self-play — it leaks
+  information.)
 - **`skipMulligans: true`** — skip the mulligan back-and-forth.
 - `startingPlayerIndex` — pin it for reproducibility (null = random).
 
@@ -150,7 +151,8 @@ The fields that matter most for spotting bugs:
   …), `description`, `affordable`, `manaCost`, target counts, and the combat candidates
   (`validAttackers`, `mandatoryAttackers`, `validAttackTargets`, `validBlockers`,
   `blockerMaxBlockCounts`, `mandatoryBlockerAssignments`).
-- `zones[]` → `cards[]` → `EntityFeatures` — the projected (post-layers) truth about each object:
+- `zones[]` → `cards[]` → `EntityFeatures` — the projected (post-layers) truth about each visible
+  object. A zone can remain `hidden: true` while `cards` contains its individually known subset:
   `oracleText`, `power`/`toughness`, `types`/`subtypes`/`keywords`/`colors`, `tapped`, `counters`,
   `attachedTo`. **`oracleText` is your oracle**: read what the card *says*, then watch whether the
   game state changes the way it says.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
@@ -2,29 +2,32 @@ package com.wingedsheep.gameserver.session
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
 class DecisionEnricher(private val cardRegistry: CardRegistry) {
-
-    private companion object {
-        /** Generic label for a face-down (morph / manifest) creature; mirrors the client state transformer. */
-        const val FACE_DOWN_CREATURE_NAME = "Face-down creature"
-    }
+    private val visibility = Visibility(cardRegistry)
 
     /**
-     * Whether [entityId]'s real name must be hidden from [viewerId]. A face-down permanent's identity
-     * is known only to the player who controls it (they may look at their own face-down creatures);
-     * everyone else sees the generic label. Mirrors the battlefield masking in ClientStateTransformer
-     * (`isFaceDown && controllerId != viewingPlayerId`). It intentionally does not honour
-     * Lens-of-Clarity-style reveals — omitting them only ever over-masks, so it can't leak.
+     * Whether [entityId]'s real name must be hidden from [viewerId]. The engine visibility authority
+     * combines controller access with explicit reveals and effect-granted access; this presenter only
+     * chooses the generic label once that semantic answer is known.
      */
     private fun isHiddenFrom(state: GameState, entityId: EntityId, viewerId: EntityId): Boolean =
         state.getEntity(entityId)?.has<FaceDownComponent>() == true &&
-            state.projectedState.getController(entityId) != viewerId
+            !visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(state.projectedState.getController(entityId) ?: viewerId, Zone.BATTLEFIELD),
+                entityId,
+                viewerId,
+            )
 
     /**
      * The source name to display for [decision] to [viewerId]. The combat board copies the (single)
@@ -51,7 +54,7 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
         val sourceName = decision.context.sourceName ?: return null
         if (decision is CombatResolutionDecision) {
             val single = decision.attackers.singleOrNull() ?: return sourceName
-            if (single.name == sourceName && isHiddenFrom(state, single.id, viewerId)) return FACE_DOWN_CREATURE_NAME
+            if (single.name == sourceName && isHiddenFrom(state, single.id, viewerId)) return FACE_DOWN_DISPLAY_NAME
         }
         return sourceName
     }
@@ -91,15 +94,15 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
                 // leak to the opponent through a shared node. Mask per viewer: the controller keeps
                 // its own creature's name, everyone else sees the generic label.
                 val maskedAttackers = decision.attackers.map {
-                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_DISPLAY_NAME) else it
                 }
                 val maskedBlockers = decision.blockers.map {
-                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_DISPLAY_NAME) else it
                 }
                 // The single-attacker prompt embeds that attacker's name; mask it in lockstep.
                 val single = decision.attackers.singleOrNull()
                 val maskedPrompt = if (single != null && isHiddenFrom(state, single.id, viewerId)) {
-                    decision.prompt.replaceFirst(single.name, FACE_DOWN_CREATURE_NAME)
+                    decision.prompt.replaceFirst(single.name, FACE_DOWN_DISPLAY_NAME)
                 } else {
                     decision.prompt
                 }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Step
@@ -114,5 +115,14 @@ class CombatDamageMaskingEnricherTest : FunSpec({
         // The opponent-decision status shown to the defender also masks the attacker's real name.
         val status = enricher.createOpponentDecisionStatus(decision, driver.state, defender)
         (status.sourceName ?: "") shouldNotContain "Centaur Courser"
+
+        // The same presenter must stop masking when the engine's shared identity authority says
+        // this viewer has learned the face-down blocker. The decision DTO stays unchanged; only
+        // the semantic visibility fact in state changes.
+        driver.replaceState(driver.state.updateEntity(manifestBlocker) { container ->
+            container.with(RevealedToComponent.to(attacker))
+        })
+        val afterReveal = enricher.enrich(decision, driver.state, attacker) as CombatResolutionDecision
+        afterReveal.blockers.single { it.id == manifestBlocker }.name shouldBe "Savannah Lions"
     }
 })

--- a/gym/README.md
+++ b/gym/README.md
@@ -106,8 +106,11 @@ multi-mode `ChooseModeDecision`, `BudgetModalDecision`) flag
 
 ### Information hiding by default
 
-`ObservationBuilder` hides opponent hand and every library when building
-a `TrainingObservation`. Only zone sizes are reported for hidden zones.
+`ObservationBuilder` delegates identity knowledge to the rules engine's `Visibility` authority.
+For a fully hidden opponent hand or library, only the zone size is reported. If one card is
+individually revealed or the top card is legitimately visible, that known card appears while the
+zone remains marked hidden for its unknown remainder. Public face-down objects expose their public
+projected characteristics but not the underlying card identity.
 A `revealAll = true` flag is available for debug tooling and must not be
 enabled in real self-play (the agent would be training on leaked
 information).

--- a/gym/build.gradle.kts
+++ b/gym/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     runtimeOnly(libs.slf4jApi)
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -79,7 +79,7 @@ import com.wingedsheep.sdk.model.EntityId
  * ```
  */
 class GameEnvironment private constructor(
-    private val cardRegistry: CardRegistry,
+    internal val cardRegistry: CardRegistry,
     private val processor: ActionProcessor,
     private val enumerator: LegalActionEnumerator,
     private val evaluator: BoardEvaluator,

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
@@ -25,7 +25,7 @@ class GameGymEnv(
     val environment: GameEnvironment,
     private val perspectivePlayerIndex: Int,
     private val defaultRevealAll: Boolean,
-    private val observationBuilder: ObservationBuilder = ObservationBuilder()
+    private val observationBuilder: ObservationBuilder = ObservationBuilder(environment.cardRegistry)
 ) : GymEnv {
 
     @Volatile

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -29,7 +29,10 @@ import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -45,6 +48,7 @@ import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
@@ -53,10 +57,11 @@ import com.wingedsheep.sdk.model.EntityId
  *
  * ## Information hiding
  *
- * By default, opponent hand and everyone's library are hidden
- * ([ZoneView.hidden] = true, [ZoneView.cards] empty). Set [revealAll] to
- * `true` to disable masking — only appropriate for debug scripts; never
- * for real self-play training.
+ * Identity visibility comes from the engine's [Visibility] authority. A hidden zone can therefore
+ * contain a visible subset in [ZoneView.cards] (an individually revealed card or a known top card)
+ * while [ZoneView.hidden] remains true for the unknown remainder. Public face-down objects retain
+ * public projected characteristics but never expose their underlying identity. Set [revealAll] to
+ * `true` to disable masking — only appropriate for debug scripts; never for real self-play training.
  *
  * ## Projected vs. base state
  *
@@ -67,8 +72,11 @@ import com.wingedsheep.sdk.model.EntityId
  * zones — see `GameState.getBattlefield`).
  */
 class ObservationBuilder(
+    cardRegistry: CardRegistry,
     private val schemaHash: String = SchemaHash.CURRENT
 ) {
+    private val visibility = Visibility(cardRegistry)
+
     fun build(
         state: GameState,
         perspectivePlayerId: EntityId,
@@ -81,7 +89,9 @@ class ObservationBuilder(
 
         val zones = buildZones(state, perspectivePlayerId, revealAll)
 
-        val stack = state.stack.map { entityId -> buildStackItem(state, entityId) }
+        val stack = state.stack.map { entityId ->
+            buildStackItem(state, entityId, perspectivePlayerId, revealAll)
+        }
 
         val pendingDecisionAndRegistry = state.pendingDecision
             ?.let { buildPendingDecision(it) }
@@ -183,24 +193,28 @@ class ObservationBuilder(
             for (zone in perPlayerZones) {
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
-                val hidden = !revealAll && isHiddenFrom(zone, playerId, perspectivePlayerId)
-                val cards = if (hidden) emptyList() else ids.map { buildEntityFeatures(state, it, zone) }
+                val wholeZoneVisible = revealAll ||
+                    visibility.isZoneVisibleTo(state, key, perspectivePlayerId)
+                val cards = ids.mapNotNull { entityId ->
+                    val identityVisible = revealAll || visibility.isCardIdentityVisibleTo(
+                        state,
+                        key,
+                        entityId,
+                        perspectivePlayerId,
+                    )
+                    if (!wholeZoneVisible && !identityVisible) null
+                    else buildEntityFeatures(state, entityId, zone, identityVisible)
+                }
                 views += ZoneView(
                     ownerId = playerId,
                     zoneType = zone,
-                    hidden = hidden,
+                    hidden = !wholeZoneVisible,
                     size = ids.size,
                     cards = cards
                 )
             }
         }
         return views
-    }
-
-    private fun isHiddenFrom(zone: Zone, owner: EntityId, perspective: EntityId): Boolean = when (zone) {
-        Zone.LIBRARY -> true
-        Zone.HAND -> owner != perspective
-        else -> false
     }
 
     // =========================================================================
@@ -210,7 +224,8 @@ class ObservationBuilder(
     private fun buildEntityFeatures(
         state: GameState,
         entityId: EntityId,
-        zone: Zone
+        zone: Zone,
+        identityVisible: Boolean,
     ): EntityFeatures {
         val container = state.getEntity(entityId) ?: ComponentContainer.EMPTY
         val card = container.get<CardComponent>()
@@ -221,29 +236,39 @@ class ObservationBuilder(
 
         val types: Set<String> = when {
             pv != null -> pv.types.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.typeLine.cardTypes.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val subtypes: Set<String> = when {
             pv != null -> pv.subtypes.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.typeLine.subtypes.mapTo(mutableSetOf()) { it.value }
             else -> emptySet()
         }
         val colors: Set<String> = when {
             pv != null -> pv.colors.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.colors.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val keywords: Set<String> = when {
             pv != null -> pv.keywords.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.baseKeywords.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
 
+        val maskedName = if (zone == Zone.EXILE) {
+            FACE_DOWN_CARD_DISPLAY_NAME
+        } else {
+            FACE_DOWN_DISPLAY_NAME
+        }
+
         return EntityFeatures(
             entityId = entityId,
-            cardDefinitionId = card?.cardDefinitionId,
-            name = card?.name ?: "",
+            cardDefinitionId = card?.cardDefinitionId.takeIf { identityVisible },
+            name = if (identityVisible) card?.name ?: "" else maskedName,
             zone = zone,
             ownerId = container.get<OwnerComponent>()?.playerId ?: card?.ownerId,
             controllerId = if (onBattlefield) projected.getController(entityId) else null,
@@ -251,9 +276,9 @@ class ObservationBuilder(
             subtypes = subtypes,
             colors = colors,
             keywords = keywords,
-            manaCost = card?.manaCost?.toString() ?: "",
-            manaValue = card?.manaValue ?: 0,
-            oracleText = card?.oracleText ?: "",
+            manaCost = if (identityVisible) card?.manaCost?.toString() ?: "" else "",
+            manaValue = if (identityVisible) card?.manaValue ?: 0 else 0,
+            oracleText = if (identityVisible) card?.oracleText ?: "" else "",
             power = if (onBattlefield) projected.getPower(entityId) else null,
             toughness = if (onBattlefield) projected.getToughness(entityId) else null,
             tapped = onBattlefield && container.get<TappedComponent>() != null,
@@ -278,9 +303,21 @@ class ObservationBuilder(
     // Stack
     // =========================================================================
 
-    private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
+    private fun buildStackItem(
+        state: GameState,
+        entityId: EntityId,
+        perspectivePlayerId: EntityId,
+        revealAll: Boolean,
+    ): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
+        val ownerId = container?.get<OwnerComponent>()?.playerId ?: card?.ownerId ?: perspectivePlayerId
+        val identityVisible = revealAll || visibility.isCardIdentityVisibleTo(
+            state,
+            ZoneKey(ownerId, Zone.STACK),
+            entityId,
+            perspectivePlayerId,
+        )
         // Stack kind inference — fall back to OTHER. A more precise classification
         // can be added once the stack carries explicit metadata.
         val kind = when {
@@ -291,9 +328,9 @@ class ObservationBuilder(
         return StackItemView(
             entityId = entityId,
             controllerId = state.projectedState.getController(entityId),
-            name = card?.name ?: "",
+            name = if (identityVisible) card?.name ?: "" else FACE_DOWN_DISPLAY_NAME,
             kind = kind,
-            oracleText = card?.oracleText ?: "",
+            oracleText = if (identityVisible) card?.oracleText ?: "" else "",
             targets = emptyList()
         )
     }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -72,8 +72,9 @@ data class TrainingObservation(
 
     /**
      * Per-zone entity views. A `(ownerId, zoneType)` pair appears at most once.
-     * Hidden zones (opponent hand, libraries) expose [ZoneView.hidden] = true
-     * and [ZoneView.cards] is empty (only [ZoneView.size] is populated).
+     * [ZoneView.hidden] means some identities remain hidden. [ZoneView.cards] contains only the
+     * identities this perspective may know, so an individually revealed card can appear while the
+     * zone remains hidden and [ZoneView.size] still reports its true size.
      */
     val zones: List<ZoneView>,
 
@@ -131,8 +132,9 @@ data class ManaPoolView(
 /**
  * A zone's contents from [TrainingObservation.perspectivePlayerId]'s point of view.
  *
- * When [hidden] is true (opponent's hand, any library), [cards] is empty and
- * only [size] is meaningful. This mirrors real-MTG information hiding.
+ * When [hidden] is true, at least one identity in the zone remains unknown. [cards] is the known
+ * subset (often empty), while [size] always reports the full zone size. Hidden-zone slot IDs and
+ * the positions of known cards among unknown cards are intentionally not part of this schema.
  */
 @Serializable
 data class ZoneView(

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
@@ -1,0 +1,271 @@
+package com.wingedsheep.gym.contract
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.engine.view.Visibility
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+/** Semantic visibility propositions shared by the engine, client view, and Gym observation. */
+class ObservationVisibilityTest : ScenarioTestBase() {
+
+    private val openThoughts = card("Open Thoughts") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = OpponentsPlayWithHandsRevealed }
+    }
+
+    private val publicTop = card("Public Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = RevealTopOfLibrary }
+    }
+
+    private val privateTop = card("Private Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = LookAtTopOfLibrary }
+    }
+
+    private val visibility: Visibility
+        get() = Visibility(cardRegistry)
+
+    init {
+        cardRegistry.register(listOf(openThoughts, publicTop, privateTop))
+
+        test("own and opponent hands use the same identity answer in engine, client, and Gym") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .build()
+            val state = game.state
+            val ownCard = state.getHand(game.player1Id).single()
+            val opposingCard = state.getHand(game.player2Id).single()
+
+            visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(game.player1Id, Zone.HAND),
+                ownCard,
+                game.player1Id,
+            ) shouldBe true
+            visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(game.player2Id, Zone.HAND),
+                opposingCard,
+                game.player1Id,
+            ) shouldBe false
+
+            val gymView = observe(state, game.player1Id)
+            zone(gymView, game.player1Id, Zone.HAND).cards.map { it.entityId } shouldContain ownCard
+            zone(gymView, game.player2Id, Zone.HAND).cards.map { it.entityId } shouldNotContain opposingCard
+
+            val clientView = ClientStateTransformer(cardRegistry).transform(state, game.player1Id)
+            clientView.cards.keys shouldContain ownCard
+            clientView.cards.keys shouldNotContain opposingCard
+        }
+
+        test("an opponent-hand reveal is whole-zone visibility only for the entitled controller") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, openThoughts.name)
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val state = game.state
+            val player2Hand = ZoneKey(game.player2Id, Zone.HAND)
+            val player1Hand = ZoneKey(game.player1Id, Zone.HAND)
+
+            visibility.isZoneVisibleTo(state, player2Hand, game.player1Id) shouldBe true
+            visibility.isZoneVisibleTo(state, player1Hand, game.player2Id) shouldBe false
+
+            val entitled = observe(state, game.player1Id)
+            zone(entitled, game.player2Id, Zone.HAND).let {
+                it.hidden shouldBe false
+                it.cards.size shouldBe it.size
+            }
+
+            val unentitled = observe(state, game.player2Id)
+            zone(unentitled, game.player1Id, Zone.HAND).let {
+                it.hidden shouldBe true
+                it.cards shouldBe emptyList()
+            }
+        }
+
+        test("an individual reveal exposes only that card to the entitled perspective") {
+            val base = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val bystander = EntityId.of("player-3")
+            val withBystander = addBystander(base.state, bystander)
+            val known = withBystander.getHand(base.player2Id).first { id ->
+                withBystander.getEntity(id)?.get<CardComponent>()?.name == "Mountain"
+            }
+            val unknown = withBystander.getHand(base.player2Id).single { it != known }
+            val revealed = withBystander.updateEntity(known) {
+                it.with(RevealedToComponent.to(base.player1Id))
+            }
+
+            visibility.isCardIdentityVisibleTo(
+                revealed,
+                ZoneKey(base.player2Id, Zone.HAND),
+                known,
+                base.player1Id,
+            ) shouldBe true
+            visibility.isCardIdentityVisibleTo(
+                revealed,
+                ZoneKey(base.player2Id, Zone.HAND),
+                known,
+                bystander,
+            ) shouldBe false
+
+            val entitled = observe(revealed, base.player1Id)
+            zone(entitled, base.player2Id, Zone.HAND).let {
+                it.hidden shouldBe true
+                it.size shouldBe 2
+                it.cards.map { card -> card.entityId } shouldContainExactly listOf(known)
+            }
+            val unentitled = observe(revealed, bystander)
+            zone(unentitled, base.player2Id, Zone.HAND).cards shouldBe emptyList()
+
+            val client = ClientStateTransformer(cardRegistry)
+            client.transform(revealed, base.player1Id).cards.keys.let {
+                it shouldContain known
+                it shouldNotContain unknown
+            }
+            client.transform(revealed, bystander).cards.keys shouldNotContain known
+
+        }
+
+        test("public and private top-card knowledge produce perspective-correct observations") {
+            val privateGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, privateTop.name)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Hill Giant")
+                .build()
+            val privateLibrary = privateGame.state.getLibrary(privateGame.player1Id)
+            val privateKnown = privateLibrary.first()
+
+            zone(observe(privateGame.state, privateGame.player1Id), gameOwner = privateGame.player1Id, Zone.LIBRARY)
+                .cards.map { it.entityId } shouldContainExactly listOf(privateKnown)
+            zone(observe(privateGame.state, privateGame.player2Id), gameOwner = privateGame.player1Id, Zone.LIBRARY)
+                .cards shouldBe emptyList()
+
+            val publicGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, publicTop.name)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .build()
+            val publicKnown = publicGame.state.getLibrary(publicGame.player1Id).first()
+            listOf(publicGame.player1Id, publicGame.player2Id).forEach { viewer ->
+                zone(observe(publicGame.state, viewer), publicGame.player1Id, Zone.LIBRARY)
+                    .cards.map { it.entityId } shouldContainExactly listOf(publicKnown)
+            }
+        }
+
+        test("face-down battlefield and stack identities are absent from the ordinary sibling surface") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Craw Wurm")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val permanent = game.state.getBattlefield().single()
+            val spell = game.state.getHand(game.player2Id).single()
+            val handKey = ZoneKey(game.player2Id, Zone.HAND)
+            val hiddenState = game.state
+                .updateEntity(permanent) { it.with(FaceDownComponent) }
+                .removeFromZone(handKey, spell)
+                .updateEntity(spell) {
+                    it.with(SpellOnStackComponent(casterId = game.player2Id, castFaceDown = true))
+                }
+                .copy(stack = listOf(spell))
+
+            val opponentView = observe(hiddenState, game.player1Id)
+            val faceDownPermanent = zone(
+                opponentView,
+                game.player2Id,
+                Zone.BATTLEFIELD,
+            ).cards.single()
+            faceDownPermanent.entityId shouldBe permanent
+            faceDownPermanent.name shouldBe FACE_DOWN_DISPLAY_NAME
+            faceDownPermanent.cardDefinitionId shouldBe null
+            faceDownPermanent.oracleText shouldBe ""
+            faceDownPermanent.types shouldBe setOf("CREATURE")
+            faceDownPermanent.power shouldBe 2
+            faceDownPermanent.toughness shouldBe 2
+            opponentView.stack.single().let {
+                it.name shouldBe FACE_DOWN_DISPLAY_NAME
+                it.oracleText shouldBe ""
+            }
+
+            val controllerView = observe(hiddenState, game.player2Id)
+            zone(controllerView, game.player2Id, Zone.BATTLEFIELD).cards.single().name shouldBe "Craw Wurm"
+            controllerView.stack.single().name shouldBe "Hill Giant"
+
+            // Independent boundary check: neither zone features nor the sibling stack/action/
+            // decision fields can recover the forbidden printed identities in this ordinary state.
+            val serialized = Json.encodeToString(TrainingObservation.serializer(), opponentView)
+            serialized.contains("Craw Wurm") shouldBe false
+            serialized.contains("Hill Giant") shouldBe false
+
+            val debugView = observe(hiddenState, game.player1Id, revealAll = true)
+            zone(debugView, game.player2Id, Zone.BATTLEFIELD).cards.single().name shouldBe "Craw Wurm"
+            debugView.stack.single().name shouldBe "Hill Giant"
+        }
+    }
+
+    private fun observe(
+        state: GameState,
+        viewer: EntityId,
+        revealAll: Boolean = false,
+    ): TrainingObservation = ObservationBuilder(cardRegistry)
+        .build(state, viewer, legalActions = emptyList(), revealAll = revealAll)
+        .observation as TrainingObservation
+
+    private fun zone(
+        observation: TrainingObservation,
+        gameOwner: EntityId,
+        zone: Zone,
+    ): ZoneView = observation.zones.single { it.ownerId == gameOwner && it.zoneType == zone }
+
+    private fun addBystander(state: GameState, playerId: EntityId): GameState {
+        var result = state.withEntity(
+            playerId,
+            ComponentContainer.of(
+                PlayerComponent("Bystander"),
+                LifeTotalComponent(20),
+                ManaPoolComponent(),
+            ),
+        ).copy(turnOrder = state.turnOrder + playerId)
+        for (zone in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD)) {
+            result = result.copy(zones = result.zones + (ZoneKey(playerId, zone) to emptyList()))
+        }
+        return result
+    }
+
+}

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -51,7 +51,7 @@ class TrainingObservationTest : FunSpec({
     test("observation includes all basic state fields and round-trips through JSON") {
         val env = newEnv()
         val perspective = env.playerIds[0]
-        val result = ObservationBuilder().build(env.state, perspective, env.legalActions())
+        val result = ObservationBuilder(env.cardRegistry).build(env.state, perspective, env.legalActions())
 
         val obs = result.observation as TrainingObservation
         obs.perspectivePlayerId shouldBe perspective
@@ -73,7 +73,7 @@ class TrainingObservationTest : FunSpec({
     test("an actionId from the observation resolves to a steppable action") {
         val env = newEnv()
         val perspective = env.playerIds[0]
-        val result = ObservationBuilder().build(env.state, perspective, env.legalActions())
+        val result = ObservationBuilder(env.cardRegistry).build(env.state, perspective, env.legalActions())
 
         val passView = result.observation.legalActions.first { it.description.contains("Pass", ignoreCase = true) || it.kind.contains("Pass", ignoreCase = true) }
         val resolved = result.registry.resolve(passView.actionId)
@@ -92,7 +92,7 @@ class TrainingObservationTest : FunSpec({
         val me = env.playerIds[0]
         val opponent = env.playerIds[1]
 
-        val masked = ObservationBuilder().build(env.state, me, env.legalActions())
+        val masked = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions())
             .observation as TrainingObservation
         val myHand = masked.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
         val theirHand = masked.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
@@ -105,7 +105,12 @@ class TrainingObservationTest : FunSpec({
         // Every library is hidden regardless of perspective.
         masked.zones.filter { it.zoneType == Zone.LIBRARY }.forEach { it.hidden.shouldBeTrue() }
 
-        val revealed = ObservationBuilder().build(env.state, me, env.legalActions(), revealAll = true)
+        val revealed = ObservationBuilder(env.cardRegistry).build(
+            env.state,
+            me,
+            env.legalActions(),
+            revealAll = true,
+        )
             .observation as TrainingObservation
         val theirHandRevealed = revealed.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
         theirHandRevealed.hidden.shouldBeFalse()
@@ -118,7 +123,11 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
 
-        val obs = ObservationBuilder().build(env.state, me, env.legalActions()).observation as TrainingObservation
+        val obs = ObservationBuilder(env.cardRegistry).build(
+            env.state,
+            me,
+            env.legalActions(),
+        ).observation as TrainingObservation
         val myHand = obs.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
 
         // At least one card should be in the opening hand; every card there
@@ -141,14 +150,14 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
 
-        val a = ObservationBuilder().build(env.state, me, env.legalActions()).observation
-        val b = ObservationBuilder().build(env.state, me, env.legalActions()).observation
+        val a = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
+        val b = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
         a.stateDigest shouldBe b.stateDigest
 
         // Advance a step and verify the digest changes.
         val pass = env.legalActions().first { it.action is PassPriority }
         env.step(pass.action)
-        val c = ObservationBuilder().build(env.state, me, env.legalActions()).observation
+        val c = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
         c.stateDigest shouldNotBe a.stateDigest
     }
 })

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -43,8 +43,10 @@ fun nameVisibleToAll(state: GameState, entityId: EntityId, fallback: String): St
  *
  * Same masking as [nameVisibleToAll], except that a player may look at a face-down object they
  * control (CR 708.5) and so keeps [fallback] for their own. A spectator never may — matching the
- * gate [com.wingedsheep.engine.view.ClientStateTransformer] applies to card views, so a per-viewer
- * label and the card it labels always agree.
+ * baseline gate used by [com.wingedsheep.engine.view.Visibility]. This helper deliberately owns
+ * only the face-down name and controller/caster baseline; consumers that have a
+ * [com.wingedsheep.engine.registry.CardRegistry] must use [com.wingedsheep.engine.view.Visibility]
+ * for the aggregate answer, including explicit reveals and effect-granted access.
  */
 fun nameVisibleTo(
     state: GameState,
@@ -54,7 +56,7 @@ fun nameVisibleTo(
     isSpectator: Boolean = false,
 ): String {
     val masked = faceDownDisplayName(state, entityId) ?: return fallback
-    val mayLook = !isSpectator && viewingPlayerId == playerWhoMayLookAt(state, entityId)
+    val mayLook = !isSpectator && viewingPlayerId == playerWhoMayLookAtFaceDown(state, entityId)
     return if (mayLook) fallback else masked
 }
 
@@ -76,7 +78,7 @@ fun nameVisibleTo(
  * Anything else keeps its name, including a face-down object that has already left all three: its
  * owner reveals it to every player as it goes (CR 708.9).
  */
-private fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
+internal fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
     val container = state.getEntity(entityId) ?: return null
 
     if (entityId in state.stack) {
@@ -100,8 +102,14 @@ private fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
     return null
 }
 
-/** The one player entitled to read [entityId]'s real name off the table (CR 708.5). */
-private fun playerWhoMayLookAt(state: GameState, entityId: EntityId): EntityId? {
+/**
+ * The one player entitled to look at [entityId] merely because they control the face-down object.
+ *
+ * Other effects can grant additional players access; [com.wingedsheep.engine.view.Visibility]
+ * combines this baseline with those explicit reveal permissions. Keeping the baseline here makes
+ * the name-only and full-identity views agree about controller/caster access.
+ */
+internal fun playerWhoMayLookAtFaceDown(state: GameState, entityId: EntityId): EntityId? {
     val container = state.getEntity(entityId) ?: return null
     return state.projectedState.getController(entityId)
         ?: container.get<SpellOnStackComponent>()?.casterId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -23,7 +23,6 @@ import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
 import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.nameVisibleTo
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.*
 import com.wingedsheep.engine.state.components.battlefield.*
@@ -128,7 +127,13 @@ class ClientStateTransformer(
                 entityIds
             } else {
                 entityIds.filter { entityId ->
-                    visibility.isCardRevealedTo(state, entityId, viewingPlayerId)
+                    visibility.isCardIdentityVisibleTo(
+                        state,
+                        zoneKey,
+                        entityId,
+                        viewingPlayerId,
+                        isSpectator,
+                    )
                 }
             }
             val zoneCardIds = if (isLibrary) entityIds else cardsWithDetails
@@ -201,73 +206,6 @@ class ClientStateTransformer(
             }
         }
         // --- FIX END ---
-
-        // Reveal top library card for players who "play with the top card revealed"
-        // (PlayFromTopOfLibrary, e.g. Future Sight; or RevealTopOfLibrary, e.g. Goblin Spy).
-        // The top card is revealed to ALL players per the card's oracle text. The two abilities
-        // differ only in play permission (handled elsewhere); the public reveal is identical.
-        for (ownerId in state.turnOrder) {
-            if (revealsTopOfLibraryPublicly(state, ownerId)) {
-                val library = state.getLibrary(ownerId)
-                if (library.isNotEmpty()) {
-                    val topCardId = library.first()
-                    if (topCardId !in cards) {
-                        val libraryZoneKey = ZoneKey(ownerId, Zone.LIBRARY)
-                        val clientCard = transformCard(state, topCardId, libraryZoneKey, projectedState, viewingPlayerId)
-                        if (clientCard != null) {
-                            cards[topCardId] = clientCard
-                            // Update the library zone entry to include this card as visible
-                            val zoneIndex = zones.indexOfFirst {
-                                it.zoneId.ownerId == ownerId && it.zoneId.zoneType == Zone.LIBRARY
-                            }
-                            if (zoneIndex >= 0) {
-                                val existingZone = zones[zoneIndex]
-                                val newCardIds = if (existingZone.cardIds.contains(topCardId)) {
-                                    existingZone.cardIds
-                                } else {
-                                    listOf(topCardId) + existingZone.cardIds
-                                }
-                                zones[zoneIndex] = existingZone.copy(
-                                    cardIds = newCardIds,
-                                    isVisible = true
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Reveal top library card privately for players with LookAtTopOfLibrary (e.g., Lens of Clarity)
-        // Unlike PlayFromTopOfLibrary, this only reveals to the controller, not all players.
-        if (!isSpectator && hasLookAtTopOfLibrary(state, viewingPlayerId)) {
-            val library = state.getLibrary(viewingPlayerId)
-            if (library.isNotEmpty()) {
-                val topCardId = library.first()
-                if (topCardId !in cards) {
-                    val libraryZoneKey = ZoneKey(viewingPlayerId, Zone.LIBRARY)
-                    val clientCard = transformCard(state, topCardId, libraryZoneKey, projectedState, viewingPlayerId)
-                    if (clientCard != null) {
-                        cards[topCardId] = clientCard
-                        val zoneIndex = zones.indexOfFirst {
-                            it.zoneId.ownerId == viewingPlayerId && it.zoneId.zoneType == Zone.LIBRARY
-                        }
-                        if (zoneIndex >= 0) {
-                            val existingZone = zones[zoneIndex]
-                            val newCardIds = if (existingZone.cardIds.contains(topCardId)) {
-                                existingZone.cardIds
-                            } else {
-                                listOf(topCardId) + existingZone.cardIds
-                            }
-                            zones[zoneIndex] = existingZone.copy(
-                                cardIds = newCardIds,
-                                isVisible = true
-                            )
-                        }
-                    }
-                }
-            }
-        }
 
         // Build player information
         val players = state.turnOrder.map { playerId ->
@@ -372,7 +310,15 @@ class ClientStateTransformer(
 
             val tally = tallies.getOrPut(definitionId) { Tally() }
             tally.copies++
-            if (!ownerKnowsIdentity(state, entityId, zoneType, viewingPlayerId)) tally.remaining++
+            if (!visibility.isCardIdentityVisibleTo(
+                    state,
+                    ZoneKey(ownerId, zoneType),
+                    entityId,
+                    viewingPlayerId,
+                )
+            ) {
+                tally.remaining++
+            }
             if (copyOf == null && tally.printingImageUri == null) {
                 tally.printingImageUri = cardComponent.imageUri
             }
@@ -396,31 +342,6 @@ class ClientStateTransformer(
                 imageUri = tally.printingImageUri ?: definition.metadata.imageUri
             )
         }.sortedWith(compareBy({ it.cmc }, { it.cardName }))
-    }
-
-    /**
-     * Whether the owner of [entityId] can currently tell *which* of their cards this one is.
-     *
-     * False for anything in their library (that's the whole point — you know what's in your deck,
-     * not where), and for a card of theirs that is face down somewhere they can't look: exiled face
-     * down, or a face-down permanent an opponent controls. Mirrors the face-down masking in
-     * [transformCard] so the tracker never claims knowledge the client wasn't sent.
-     */
-    private fun ownerKnowsIdentity(
-        state: GameState,
-        entityId: EntityId,
-        zoneType: Zone,
-        viewingPlayerId: EntityId
-    ): Boolean {
-        if (zoneType == Zone.LIBRARY) return false
-        val container = state.getEntity(entityId) ?: return false
-        val isInFaceDownZone =
-            zoneType == Zone.BATTLEFIELD || zoneType == Zone.STACK || zoneType == Zone.EXILE
-        if (!isInFaceDownZone || !container.has<FaceDownComponent>()) return true
-        val controllerId = container.get<ControllerComponent>()?.playerId
-        return controllerId == viewingPlayerId ||
-            visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
-            (zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
     }
 
     /**
@@ -521,12 +442,6 @@ class ClientStateTransformer(
      * This is used for "look at hand" or "reveal hand" effects where the viewing player
      * can see specific cards in an otherwise hidden zone.
      */
-    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
-        visibility.revealsTopOfLibraryPublicly(state, playerId)
-
-    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
-        visibility.hasLookAtTopOfLibrary(state, playerId)
-
     /**
      * Transform an activated or triggered ability on the stack into a ClientCard DTO.
      * These don't have CardComponent, so we create a synthetic card representation.
@@ -849,9 +764,12 @@ class ClientStateTransformer(
             // Check if the face-down card has been revealed to the viewing player (e.g., via Spy Network)
             // Also check LookAtFaceDownCreatures (e.g., Lens of Clarity) — only for battlefield creatures,
             // not face-down spells on the stack (per ruling).
-            val isRevealedToViewer = !isSpectator && (
-                visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
-                (zoneKey.zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
+            val isRevealedToViewer = visibility.isCardIdentityVisibleTo(
+                state,
+                zoneKey,
+                entityId,
+                viewingPlayerId,
+                isSpectator,
             )
 
             // Face-down exiled cards show minimal info (not creatures, no P/T)
@@ -1751,8 +1669,8 @@ class ClientStateTransformer(
     /**
      * Build per-mode target groups for a modal spell on the stack, aligned with
      * [SpellOnStackComponent.modeTargetsOrdered]. Hidden-zone targets are redacted to a generic
-     * "a card in X's hand/library" string when the viewer does not own the zone, and a face-down
-     * object is redacted for every viewer but the one who may look at it (see
+     * "a card in X's hand/library" string, and a face-down object gets its generic public name,
+     * whenever the shared identity authority says this viewer may not know it (see
      * [resolveTargetDisplayName]).
      */
     private fun buildPerModeTargetGroups(
@@ -1787,8 +1705,8 @@ class ClientStateTransformer(
     }
 
     /**
-     * Resolve a [ChosenTarget] to a human-readable display name for the stack view. Cards in
-     * hidden zones are redacted unless the viewing player owns the zone.
+     * Resolve a [ChosenTarget] to a human-readable display name for the stack view. The engine's
+     * [Visibility] authority decides identity; this method owns only the client-facing placeholder.
      */
     private fun resolveTargetDisplayName(
         state: GameState,
@@ -1798,29 +1716,56 @@ class ClientStateTransformer(
     ): String = when (target) {
         is ChosenTarget.Player -> state.getEntity(target.playerId)
             ?.get<PlayerComponent>()?.name ?: "a player"
-        // A face-down object is nameless (CR 708.2a / 708.4), but this label has an audience, so
-        // it is masked per viewer rather than for everyone: a player may look at a face-down
-        // object they control (CR 708.5). That also keeps modal spells consistent with non-modal
-        // ones, whose targets ship as bare entity ids and are named client-side from the card
-        // view — which applies exactly this gate.
-        is ChosenTarget.Permanent -> state.getEntity(target.entityId)
-            ?.get<CardComponent>()?.name
-            ?.let { nameVisibleTo(state, target.entityId, it, viewingPlayerId, isSpectator) }
-            ?: "a permanent"
-        is ChosenTarget.Spell -> state.getEntity(target.spellEntityId)
-            ?.get<CardComponent>()?.name
-            ?.let { nameVisibleTo(state, target.spellEntityId, it, viewingPlayerId, isSpectator) }
-            ?: "a spell"
+        is ChosenTarget.Permanent -> {
+            val controllerId = state.projectedState.getController(target.entityId) ?: viewingPlayerId
+            if (visibility.isCardIdentityVisibleTo(
+                    state,
+                    ZoneKey(controllerId, Zone.BATTLEFIELD),
+                    target.entityId,
+                    viewingPlayerId,
+                    isSpectator,
+                )
+            ) {
+                state.getEntity(target.entityId)?.get<CardComponent>()?.name ?: "a permanent"
+            } else {
+                FACE_DOWN_DISPLAY_NAME
+            }
+        }
+        is ChosenTarget.Spell -> {
+            if (visibility.isCardIdentityVisibleTo(
+                    state,
+                    ZoneKey(viewingPlayerId, Zone.STACK),
+                    target.spellEntityId,
+                    viewingPlayerId,
+                    isSpectator,
+                )
+            ) {
+                state.getEntity(target.spellEntityId)?.get<CardComponent>()?.name ?: "a spell"
+            } else {
+                FACE_DOWN_DISPLAY_NAME
+            }
+        }
         is ChosenTarget.Card -> {
-            val hiddenZone = target.zone == Zone.HAND || target.zone == Zone.LIBRARY
-            if (hiddenZone && target.ownerId != viewingPlayerId) {
+            val identityVisible = visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(target.ownerId, target.zone),
+                target.cardId,
+                viewingPlayerId,
+                isSpectator,
+            )
+            if (identityVisible) {
+                state.getEntity(target.cardId)?.get<CardComponent>()?.name ?: "a card"
+            } else if (target.zone == Zone.HAND ||
+                target.zone == Zone.LIBRARY ||
+                target.zone == Zone.SIDEBOARD
+            ) {
                 val ownerName = state.getEntity(target.ownerId)
                     ?.get<PlayerComponent>()?.name ?: "opponent"
                 "a card in ${ownerName}'s ${target.zone.name.lowercase()}"
+            } else if (target.zone == Zone.EXILE) {
+                FACE_DOWN_CARD_DISPLAY_NAME
             } else {
-                state.getEntity(target.cardId)?.get<CardComponent>()?.name
-                    ?.let { nameVisibleTo(state, target.cardId, it, viewingPlayerId, isSpectator) }
-                    ?: "a card"
+                "a card"
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -3,11 +3,14 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.faceDownDisplayName
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.playerWhoMayLookAtFaceDown
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.permissions.hasMayPlayFor
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
@@ -19,11 +22,14 @@ import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.StaticAbility
 
 /**
- * The engine's single source of truth for which hidden-zone identities a player may see.
+ * The engine's single source of truth for which card identities a player may see.
  *
- * Client masking and AI determinization deliberately share this service. Adding a reveal rule to
- * one without the other would either leak information to the AI or hide information it is legally
- * entitled to use.
+ * This covers both identities in hidden zones and face-down objects in otherwise public zones.
+ * Client state and decision masking, AI determinization, and Gym observations deliberately share
+ * this service. Adding a reveal rule to one without the others would either leak information or
+ * hide information a perspective is legally entitled to use. Consumers still own their
+ * representations: knowing an identity does not prescribe a client card DTO, a Gym feature vector,
+ * or opaque zone slots.
  */
 class Visibility(
     private val cardRegistry: CardRegistry,
@@ -38,18 +44,63 @@ class Visibility(
         isSpectator: Boolean = false,
     ): Boolean = when (zoneKey.zoneType) {
         Zone.LIBRARY -> false
-        Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
-            (!isSpectator && zoneKey.ownerId in state.teammatesOf(viewingPlayerId)) ||
-            (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
-                revealsOpponentHandsTo(state, viewingPlayerId))
-        Zone.SIDEBOARD -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
+        Zone.HAND -> debugMode || (!isSpectator && (
+            zoneKey.ownerId == viewingPlayerId ||
+                state.actorFor(zoneKey.ownerId) == viewingPlayerId ||
+                zoneKey.ownerId in state.teammatesOf(viewingPlayerId) ||
+                (zoneKey.ownerId != viewingPlayerId && revealsOpponentHandsTo(state, viewingPlayerId))
+            ))
+        Zone.SIDEBOARD -> debugMode || (!isSpectator && (
+            zoneKey.ownerId == viewingPlayerId ||
+                state.actorFor(zoneKey.ownerId) == viewingPlayerId
+            ))
         Zone.BATTLEFIELD,
         Zone.GRAVEYARD,
         Zone.STACK,
         Zone.EXILE,
         Zone.COMMAND -> true
+    }
+
+    /**
+     * Whether [viewingPlayerId] may know the identity of [entityId] in [zoneKey].
+     *
+     * A hidden zone is not all-or-nothing: [RevealedToComponent] and top-of-library effects can
+     * expose one card while the rest stays hidden. Conversely, a public zone does not make the
+     * identity under a face-down object public. This query combines those identity facts while
+     * leaving ordered hidden-zone structure and consumer-specific presentation to the caller.
+     */
+    fun isCardIdentityVisibleTo(
+        state: GameState,
+        zoneKey: ZoneKey,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean {
+        // Public-zone visibility does not reveal what is underneath a face-down object.
+        if (faceDownDisplayName(state, entityId) != null) {
+            if (isSpectator) return false
+            if (playerWhoMayLookAtFaceDown(state, entityId) == viewingPlayerId) return true
+            if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
+            if (zoneKey.zoneType == Zone.BATTLEFIELD &&
+                hasLookAtFaceDownCreatures(state, viewingPlayerId)
+            ) return true
+            if (zoneKey.zoneType == Zone.EXILE &&
+                state.hasMayPlayFor(entityId, viewingPlayerId, conditionEvaluator, cardRegistry)
+            ) return true
+            return false
+        }
+
+        if (isZoneVisibleTo(state, zoneKey, viewingPlayerId, isSpectator)) return true
+
+        // A spectator receives public reveals but never a player's private reveal memory.
+        val isTopCard = zoneKey.zoneType == Zone.LIBRARY &&
+            state.getLibrary(zoneKey.ownerId).firstOrNull() == entityId
+        if (isTopCard && revealsTopOfLibraryPublicly(state, zoneKey.ownerId)) return true
+        if (isSpectator) return false
+
+        if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
+        return isTopCard && zoneKey.ownerId == viewingPlayerId &&
+            hasLookAtTopOfLibrary(state, viewingPlayerId)
     }
 
     fun isCardRevealedTo(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.engine.view.ClientDeckCard
 import com.wingedsheep.engine.view.ClientStateTransformer
@@ -180,6 +181,24 @@ class DeckListClientViewTest : ScenarioTestBase() {
             val row = row(faceDown, "Grizzly Bears")
             row.shouldNotBeNull()
             row.remaining shouldBe 0
+        }
+
+        test("an individually known library card is accounted for without treating the zone as public") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .build()
+
+            val known = game.state.getLibrary(p1).first()
+            val withKnownTop = game.state.updateEntity(known) {
+                it.with(RevealedToComponent.to(p1))
+            }
+
+            val bolt = row(withKnownTop, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.copies shouldBe 2
+            bolt.remaining shouldBe 1
         }
 
         test("spectators are told nothing about anyone's deck") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/ModalSpellStackVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/ModalSpellStackVisibilityTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.support.GameTestDriver
@@ -233,6 +234,19 @@ class ModalSpellStackVisibilityTest : FunSpec({
         redactedName shouldNotContain "Savannah Lions"
         redactedName.lowercase() shouldContain "card in"
         redactedName.lowercase() shouldContain "hand"
+
+        // A per-card reveal changes the semantic identity answer without making the whole hand
+        // public. Stack target presentation must follow that answer rather than the old owner-only
+        // shortcut.
+        d.replaceState(d.state.updateEntity(secret) { container ->
+            container.with(RevealedToComponent.to(p2))
+        })
+        val revealedOpponentGroups = transformer(d)
+            .transform(d.state, viewingPlayerId = p2)
+            .cards[stackSpellId]
+            ?.perModeTargets
+        revealedOpponentGroups.shouldNotBeNull()
+        revealedOpponentGroups[1].targetNames shouldBe listOf("Savannah Lions")
 
         // Mode descriptions are still public to the opponent — only the card identity is hidden.
         opponentView.cards[stackSpellId]?.chosenModeDescriptions?.size shouldBe 2


### PR DESCRIPTION
Argentum already has an engine-level `Visibility` service, but several consumers still answer a narrower question independently: “does this viewer know this card’s identity?” Those local approximations disagree in real states.

The clearest example is Gym. Its observation builder historically treated visibility mostly as a whole-zone property: your hand was visible, an opponent’s hand was hidden, and libraries were hidden. That works for the ordinary case, but Magic allows partial knowledge. If one card in an opponent’s two-card hand has been individually revealed to you, the hand is still a hidden zone, but you know one of its identities. Likewise, an effect may let only its controller look at the top card of a library, while another effect may reveal that top card publicly. The engine already represents these distinctions, but Gym collapsed all of them to “zone hidden” and therefore either omitted legally known cards or needed its own special cases.

The opposite problem appears with face-down objects. A battlefield or stack is normally public, but that does not make the underlying identity of a face-down permanent or face-down spell public. A Gym observation could therefore expose `"Craw Wurm"` or `"Hill Giant"` simply because the object lived in an otherwise public zone, even though an opponent should see only the face-down object’s public characteristics. The controller, meanwhile, is normally entitled to know what their own face-down object is. These are object-level identity rules, not zone-level rules.

This change makes that distinction explicit with `Visibility.isCardIdentityVisibleTo`. The query composes the identity rules Argentum already models: whole-zone access, individual `RevealedToComponent` knowledge, public and private top-of-library access, who may look at a face-down object, effect-granted face-down access, playable face-down cards in exile, and spectator restrictions.

Consumers still choose their own representation. For example, Gym now represents an opponent hand with one revealed card as a hidden zone of size two whose `cards` list contains only the one identity the perspective actually knows. It does not expose the unknown slot. A face-down battlefield object still exposes its public projected creature characteristics, such as its face-down P/T, but its `cardDefinitionId`, printed name, mana cost, and oracle text stay hidden from an opponent. `revealAll` remains an explicit debug escape hatch.

The same semantic question had also accumulated nearby ad hoc answers outside Gym. AI determinization separately excluded public top cards, individually revealed cards, and visible hands when deciding which hidden identities it could rewrite. Client modal-target presentation used owner/zone shortcuts for hidden card names. The deck tracker had its own approximation of whether the viewer knew which physical copy a card was. Combat-decision presentation masked face-down names using controller identity alone, so an explicit reveal could remain hidden in the decision UI even though the engine knew the viewer had learned the card.

Those paths now delegate identity entitlement to the same `Visibility` query. This removes cases where one subsystem knows a card while another hides it, or where one presentation leaks an identity another correctly masks.

The tests exercise the distinctions rather than just the helper itself. For example:

- with two cards in Player 2’s hand, revealing only the Mountain to Player 1 gives Player 1 exactly that identity while a third-player bystander still sees none;
- a private top-of-library effect reveals the top card only to its controller, while a public reveal exposes it to both players;
- a face-down `Craw Wurm` on the battlefield and a face-down `Hill Giant` on the stack expose their underlying identities to their controller but serialize no such names for the opponent;
- after a face-down combat object is explicitly revealed, server decision presentation stops masking its name;
- a modal spell targeting a hidden hand card initially shows only “a card in … hand”, then shows the real card name once that specific card is revealed;
- AI determinization now asks the same per-card visibility question before deciding whether an identity is safe to rewrite.

This deliberately does not create a shared client/Gym DTO, change Gym input-authority semantics, or merge presentation policy into the rules engine. `Visibility` owns only the semantic answer to whether a perspective may know an identity; Gym, client, server, and AI continue to own what they do with that answer.

Verification:

- `just test-class ObservationVisibilityTest`
- `just test-class ModalSpellStackVisibilityTest`
- `just test-class DeckListClientViewTest`
- `just test-class CombatDamageMaskingEnricherTest`
- `just test-class DeterminizerInvariantsTest`
- `just test-rules`
- `just test-ai`
- `just test-gym`
- `just test-server`