### PR TITLE
Expire the streamed combat previews with their declaration step

### DIFF
--- a/web-client/src/components/combat/CombatArrows.tsx
+++ b/web-client/src/components/combat/CombatArrows.tsx
@@ -278,6 +278,14 @@ export function CombatArrows() {
   // Check if we're still in combat phase
   const isInCombatPhase = currentStep && COMBAT_STEPS.has(currentStep as Step)
 
+  // The opponent's streamed declaration previews are only meaningful while that declaration is
+  // being made. Without this bound a preview that never became a declaration (the attacker
+  // cancelled, or declared no attackers) has nothing to clear it — `gameState.combat` stays
+  // null, which is the very condition the preview draws under — and its arrows stay painted
+  // for the rest of the game. The store clears the stale value too; this keeps it unpaintable.
+  const isDeclareAttackersStep = currentStep === Step.DECLARE_ATTACKERS
+  const isDeclareBlockersStep = currentStep === Step.DECLARE_BLOCKERS
+
   // Check if we're selecting damage order (hide blocker arrows during this UI)
   const isSelectingDamageOrder = pendingDecision?.type === 'OrderObjectsDecision' &&
     pendingDecision?.context?.phase === 'COMBAT'
@@ -371,7 +379,7 @@ export function CombatArrows() {
             }
           }
         }
