### PR TITLE
Align Gym public object semantics

### DIFF
--- a/gym/build.gradle.kts
+++ b/gym/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     runtimeOnly(libs.slf4jApi)
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -39,12 +39,17 @@ import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
@@ -243,7 +248,7 @@ class ObservationBuilder(
         return EntityFeatures(
             entityId = entityId,
             cardDefinitionId = card?.cardDefinitionId,
-            name = card?.name ?: "",
+            name = pv?.name ?: card?.name ?: "",
             zone = zone,
             ownerId = container.get<OwnerComponent>()?.playerId ?: card?.ownerId,
             controllerId = if (onBattlefield) projected.getController(entityId) else null,
@@ -254,8 +259,16 @@ class ObservationBuilder(
             manaCost = card?.manaCost?.toString() ?: "",
             manaValue = card?.manaValue ?: 0,
             oracleText = card?.oracleText ?: "",
-            power = if (onBattlefield) projected.getPower(entityId) else null,
-            toughness = if (onBattlefield) projected.getToughness(entityId) else null,
+            power = if (onBattlefield && projected.isCreature(entityId)) {
+                projected.getPower(entityId)
+            } else {
+                null
+            },
+            toughness = if (onBattlefield && projected.isCreature(entityId)) {
+                projected.getToughness(entityId)
+            } else {
+                null
+            },
             tapped = onBattlefield && container.get<TappedComponent>() != null,
             // Only creatures meaningfully suffer summoning sickness — the engine attaches the
             // marker to every entering permanent so Vehicles / animated lands inherit the
@@ -264,7 +277,8 @@ class ObservationBuilder(
             // played Mountain would mislead the agent into thinking it can't tap for mana.
             summoningSick = onBattlefield
                 && container.get<SummoningSicknessComponent>() != null
-                && projected.isCreature(entityId),
+                && projected.isCreature(entityId)
+                && Keyword.HASTE.name !in keywords,
             faceDown = container.get<FaceDownComponent>() != null,
             damageMarked = container.get<DamageComponent>()?.amount ?: 0,
             counters = container.get<CountersComponent>()?.counters
@@ -281,16 +295,23 @@ class ObservationBuilder(
     private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
-        // Stack kind inference — fall back to OTHER. A more precise classification
-        // can be added once the stack carries explicit metadata.
+        val spell = container?.get<SpellOnStackComponent>()
+        val triggeredAbility = container?.get<TriggeredAbilityOnStackComponent>()
+        val activatedAbility = container?.get<ActivatedAbilityOnStackComponent>()
         val kind = when {
-            card?.spellEffect != null -> StackItemKind.SPELL
-            card != null -> StackItemKind.SPELL
+            spell != null || card != null -> StackItemKind.SPELL
+            triggeredAbility != null -> StackItemKind.TRIGGERED_ABILITY
+            activatedAbility != null -> StackItemKind.ACTIVATED_ABILITY
             else -> StackItemKind.OTHER
         }
         return StackItemView(
             entityId = entityId,
-            controllerId = state.projectedState.getController(entityId),
+            // Battlefield projection deliberately has no entries for stack objects. Stack
+            // components are the engine authority for the caster/controller of each kind.
+            controllerId = spell?.casterId
+                ?: triggeredAbility?.controllerId
+                ?: activatedAbility?.controllerId
+                ?: container?.get<ControllerComponent>()?.playerId,
             name = card?.name ?: "",
             kind = kind,
             oracleText = card?.oracleText ?: "",

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.gym.contract
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.blc.cards.RollingHamsphere
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Effects
+import io.kotest.matchers.shouldBe
+
+/** Public Gym fields must read the engine semantic authority for the object kind in question. */
+class ObservationProjectedStateTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(RollingHamsphere)
+
+        test("battlefield names follow the layer projection") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Test Hasty Prospector")
+                .withCardOnBattlefield(1, "Witness Protection")
+                .build()
+            val creature = permanentNamed(game.state, "Test Hasty Prospector")
+            val aura = permanentNamed(game.state, "Witness Protection")
+            val enchanted = game.state.updateEntity(aura) { it.with(AttachedToComponent(creature)) }
+
+            enchanted.projectedState.getName(creature) shouldBe "Legitimate Businessperson"
+            entity(observe(enchanted, game.player1Id), creature).name shouldBe
+                "Legitimate Businessperson"
+        }
+
+        test("an uncrewed Vehicle has no public power or toughness") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, RollingHamsphere.name)
+                .build()
+            val vehicle = permanentNamed(game.state, RollingHamsphere.name)
+
+            game.state.projectedState.isCreature(vehicle) shouldBe false
+            // Projection retains the printed values for a later animation, but public P/T is
+            // conditional on the object currently being a creature.
+            game.state.projectedState.getPower(vehicle) shouldBe 4
+            entity(observe(game.state, game.player1Id), vehicle).let {
+                it.power shouldBe null
+                it.toughness shouldBe null
+            }
+        }
+
+        test("haste suppresses effective summoning sickness in the observation") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(
+                    1,
+                    "Test Hasty Prospector",
+                    summoningSickness = true,
+                )
+                .build()
+            val creature = permanentNamed(game.state, "Test Hasty Prospector")
+
+            game.state.projectedState.hasKeyword(creature, Keyword.HASTE) shouldBe true
+            entity(observe(game.state, game.player1Id), creature).summoningSick shouldBe false
+        }
+
+        test("stack controller and kind come from stack components rather than battlefield projection") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val spell = game.state.getHand(game.player2Id).single()
+            val trigger = EntityId.of("trigger-on-stack")
+            val activation = EntityId.of("activation-on-stack")
+            val state = game.state
+                .removeFromZone(ZoneKey(game.player2Id, Zone.HAND), spell)
+                .updateEntity(spell) { it.with(SpellOnStackComponent(casterId = game.player2Id)) }
+                .withEntity(
+                    trigger,
+                    ComponentContainer.of(
+                        TriggeredAbilityOnStackComponent(
+                            sourceId = EntityId.of("trigger-source"),
+                            sourceName = "Trigger Source",
+                            controllerId = game.player1Id,
+                            effect = Effects.DrawCards(1),
+                            description = "Draw a card",
+                        ),
+                    ),
+                )
+                .withEntity(
+                    activation,
+                    ComponentContainer.of(
+                        ActivatedAbilityOnStackComponent(
+                            sourceId = EntityId.of("activation-source"),
+                            sourceName = "Activation Source",
+                            controllerId = game.player2Id,
+                            effect = Effects.DrawCards(1),
+                        ),
+                    ),
+                )
+                .copy(stack = listOf(spell, trigger, activation))
+
+            val stack = observe(state, game.player1Id).stack.associateBy { it.entityId }
+            stack.getValue(spell).let {
+                it.kind shouldBe StackItemKind.SPELL
+                it.controllerId shouldBe game.player2Id
+            }
+            stack.getValue(trigger).let {
+                it.kind shouldBe StackItemKind.TRIGGERED_ABILITY
+                it.controllerId shouldBe game.player1Id
+            }
+            stack.getValue(activation).let {
+                it.kind shouldBe StackItemKind.ACTIVATED_ABILITY
+                it.controllerId shouldBe game.player2Id
+            }
+        }
+    }
+
+    private fun observe(
+        state: com.wingedsheep.engine.state.GameState,
+        viewer: EntityId,
+    ): TrainingObservation = ObservationBuilder()
+        .build(state, viewer, legalActions = emptyList())
+        .observation as TrainingObservation
+
+    private fun entity(observation: TrainingObservation, entityId: EntityId): EntityFeatures =
+        observation.zones.flatMap { it.cards }.single { it.entityId == entityId }
+
+    private fun permanentNamed(
+        state: com.wingedsheep.engine.state.GameState,
+        name: String,
+    ): EntityId = state.getBattlefield().single { id ->
+        state.getEntity(id)?.get<CardComponent>()?.name == name
+    }
+}


