### PR TITLE
Keep a transformed permanent from flipping back (CR 701.28f)

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SoulcipherBoard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SoulcipherBoard.kt
@@ -54,6 +54,17 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * counters, not one. "From anywhere" is expressed by leaving `from` unset. The follow-up
  * "Then if it has no omen counters on it" is an intervening check at resolution, so it is a
  * [ConditionalEffect] over the *current* counter count rather than a second trigger.
+ *
+ * `nontoken()` is the printed word "**card**": a dying creature *token* is not a card and never
+ * counts down the board (the card's second Gatherer ruling says so outright). The engine's LKI
+ * matcher answers it off the death event's `wasToken` snapshot, since 704.5d has already swept the
+ * token by the time the trigger is matched.
+ *
+ * Two triggers can be waiting on the stack together — two creature cards hitting the graveyard at
+ * once — and the second one finds no counter to remove and a counter count of zero, so its "then
+ * if" check passes. It does *not* flip the permanent back: CR 701.28f ignores an ability's
+ * instruction to transform the permanent it's on once that permanent has transformed since the
+ * ability went on the stack, which the engine enforces in `TransformEffectExecutor`.
  */
 
 private val SoulcipherBoardFront = card("Soulcipher Board") {
@@ -87,7 +98,7 @@ private val SoulcipherBoardFront = card("Soulcipher Board") {
     triggeredAbility {
         trigger = TriggerSpec(
             event = ZoneChangeEvent(
-                filter = GameObjectFilter.Creature.ownedByYou(),
+                filter = GameObjectFilter.Creature.ownedByYou().nontoken(),
                 to = Zone.GRAVEYARD,
             ),
             binding = TriggerBinding.ANY,

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulcipherBoardScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulcipherBoardScenarioTest.kt
@@ -1,12 +1,22 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.vow.cards.SoulcipherBoard
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
@@ -23,12 +33,38 @@ import io.kotest.matchers.shouldNotBe
  *  this artifact. Then if it has no omen counters on it, transform it."
  *
  * Covers the new [com.wingedsheep.sdk.core.Counters.OMEN] countdown counter, the per-card (not
- * batching) graveyard trigger, and the transform once the last counter is gone.
+ * batching) graveyard trigger, and the transform once the last counter is gone — plus the two
+ * ways the countdown must *not* run: a dying creature token isn't a card, and a second trigger
+ * resolving after the board has already turned over must not turn it back (CR 701.28f).
  */
 class SoulcipherBoardScenarioTest : FunSpec({
 
     fun omenCounters(driver: GameTestDriver, id: EntityId): Int =
         driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.OMEN) ?: 0
+
+    /** A real 1/1 creature token — no card definition behind it, so it is not a creature card. */
+    fun GameTestDriver.createMouseToken(playerId: EntityId): EntityId {
+        val tokenId = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = "token:Mouse",
+                name = "Mouse Token",
+                manaCost = ManaCost.ZERO,
+                typeLine = TypeLine.parse("Creature - Mouse"),
+                baseStats = CreatureStats(1, 1),
+                colors = setOf(Color.WHITE),
+                ownerId = playerId,
+            ),
+            TokenComponent,
+            ControllerComponent(playerId),
+            SummoningSicknessComponent,
+        )
+        replaceState(
+            state.withEntity(tokenId, container)
+                .addToZone(ZoneKey(playerId, Zone.BATTLEFIELD), tokenId)
+        )
+        return tokenId
+    }
 
     /** Cast Soulcipher Board for real so its enters-with-counters replacement runs. */
     fun boardOnBattlefield(): Pair<GameTestDriver, EntityId> {
@@ -120,6 +156,71 @@ class SoulcipherBoardScenarioTest : FunSpec({
 
         driver.getGraveyard(me).contains(bolt) shouldBe true
         withClue("only creature cards count down the omen counters") {
+            omenCounters(driver, board) shouldBe 3
+        }
+    }
+    /**
+     * Two creature cards reaching the graveyard together put *two* triggers on the stack. With one
+     * omen counter left, the first removes it and transforms the board; the second then finds no
+     * counter to remove and a counter count of zero, so its "then if it has no omen counters"
+     * check passes and it reaches the transform instruction too.
+     *
+     * CR 701.28f: that instruction is ignored, because the permanent has already transformed since
+     * that ability was put onto the stack. Before the rule was enforced the board flipped straight
+     * back to its artifact face and Cipherbound Spirit vanished from the battlefield.
+     */
+    test("a second trigger resolving after the transform does not turn the board back over") {
+        val (driver, board) = boardOnBattlefield()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.addComponent(board, CountersComponent(mapOf(CounterType.OMEN to 1)))
+
+        // Two of my creatures trade in combat, so both hit my graveyard at the same time.
+        val attackerA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val attackerB = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(attackerA)
+        driver.removeSummoningSickness(attackerB)
+        val blockerA = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val blockerB = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attackerA, attackerB), opp).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            opp,
+            mapOf(blockerA to listOf(attackerA), blockerB to listOf(attackerB))
+        ).error shouldBe null
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        withClue("both creature cards did reach my graveyard, so both triggers fired") {
+            driver.getGraveyardCardNames(me).count { it == "Grizzly Bears" } shouldBe 2
+        }
+        withClue("the transformed permanent stays on the battlefield as Cipherbound Spirit") {
+            driver.getCardName(board) shouldBe "Cipherbound Spirit"
+            driver.findPermanent(me, "Cipherbound Spirit") shouldNotBe null
+            driver.findPermanent(me, "Soulcipher Board") shouldBe null
+        }
+    }
+
+    /**
+     * "Whenever a creature **card** is put into your graveyard" — a token creature dying is not a
+     * card and never counts the board down (the card's second Gatherer ruling).
+     */
+    test("a dying creature token removes no counter") {
+        val (driver, board) = boardOnBattlefield()
+        val me = driver.activePlayer!!
+
+        val token = driver.createMouseToken(me)
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(token)).isSuccess shouldBe true
+        driver.bothPass()
+
+        withClue("the token died") {
+            driver.getPermanents(me).contains(token) shouldBe false
+        }
+        withClue("a token is not a creature card, so the countdown does not run") {
             omenCounters(driver, board) shouldBe 3
         }
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -16841,7 +16841,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "ZoneChangeEvent",
-                    "filter": "creature own:you",
+                    "filter": "creature nontoken own:you",
                     "to": "Graveyard"
                 },
                 "binding": "ANY",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -894,6 +894,13 @@ class TriggerProcessor(
             description = ability.description,
             abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
             granterId = trigger.granterId,
+            // CR 701.28f — freeze the source's face-change clock as the trigger goes on the stack,
+            // so an instruction inside it to transform that same permanent is ignored if the
+            // permanent turns over first (a second trigger of a countdown card such as
+            // Soulcipher Board must not flip it straight back).
+            sourceFaceChanges = state.getEntity(trigger.sourceId)
+                ?.get<com.wingedsheep.engine.state.components.identity.DoubleFacedComponent>()
+                ?.faceChanges,
             descriptionOverride = ability.descriptionOverride,
             triggerDamageAmount = trigger.triggerContext.damageAmount,
             triggeringEntityId = trigger.triggerContext.triggeringEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -68,6 +68,14 @@ data class EffectContext(
      * effect-resolution context — there is no candidate once an effect is executing.
      */
     val candidatePlayerId: EntityId? = null,
+    /**
+     * The face-change tally [sourceId] carried when this ability was put onto the stack (CR
+     * 701.28f). `TransformEffectExecutor` compares it against the source's current tally and
+     * ignores a self-transform when the two differ — the permanent has already turned over since,
+     * so the instruction does nothing. Null for spells, for a non-double-faced source, and for
+     * synthesized abilities that carry no such restriction.
+     */
+    val sourceFaceChanges: Int? = null,
     val targets: List<ChosenTarget> = emptyList(),
     /**
      * Positionally-aligned view of [targets]: the same length as the originally-chosen target
@@ -540,6 +548,7 @@ data class EffectContext(
             controllerId = ability.controllerId,
             granterId = ability.granterId,
             abilityIdentity = ability.abilityIdentity,
+            sourceFaceChanges = ability.sourceFaceChanges,
             targets = targets,
             triggerDamageAmount = ability.triggerDamageAmount,
             triggerCounterCount = ability.triggerCounterCount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1928,6 +1928,12 @@ class ActivateAbilityHandler(
                 cardComponent.cardDefinitionId, ability.id
             ),
             granterId = staticGranterId,
+            // CR 701.28f — freeze the source's face-change clock as the ability goes on the stack;
+            // an instruction inside it to transform that same permanent is ignored if the permanent
+            // turns over before this resolves.
+            sourceFaceChanges = state.getEntity(action.sourceId)
+                ?.get<com.wingedsheep.engine.state.components.identity.DoubleFacedComponent>()
+                ?.faceChanges,
             // Lock in the activation-time damage division (CR 601.2d) so removal in response
             // can't hand the controller a fresh division at resolution.
             damageDistribution = action.damageDistribution

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -72,6 +72,23 @@ class TransformEffectExecutor(
             return EffectResult.success(state)
         }
 
+        // CR 701.28f — an activated or triggered ability of a permanent that tries to transform
+        // *that same permanent* does so only if the permanent hasn't transformed or converted
+        // since the ability was put onto the stack; otherwise the instruction is ignored. The
+        // shape it protects is a countdown card whose triggers can stack up: two creature cards
+        // hit the graveyard at once while Soulcipher Board is on its last omen counter, and
+        // without this the first trigger flips it to Cipherbound Spirit and the second — finding
+        // no counters to remove and so passing its own "if it has no omen counters" check —
+        // flips it straight back. Same story for Thing in the Ice on one ice counter with two
+        // spells on the stack.
+        if (targetId == context.sourceId &&
+            context.sourceFaceChanges != null &&
+            context.sourceFaceChanges != state.getEntity(targetId)
+                ?.get<DoubleFacedComponent>()?.faceChanges
+        ) {
+            return EffectResult.success(state)
+        }
+
         // A non-DFC target is a silent no-op (CR 701.27b — "if a permanent that isn't a
         // transforming double-faced permanent would transform, nothing happens").
         val (newState, event) = flipDfcInPlace(state, cardRegistry, targetId)
@@ -190,9 +207,14 @@ internal fun setDfcFace(
 
     // Rule 712.8a: save the front face card so ZoneTransitionService can restore it
     // without a registry lookup when the DFC leaves the battlefield on its back face.
+    // The face-change tally advances on every real swap — CR 701.28f's clock, see
+    // [DoubleFacedComponent.faceChanges].
+    val faceChanges = dfc.faceChanges + if (nextFace == dfc.currentFace) 0 else 1
     val updatedDfc = when (nextFace) {
-        DoubleFacedComponent.Face.BACK -> dfc.copy(currentFace = nextFace, frontFaceCard = currentCard)
-        DoubleFacedComponent.Face.FRONT -> dfc.copy(currentFace = nextFace, frontFaceCard = null)
+        DoubleFacedComponent.Face.BACK ->
+            dfc.copy(currentFace = nextFace, frontFaceCard = currentCard, faceChanges = faceChanges)
+        DoubleFacedComponent.Face.FRONT ->
+            dfc.copy(currentFace = nextFace, frontFaceCard = null, faceChanges = faceChanges)
     }
 
     val staticAbilityHandler = StaticAbilityHandler(cardRegistry)
@@ -419,11 +441,16 @@ internal fun returnDfcFace(
             dfcBackFaceManaValue(cardRegistry.getCard(dfc.frontCardDefinitionId), currentCard.manaValue)
         } else null,
     )
+    val returnFaceChanges = dfc.faceChanges + if (destinationFace == dfc.currentFace) 0 else 1
     val updatedDfc = when (destinationFace) {
         // currentCard is the front face here (the entity reverts to its front face on leaving the
         // battlefield, Rule 712.8a) — stash it so the back face can restore it on its next exit.
-        DoubleFacedComponent.Face.BACK -> dfc.copy(currentFace = destinationFace, frontFaceCard = currentCard)
-        DoubleFacedComponent.Face.FRONT -> dfc.copy(currentFace = destinationFace, frontFaceCard = null)
+        DoubleFacedComponent.Face.BACK -> dfc.copy(
+            currentFace = destinationFace, frontFaceCard = currentCard, faceChanges = returnFaceChanges
+        )
+        DoubleFacedComponent.Face.FRONT -> dfc.copy(
+            currentFace = destinationFace, frontFaceCard = null, faceChanges = returnFaceChanges
+        )
     }
 
     val prepared = state.updateEntity(entityId) { c ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2939,6 +2939,7 @@ class StackResolver(
             controllerId = abilityComponent.controllerId,
             granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
+            sourceFaceChanges = abilityComponent.sourceFaceChanges,
             targets = activatedTargets,
             alignedTargets = alignedActivatedTargets,
             sacrificedPermanents = abilityComponent.sacrificedPermanents,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/DoubleFacedComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/DoubleFacedComponent.kt
@@ -27,7 +27,22 @@ data class DoubleFacedComponent(
     /** Which face is currently up. */
     val currentFace: Face = Face.FRONT,
     /** Saved front-face card data used to restore Rule 712.8a when leaving the battlefield. */
-    val frontFaceCard: CardComponent? = null
+    val frontFaceCard: CardComponent? = null,
+    /**
+     * How many times this object has turned over — CR 701.28f's "has it transformed or converted
+     * since the ability was put onto the stack?" clock.
+     *
+     * A plain monotonic tally rather than a face comparison, because two flips return the object
+     * to the face it started on while still counting as having transformed. Every face swap bumps
+     * it, whichever direction and whatever the cause: a [com.wingedsheep.sdk.scripting.effects
+     * .TransformEffect], a day/night convert, a craft return. Never reset — an object that leaves
+     * and re-enters the battlefield keeps its tally, so a stale ability from before the move can
+     * never mistake the new object's clock for its own.
+     *
+     * Read back through [com.wingedsheep.engine.handlers.EffectContext.sourceFaceChanges], which
+     * carries the value an ability's source had when the ability went on the stack.
+     */
+    val faceChanges: Int = 0
 ) : Component {
     @Serializable
     enum class Face { FRONT, BACK }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -295,6 +295,14 @@ data class TriggeredAbilityOnStackComponent(
      */
     val carriedPipeline: com.wingedsheep.engine.handlers.PipelineState? = null,
     /**
+     * The source permanent's [com.wingedsheep.engine.state.components.identity.DoubleFacedComponent]
+     * face-change tally the moment this ability was put onto the stack — CR 701.28f's clock. If the
+     * source has turned over since, an instruction in this ability to transform *it* is ignored.
+     * Null when the source is not a double-faced permanent, and for synthesized abilities (copies,
+     * reflexive triggers) that carry no restriction.
+     */
+    val sourceFaceChanges: Int? = null,
+    /**
      * The ability's intervening-"if" clause (CR 603.4), carried onto the stack object because the
      * ability itself is no longer reachable by the time this resolves — the trigger has been
      * detected, the source may have left the battlefield, and the granting static may be gone.
@@ -383,6 +391,14 @@ data class ActivatedAbilityOnStackComponent(
      * Boomerang's "Return [this Equipment] to its owner's hand". Null for non-granted abilities.
      */
     val granterId: EntityId? = null,
+    /**
+     * The source permanent's [com.wingedsheep.engine.state.components.identity.DoubleFacedComponent]
+     * face-change tally the moment this ability was put onto the stack — CR 701.28f's clock. If the
+     * source has turned over since, an instruction in this ability to transform *it* is ignored.
+     * Null when the source is not a double-faced permanent, and for synthesized abilities (copies,
+     * reflexive triggers) that carry no restriction.
+     */
+    val sourceFaceChanges: Int? = null,
     /**
      * Division chosen at activation for a `DividedDamageEffect` ability (target -> damage), locked
      * onto the stack object so responding removal can't make the controller re-divide (CR 601.2d).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoubleFacedCardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoubleFacedCardTest.kt
@@ -15,9 +15,15 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -237,4 +243,73 @@ class DoubleFacedCardTest : FunSpec({
         projected.getPower(entityId) shouldBe 6
         projected.getToughness(entityId) shouldBe 6
     }
+    /**
+     * CR 701.28f — "If an activated or triggered ability of a permanent that isn't a delayed
+     * triggered ability of that permanent tries to transform it, the permanent does so only if it
+     * hasn't transformed or converted since the ability was put onto the stack. […] if the
+     * permanent has already transformed or converted, an instruction to do either is ignored."
+     *
+     * Activating the free self-transform twice stacks two copies of the same instruction. The
+     * first turns the permanent over; the second must do nothing rather than turn it straight
+     * back. That second flip is what made a transformed Soulcipher Board disappear from the
+     * battlefield mid-combat.
+     */
+    test("a permanent's own ability does not transform it a second time from the same stack") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + SelfTransformer)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Island" to 20), skipMulligans = true)
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val entityId = driver.putCreatureOnBattlefield(caster, "Self Transformer")
+        driver.removeSummoningSickness(entityId)
+
+        fun activate() {
+            val action = driver.legalActions(caster)
+                .first { it.description.contains("Transform", ignoreCase = true) }
+            driver.submitSuccess(action.action)
+        }
+
+        // Both instances go on the stack before either resolves.
+        activate()
+        activate()
+        driver.assertStackSize(2)
+
+        driver.bothPass() // first instance: turns it over
+        driver.getCardName(entityId) shouldBe "Self Transformer Back"
+
+        driver.bothPass() // second instance: CR 701.28f ignores its transform instruction
+        driver.getCardName(entityId) shouldBe "Self Transformer Back"
+        driver.state.getEntity(entityId)!!.get<DoubleFacedComponent>()!!
+            .currentFace shouldBe DoubleFacedComponent.Face.BACK
+    }
 })