-      } else if (opponentBlockerAssignments && Object.keys(opponentBlockerAssignments).length > 0 && isInCombatPhase) {
+      } else if (opponentBlockerAssignments && Object.keys(opponentBlockerAssignments).length > 0 && isDeclareBlockersStep) {
         // Use opponent's real-time blocker assignments (for attacking player, only during combat)
         for (const [blockerIdStr, attackerIds] of Object.entries(opponentBlockerAssignments)) {
           const blockerId = blockerIdStr as EntityId
@@ -523,7 +531,7 @@ export function CombatArrows() {
       }
 
       // Compute opponent's real-time attacker target arrows (for defending player and spectators, always show)
-      if (opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && !gameStateCombat) {
+      if (opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && !gameStateCombat && isDeclareAttackersStep) {
         for (const [attackerIdStr, targetId] of Object.entries(opponentAttackerTargets.attackerTargets)) {
           const attackerId = attackerIdStr as EntityId
           if (!opponentAttackerTargets.selectedAttackers.includes(attackerId)) continue
@@ -569,7 +577,7 @@ export function CombatArrows() {
             newIndicators.push({ x: pos.x, y: pos.y, direction, attackerId, color: indicatorColorFor(targetId) })
           }
         }
-      } else if (opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && !gameStateCombat) {
+      } else if (opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && !gameStateCombat && isDeclareAttackersStep) {
         // Opponent's real-time attacker selections (for defending player and spectators)
         for (const attackerId of opponentAttackerTargets.selectedAttackers) {
           const targetId = opponentAttackerTargets.attackerTargets[attackerId]
@@ -612,7 +620,7 @@ export function CombatArrows() {
     updateArrows()
     const interval = setInterval(updateArrows, 100)
     return () => clearInterval(interval)
-  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, cards, isSpectating, isSelectingDamageOrder, players, teamMap, isMulti, viewedOpponentId, viewingPlayerId])
+  }, [combatState, gameStateCombat, opponentAttackerTargets, opponentBlockerAssignments, isDeclaringBlockers, isInCombatPhase, isDeclareAttackersStep, isDeclareBlockersStep, cards, isSpectating, isSelectingDamageOrder, players, teamMap, isMulti, viewedOpponentId, viewingPlayerId])
 
   // Don't render during full-screen overlay decisions
   if (hasOverlayDecision) {
@@ -621,11 +629,12 @@ export function CombatArrows() {
 
   // Don't render if no arrows to show (only show during combat phase)
   const hasBlockers = isDeclaringBlockers ||
-    (opponentBlockerAssignments && Object.keys(opponentBlockerAssignments).length > 0 && isInCombatPhase) ||
+    (opponentBlockerAssignments && Object.keys(opponentBlockerAssignments).length > 0 && isDeclareBlockersStep) ||
     (gameStateCombat && gameStateCombat.blockers.length > 0 && isInCombatPhase)
   const hasAttackers = gameStateCombat && gameStateCombat.attackers.length > 0
   const hasSelectedAttackers = combatState?.mode === 'declareAttackers' && combatState.selectedAttackers.length > 0
-  const hasOpponentAttackers = opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0
+  const hasOpponentAttackers =
+    opponentAttackerTargets && opponentAttackerTargets.selectedAttackers.length > 0 && isDeclareAttackersStep
   if (!hasBlockers && !hasAttackers && !hasSelectedAttackers && !hasOpponentAttackers && !draggingBlockerId && !draggingAttackerId) {
     return null
   }

--- a/web-client/src/store/slices/handlers/combatPreview.test.ts
+++ b/web-client/src/store/slices/handlers/combatPreview.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { keepAttackerPreview, keepBlockerPreview } from './combatPreview'
+import { Step } from '@/types'
+
+/**
+ * The bug these pin: an attacker selection streamed to the table, then *not* declared — the
+ * attacker cancelled, or declared no attackers — used to be cleared only by "the server's combat
+ * state now exists". No attackers means no combat state, so nothing ever cleared it, and its
+ * arrows stayed painted over the board for the rest of the game (free-for-all worst of all, where
+ * the preview carries a defender per attacker and so draws full arrows).
+ */
+describe('keepAttackerPreview', () => {
+  it('keeps the preview while attackers are being declared', () => {
+    expect(keepAttackerPreview(Step.DECLARE_ATTACKERS, false)).toBe(true)
+  })
+
+  it('drops it once the declaration landed and combat carries the real attackers', () => {
+    expect(keepAttackerPreview(Step.DECLARE_ATTACKERS, true)).toBe(false)
+  })
+
+  it('drops it when the declaration never landed — no attackers, so no combat state', () => {
+    // The step has moved on with `combat` still null: exactly the case that used to stick.
+    expect(keepAttackerPreview(Step.DECLARE_BLOCKERS, false)).toBe(false)
+    expect(keepAttackerPreview(Step.END_COMBAT, false)).toBe(false)
+    expect(keepAttackerPreview(Step.POSTCOMBAT_MAIN, false)).toBe(false)
+    expect(keepAttackerPreview(Step.END, false)).toBe(false)
+  })
+
+  it('drops it when the step is unknown, rather than painting on a guess', () => {
+    expect(keepAttackerPreview(null, false)).toBe(false)
+    expect(keepAttackerPreview(undefined, false)).toBe(false)
+  })
+})
+
+describe('keepBlockerPreview', () => {
+  it('keeps the preview while blockers are being declared and none are in combat yet', () => {
+    expect(keepBlockerPreview(Step.DECLARE_BLOCKERS, true, false)).toBe(true)
+  })
+
+  it('drops it once the declaration landed — combat carries the blockers', () => {
+    expect(keepBlockerPreview(Step.DECLARE_BLOCKERS, true, true)).toBe(false)
+  })
+
+  it('drops it past the declare blockers step, even with combat still running', () => {
+    expect(keepBlockerPreview(Step.COMBAT_DAMAGE, true, false)).toBe(false)
+    expect(keepBlockerPreview(Step.END_COMBAT, true, false)).toBe(false)
+  })
+
+  it('drops it when there is no combat at all', () => {
+    expect(keepBlockerPreview(Step.DECLARE_BLOCKERS, false, false)).toBe(false)
+  })
+})

--- a/web-client/src/store/slices/handlers/combatPreview.ts
+++ b/web-client/src/store/slices/handlers/combatPreview.ts
@@ -1,0 +1,37 @@
+/**
+ * How long the opponent's *streamed* combat declaration survives.
+ *
+ * While a player is picking attackers or blockers, their client streams the work-in-progress
+ * selection to everyone else (`opponentAttackerTargets` / `opponentBlockerAssignments`) so the
+ * table watches the arrows move in real time. Nothing in that stream says "I'm done" — it is
+ * cancelled by the state update that supersedes it, and these two predicates are that rule.
+ *
+ * The bound is the declaration's own *step*. Keying it to the server's combat state alone is not
+ * enough: a selection that never becomes a declaration — the attacker cancelled, or declared no
+ * attackers at all — leaves `combat` null, which is the very condition the preview draws under,
+ * so it would never be cleared and its arrows would stay painted for the rest of the game.
+ * Multiplayer feels that worst, because there the attacker preview carries a per-attacker
+ * defender and so draws full arrows rather than only the small direction chevrons.
+ */
+import { Step } from '@/types'
+
+/**
+ * Keep the attacker preview only while attackers are being declared and the declaration has not
+ * landed yet — once it has, `combat` carries the real attackers and takes over.
+ */
+export function keepAttackerPreview(step: Step | null | undefined, hasCombat: boolean): boolean {
+  return !hasCombat && step === Step.DECLARE_ATTACKERS
+}
+
+/**
+ * Keep the blocker preview only while blockers are being declared. Unlike attackers, combat
+ * already exists throughout (the attackers are on the battlefield), so the declaration landing
+ * shows up as blockers appearing in it.
+ */
+export function keepBlockerPreview(
+  step: Step | null | undefined,
+  hasCombat: boolean,
+  hasDeclaredBlockers: boolean,
+): boolean {
+  return hasCombat && !hasDeclaredBlockers && step === Step.DECLARE_BLOCKERS
+}

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -8,6 +8,7 @@ import type { ClientGameState, ClientEvent, LegalActionInfo, PendingDecision, Op
 import { trackEvent, setInGame } from '@/utils/analytics.ts'
 import { applyStateDelta } from '@/network/deltaApplicator.ts'
 import { getWebSocket, clearLobbyId, requestReauth } from '../shared'
+import { keepAttackerPreview, keepBlockerPreview } from './combatPreview'
 import type { SetState, GetState } from './types'
 import type {
   LogEntry,
@@ -541,8 +542,17 @@ function processStateUpdate(
           ? null
           : { cardIds: filteredReveal.cardIds, cardNames: filteredReveal.cardNames, imageUris: filteredReveal.imageUris, source: filteredReveal.source, isYourReveal: filteredReveal.revealingPlayerId === playerId, fromZone: filteredReveal.fromZone ?? null, toZone: filteredReveal.toZone ?? null, ...(filteredReveal.cardOwnerIsYours ? { cardOwnerIsYours: filteredReveal.cardOwnerIsYours } : {}) })
       : cardsRevealedEvent ? null : state.revealedCardsInfo,
-    opponentAttackerTargets: resolvedState.combat ? null : state.opponentAttackerTargets,
-    opponentBlockerAssignments: (resolvedState.combat?.blockers?.length || !resolvedState.combat) ? null : state.opponentBlockerAssignments,
+    // The opponent's streamed declaration previews expire with their own declaration step.
+    opponentAttackerTargets: keepAttackerPreview(resolvedState.currentStep, resolvedState.combat != null)
+      ? state.opponentAttackerTargets
+      : null,
+    opponentBlockerAssignments: keepBlockerPreview(
+      resolvedState.currentStep,
+      resolvedState.combat != null,
+      (resolvedState.combat?.blockers?.length ?? 0) > 0,
+    )
+      ? state.opponentBlockerAssignments
+      : null,
   }))
 
   // Auto-initialize inline distribute state for DistributeDecision

--- a/web-client/src/store/slices/handlers/spectatingHandlers.ts
+++ b/web-client/src/store/slices/handlers/spectatingHandlers.ts
@@ -2,6 +2,7 @@
  * Handlers for spectating, combat UI, and disconnect messages.
  */
 import type { MessageHandlers } from '@/network/messageHandlers.ts'
+import { keepAttackerPreview, keepBlockerPreview } from './combatPreview'
 import type { SetState, GetState } from './types'
 
 type SpectatingHandlerKeys =
@@ -75,6 +76,11 @@ export function createSpectatingHandlers(set: SetState, get: GetState): Pick<Mes
         }
       }
 
+      // The spectator stream carries the full client state, so the declaration step bounds the
+      // preview exactly as it does for players. A stream without it drops the preview rather
+      // than keeping it — a missing arrow is a nicety lost, a stuck one is the bug.
+      const spectatorStep = msg.gameState?.currentStep ?? null
+
       set((state) => ({
         spectatingState: {
           gameSessionId: msg.gameSessionId,
@@ -91,8 +97,16 @@ export function createSpectatingHandlers(set: SetState, get: GetState): Pick<Mes
           combat: msg.combat,
           decisionStatus: msg.decisionStatus ?? null,
         },
-        opponentAttackerTargets: msg.combat ? null : state.opponentAttackerTargets,
-        opponentBlockerAssignments: (msg.combat?.attackers?.some(a => a.blockedBy.length > 0) || !msg.combat) ? null : state.opponentBlockerAssignments,
+        opponentAttackerTargets: keepAttackerPreview(spectatorStep, msg.combat != null)
+          ? state.opponentAttackerTargets
+          : null,
+        opponentBlockerAssignments: keepBlockerPreview(
+          spectatorStep,
+          msg.combat != null,
+          msg.combat?.attackers?.some(a => a.blockedBy.length > 0) ?? false,
+        )
+          ? state.opponentBlockerAssignments
+          : null,
       }))
     },
 


