### PR TITLE
Include observable facts in Gym state digest

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
@@ -60,7 +60,9 @@ object StateDigest {
                 sb.append("Z[").append(z.ownerId.value).append('/').append(z.zoneType.name)
                     .append("]:hidden=").append(z.hidden)
                     .append(":size=").append(z.size)
-                if (!z.hidden) {
+                // A hidden zone may still contain identities this perspective knows. Encode every
+                // supplied card; a completely unknown hidden zone has an empty cards list.
+                if (z.cards.isNotEmpty()) {
                     sb.append(":ids=")
                     z.cards.forEach { c ->
                         sb.append(c.entityId.value).append(',')
@@ -74,7 +76,12 @@ object StateDigest {
         // Stack — order is meaningful (bottom → top).
         obs.stack.forEachIndexed { i, s ->
             sb.append("S[").append(i).append("]=").append(s.entityId.value)
-                .append(':').append(s.kind.name).append('|')
+                .append(":ctl=").append(s.controllerId?.value)
+                .append(":name=").append(s.name)
+                .append(":kind=").append(s.kind.name)
+                .append(":text=").append(s.oracleText)
+                .append(":targets=").append(s.targets.joinToString(",") { it.value })
+                .append("|")
         }
 
         // Pending decision — identity + kind only; per-option IDs are not

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -134,6 +135,72 @@ class TrainingObservationTest : FunSpec({
         decoded.zones.flatMap { it.cards }.forEach { c ->
             // Every serialized card either has empty oracle text or preserves it.
             c.oracleText shouldBe (obs.zones.flatMap { it.cards }.first { it.entityId == c.entityId }.oracleText)
+        }
+    }
+
+    test("stateDigest includes known card details supplied inside a hidden zone") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation as TrainingObservation
+
+        val hiddenIndex = base.zones.indexOfFirst {
+            it.hidden && it.zoneType == Zone.HAND
+        }
+        hiddenIndex shouldNotBe -1
+
+        val hidden = base.zones[hiddenIndex]
+        val template = base.zones
+            .first { !it.hidden && it.cards.isNotEmpty() }
+            .cards.first()
+
+        val knownA = template.copy(
+            entityId = EntityId.of("known-hidden-card"),
+            cardDefinitionId = "known-a",
+            name = "Known A",
+            ownerId = hidden.ownerId,
+        )
+        val knownB = knownA.copy(
+            cardDefinitionId = "known-b",
+            name = "Known B",
+        )
+
+        fun withKnown(card: EntityFeatures): TrainingObservation {
+            val zones = base.zones.toMutableList()
+            zones[hiddenIndex] = hidden.copy(cards = listOf(card))
+            return base.copy(zones = zones)
+        }
+
+        StateDigest.compute(withKnown(knownA)) shouldNotBe
+            StateDigest.compute(withKnown(knownB))
+    }
+
+    test("stateDigest includes observable stack details") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val opponent = env.playerIds[1]
+        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation as TrainingObservation
+
+        val targetA = EntityId.of("target-a")
+        val targetB = EntityId.of("target-b")
+        val stackItem = StackItemView(
+            entityId = EntityId.of("stack-item"),
+            controllerId = me,
+            name = "Visible Spell",
+            kind = StackItemKind.SPELL,
+            oracleText = "Visible rules text",
+            targets = listOf(targetA),
+        )
+        val baseline = StateDigest.compute(base.copy(stack = listOf(stackItem)))
+
+        listOf(
+            stackItem.copy(controllerId = opponent),
+            stackItem.copy(name = "Different Visible Spell"),
+            stackItem.copy(oracleText = "Different visible rules text"),
+            stackItem.copy(targets = listOf(targetB)),
+        ).forEach { changed ->
+            StateDigest.compute(base.copy(stack = listOf(changed))) shouldNotBe baseline
         }
     }
 


### PR DESCRIPTION
`StateDigest` is intended to identify the observable information-set represented by a `TrainingObservation`. At present, two observations can differ in information explicitly present in the DTO while still receiving the same digest because some of those fields are omitted from the canonical encoding.

The first case is a hidden zone that contains a known subset. `ZoneView.hidden` describes whether some identities in the zone remain unknown; it does not necessarily mean `cards` is empty. For example, a two-card opponent hand may remain hidden while one specific card has been revealed. The observation can therefore legitimately contain a hidden zone of size two with one `EntityFeatures` entry describing the known card.

`StateDigest` currently encodes zone card details only when `hidden == false`. As a result, two observations that differ only in which card is known inside the same hidden zone hash identically, even though the perspective has different information in the two states.

The digest now encodes every card actually supplied by `ZoneView.cards`. A completely unknown hidden zone still has an empty `cards` list, so its concealed contents remain absent from the digest. This preserves the intended information-set boundary while allowing partially known hidden zones to contribute the information the observation actually exposes.

The second case is the stack. `StackItemView` already represents the item's entity ID, controller, name, kind, oracle text, and targets, but the digest currently hashes only entity ID and kind. Consequently, observations can collide even when a visible spell has a different controller or target, or when the visible name or rules text of a stack item differs.

For example, these two observations currently produce the same stack encoding:

- `"Visible Spell"` controlled by Player 1 targeting object A;
- `"Visible Spell"` controlled by Player 2 targeting object B.

Those are not interchangeable information states for a search or transposition-table consumer. The digest now includes the stack item's observable controller, name, kind, oracle text, and ordered target list.

The tests exercise `StateDigest` directly at the `TrainingObservation` contract boundary rather than depending on how `ObservationBuilder` currently constructs observations. One regression constructs two otherwise identical observations whose hidden zone contains a different known card and verifies that their digests differ. Another holds a stack item fixed and independently changes its controller, name, oracle text, and target, verifying that each observable change alters the digest.

This deliberately does not make `StateDigest` a byte-for-byte hash of every DTO field. Derived fields such as legal actions and the digest itself remain excluded, and existing canonicalization of unordered collections is unchanged. The change is limited to observable, stable information already represented by the observation but previously omitted from its information-state identity.

Verification:

- `just test-class TrainingObservationTest`
- `just test-gym`
- `git diff --check`