+
+/**
+ * A 1/1 DFC whose front face carries a free activated ability that turns it over — the minimal
+ * shape CR 701.28f governs, since two activations can sit on the stack together.
+ */
+private val SelfTransformer: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = CardDefinition(
+        name = "Self Transformer",
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.creature(setOf(Subtype("Human"))),
+        oracleText = "Transform this creature.",
+        creatureStats = CreatureStats(1, 1),
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = AbilityId("self-transformer-flip"),
+                cost = AbilityCost.Free,
+                effect = TransformEffect(EffectTarget.Self),
+            )
+        )
+    ),
+    backFace = CardDefinition.creature(
+        name = "Self Transformer Back",
+        manaCost = ManaCost.ZERO,
+        subtypes = setOf(Subtype("Spirit")),
+        power = 3,
+        toughness = 3,
+        oracleText = ""
+    )
+)


### PR DESCRIPTION
## The bug

Soulcipher Board transformed into Cipherbound Spirit and then turned straight back into the artifact — the Spirit never stayed on the battlefield.

Two creature cards reaching your graveyard together put **two** copies of the countdown trigger on the stack. With one omen counter left:

1. Trigger A removes the last counter → `ConditionalEffect` sees zero counters → transforms the board into Cipherbound Spirit.
2. Trigger B resolves. There is no counter to remove, so its "then if it has no omen counters on it" check *also* passes — and it transformed the permanent straight back.