### PR DESCRIPTION
## The bug

In a free-for-all game, attack arrows sometimes stayed painted over the board after the combat phase was over.

While a player picks attackers, their client streams the work-in-progress selection to everyone else (`updateAttackerTargets` → `opponentAttackerTargets`) so the table watches the arrows move in real time. That stream carries no "I'm done" message — it was cancelled by the next state update whose `combat` was non-null:

```ts
opponentAttackerTargets: resolvedState.combat ? null : state.opponentAttackerTargets,
```

Which never arrives when the selection doesn't become a declaration. Cancel the attack, or declare no attackers at all, and no creature ends up with an `AttackingComponent`, so `ClientStateTransformer.transformCombat` returns `null` — *the very condition the preview draws under* (`… && !gameStateCombat`). Nothing cleared the value and nothing stopped it painting, so the arrows stayed up for the rest of the game, until someone finally did attack.

Free-for-all shows it worst because there the preview carries a defender per attacker, so `pushAttackArrow` draws full arrows; a two-player game with no planeswalkers has an empty `attackerTargets` map and leaks only the small direction chevrons.

The blocker preview had the same shape one notch weaker: bounded by the whole combat phase (`isInCombatPhase`), so a cancelled block survived into combat damage.

## The fix

The honest bound is the declaration's own **step**. `keepAttackerPreview` / `keepBlockerPreview` (new `handlers/combatPreview.ts`) state that rule once:

- attacker preview lives only during `DECLARE_ATTACKERS`, and only until `combat` carries the real attackers;
- blocker preview lives only during `DECLARE_BLOCKERS`, and only until `combat` carries the blockers.

Both the player stream (`gameplayHandlers`) and the spectator stream (`spectatingHandlers`) use them, and `CombatArrows` applies the same gate at the paint site, so a stale value arriving by any other path can't render either. A spectator stream with no client state drops the preview rather than keeping it — a missing arrow is a nicety lost, a stuck one is the bug.

## Verification

- `npx vitest run` in `web-client` — 55 files / 789 tests pass, including the 8 new `combatPreview.test.ts` cases that pin the "step moved on with `combat` still null" case that used to stick.
- `npx tsc --noEmit` clean.

No engine, server or card changes, so no Gradle gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y2Z1SDg8jcuSyDUcnsoJo