### PR DESCRIPTION
`TrainingObservation` is intended to describe the game state an agent is actually acting on, including continuous effects and stack state. Several Gym fields currently approximate that information from the wrong source, which produces observations that disagree with the rules engine even though the engine already has the authoritative values.

For battlefield objects, Gym already uses `GameState.projectedState` for types, colors, keywords, controller, power, and toughness, but still reports the printed `CardComponent.name`. That creates internally inconsistent observations when Layer 3 changes an object's name. For example, after Witness Protection turns a creature into `Legitimate Businessperson`, its projected characteristics describe the modified permanent while Gym still names the object by its printed card name. This change reads the projected name when one exists and falls back to the printed name otherwise.

Power and toughness have a related issue. `ProjectedState` retains P/T values that may become relevant if an object later becomes a creature, but those values are not themselves evidence that the permanent is currently a creature. An uncrewed Vehicle can therefore have projected numerical P/T values while Magic does not currently treat it as having creature P/T. Gym previously emitted those numbers unconditionally for every battlefield permanent. It now exposes P/T only when `projectedState.isCreature(entityId)` is true.

The existing `summoningSick` field had the inverse problem. Gym correctly restricts it to objects that are currently creatures, but it reported a creature as effectively summoning-sick whenever the engine's entry marker was present, even when the projected object has haste. The marker is still important engine state—if haste disappears before the permanent has been controlled since the beginning of the turn, the restriction becomes relevant again—but the observation field is describing the creature's current effective restriction. A newly entered creature with projected haste therefore now reports `summoningSick = false`.