Any combat or board wipe that puts more creature cards into your graveyard than the board has counters left hits this. Thing in the Ice on one ice counter with two spells on the stack is the same shape.

## The rule

**CR 701.28f** — "If an activated or triggered ability of a permanent that isn't a delayed triggered ability of that permanent tries to transform it, the permanent does so only if it hasn't transformed or converted since the ability was put onto the stack. […] if the permanent has already transformed or converted, an instruction to do either is ignored."

The engine had no such check.

## The fix

- `DoubleFacedComponent.faceChanges` — a monotonic tally bumped by every face swap, in `setDfcFace` and `returnDfcFace`. A tally rather than a face comparison, because two flips return the object to the face it started on and still count as having transformed; never reset, so an object that leaves and re-enters can't be mistaken for the one a stale ability was stamped against.
- Each activated / triggered ability freezes its source's tally as it goes on the stack (`ActivateAbilityHandler`, `TriggerProcessor` → `sourceFaceChanges` on the two stack components → `EffectContext`).
- `TransformEffectExecutor` ignores a self-transform when the stamp no longer matches the source's current tally.

Scoped to `targetId == context.sourceId` with a non-null stamp, so a **spell** transforming the permanent is untouched — 701.28f governs the permanent's own abilities. The existing `a DFC can transform back to its front face` test (a sorcery) still passes.

