### PR TITLE
Share one hidden-slot rewrite between the determinizer and materializer

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -1,23 +1,11 @@
 package com.wingedsheep.ai.engine.hidden
 
-import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.hidden.HiddenSlotRewrite
 import com.wingedsheep.engine.registry.CardRegistry
-import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.CantBeCopiedComponent
-import com.wingedsheep.engine.state.components.identity.CantBeCounteredComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
-import com.wingedsheep.engine.state.components.identity.HexproofFromComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
-import com.wingedsheep.engine.state.components.identity.ProtectionComponent
-import com.wingedsheep.engine.state.components.identity.RevealedToComponent
-import com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent
-import com.wingedsheep.engine.state.components.identity.ToxicComponent
-import com.wingedsheep.engine.state.components.stack.ChosenTarget
-import com.wingedsheep.engine.state.components.stack.TargetsComponent
 import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
@@ -92,9 +80,7 @@ class Determinizer(
             for ((entityId, cardDef) in hidden.zip(definitions)) {
                 val old = sampled.getEntity(entityId) ?: continue
                 val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
-                var replacement = CardEntityFactory.create(cardDef, ownerId)
-                old.get<RevealedToComponent>()?.let { replacement = replacement.with(it) }
-                sampled = sampled.withEntity(entityId, replacement)
+                sampled = HiddenSlotRewrite.rewrite(sampled, entityId, cardDef, ownerId)
             }
 
             val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
@@ -126,16 +112,7 @@ class Determinizer(
             visibility.revealsTopOfLibraryPublicly(state, opponentId) ||
                 (opponentId == viewerId && visibility.hasLookAtTopOfLibrary(state, viewerId))
         }
-        val referencedByStack = state.stack.flatMapTo(mutableSetOf()) { stackId ->
-            state.getEntity(stackId)?.get<TargetsComponent>()?.targets.orEmpty().mapNotNull {
-                when (it) {
-                    is ChosenTarget.Card -> it.cardId
-                    is ChosenTarget.Permanent -> it.entityId
-                    is ChosenTarget.Spell -> it.spellEntityId
-                    is ChosenTarget.Player -> null
-                }
-            }
-        }
+        val referencedByStack = HiddenSlotRewrite.stackReferencedEntities(state)
         return candidates.filter { id ->
             id != visibleTop &&
                 id !in referencedByStack &&
@@ -144,31 +121,24 @@ class Determinizer(
                 // fallback until those shapes share a common reference visitor.
                 state.continuationStack.isEmpty() &&
                 !visibility.isCardRevealedTo(state, id, viewerId) &&
-                isSafeToRewrite(state.getEntity(id))
+                isSafeToRewrite(state, id)
         }
     }
 
     /**
-     * A normal hidden card has only definition-derived identity/ownership components. Anything
-     * else may be referenced by an in-flight effect or carry state that a different definition
-     * cannot legally inherit, so it is pinned.
+     * A normal hidden card has only components [com.wingedsheep.engine.core.CardEntityFactory]
+     * derives from its printed definition. Anything else may be referenced by an in-flight effect
+     * or carry state that a different definition cannot legally inherit, so the slot is pinned.
+     * A card whose definition is no longer registered is pinned too: without it there is nothing to
+     * compare the slot against.
      */
-    private fun isSafeToRewrite(container: ComponentContainer?): Boolean {
-        if (container == null) return false
-        return container.all().all {
-            it is CardComponent ||
-                it is OwnerComponent ||
-                it is ControllerComponent ||
-                it is RevealedToComponent ||
-                it is CantBeCounteredComponent ||
-                it is CantBeCopiedComponent ||
-                it is HasMorphAbilityComponent ||
-                it is com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent ||
-                it is ProtectionComponent ||
-                it is SelfZoneRedirectComponent ||
-                it is HexproofFromComponent ||
-                it is ToxicComponent
-        }
+    private fun isSafeToRewrite(state: GameState, entityId: EntityId): Boolean {
+        val container = state.getEntity(entityId) ?: return false
+        val ownerId = container.get<OwnerComponent>()?.playerId ?: return false
+        val definition = container.get<CardComponent>()
+            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            ?: return false
+        return HiddenSlotRewrite.runtimeBlockers(container, definition, ownerId).isEmpty()
     }
 
     private fun fromKnownDecklist(

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -176,6 +176,16 @@ Phase 8 starts with one shared determinization per search. More worlds compete d
 count, so raising K requires an arena result showing it buys more strength at the same wall-clock
 budget.
 
+The mechanics of a swap — which slots are safe, which are pinned by a stack target, how the
+rebuild is applied — live in `HiddenSlotRewrite` in `rules-engine`, not here. `Determinizer` keeps
+the policy: it decides *which* slots are hidden from the viewer and *what* to put in them. The other
+caller of that primitive is `HiddenWorldMaterializer`, for callers that already own an assignment:
+it takes an explicit `EntityId → CardDefinition` map plus a caller-selected RNG for future simulated
+events, and refuses the whole request rather than pinning what it cannot install. Neither accepts a
+`ClientGameState` or a Gym observation — those are lossy views, while both operate on a trusted
+complete engine state. Callers needing hypothetical randomness independent of an authoritative game
+must supply an independently derived RNG; reusing the source stream stays an explicit choice.
+
 ---
 
 ## Scores are in raw evaluator units, everywhere above the leaf

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -469,6 +469,15 @@ combat state, attachments — leaving only the immutable identity (`CardComponen
   the immutable `GameState` — modifying a component means creating a new container, which means
   creating a new entity map, which means creating a new `GameState`.
 
+Because a card entity is a slot rather than an identity, a simulation caller can swap the definition
+occupying a hidden hand or library slot without disturbing the entity id, its zone position, or any
+reference pointing at it — that is what `HiddenSlotRewrite` (`rules-engine/hidden`) does, and what
+lets the AI reason about hypothetical opponent hands. It derives the safe set from what
+`CardEntityFactory` would build for the card currently there, so a slot carrying anything else —
+last-known battlefield information, a reveal someone has been shown — is refused rather than
+transplanted. `HiddenWorldMaterializer` is the all-or-nothing caller (`docs/ai/architecture.md`
+covers the sampling one).
+
 ### 2.3 Rule 613: Base State vs. Projected State
 
 **Principle:** The engine explicitly separates stored state from derived state.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Swapping the card identity occupying a hidden zone slot, without disturbing anything else.
+ *
+ * Both hidden-information callers need the same three answers — is this slot safe to rewrite,
+ * which slots are pinned by in-flight stack references, and how is the rewrite applied — while
+ * differing entirely in *policy*: [com.wingedsheep.engine.hidden.HiddenWorldMaterializer] installs
+ * a caller-supplied assignment and refuses anything it cannot install, whereas the AI's
+ * `Determinizer` samples an assignment from a visibility model and silently pins whatever it
+ * cannot rewrite. Keeping the mechanics here means those two policies cannot drift into two
+ * different notions of "safe".
+ */
+object HiddenSlotRewrite {
+
+    /**
+     * The components on [container] that block rewriting the slot to a different card identity,
+     * by simple name and sorted.
+     *
+     * The safe set is derived rather than listed: build what [CardEntityFactory] would produce for
+     * the definition *currently* occupying the slot, and every component that doesn't match is
+     * runtime state. That keeps the check in lockstep with new definition-derived components
+     * instead of drifting from a hand-maintained allowlist. Two consequences worth naming:
+     *
+     * - [CardComponent] is excluded, because it is exactly the identity being replaced. It is also
+     *   the one component that legitimately differs from the factory output on a well-formed slot:
+     *   scenario builders and pinned printings stamp their own.
+     * - `RevealedToComponent` is *not* excluded, so a slot someone has already been shown is
+     *   blocked. Preserving a reveal across an identity swap would leave a player holding a
+     *   pointer to a card they never saw, which is the incoherence this check exists to prevent.
+     *
+     * Components the factory would produce that are *missing* from [container] are not blockers:
+     * the rewrite regenerates them, and a zone transition legitimately strips [ControllerComponent].
+     */
+    fun runtimeBlockers(
+        container: ComponentContainer,
+        currentDefinition: CardDefinition,
+        ownerId: EntityId,
+    ): List<String> {
+        val expectedByType = CardEntityFactory.create(currentDefinition, ownerId)
+            .all()
+            .associateBy { it::class.java }
+        return container.all()
+            .filterNot { it is CardComponent }
+            .filter { component -> expectedByType[component::class.java] != component }
+            .map { component -> component::class.simpleName ?: component::class.java.name }
+            .sorted()
+    }
+
+    /**
+     * Every entity id a stack object's chosen targets point at.
+     *
+     * A stack object records the object it targets, so rewriting that object's identity underneath
+     * it produces a spell aimed at a card that was never there. Targets are the one in-flight
+     * reference shape with a uniform representation ([TargetsComponent]); continuation frames and
+     * pending decisions carry entity references in per-effect shapes with no common visitor, so
+     * callers gate on those wholesale rather than per slot.
+     */
+    fun stackReferencedEntities(state: GameState): Set<EntityId> =
+        state.stack.flatMapTo(mutableSetOf()) { stackId ->
+            state.getEntity(stackId)?.get<TargetsComponent>()?.targets.orEmpty().mapNotNull {
+                when (it) {
+                    is ChosenTarget.Card -> it.cardId
+                    is ChosenTarget.Permanent -> it.entityId
+                    is ChosenTarget.Spell -> it.spellEntityId
+                    is ChosenTarget.Player -> null
+                }
+            }
+        }
+
+    /**
+     * Rebuild [entityId] as [definition], keeping the slot itself intact.
+     *
+     * The entity id, its position in its zone, and every other part of [state] are untouched;
+     * only the components [CardEntityFactory] derives from the printed card are replaced. The
+     * source's [ControllerComponent] carries over as-is — including its absence, which is how a
+     * card that has left the battlefield looks.
+     *
+     * Callers must have cleared [runtimeBlockers] for this slot first: this function applies the
+     * rewrite, it does not re-check whether the rewrite is safe.
+     */
+    fun rewrite(
+        state: GameState,
+        entityId: EntityId,
+        definition: CardDefinition,
+        ownerId: EntityId,
+    ): GameState {
+        val source = state.getEntity(entityId) ?: return state
+        val rebuilt = CardEntityFactory.create(definition, ownerId)
+        val withController = source.get<ControllerComponent>()
+            ?.let { rebuilt.with(it) }
+            ?: rebuilt.without<ControllerComponent>()
+        return state.withEntity(entityId, withController)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -1,0 +1,232 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+
+/**
+ * An explicit assignment of card definitions to unresolved hidden-zone entity slots.
+ *
+ * This request deliberately contains no sampling policy. The caller decides which slots are
+ * unresolved, which definitions occupy them, and which random stream future simulated game events
+ * use. Assigning definitions to the existing entity ids also assigns the ordered library: zone
+ * membership and entity order are preserved exactly. The keys must include every slot the caller
+ * considers unresolved; unmentioned slots are intentionally left unchanged because the complete
+ * [GameState] substrate cannot reveal a semantic omission.
+ */
+data class HiddenWorldMaterializationRequest(
+    val slotAssignments: Map<EntityId, CardDefinition>,
+    val futureRng: GameRng,
+)
+
+/** Why an explicit hidden-world assignment cannot safely be applied. */
+enum class UnsupportedHiddenWorldKind {
+    /** The request names a missing entity, an unknown source definition, or a non-hand/library slot. */
+    INVALID_ASSIGNMENT,
+
+    /** A stack target, pending decision, or continuation frame depends on the identity being replaced. */
+    IN_FLIGHT_REFERENCES,
+
+    /** The hidden object carries state beyond its printed-definition-derived components. */
+    RUNTIME_STATE,
+}
+
+data class UnsupportedHiddenWorld(
+    val kind: UnsupportedHiddenWorldKind,
+    val entityId: EntityId? = null,
+    val details: List<String> = emptyList(),
+)
+
+sealed interface HiddenWorldMaterializationResult {
+    data class Materialized(val state: GameState) : HiddenWorldMaterializationResult
+    data class Unsupported(val reason: UnsupportedHiddenWorld) : HiddenWorldMaterializationResult
+}
+
+/**
+ * Applies caller-supplied hidden card identities to a hypothetical engine state.
+ *
+ * This is the engine-coherence half of hidden-world construction, not a visibility oracle or a
+ * determinizer. It never chooses slots, reads their current identities as candidate assignments,
+ * checks deck composition, or assigns probabilities. A caller operating from incomplete
+ * information must name every unresolved slot itself. The source definition is inspected only to
+ * verify that the slot's component shape is factory-derived; it is never copied into an assignment.
+ *
+ * Supported slots are ordinary cards in hand or library. Their entity ids, owners, controller
+ * component, zone membership, and zone order are preserved while [CardEntityFactory] rebuilds
+ * every component derived from the requested definition. An object with any other runtime state —
+ * a reveal someone has already been shown included — is refused rather than transplanting that
+ * state onto a different card. The mechanics live in [HiddenSlotRewrite], shared with the AI's
+ * determinizer so the two cannot disagree about what is safe.
+ *
+ * References stored elsewhere in the state keep pointing at the same entity. Live consumers
+ * therefore see the assigned current definition, while frozen historical snapshots remain frozen.
+ * The materializer validates current structural safety, not whether the assignment could have been
+ * reached through the state's recorded history.
+ *
+ * [HiddenWorldMaterializationRequest.slotAssignments] is also the caller's explicit declaration of
+ * which slots are unresolved. Unmentioned slots are deliberately preserved. Because [GameState]
+ * itself always contains complete identities, this utility cannot infer that a caller omitted a
+ * semantically hidden slot and is not an information-security boundary.
+ *
+ * [HiddenWorldMaterializationRequest.futureRng] is mandatory and is installed verbatim.
+ * Consequently a hypothetical world never inherits the source state's authoritative future random
+ * stream unless the caller explicitly asks for that exact generator. Search callers that require
+ * information separation must derive this generator from caller-owned randomness, not [GameState.rng].
+ */
+class HiddenWorldMaterializer(
+    private val cardRegistry: CardRegistry,
+) {
+    /**
+     * A request is answered as a whole: either every named slot is installed, or nothing is and the
+     * first obstruction is reported. Partial worlds are not a useful answer to "is this hypothesis
+     * coherent", and a caller that wants per-slot pinning is choosing a sampling policy this class
+     * deliberately doesn't own.
+     */
+    fun materialize(
+        state: GameState,
+        request: HiddenWorldMaterializationRequest,
+    ): HiddenWorldMaterializationResult {
+        // Gated whether or not the request names slots: an empty assignment still installs
+        // `futureRng`, and rewriting the future random stream of a state that is mid-decision is
+        // the same hazard as rewriting a card in it.
+        unsupportedInFlightState(state)?.let { return it }
+
+        val stackReferenced = HiddenSlotRewrite.stackReferencedEntities(state)
+        var materialized = state
+
+        // Slots are independent, so the order only decides *which* obstruction is reported when a
+        // request has several. Sorting makes that report stable across equal requests.
+        for ((entityId, replacementDefinition) in request.slotAssignments.entries.sortedBy { it.key.value }) {
+            val container = state.getEntity(entityId)
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity does not exist"),
+                )
+            if (entityId in stackReferenced) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES,
+                    entityId,
+                    listOf("slot is the chosen target of a stack object"),
+                )
+            }
+            val zones = state.zones.filterValues { entityId in it }
+            val occurrences = zones.values.sumOf { zone -> zone.count { it == entityId } }
+            if (occurrences != 1 || zones.keys.singleOrNull()?.zoneType !in SUPPORTED_ZONES) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf(
+                        if (occurrences == 0) "entity is not in a zone"
+                        else if (occurrences > 1) "entity occurs in zones $occurrences times"
+                        else "supported slots are HAND/LIBRARY; found ${zones.keys.single().zoneType.name}"
+                    ),
+                )
+            }
+            val zoneKey = zones.keys.single()
+
+            val ownerId = container.get<OwnerComponent>()?.playerId
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity has no owner"),
+                )
+            if (zoneKey.ownerId != ownerId) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("zone owner ${zoneKey.ownerId.value} differs from card owner ${ownerId.value}"),
+                )
+            }
+            val currentCard = container.get<CardComponent>()
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("entity has no card identity"),
+                )
+            if (currentCard.ownerId != ownerId) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("card identity owner differs from OwnerComponent"),
+                )
+            }
+            val currentDefinition = cardRegistry.getCard(currentCard.cardDefinitionId)
+                ?: return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("source definition is not registered: ${currentCard.cardDefinitionId}"),
+                )
+            val blockers = HiddenSlotRewrite.runtimeBlockers(container, currentDefinition, ownerId)
+            if (blockers.isNotEmpty()) {
+                return unsupported(UnsupportedHiddenWorldKind.RUNTIME_STATE, entityId, blockers)
+            }
+            if (isTransformBackFace(replacementDefinition)) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("replacement HAND/LIBRARY identity is a DFC back face: ${replacementDefinition.name}"),
+                )
+            }
+            val replacementDefinitionId = CardEntityFactory.create(replacementDefinition, ownerId)
+                .require<CardComponent>()
+                .cardDefinitionId
+            if (cardRegistry.getCard(replacementDefinitionId) != replacementDefinition) {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT,
+                    entityId,
+                    listOf("replacement definition is not registered: $replacementDefinitionId"),
+                )
+            }
+            materialized = HiddenSlotRewrite.rewrite(materialized, entityId, replacementDefinition, ownerId)
+        }
+
+        return HiddenWorldMaterializationResult.Materialized(
+            materialized.copy(rng = request.futureRng)
+        )
+    }
+
+    /**
+     * Continuation frames and pending decisions carry entity references in per-effect shapes with
+     * no common visitor, so neither can be audited slot by slot the way stack targets can. Both are
+     * therefore whole-state refusals: a search root taken at a quiet priority point has neither.
+     */
+    private fun unsupportedInFlightState(state: GameState): HiddenWorldMaterializationResult.Unsupported? {
+        val details = buildList {
+            state.pendingDecision?.let { add(it::class.simpleName ?: "PendingDecision") }
+            if (state.continuationStack.isNotEmpty()) {
+                add("continuationDepth=${state.continuationStack.size}")
+            }
+        }
+        if (details.isEmpty()) return null
+        return unsupported(UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES, details = details)
+    }
+
+    /**
+     * Transform DFCs register their back face as a standalone definition so the transform machinery
+     * can resolve it, but a back face is never a legal card identity in hand or library. Modal DFC
+     * backs are outside this check by construction: they are faces of one definition, not separate
+     * registrations, so a caller cannot name one in the first place.
+     */
+    private fun isTransformBackFace(definition: CardDefinition): Boolean =
+        cardRegistry.getFrontFace(definition.name) != null
+
+    private fun unsupported(
+        kind: UnsupportedHiddenWorldKind,
+        entityId: EntityId? = null,
+        details: List<String> = emptyList(),
+    ): HiddenWorldMaterializationResult.Unsupported =
+        HiddenWorldMaterializationResult.Unsupported(
+            UnsupportedHiddenWorld(kind, entityId, details)
+        )
+
+    private companion object {
+        val SUPPORTED_ZONES = setOf(Zone.HAND, Zone.LIBRARY)
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -1,0 +1,375 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.MadnessComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class HiddenWorldMaterializerTest : ScenarioTestBase() {
+
+    private val materializer = HiddenWorldMaterializer(cardRegistry)
+
+    init {
+        test("explicit assignments preserve slots and unrelated state while installing future RNG") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Forest")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Craw Wurm")
+                .withRngSeed(101L)
+                .build()
+            val hiddenHandId = game.state.getHand(game.player2Id).single()
+            val hiddenLibraryIds = game.state.getLibrary(game.player2Id)
+            val assignedIds = listOf(hiddenHandId) + hiddenLibraryIds
+            val source = game.state
+                .copy(lastCardDrawnThisTurnByPlayer = mapOf(game.player2Id to hiddenHandId))
+            val futureRng = GameRng.seeded(202L)
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(
+                        hiddenHandId to cardRegistry.requireCard("Fiery Temper"),
+                        hiddenLibraryIds[0] to cardRegistry.requireCard("Mountain"),
+                        hiddenLibraryIds[1] to cardRegistry.requireCard("Island"),
+                    ),
+                    futureRng = futureRng,
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+            val world = result.state
+
+            world.rng shouldBe futureRng
+            source.rng shouldBe GameRng.seeded(101L)
+            world.entities.keys shouldBe source.entities.keys
+            world.zones shouldBe source.zones
+            world.lastCardDrawnThisTurnByPlayer shouldBe mapOf(game.player2Id to hiddenHandId)
+            cardName(world, hiddenHandId) shouldBe "Fiery Temper"
+            cardName(world, hiddenLibraryIds[0]) shouldBe "Mountain"
+            cardName(world, hiddenLibraryIds[1]) shouldBe "Island"
+            withClue("definition-derived components are rebuilt for the assigned identity") {
+                world.getEntity(hiddenHandId)?.has<MadnessComponent>() shouldBe true
+            }
+
+            val restored = world.copy(
+                entities = world.entities + assignedIds.associateWith { source.entities.getValue(it) },
+                rng = source.rng,
+            )
+            withClue("only assigned entity containers and the future RNG may change") {
+                restored shouldBe source
+            }
+            withClue("materialization is purely functional") {
+                game.state.getEntity(hiddenHandId)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+            }
+        }
+
+        test("caller-generated assignments are reproducible and do not consume source randomness") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withRngSeed(303L)
+                .build()
+            val slots = game.state.getLibrary(game.player2Id)
+            val candidates = listOf("Plains", "Island", "Swamp", "Mountain")
+                .map(cardRegistry::requireCard)
+            val futureRng = GameRng.seeded(404L)
+
+            fun worldFor(assignmentSeed: Long): GameState {
+                val (definitions, _) = GameRng.seeded(assignmentSeed).shuffle(candidates)
+                val request = HiddenWorldMaterializationRequest(slots.zip(definitions).toMap(), futureRng)
+                return materializer.materialize(game.state, request)
+                    .shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>()
+                    .state
+            }
+
+            worldFor(7L) shouldBe worldFor(7L)
+            val worlds = (7L..22L).map { seed ->
+                val world = worldFor(seed)
+                world.getLibrary(game.player2Id).map { cardName(world, it) }
+            }
+            worlds.distinct().size shouldNotBe 1
+            game.state.rng shouldBe GameRng.seeded(303L)
+            worlds.forEach { it.toSet() shouldBe setOf("Plains", "Island", "Swamp", "Mountain") }
+        }
+
+        test("a hidden card carrying battlefield last-known information is refused") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val source = ZoneTransitionService.moveToZone(
+                game.state,
+                bears,
+                Zone.HAND,
+            ).state
+            source.getEntity(bears)?.has<LastKnownPermanentComponent>() shouldBe true
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(bears to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(505L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe bears
+            result.reason.details shouldContain LastKnownPermanentComponent::class.simpleName
+            source.getEntity(bears)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+
+            val cleanAgain = ZoneTransitionService.moveToZone(source, bears, Zone.LIBRARY).state
+            cleanAgain.getEntity(bears)?.has<LastKnownPermanentComponent>() shouldBe false
+            cleanAgain.getEntity(bears)?.has<ControllerComponent>() shouldBe false
+            val cleanWorld = materializer.materialize(
+                cleanAgain,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(bears to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(506L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+            withClue("a zone transition strips the controller component and the rewrite keeps it stripped") {
+                cleanWorld.getEntity(bears)?.has<ControllerComponent>() shouldBe false
+            }
+        }
+
+        test("a slot someone has already been shown is refused rather than keeping the reveal") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val revealedId = game.state.getHand(game.player2Id).single()
+            val source = game.state.updateEntity(revealedId) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(revealedId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(515L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.RUNTIME_STATE
+            result.reason.entityId shouldBe revealedId
+            withClue("preserving the reveal would point player 1 at a card they never saw") {
+                result.reason.details shouldContain RevealedToComponent::class.simpleName
+            }
+        }
+
+        test("a live stack pins the slots it targets and leaves the rest materializable") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Shock")
+                .withCardOnBattlefield(1, "Mountain")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .build()
+            val handId = game.state.getHand(game.player2Id).single()
+            val libraryId = game.state.getLibrary(game.player2Id).single()
+            val target = game.findPermanent("Hill Giant")!!
+            game.castSpell(1, "Shock", targetId = target).error shouldBe null
+            val source = game.state
+            source.stack.size shouldBe 1
+
+            withClue("a search root with a spell on the stack is the normal MCTS position") {
+                val world = materializer.materialize(
+                    source,
+                    HiddenWorldMaterializationRequest(
+                        slotAssignments = mapOf(handId to cardRegistry.requireCard("Mountain")),
+                        futureRng = GameRng.seeded(606L),
+                    ),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+                cardName(world, handId) shouldBe "Mountain"
+                world.stack shouldBe source.stack
+            }
+
+            // A stack object can name a card in a hidden zone (Chosen a card in a library or hand).
+            // Shock targets a permanent, so the library slot is attached to its TargetsComponent
+            // directly to exercise the guard on the shape the engine stores.
+            val stackId = source.stack.single()
+            val targeted = source.updateEntity(stackId) { container ->
+                val existing = container.require<TargetsComponent>()
+                container.with(
+                    existing.copy(
+                        targets = existing.targets +
+                            ChosenTarget.Card(libraryId, game.player2Id, Zone.LIBRARY)
+                    )
+                )
+            }
+
+            val result = materializer.materialize(
+                targeted,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(libraryId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(607L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+            result.reason.entityId shouldBe libraryId
+            result.reason.details shouldContain "slot is the chosen target of a stack object"
+            cardName(targeted, libraryId) shouldBe "Hill Giant"
+        }
+
+        test("a pending decision and its continuation frames refuse the whole request") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Preordain")
+                .withCardOnBattlefield(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+            game.castSpell(1, "Preordain").error shouldBe null
+            game.resolveStack()
+
+            // Preordain scries before it draws, so the engine is parked on a decision with the
+            // rest of the resolution held in a continuation frame.
+            val source = game.state
+            source.pendingDecision shouldNotBe null
+            source.continuationStack.isNotEmpty() shouldBe true
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(616L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+            result.reason.entityId shouldBe null
+            result.reason.details shouldContain
+                (source.pendingDecision!!::class.simpleName ?: "PendingDecision")
+            result.reason.details shouldContain "continuationDepth=${source.continuationStack.size}"
+            cardName(source, hiddenId) shouldBe "Grizzly Bears"
+        }
+
+        test("an empty assignment is gated too, because it still installs the future RNG") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Preordain")
+                .withCardOnBattlefield(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .build()
+            game.castSpell(1, "Preordain").error shouldBe null
+            game.resolveStack()
+            game.state.pendingDecision shouldNotBe null
+
+            materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(626L)),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+                .reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+
+            withClue("a quiet position accepts the same empty request") {
+                val quiet = scenario().withPlayers().withRngSeed(1L).build().state
+                val world = materializer.materialize(
+                    quiet,
+                    HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(636L)),
+                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+                world shouldBe quiet.copy(rng = GameRng.seeded(636L))
+            }
+        }
+
+        test("a DFC back face cannot be materialized directly into a hidden zone") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+
+            val result = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(
+                        hiddenId to cardRegistry.requireCard("Test DFC Back")
+                    ),
+                    futureRng = GameRng.seeded(650L),
+                ),
+            )
+
+            val unsupported =
+                result.shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+            unsupported.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+            unsupported.reason.entityId shouldBe hiddenId
+            unsupported.reason.details shouldContain
+                "replacement HAND/LIBRARY identity is a DFC back face: Test DFC Back"
+        }
+
+        test("an unregistered replacement is a typed unsupported request") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player2Id).single()
+            val unregistered = card("Unregistered Hypothesis") {
+                manaCost = "{1}"
+                typeLine = "Sorcery"
+            }
+
+            val result = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to unregistered),
+                    futureRng = GameRng.seeded(707L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.INVALID_ASSIGNMENT
+            result.reason.entityId shouldBe hiddenId
+        }
+
+        test("a materialized world can continue through ordinary engine simulation") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Grizzly Bears")
+                .build()
+            val hiddenId = game.state.getHand(game.player1Id).single()
+            val world = materializer.materialize(
+                game.state,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(hiddenId to cardRegistry.requireCard("Forest")),
+                    futureRng = GameRng.seeded(808L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+
+            val simulated = actionProcessor.process(
+                world,
+                PlayLand(game.player1Id, hiddenId),
+            ).result
+
+            simulated.error shouldBe null
+            simulated.state.getZone(ZoneKey(game.player1Id, Zone.BATTLEFIELD)) shouldContain hiddenId
+            cardName(simulated.state, hiddenId) shouldBe "Forest"
+        }
+    }
+
+    private fun cardName(state: GameState, entityId: EntityId): String? =
+        state.getEntity(entityId)?.get<CardComponent>()?.name
+}


### PR DESCRIPTION
Reworks #2143 so the new hidden-world primitive has a real second caller instead of being a parallel copy of logic the AI already owns. Opened on top of `main`; #2143 can be closed in favour of this.

## The shape

Two callers need the same three mechanics — is this slot safe to rewrite, which slots are pinned by an in-flight stack target, and how is the rebuild applied — while differing entirely in *policy*. `HiddenSlotRewrite` (`rules-engine/hidden`) now owns the mechanics:

- `runtimeBlockers(container, currentDefinition, ownerId)` — the components that block a rewrite.
- `stackReferencedEntities(state)` — slots a stack object's chosen targets name.
- `rewrite(state, entityId, definition, ownerId)` — rebuild the slot's definition-derived components, keeping the entity id, its zone position, and every reference pointing at it.

`Determinizer` keeps its policy (which slots are hidden from the viewer, and what to put in them) and drops 46 lines, including its hand-maintained 12-component allowlist. The safe set is now *derived* from what `CardEntityFactory` would build for the definition currently in the slot, so it can't drift as new definition-derived components are added — that derivation is the one genuinely new idea from #2143 and it is now what protects the shipped AI path, not just the new one.

`HiddenWorldMaterializer` is the second caller, for callers that already own an assignment: an explicit `EntityId -> CardDefinition` map plus a caller-selected RNG for future simulated events. It preserves entity ids, owner, controller-component state, zone membership and exact zone ordering, and answers a request as a whole — either every named slot installs, or nothing does and the first obstruction is reported as a typed `Unsupported`. Partial worlds are not a useful answer to "is this hypothesis coherent", and per-slot pinning is a sampling policy it deliberately doesn't own.

It has no viewer, deck model, or probability semantics, and takes neither a `ClientGameState` nor a Gym observation — those are lossy views, while both callers operate on a trusted complete engine state.

## What the shared check makes uniform

**A slot someone has already been shown is refused.** #2143 preserved `RevealedToComponent` across an identity swap, which leaves a player holding a pointer to a card they never saw. `Determinizer` had always treated a reveal as disqualifying, via a viewer-relative visibility check; deriving the blocker set makes the refusal structural and viewer-independent, so a card revealed to a *third* player is now pinned too.

**A live stack pins only the slots its chosen targets name.** #2143 refused the entire request whenever the stack was non-empty, which is exactly the position MCTS determinizes from — `sampleForSearch` exists for it. Targets are the one in-flight reference shape with a uniform representation (`TargetsComponent`), so they are audited per slot. Continuation frames and pending decisions carry entity references in per-effect shapes with no common visitor, so those stay whole-state refusals.

**The whole-state gate applies to an empty assignment too**, because an empty request still installs a new future RNG — rewriting the future random stream of a state that is mid-decision is the same hazard as rewriting a card in it.

A transform DFC's back face is registered so the transform machinery can resolve it, but is never a legal standalone identity in hand or library, so it is rejected as an invalid assignment. Modal DFC backs are outside that check by construction: they are faces of one definition rather than separate registrations, so a caller cannot name one.

## Coverage

`HiddenWorldMaterializerTest` (10 cases): explicit hand/library assignment preserving entity ids and zone order, with a `restored shouldBe source` invariant proving only the assigned containers and the RNG changed; reconstruction of definition-derived components (Madness); reproducible caller-generated assignments that don't consume source randomness; typed refusal of battlefield last-known state, then success once a later zone transition clears it; typed refusal of an already-revealed slot; a live stack materializing an untargeted slot while refusing a targeted one; a real Preordain scry parking the engine on a decision plus continuation frame, refusing both by name; the empty-assignment gate and its quiet-position counterpart; unregistered and DFC-back-face rejections; and ordinary `ActionProcessor` execution from a materialized world.

`DeterminizerInvariantsTest` is unchanged and still green, which is the point — the migration is behaviour-preserving for the shipped AI path apart from the two refusals above, both of which are strictly safer.

## Verification

- `just test-class HiddenWorldMaterializerTest` — 10/10 pass
- `just test-class DeterminizerInvariantsTest` — 6/6 pass
- `just test-ai` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HssvzYgCKxgb2NUMTcLADq