Stack objects exposed another version of the same ownership problem. ObservationBuilder tried to derive a stack item’s controller through battlefield projection, but battlefield projection deliberately has no entry for stack objects. It also classified anything with a CardComponent as a spell and otherwise fell back to OTHER, so activated and triggered abilities lost their actual kind.

This change correctly classifies spells, triggered abilities, and activated abilities from their stack components, and correctly reads the controllers stored on triggered and activated ability components. For spells, however, the merged implementation reports SpellOnStackComponent.casterId as StackItemView.controllerId. That is correct for an ordinary cast whose control has not subsequently changed, but it is not a general current-controller authority: under CR 112.2 the caster is the controller only by default, and effects such as Commandeer can change control of a spell.

Argentum already reflects this distinction elsewhere: when it needs the controller of a spell, ProjectedState prefers ControllerComponent when present and falls back to SpellOnStackComponent.casterId. The Gym implementation in this PR should ultimately use the same semantic authority rather than treating caster identity as current control.

The tests exercise each discrepancy against the engine authority rather than merely checking the new implementation:

- Witness Protection changes a battlefield creature's projected name to `Legitimate Businessperson`, and Gym now reports that same name.
- An uncrewed Vehicle retains projected numerical P/T internally but Gym reports no public P/T until it is actually a creature.
- A newly entered creature with projected haste carries the engine's summoning-sickness marker but reports `summoningSick = false`.
- A spell, triggered ability, and activated ability placed on the stack report their distinct kinds; triggered and activated abilities report their component controllers, while ordinary spells currently report their caster pending the follow-up current-spell-controller fix.

This does not introduce a new projection layer or duplicate rules logic in Gym. It makes ObservationBuilder use existing engine state for projected battlefield characteristics and stack metadata. One post-merge exception is the spell controllerId field: the implementation currently exposes casterId, which is not sufficient once control of a spell changes. That is tracked separately so Gym can consume the engine’s current-controller semantics rather than casting provenance.

Verification:

- `just test-class ObservationProjectedStateTest`
- `just test-gym`
- `git diff --check`