## Second defect on the same card

The countdown also ran on dying creature **tokens**. The printed word is "creature *card*", and the card's second Gatherer ruling says outright that token creatures never trigger it. Fixed with `nontoken()` on the trigger filter — the LKI matcher already answers that predicate off the death event's `wasToken` snapshot (704.5d has swept the token by then). VOW snapshot re-blessed for the one changed filter line.

## Left alone, deliberately

The card's *first* ruling says an animated land dying must **not** count the board down, and a creature card made noncreature **must**. The zone-change matcher reads the last-known *projected* type line for battlefield leaves, so both read the wrong way round. Fixing it needs "the printed card's types" vocabulary the SDK doesn't have — `add-feature` work, not a bug fix.

## Tests

- `DoubleFacedCardTest` — engine-level: a small DFC with a free self-transform ability, activated twice onto one stack; the second instance must not turn it back (fails without the fix).
- `SoulcipherBoardScenarioTest` — two Grizzly Bears trading in combat with one omen counter left; Cipherbound Spirit stays on the battlefield (fails without the fix). Plus a dying 1/1 token leaving all three counters on.

## Verification

- `just test-rules` ✅ (engine + every card scenario)
- `:mtg-sets:test` ✅ after `just rebless-cards` (one line: `creature own:you` → `creature nontoken own:you`)
- `just assay-differential --set VOW` ✅ 70/70, 0 divergent
- `just check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qro4j86oUcgMTUghRgB8qZ