### PR TITLE
Keep automatic decisions strictly forced, with one definition of 'forced'

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.EnumerationMode
 import com.wingedsheep.engine.legalactions.LegalAction
@@ -67,6 +68,14 @@ class GameSimulator(
     /** Guard against recursive resolution — inner simulations (from DecisionResponder
      *  evaluating alternatives) should NOT re-enter the resolver. */
     private var isResolving = false
+
+    /**
+     * The constant-time policy used while [isResolving] blocks the strategic resolver.
+     *
+     * Only reached from inside a resolver's own simulation, where the choice is between one cheap
+     * heuristic answer and abandoning the resolution entirely.
+     */
+    private val fallbackResponder = FastDecisionResponder()
     /**
      * Simulate an action and resolve the stack to completion.
      *
@@ -154,23 +163,32 @@ class GameSimulator(
                     iterations++
                     continue
                 }
-                // Non-trivial decision: try the pluggable resolver (but not recursively —
-                // inner simulations from DecisionResponder evaluating alternatives break here)
+                // Non-trivial decision: hand it to the pluggable resolver.
                 val resolver = decisionResolver
-                if (resolver != null && !isResolving) {
+                if (resolver != null) {
                     if (iterations >= maxAutomaticTransitions) {
                         return stoppedAtLimit(current, allEvents, iterations)
                     }
-                    try {
-                        isResolving = true
-                        val response = resolver(current.state, decision)
-                        val submitAction = SubmitDecision(decision.playerId, response)
-                        current = processor.process(current.state, submitAction).result
-                        allEvents = allEvents + current.events
-                        iterations++
-                    } finally {
-                        isResolving = false
+                    val response = if (isResolving) {
+                        // The strategic resolver scores its alternatives by simulating them, so it
+                        // cannot be re-entered from inside one of its own simulations. Answering
+                        // with the O(1) rollout policy is what the playout path already does, and
+                        // it beats stopping: an abandoned resolution scores a board with the ward
+                        // unpaid or the combat damage unassigned — a position the game never
+                        // actually reaches.
+                        fallbackResponder.respond(current.state, decision, decision.playerId)
+                    } else {
+                        try {
+                            isResolving = true
+                            resolver(current.state, decision)
+                        } finally {
+                            isResolving = false
+                        }
                     }
+                    val submitAction = SubmitDecision(decision.playerId, response)
+                    current = processor.process(current.state, submitAction).result
+                    allEvents = allEvents + current.events
+                    iterations++
                     continue
                 }
                 return SimulationResult.NeedsDecision(current.state, decision, allEvents)

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
@@ -41,10 +41,8 @@ object TrivialDecisions {
         // cap. Cross-requirement distinctness is not represented on ChooseTargetsDecision, so a
         // multi-requirement response cannot be proved unique here.
         is ChooseTargetsDecision -> {
-            val requirementIndices = decision.targetRequirements.map { it.index }
             val allForced = !decision.canCancel &&
-                requirementIndices.size <= 1 &&
-                requirementIndices.size == requirementIndices.toSet().size &&
+                decision.targetRequirements.size <= 1 &&
                 decision.targetRequirements.all { req ->
                     val targets = decision.legalTargets[req.index] ?: emptyList()
                     targets.size == 1 &&

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/TrivialDecisions.kt
@@ -8,9 +8,7 @@ import com.wingedsheep.engine.core.ChooseNumberDecision
 import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.ColorChosenResponse
-import com.wingedsheep.engine.core.DamageAssignmentResponse
 import com.wingedsheep.engine.core.DecisionResponse
-import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
 import com.wingedsheep.engine.core.ModesChosenResponse
 import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.core.OptionChosenResponse
@@ -31,21 +29,30 @@ import com.wingedsheep.engine.core.TargetsResponse
  * ([com.wingedsheep.ai.engine.rollout.FastDecisionResponder], inside a playout) start here and only
  * fall through to their own policy when the choice is real.
  *
- * Extracted from `GameSimulator` in Phase 7 unchanged, rather than reimplemented: a playout that
- * answered a forced decision differently from the simulator would make rollout scores incomparable
- * with the static ones they replace, for no benefit.
+ * This helper is deliberately conservative. Defaults, solver suggestions, and decisions whose
+ * uniqueness depends on state stay with the caller's policy; surfacing a forced decision is cheaper
+ * than silently making a strategic choice here.
  */
 object TrivialDecisions {
 
     /** The forced response to [decision], or null when the choice is a real one. */
     fun responseFor(decision: PendingDecision): DecisionResponse? = when (decision) {
-        // Single target, single requirement → auto-select
+        // A single requirement has one mandatory target, with no cancellation or state-dependent
+        // cap. Cross-requirement distinctness is not represented on ChooseTargetsDecision, so a
+        // multi-requirement response cannot be proved unique here.
         is ChooseTargetsDecision -> {
-            val allSingle = decision.targetRequirements.all { req ->
-                val targets = decision.legalTargets[req.index] ?: emptyList()
-                targets.size == 1 && req.minTargets == 1 && req.maxTargets == 1
-            }
-            if (allSingle) {
+            val requirementIndices = decision.targetRequirements.map { it.index }
+            val allForced = !decision.canCancel &&
+                requirementIndices.size <= 1 &&
+                requirementIndices.size == requirementIndices.toSet().size &&
+                decision.targetRequirements.all { req ->
+                    val targets = decision.legalTargets[req.index] ?: emptyList()
+                    targets.size == 1 &&
+                        req.minTargets == 1 &&
+                        req.maxTargets == 1 &&
+                        req.totalManaValueAtMost == null
+                }
+            if (allForced) {
                 TargetsResponse(
                     decisionId = decision.id,
                     selectedTargets = decision.targetRequirements.associate { req ->
@@ -55,36 +62,39 @@ object TrivialDecisions {
             } else null
         }
 
-        // Forced card selection (min == max == options.size)
+        // The shared response contract intentionally permits repeated IDs for distributed counter
+        // removal. Without metadata distinguishing that use, only zero/one-option selections can
+        // prove uniqueness here; larger all-options selections stay policy-owned.
         is SelectCardsDecision -> {
-            if (decision.minSelections == decision.options.size &&
+            val hasStateDependentConstraints = decision.onePerCardType ||
+                decision.onePerColor ||
+                decision.onePerCardName ||
+                decision.onePerBasicLandType ||
+                decision.onePerPower ||
+                decision.maxTotalManaValue != null ||
+                decision.minTotalManaValue != null ||
+                decision.maxTotalPower != null ||
+                decision.conditionalMinimums.isNotEmpty()
+            if (decision.options.size <= 1 &&
+                !hasStateDependentConstraints &&
+                decision.minSelections == decision.options.size &&
                 decision.maxSelections == decision.options.size
             ) {
                 CardsSelectedResponse(decision.id, decision.options)
             } else null
         }
 
-        // Damage assignment with defaults
-        is AssignDamageDecision -> {
-            if (decision.defaultAssignments.isNotEmpty()) {
-                DamageAssignmentResponse(decision.id, decision.defaultAssignments)
-            } else null
-        }
+        // A default assignment is an initial policy choice, not proof that no other distribution is
+        // legal. The rollout responder may still confirm it as its own heuristic.
+        is AssignDamageDecision -> null
 
-        // Mana sources — auto-pay is trivial only when the solver actually found a
-        // solution. When autoPaySuggestion is empty (e.g. the only available mana
-        // requires sacrificing a Treasure), autoPay=true errors and the resumer
-        // would re-prompt the same decision; fall through so the pluggable
-        // resolver (DecisionResponder.respondManaSelection) handles it.
-        is SelectManaSourcesDecision -> {
-            if (decision.autoPaySuggestion.isNotEmpty()) {
-                ManaSourcesSelectedResponse(decision.id, autoPay = true)
-            } else null
-        }
+        // autoPaySuggestion is one solver-selected payment. Manual source choices, mana abilities
+        // with side effects, and (when offered) declining remain strategy-owned.
+        is SelectManaSourcesDecision -> null
 
-        // Single option
+        // Single option with no separate cancel response.
         is ChooseOptionDecision -> {
-            if (decision.options.size == 1) {
+            if (!decision.canCancel && decision.options.size == 1) {
                 OptionChosenResponse(decision.id, 0)
             } else null
         }
@@ -96,10 +106,11 @@ object TrivialDecisions {
             } else null
         }
 
-        // Single mode, min==max==1
+        // Exact one-mode contract. A broader maximum is left conservative because the current
+        // response contract does not independently describe repeatability.
         is ChooseModeDecision -> {
             val available = decision.modes.filter { it.available }
-            if (available.size == 1 && decision.minModes == 1) {
+            if (available.size == 1 && decision.minModes == 1 && decision.maxModes == 1) {
                 ModesChosenResponse(decision.id, listOf(available.first().index))
             } else null
         }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
 import com.wingedsheep.engine.core.ChooseNumberDecision
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.PassPriority
@@ -17,6 +18,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -85,5 +87,43 @@ class GameSimulatorForcedDecisionTest : FunSpec({
         val manaDecision = result.decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
         manaDecision.availableSources.size shouldBe 2
         manaDecision.autoPaySuggestion.size shouldBe 1
+    }
+
+    test("a resolver that cannot re-enter still finishes the payment on rollout policy") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+
+        val payer = driver.player1
+        val source = driver.putCreatureOnBattlefield(payer, "Goblin Guide")
+        driver.putLandOnBattlefield(payer, "Forest")
+        driver.putLandOnBattlefield(payer, "Forest")
+
+        val payment = CostPaymentService(EngineServices(driver.cardRegistry)).pay(
+            state = driver.state,
+            payerId = payer,
+            cost = Costs.pay.Mana(ManaCost.parse("{G}")),
+            sourceId = source,
+        ).shouldBeInstanceOf<PaymentResult.Pending>()
+
+        val accept = YesNoResponse(payment.pendingDecision.id, choice = true)
+
+        // A strategic resolver scores its options by simulating them, so the inner simulation runs
+        // with the resolver locked out. The line it replays reaches this very mana decision again:
+        // without a fallback the inner run abandons the resolution and scores a board with the
+        // cost half-paid.
+        val simulator = GameSimulator(driver.cardRegistry)
+        var innerResult: SimulationResult? = null
+        simulator.decisionResolver = { state, decision ->
+            if (innerResult == null) {
+                innerResult = simulator.simulateDecision(payment.state, accept)
+            }
+            FastDecisionResponder().respond(state, decision, decision.playerId)
+        }
+
+        simulator.simulateDecision(payment.state, accept)
+            .shouldBeInstanceOf<SimulationResult.Terminal>()
+
+        innerResult.shouldNotBeNull().shouldBeInstanceOf<SimulationResult.Terminal>()
     }
 })

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameSimulatorForcedDecisionTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.engine.mechanics.cost.PaymentResult
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class GameSimulatorForcedDecisionTest : FunSpec({
+
+    fun simulateNumberDecision(minValue: Int, maxValue: Int): SimulationResult {
+        val testCard = card("Number Choice $minValue-$maxValue") {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                effect = Effects.ChooseNumberThen(
+                    then = Effects.GainLife(1),
+                    minValue = minValue,
+                    maxValue = maxValue,
+                )
+            }
+        }
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + testCard)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val cardId = driver.putCardInHand(caster, testCard.name)
+        driver.castSpell(caster, cardId).isSuccess.shouldBeTrue()
+
+        val priority = driver.state.priorityPlayerId!!
+        return GameSimulator(driver.cardRegistry).simulate(driver.state, PassPriority(priority))
+    }
+
+    test("simulator traverses a genuinely forced number decision") {
+        simulateNumberDecision(minValue = 4, maxValue = 4)
+            .shouldBeInstanceOf<SimulationResult.Terminal>()
+    }
+
+    test("simulator stops when the analogous number decision has a real choice") {
+        val result = simulateNumberDecision(minValue = 3, maxValue = 4)
+            .shouldBeInstanceOf<SimulationResult.NeedsDecision>()
+
+        result.decision.shouldBeInstanceOf<ChooseNumberDecision>()
+    }
+
+    test("simulator leaves a solver-suggested mana payment to strategy") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+
+        val payer = driver.player1
+        val source = driver.putCreatureOnBattlefield(payer, "Goblin Guide")
+        driver.putLandOnBattlefield(payer, "Forest")
+        driver.putLandOnBattlefield(payer, "Forest")
+
+        val payment = CostPaymentService(EngineServices(driver.cardRegistry)).pay(
+            state = driver.state,
+            payerId = payer,
+            cost = Costs.pay.Mana(ManaCost.parse("{G}")),
+            sourceId = source,
+        ).shouldBeInstanceOf<PaymentResult.Pending>()
+
+        val result = GameSimulator(driver.cardRegistry).simulateDecision(
+            payment.state,
+            YesNoResponse(payment.pendingDecision.id, choice = true),
+        ).shouldBeInstanceOf<SimulationResult.NeedsDecision>()
+
+        val manaDecision = result.decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        manaDecision.availableSources.size shouldBe 2
+        manaDecision.autoPaySuggestion.size shouldBe 1
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/TrivialDecisionsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/TrivialDecisionsTest.kt
@@ -1,0 +1,337 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
+import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseModeDecision
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DamageAssignmentResponse
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.ManaSourceOption
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.ModeOption
+import com.wingedsheep.engine.core.ModesChosenResponse
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SearchCardInfo
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class TrivialDecisionsTest : FunSpec({
+
+    val player = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val context = DecisionContext(phase = DecisionPhase.RESOLUTION)
+
+    test("structurally forced decisions produce validator-approved responses") {
+        val decisions = listOf(
+            ChooseTargetsDecision(
+                id = "targets",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                targetRequirements = listOf(
+                    TargetRequirementInfo(index = 0, description = "first target"),
+                ),
+                legalTargets = mapOf(0 to listOf(first)),
+            ),
+            SelectCardsDecision(
+                id = "cards",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                options = listOf(first),
+                minSelections = 1,
+                maxSelections = 1,
+            ),
+            ChooseOptionDecision(
+                id = "option",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                options = listOf("Only option"),
+            ),
+            ChooseColorDecision(
+                id = "color",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                availableColors = setOf(Color.BLUE),
+            ),
+            ChooseModeDecision(
+                id = "mode",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                modes = listOf(
+                    ModeOption(index = 4, text = "Only available"),
+                    ModeOption(index = 9, text = "Unavailable", available = false),
+                ),
+                minModes = 1,
+                maxModes = 1,
+            ),
+            ChooseNumberDecision(
+                id = "number",
+                playerId = player,
+                prompt = "Choose",
+                context = context,
+                minValue = 3,
+                maxValue = 3,
+            ),
+            OrderObjectsDecision(
+                id = "order",
+                playerId = player,
+                prompt = "Order",
+                context = context,
+                objects = listOf(first),
+            ),
+            ReorderLibraryDecision(
+                id = "library-order",
+                playerId = player,
+                prompt = "Order",
+                context = context,
+                cards = listOf(first),
+                cardInfo = mapOf(first to SearchCardInfo("Card", "", "Land")),
+            ),
+        )
+
+        for (decision in decisions) {
+            val response = TrivialDecisions.responseFor(decision)
+            response.shouldNotBeNull()
+            DecisionValidators.validate(decision, response, GameState()) shouldBe null
+        }
+    }
+
+    test("a lone target is not forced when cancellation or declining is legal") {
+        val cancellable = ChooseTargetsDecision(
+            id = "target",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(TargetRequirementInfo(index = 0, description = "target")),
+            legalTargets = mapOf(0 to listOf(first)),
+            canCancel = true,
+        )
+        val targetResponse = TargetsResponse(cancellable.id, mapOf(0 to listOf(first)))
+        val cancelResponse = CancelDecisionResponse(cancellable.id)
+
+        DecisionValidators.validate(cancellable, targetResponse) shouldBe null
+        DecisionValidators.validate(cancellable, cancelResponse) shouldBe null
+        TrivialDecisions.responseFor(cancellable).shouldBeNull()
+
+        val optional = cancellable.copy(
+            id = "optional-target",
+            canCancel = false,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "up to one target", minTargets = 0),
+            ),
+        )
+        DecisionValidators.validate(optional, TargetsResponse(optional.id, emptyMap())) shouldBe null
+        TrivialDecisions.responseFor(optional).shouldBeNull()
+    }
+
+    test("a lone target with a state-dependent legality cap is not guessed without state") {
+        val decision = ChooseTargetsDecision(
+            id = "aggregate-target",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(
+                    index = 0,
+                    description = "target with limited total mana value",
+                    totalManaValueAtMost = 0,
+                ),
+            ),
+            legalTargets = mapOf(0 to listOf(first)),
+        )
+
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("singleton target groups remain nontrivial when cross-group independence is not represented") {
+        val decision = ChooseTargetsDecision(
+            id = "multiple-target-groups",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            targetRequirements = listOf(
+                TargetRequirementInfo(index = 0, description = "first target"),
+                TargetRequirementInfo(index = 1, description = "another target"),
+            ),
+            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second)),
+        )
+
+        // The original TargetRequirement objects may impose cross-slot distinctness (for example,
+        // TargetOther), but ChooseTargetsDecision exposes no such field to this state-free helper.
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("a lone option is not forced when the decision can be cancelled") {
+        val decision = ChooseOptionDecision(
+            id = "option",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            options = listOf("Only option"),
+            canCancel = true,
+        )
+
+        DecisionValidators.validate(decision, CancelDecisionResponse(decision.id)) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("one visible mode is not forced when the response contract permits another answer") {
+        val optional = ChooseModeDecision(
+            id = "mode",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            modes = listOf(ModeOption(index = 0, text = "Only available")),
+            minModes = 0,
+            maxModes = 1,
+        )
+        DecisionValidators.validate(optional, ModesChosenResponse(optional.id, emptyList())) shouldBe null
+        DecisionValidators.validate(optional, ModesChosenResponse(optional.id, listOf(0))) shouldBe null
+        TrivialDecisions.responseFor(optional).shouldBeNull()
+
+        val broaderMaximum = optional.copy(
+            id = "repeatable-mode-contract",
+            minModes = 1,
+            maxModes = 2,
+        )
+        // A wider maximum does not prove that the single available mode is repeatable,
+        // so the forced-only helper must not infer a unique response.
+        TrivialDecisions.responseFor(broaderMaximum).shouldBeNull()
+    }
+
+    test("selecting every card is not forced when order is a player choice") {
+        val decision = SelectCardsDecision(
+            id = "ordered-cards",
+            playerId = player,
+            prompt = "Choose an order",
+            context = context,
+            options = listOf(first, second),
+            minSelections = 2,
+            maxSelections = 2,
+            ordered = true,
+        )
+
+        DecisionValidators.validate(decision, CardsSelectedResponse(decision.id, listOf(first, second))) shouldBe null
+        DecisionValidators.validate(decision, CardsSelectedResponse(decision.id, listOf(second, first))) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("multi-card selection is not forced without explicit repeated-selection semantics") {
+        val decision = SelectCardsDecision(
+            id = "shared-card-selection",
+            playerId = player,
+            prompt = "Choose two",
+            context = context,
+            options = listOf(first, second),
+            minSelections = 2,
+            maxSelections = 2,
+        )
+
+        // The same pending-decision shape is used by distributed counter-removal costs,
+        // where repeated IDs carry multiplicity. The decision itself does not identify
+        // that use, so selecting each option once is not provably the unique response.
+        DecisionValidators.validate(
+            decision,
+            CardsSelectedResponse(decision.id, listOf(first, second)),
+        ) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<CardsSelectedResponse>()
+        rollout.selectedCards shouldBe listOf(first, second)
+    }
+
+    test("state-dependent card constraints are not guessed without state") {
+        val decision = SelectCardsDecision(
+            id = "constrained-cards",
+            playerId = player,
+            prompt = "Choose",
+            context = context,
+            options = listOf(first),
+            minSelections = 1,
+            maxSelections = 1,
+            onePerCardType = true,
+        )
+
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+    }
+
+    test("a default damage assignment is policy when another legal assignment exists") {
+        val blockerOne = EntityId.of("blocker-one")
+        val blockerTwo = EntityId.of("blocker-two")
+        val default = mapOf(blockerOne to 3)
+        val alternative = mapOf(blockerOne to 2, blockerTwo to 1)
+        val decision = AssignDamageDecision(
+            id = "damage",
+            playerId = player,
+            prompt = "Assign damage",
+            context = context,
+            attackerId = first,
+            availablePower = 3,
+            orderedTargets = listOf(blockerOne, blockerTwo),
+            defenderId = null,
+            minimumAssignments = mapOf(blockerOne to 2, blockerTwo to 2),
+            defaultAssignments = default,
+            hasTrample = false,
+            hasDeathtouch = false,
+        )
+
+        DecisionValidators.validate(decision, DamageAssignmentResponse(decision.id, default)) shouldBe null
+        DecisionValidators.validate(decision, DamageAssignmentResponse(decision.id, alternative)) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<DamageAssignmentResponse>()
+        rollout.assignments shouldBe default
+    }
+
+    test("an auto-pay suggestion remains rollout policy rather than forced infrastructure") {
+        val landOne = ManaSourceOption(first, "Island", setOf(Color.BLUE), producesColorless = false)
+        val landTwo = ManaSourceOption(second, "Island", setOf(Color.BLUE), producesColorless = false)
+        val decision = SelectManaSourcesDecision(
+            id = "mana",
+            playerId = player,
+            prompt = "Pay {U}",
+            context = context,
+            availableSources = listOf(landOne, landTwo),
+            requiredCost = "{U}",
+            autoPaySuggestion = listOf(first),
+            canDecline = true,
+        )
+        val auto = ManaSourcesSelectedResponse(decision.id, autoPay = true)
+        val manual = ManaSourcesSelectedResponse(decision.id, selectedSources = listOf(second))
+        val decline = ManaSourcesSelectedResponse(decision.id, declined = true)
+
+        DecisionValidators.validate(decision, auto) shouldBe null
+        DecisionValidators.validate(decision, manual) shouldBe null
+        DecisionValidators.validate(decision, decline) shouldBe null
+        TrivialDecisions.responseFor(decision).shouldBeNull()
+
+        val rollout = FastDecisionResponder().respond(GameState(), decision, player)
+        rollout.shouldBeInstanceOf<ManaSourcesSelectedResponse>()
+        rollout.autoPay shouldBe true
+    }
+})

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -99,6 +99,17 @@ sealed interface TargetRequirement : TextReplaceable<TargetRequirement> {
 
     /** Effective minimum after considering optional/unlimited flags */
     val effectiveMinCount: Int get() = if (optional || unlimited) 0 else minCount
+
+    /**
+     * True when this requirement takes exactly one target and declining it is not legal.
+     *
+     * The engine may fill such a requirement without asking whenever exactly one legal object
+     * exists — every other shape leaves the player a real choice, including "up to one target",
+     * whose empty selection stays legal no matter how few objects are on the battlefield
+     * (CR 601.2c). Read this rather than re-deriving it: the two spellings drifted apart once
+     * already.
+     */
+    val requiresExactlyOneTarget: Boolean get() = count == 1 && effectiveMinCount == 1
 }
 
 // =============================================================================

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/RequiresExactlyOneTargetTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/RequiresExactlyOneTargetTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.sdk.scripting.targets
+
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [TargetRequirement.requiresExactlyOneTarget] — the predicate every engine path that
+ * fills a target *without asking* now reads.
+ *
+ * The distinction it draws is the one that matters at a lone legal object: "target creature" has
+ * nothing left to choose, while "up to one target creature" still has the empty selection
+ * (CR 601.2c). Getting that wrong is silent — the player simply never sees the prompt.
+ */
+class RequiresExactlyOneTargetTest : FunSpec({
+
+    test("a plain single target is settled once one legal object exists") {
+        TargetObject(filter = TargetFilter.Creature).requiresExactlyOneTarget shouldBe true
+        TargetPlayer().requiresExactlyOneTarget shouldBe true
+    }
+
+    test("up to one leaves the empty selection, so it is never settled") {
+        TargetObject(optional = true, filter = TargetFilter.Creature)
+            .requiresExactlyOneTarget shouldBe false
+    }
+
+    test("any number is never settled even though count stays at its default of one") {
+        // `unlimited` leaves `count` at 1 by convention, so the minimum is what distinguishes it.
+        val req = TargetObject(unlimited = true, filter = TargetFilter.Creature)
+        req.count shouldBe 1
+        req.requiresExactlyOneTarget shouldBe false
+    }
+
+    test("a multi-target requirement is not settled by one legal object") {
+        TargetObject(count = 2, filter = TargetFilter.Creature).requiresExactlyOneTarget shouldBe false
+        TargetObject(count = 2, minCount = 1, filter = TargetFilter.Creature)
+            .requiresExactlyOneTarget shouldBe false
+    }
+
+    test("narrowing an optional slot to one target does not make it mandatory") {
+        val narrowed = TargetObject(count = 2, optional = true, filter = TargetFilter.Creature)
+            .withCount(1)
+        narrowed.count shouldBe 1
+        narrowed.requiresExactlyOneTarget shouldBe false
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.engine.handlers.effects.composite.asOptionalManaPayment
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.StoreNumberEffect
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.sdk.scripting.targets.TargetChooser
@@ -723,10 +724,8 @@ class TriggerProcessor(
         // "you may have target opponent discard a card" (Ebon Dragon) never asked in a two-player
         // game. An "up to one target player" requirement skips this via `effectiveMinCount == 0`.
         if (allRequirements.size == 1) {
-            val isPlayerTarget = targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
-                                 targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetOpponent
             val legalTargets = allLegalTargets[0] ?: emptyList()
-            if (isPlayerTarget && legalTargets.size == 1 && targetRequirement.effectiveMinCount == 1 && targetRequirement.count == 1) {
+            if (TargetEnumerationUtils.shouldAutoSelectPlayerTarget(targetRequirement, legalTargets)) {
                 val autoSelectedTarget = legalTargets.first()
                 val chosenTarget = createChosenTarget(state, autoSelectedTarget)
                 return putTriggerOnStack(state, trigger, listOf(chosenTarget))
@@ -1160,13 +1159,7 @@ class TriggerProcessor(
             // processTargetedTrigger's single-player-target shortcut).
             val soleReq = mode.targetRequirements.singleOrNull()
             val soleLegal = legalTargetsMap[0].orEmpty()
-            val isPlayerTarget = soleReq is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
-                soleReq is com.wingedsheep.sdk.scripting.targets.TargetOpponent
-            if (isPlayerTarget &&
-                soleLegal.size == 1 &&
-                soleReq.count == 1 &&
-                soleReq.effectiveMinCount == 1
-            ) {
+            if (soleReq != null && TargetEnumerationUtils.shouldAutoSelectPlayerTarget(soleReq, soleLegal)) {
                 targetsAccum = targetsAccum + listOf(listOf(createChosenTarget(state, soleLegal.first())))
                 ordinal++
                 continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -1156,13 +1156,17 @@ class TriggerProcessor(
                 )
             }
 
-            // Auto-select the lone legal player target instead of prompting (mirrors
+            // Auto-select the lone mandatory legal player target instead of prompting (mirrors
             // processTargetedTrigger's single-player-target shortcut).
             val soleReq = mode.targetRequirements.singleOrNull()
             val soleLegal = legalTargetsMap[0].orEmpty()
             val isPlayerTarget = soleReq is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
                 soleReq is com.wingedsheep.sdk.scripting.targets.TargetOpponent
-            if (isPlayerTarget && soleLegal.size == 1 && soleReq.count == 1) {
+            if (isPlayerTarget &&
+                soleLegal.size == 1 &&
+                soleReq.count == 1 &&
+                soleReq.effectiveMinCount == 1
+            ) {
                 targetsAccum = targetsAccum + listOf(listOf(createChosenTarget(state, soleLegal.first())))
                 ordinal++
                 continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -13,14 +13,13 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.components.battlefield.withCastChoice
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
-import com.wingedsheep.sdk.scripting.targets.TargetOpponent
-import com.wingedsheep.sdk.scripting.targets.TargetPlayer
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 class ModalAndCloneContinuationResumer(
@@ -1739,12 +1738,7 @@ internal fun processChosenModeQueue(
     if (head.targetRequirements.size == 1) {
         val req = head.targetRequirements[0]
         val targets = legalTargetsMap[0] ?: emptyList()
-        val isPlayerTarget = req is TargetPlayer || req is TargetOpponent
-        if (isPlayerTarget &&
-            targets.size == 1 &&
-            req.count == 1 &&
-            req.effectiveMinCount == 1
-        ) {
+        if (TargetEnumerationUtils.shouldAutoSelectPlayerTarget(req, targets)) {
             val chosenTargets = listOf(entityIdToChosenTarget(state, targets[0]))
             val context = EffectContext(
                 sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -1735,12 +1735,16 @@ internal fun processChosenModeQueue(
         )
     }
 
-    // Auto-select single player target.
+    // Auto-select a single mandatory player target.
     if (head.targetRequirements.size == 1) {
         val req = head.targetRequirements[0]
         val targets = legalTargetsMap[0] ?: emptyList()
         val isPlayerTarget = req is TargetPlayer || req is TargetOpponent
-        if (isPlayerTarget && targets.size == 1 && req.count == 1) {
+        if (isPlayerTarget &&
+            targets.size == 1 &&
+            req.count == 1 &&
+            req.effectiveMinCount == 1
+        ) {
             val chosenTargets = listOf(entityIdToChosenTarget(state, targets[0]))
             val context = EffectContext(
                 sourceId = sourceId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
@@ -17,8 +17,12 @@ import kotlin.reflect.KClass
  * Finds legal targets using [TargetFinder], then:
  * - **No legal targets** → stores empty collection, pipeline continues
  * - **Single legal target (non-optional)** → auto-selects, stores in [updatedCollections]
- * - **Multiple legal targets** → creates [ChooseTargetsDecision], pushes
- *   [SelectTargetPipelineContinuation], returns paused
+ * - **Multiple legal targets, or a single one the player may decline** → creates
+ *   [ChooseTargetsDecision], pushes [SelectTargetPipelineContinuation], returns paused
+ *
+ * The requirement is single-target by construction — [createDecision] offers one slot — so a
+ * requirement asking for more is rejected up front rather than turned into a decision no response
+ * can satisfy.
  */
 class SelectTargetPipelineExecutor(
     private val targetFinder: TargetFinder = TargetFinder()
@@ -56,7 +60,7 @@ class SelectTargetPipelineExecutor(
             )
         }
 
-        if (legalTargets.size == 1 && effect.requirement.effectiveMinCount == 1) {
+        if (legalTargets.size == 1 && effect.requirement.requiresExactlyOneTarget) {
             // Single mandatory legal target — auto-select
             return EffectResult.success(state).copy(
                 updatedCollections = mapOf(effect.storeAs to legalTargets)
@@ -77,6 +81,10 @@ class SelectTargetPipelineExecutor(
         val controllerId = context.controllerId
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
+        require(effect.requirement.count == 1) {
+            "SelectTargetEffect offers one target slot, but ${effect.requirement.description} asks " +
+                "for ${effect.requirement.count}"
+        }
         val requirementInfo = TargetRequirementInfo(
             index = 0,
             description = effect.requirement.description,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
@@ -56,14 +56,14 @@ class SelectTargetPipelineExecutor(
             )
         }
 
-        if (legalTargets.size == 1) {
-            // Single legal target — auto-select
+        if (legalTargets.size == 1 && effect.requirement.effectiveMinCount == 1) {
+            // Single mandatory legal target — auto-select
             return EffectResult.success(state).copy(
                 updatedCollections = mapOf(effect.storeAs to legalTargets)
             )
         }
 
-        // Multiple legal targets — pause for player decision
+        // Multiple legal targets or an optional singleton — pause for player decision
         return createDecision(state, context, effect, legalTargets)
     }
 
@@ -80,7 +80,7 @@ class SelectTargetPipelineExecutor(
         val requirementInfo = TargetRequirementInfo(
             index = 0,
             description = effect.requirement.description,
-            minTargets = 1,
+            minTargets = effect.requirement.effectiveMinCount,
             maxTargets = 1
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -1004,7 +1004,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             tapForGenericPermanents = abilityWaterbendPermanents,
                             tapForGenericLabel = TapForGeneric.WATERBEND.label.takeIf { ability.hasWaterbend }
                         ))
-                    } else if (targetReqs.size == 1 && firstReqInfo.validTargets.size == 1 && firstReqInfo.validTargets.first() == entityId) {
+                    } else if (targetReqs.size == 1 &&
+                        firstReq.effectiveMinCount == 1 &&
+                        firstReqInfo.validTargets.size == 1 &&
+                        firstReqInfo.validTargets.first() == entityId
+                    ) {
                         // Self-targeting: only valid target is the source itself — auto-select and offer repeat
                         val autoSelectedTarget = ChosenTarget.Permanent(entityId)
                         result.add(LegalAction(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.TapForGeneric
 import com.wingedsheep.engine.legalactions.*
 import com.wingedsheep.engine.legalactions.utils.AbilityCostReduction
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -986,7 +987,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     val firstReqInfo = targetReqInfos.first()
 
                     // Check if we can auto-select player targets (single target requirement, single valid choice)
-                    if (targetReqs.size == 1 && context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)) {
+                    if (targetReqs.size == 1 && TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)) {
                         val autoSelectedTarget = ChosenTarget.Player(firstReqInfo.validTargets.first())
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
@@ -1005,7 +1006,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             tapForGenericLabel = TapForGeneric.WATERBEND.label.takeIf { ability.hasWaterbend }
                         ))
                     } else if (targetReqs.size == 1 &&
-                        firstReq.effectiveMinCount == 1 &&
+                        firstReq.requiresExactlyOneTarget &&
                         firstReqInfo.validTargets.size == 1 &&
                         firstReqInfo.validTargets.first() == entityId
                     ) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.identity.PlayWithFixedAlternative
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
@@ -2651,7 +2652,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         val firstReqInfo = targetReqInfos.first()
 
                         val canAutoSelect = targetReqs.size == 1 &&
-                            context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
+                            TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
 
                         if (canAutoSelect) {
                             val autoSelectedTarget = ChosenTarget.Player(firstReqInfo.validTargets.first())

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.legalactions.TapForGenericPermanentData
 import com.wingedsheep.engine.legalactions.TapForPowerCreatureData
 import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.legalactions.utils.SelectionCostPresentation
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.engine.mechanics.cost.VariablePermanentsCost
 import com.wingedsheep.engine.mechanics.EscalateCosts
 import com.wingedsheep.engine.mechanics.ModalChooseCounts
@@ -1033,7 +1034,7 @@ class CastSpellEnumerator : ActionEnumerator {
 
                             // Check for auto-select (single player target, single valid choice)
                             val canAutoSelect = modeTargetReqs.size == 1 &&
-                                context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
+                                TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
 
                             if (canAutoSelect) {
                                 val autoTarget = ChosenTarget.Player(firstInfo.validTargets.first())
@@ -1187,7 +1188,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 if (allRequirementsSatisfied) {
                     // Check if we can auto-select player targets (single target, single valid choice)
                     val canAutoSelect = targetReqs.size == 1 &&
-                        context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
+                        TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
 
                     if (canAutoSelect) {
                         // Auto-select the single valid player target
@@ -2442,7 +2443,7 @@ class CastSpellEnumerator : ActionEnumerator {
                         val firstReqInfo = targetReqInfos.first()
 
                         val canAutoSelect = targetReqs.size == 1 &&
-                            context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
+                            TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
 
                         if (canAutoSelect) {
                             val autoSelectedTarget = ChosenTarget.Player(firstReqInfo.validTargets.first())
@@ -2596,7 +2597,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 val firstReqInfo = targetReqInfos.first()
 
                 val canAutoSelect = targetReqs.size == 1 &&
-                    context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
+                    TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstReqInfo.validTargets)
 
                 if (canAutoSelect) {
                     val autoSelectedTarget = ChosenTarget.Player(firstReqInfo.validTargets.first())
@@ -3129,7 +3130,7 @@ class CastSpellEnumerator : ActionEnumerator {
         // Auto-select a sole legal player target (e.g. "target player" in a 2-player game where
         // only one player is legal), matching the normal cast path's UX.
         val canAutoSelect = targetReqs.size == 1 &&
-            context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
+            TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
         if (canAutoSelect) {
             val autoTarget = ChosenTarget.Player(firstInfo.validTargets.first())
             result.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.legalactions.AdditionalCostData
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.utils.AbilityCostReduction
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
@@ -231,7 +232,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                     val firstInfo = targetInfos.first()
 
                     if (targetReqs.size == 1 &&
-                        context.targetUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
+                        TargetEnumerationUtils.shouldAutoSelectPlayerTarget(firstReq, firstInfo.validTargets)
                     ) {
                         val autoSelectedTarget = ChosenTarget.Player(firstInfo.validTargets.first())
                         result.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -132,16 +132,6 @@ class TargetEnumerationUtils(
             sourceId
         }
 
-    fun shouldAutoSelectPlayerTarget(
-        requirement: TargetRequirement,
-        validTargets: List<EntityId>
-    ): Boolean {
-        val isPlayerTarget = requirement is TargetPlayer || requirement is TargetOpponent
-        val requiresExactlyOne = requirement.count == 1 && requirement.effectiveMinCount == 1
-        val hasExactlyOneChoice = validTargets.size == 1
-        return isPlayerTarget && requiresExactlyOne && hasExactlyOneChoice
-    }
-
     fun findValidPermanentTargets(
         state: GameState,
         playerId: EntityId,
@@ -454,4 +444,22 @@ class TargetEnumerationUtils(
     fun playerHasProtectionFrom(state: GameState, playerId: EntityId, sourceId: EntityId?, casterId: EntityId): Boolean =
         com.wingedsheep.engine.mechanics.targeting.PlayerProtectionRules
             .isProtectedFromSource(state, playerId, sourceId, casterId)
+
+    companion object {
+        /**
+         * The one definition of "this player target is already decided".
+         *
+         * Every path that fills a target without asking — the four enumerators, the trigger
+         * processor, the modal resumer — goes through here, so the rule cannot drift between them
+         * again. It reads no state, hence the companion: the callers outside enumeration have no
+         * [TargetEnumerationUtils] instance to reach for.
+         */
+        fun shouldAutoSelectPlayerTarget(
+            requirement: TargetRequirement,
+            validTargets: List<EntityId>
+        ): Boolean {
+            val isPlayerTarget = requirement is TargetPlayer || requirement is TargetOpponent
+            return isPlayerTarget && requirement.requiresExactlyOneTarget && validTargets.size == 1
+        }
+    }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTargetForcednessTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTargetForcednessTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ModalTargetForcednessTest : FunSpec({
+
+    fun mode(optional: Boolean) = Mode.withTarget(
+        effect = Effects.GainLife(1),
+        target = TargetOpponent(optional = optional),
+        description = if (optional) "Gain life with up to one target opponent" else "Gain life with target opponent",
+    )
+
+    fun processMode(optional: Boolean): Pair<GameTestDriver, ExecutionResult> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        val controller = driver.player1
+
+        val result = processChosenModeQueue(
+            services = EngineServices(driver.cardRegistry),
+            state = driver.state,
+            queue = listOf(mode(optional)),
+            controllerId = controller,
+            sourceId = null,
+            sourceName = "Test modal effect",
+            xValue = null,
+            triggeringEntityId = null,
+            allowCancelBackToModesList = null,
+            outerTargets = emptyList(),
+            outerNamedTargets = emptyMap(),
+            accumulatedEvents = emptyList(),
+            checkForMore = { state, events -> ExecutionResult.success(state, events) },
+        )
+        return driver to result
+    }
+
+    test("resolution-time modal target is surfaced when the lone opponent may be declined") {
+        val (driver, result) = processMode(optional = true)
+
+        result.isPaused.shouldBeTrue()
+        val decision = result.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+        decision.legalTargets.values.single() shouldBe listOf(driver.player2)
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+            result.state,
+        ).shouldBeNull()
+    }
+
+    test("resolution-time modal target still auto-selects the lone mandatory opponent") {
+        val (driver, result) = processMode(optional = false)
+
+        result.isPaused.shouldBeFalse()
+        result.isSuccess.shouldBeTrue()
+        result.state.lifeTotal(driver.player1) shouldBe driver.state.lifeTotal(driver.player1) + 1
+    }
+
+    fun triggeredModalCard(optional: Boolean) = card(
+        if (optional) "Optional Player Modal Trigger" else "Mandatory Player Modal Trigger"
+    ) {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = ModalEffect.chooseOne(
+                mode(optional),
+                Mode.noTarget(Effects.GainLife(2), "Gain 2 life"),
+            )
+        }
+    }
+
+    fun chooseFirstTriggeredMode(optional: Boolean): GameTestDriver {
+        val testCard = triggeredModalCard(optional)
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + testCard)
+        driver.initMirrorMatch(Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val controller = driver.activePlayer!!
+        val cardId = driver.putCardInHand(controller, testCard.name)
+        driver.castSpell(controller, cardId).isSuccess.shouldBeTrue()
+
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        val modeDecision = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        driver.submitDecision(controller, OptionChosenResponse(modeDecision.id, optionIndex = 0))
+        return driver
+    }
+
+    test("stack-time modal target is surfaced when the lone opponent may be declined") {
+        val driver = chooseFirstTriggeredMode(optional = true)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, emptyMap()),
+            driver.state,
+        ).shouldBeNull()
+    }
+
+    test("stack-time modal target still auto-selects the lone mandatory opponent") {
+        val driver = chooseFirstTriggeredMode(optional = false)
+
+        driver.pendingDecision.shouldBeNull()
+        driver.state.stack.isNotEmpty().shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ForcedTargetEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ForcedTargetEnumerationTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class ForcedTargetEnumerationTest : FunSpec({
+
+    fun testCard(optional: Boolean) = card(
+        if (optional) "Optional Self Target" else "Mandatory Self Target"
+    ) {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Free
+            target("creature", TargetCreature(optional = optional))
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun sourceId(driver: com.wingedsheep.engine.legalactions.support.EnumerationTestDriver, name: String): EntityId =
+        driver.game.state.getBattlefield(driver.player1).single { id ->
+            driver.game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    test("optional self target remains an explicit zero-or-one choice") {
+        val card = testCard(optional = true)
+        val driver = setupP1(battlefield = listOf(card.name), extraSetCards = listOf(card))
+        val source = sourceId(driver, card.name)
+
+        val actions = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(source)
+        actions.shouldHaveSize(1)
+        val legalAction = actions.single()
+        val action = legalAction.action as ActivateAbility
+
+        action.targets shouldBe emptyList()
+        legalAction.requiresTargets shouldBe true
+        legalAction.minTargets shouldBe 0
+        legalAction.validTargets.shouldContainExactly(source)
+    }
+
+    test("mandatory self target still auto-selects its only legal target") {
+        val card = testCard(optional = false)
+        val driver = setupP1(battlefield = listOf(card.name), extraSetCards = listOf(card))
+        val source = sourceId(driver, card.name)
+
+        val actions = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(source)
+        actions.shouldHaveSize(1)
+        val legalAction = actions.single()
+        val action = legalAction.action as ActivateAbility
+
+        action.targets.shouldContainExactly(ChosenTarget.Permanent(source))
+        legalAction.requiresTargets shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelectTargetPipelineTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelectTargetPipelineTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -52,9 +53,29 @@ class SelectTargetPipelineTest : FunSpec({
         )
     )
 
+    val OptionalPipelineBolt = CardDefinition.sorcery(
+        name = "Optional Pipeline Bolt",
+        manaCost = ManaCost.parse("{R}"),
+        oracleText = "Choose up to one creature. Deal 3 damage to it.",
+        script = CardScript.spell(
+            effect = CompositeEffect(
+                listOf(
+                    SelectTargetEffect(
+                        requirement = TargetCreature(optional = true),
+                        storeAs = "chosen"
+                    ),
+                    DealDamageEffect(
+                        amount = 3,
+                        target = EffectTarget.PipelineTarget("chosen")
+                    )
+                )
+            )
+        )
+    )
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(PipelineBolt))
+        driver.registerCards(TestCards.all + listOf(PipelineBolt, OptionalPipelineBolt))
         return driver
     }
 
@@ -96,6 +117,27 @@ class SelectTargetPipelineTest : FunSpec({
         // With only one legal creature, SelectTargetEffect auto-selects.
         // DealDamageEffect deals 3 to the 2/2 Bear → it dies.
         driver.assertInGraveyard(opponent, "Grizzly Bears")
+    }
+
+    test("single legal target is still offered when selecting it is optional") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            startingLife = 20
+        )
+
+        val (caster, opponent) = setupForCast(driver)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val boltId = driver.putCardInHand(caster, "Optional Pipeline Bolt")
+        driver.castSpell(caster, boltId)
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.targetRequirements.single().minTargets shouldBe 0
+
+        driver.submitTargetSelection(caster, emptyList())
+        driver.getCreatures(opponent).shouldContain(bear)
     }
 
     test("multiple legal targets presents decision and deals damage to chosen") {


### PR DESCRIPTION
Supersedes #2142 — it contains that PR's commit plus the review follow-ups, and is based on `main`.

## What #2142 established

An automatic decision response is produced only when the decision schema itself proves there is exactly one legal, non-cancellable response. "Exactly one legal object" is not that proof:

| printed | one legal object | forced? |
|---|---|---|
| `target creature` | A | yes |
| `up to one target creature` | A | **no** — choosing nothing stays legal (CR 601.2c) |
| `autoPaySuggestion = [A]` | sources A, B | **no** — the solver found *a* payment, not the only one |
| `defaultAssignments` populated | 2 blockers | **no** — a default can be validator-approved alongside others |

Defaults and heuristics stay available to the AI/rollout policy; they just stop masquerading as forced game actions. `TrivialDecisions` tightens accordingly, and four rules-engine paths that filled a singleton target without asking now require the requirement to be mandatory: modal triggered-ability targeting in `TriggerProcessor`, resolution-time modal targeting in `ModalAndCloneContinuationResumer`, activated-ability target embedding in `ActivatedAbilityEnumerator`, and mid-pipeline targeting in `SelectTargetPipelineExecutor`.

One shipped card changes behaviour, correctly: Airbender Ascension's *exile **up to one** target creature you control* auto-picked the lone creature and now prompts. It is the only card in the corpus with an optional `SelectTargetEffect` requirement.

## What this PR adds on top

**One definition of "already decided."** #2142 fixed its four sites by writing the same three-clause test out by hand — the fifth and sixth copies of a rule whose earlier copies drifting apart is precisely why the PR was needed. `TargetEnumerationUtils.shouldAutoSelectPlayerTarget` already encoded it and four enumerators already called it.

```kotlin
// TargetRequirement.kt, beside effectiveMinCount
val requiresExactlyOneTarget: Boolean get() = count == 1 && effectiveMinCount == 1
```

`shouldAutoSelectPlayerTarget` reduces to `isPlayerTarget && requirement.requiresExactlyOneTarget && validTargets.size == 1` and moves to the companion object (it reads no state, and the callers outside enumeration have no instance to reach for); `TriggerProcessor` — both its sites, including the one that already had the rule right — and `ModalAndCloneContinuationResumer` call it instead of re-deriving it. The two non-player sites read the SDK property directly. Eight enumerator call sites move from `context.targetUtils.` to `TargetEnumerationUtils.`.

**`SelectTargetPipelineExecutor` fails loudly on a slot mismatch.** It offers exactly one target slot, so `minTargets = effectiveMinCount` against a hardcoded `maxTargets = 1` could build a min-2/max-1 decision no response satisfies. A `require` on `count == 1` states the assumption instead of leaving it latent. Its class KDoc also now names the optional-singleton case (the "(non-optional)" on the auto-select bullet was already right, which is how you can tell the code was the drift, not the contract).

**`TrivialDecisions` loses a dead clause** — a distinctness check over a list the line above has already limited to one element.

**`GameSimulator` stops abandoning resolutions it can no longer answer.** `isResolving` locks out the strategic resolver inside the resolver's own simulations. With damage defaults and auto-pay out of `TrivialDecisions`, that path had no policy left at all: it returned `NeedsDecision`, and the evaluator scored a board with the ward unpaid or the combat damage unassigned — a position the game never reaches. It now falls back to the same O(1) `FastDecisionResponder` the playout path uses. `NeedsDecision` still means what it meant when no resolver is installed at all.

## Tests

On top of #2142's `TrivialDecisionsTest` / `GameSimulatorForcedDecisionTest` / `ModalTargetForcednessTest` / `ForcedTargetEnumerationTest` / `SelectTargetPipelineTest`:

- `RequiresExactlyOneTargetTest` — the predicate at each shape that has bitten before: plain single target, `up to one`, `any number` (whose `count` stays at 1, so the *minimum* is the discriminator), a multi-target requirement, and an optional slot narrowed to one target by `withCount`.
- `GameSimulatorForcedDecisionTest > a resolver that cannot re-enter still finishes the payment on rollout policy` — a resolver that replays a line reaching its own mana decision; both the inner and outer simulation reach `Terminal`.

## Verification

- `just test-rules` — BUILD SUCCESSFUL
- `just test-ai` — BUILD SUCCESSFUL; `PuzzleSuiteTest > the AI solves every puzzle outside KNOWN_FAILURES` passes with `KNOWN_FAILURES` unchanged, which is the signal that the `GameSimulator` fallback is not a behaviour regression
- `:mtg-sdk:test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmcTpwbbNobTbXLw7kfRgk
