### PR TITLE
Make the Gym observation produce the facts its digest hashes

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -39,11 +39,19 @@ import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.AbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -54,9 +62,12 @@ import com.wingedsheep.sdk.model.EntityId
  * ## Information hiding
  *
  * By default, opponent hand and everyone's library are hidden
- * ([ZoneView.hidden] = true, [ZoneView.cards] empty). Set [revealAll] to
- * `true` to disable masking — only appropriate for debug scripts; never
- * for real self-play training.
+ * ([ZoneView.hidden] = true). A hidden zone is not necessarily an empty one:
+ * a card a hand-peek effect has shown this perspective stays visible to it
+ * (`RevealedToComponent`), so [ZoneView.cards] carries the subset this player
+ * knows while [ZoneView.size] stays the true count. Set [revealAll] to `true`
+ * to disable masking — only appropriate for debug scripts; never for real
+ * self-play training.
  *
  * ## Projected vs. base state
  *
@@ -184,7 +195,10 @@ class ObservationBuilder(
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
                 val hidden = !revealAll && isHiddenFrom(zone, playerId, perspectivePlayerId)
-                val cards = if (hidden) emptyList() else ids.map { buildEntityFeatures(state, it, zone) }
+                // A hidden zone still exposes what this perspective has already been shown —
+                // "look at target opponent's hand" leaves those cards visible to the viewer.
+                val knownIds = if (hidden) ids.filter { isRevealedTo(state, it, perspectivePlayerId) } else ids
+                val cards = knownIds.map { buildEntityFeatures(state, it, zone) }
                 views += ZoneView(
                     ownerId = playerId,
                     zoneType = zone,
@@ -202,6 +216,14 @@ class ObservationBuilder(
         Zone.HAND -> owner != perspective
         else -> false
     }
+
+    /**
+     * Mirrors `Visibility.isCardRevealedTo`. The gym builder deliberately stops at the per-card
+     * component: the whole-hand reveal that class also honours needs a `CardRegistry` to find the
+     * granting static ability, which an observation builder has no other use for.
+     */
+    private fun isRevealedTo(state: GameState, entityId: EntityId, perspective: EntityId): Boolean =
+        state.getEntity(entityId)?.get<RevealedToComponent>()?.isRevealedTo(perspective) == true
 
     // =========================================================================
     // Entities
@@ -281,21 +303,41 @@ class ObservationBuilder(
     private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
-        // Stack kind inference — fall back to OTHER. A more precise classification
-        // can be added once the stack carries explicit metadata.
+        val triggered = container?.get<TriggeredAbilityOnStackComponent>()
+        val activated = container?.get<ActivatedAbilityOnStackComponent>()
+        val legacyAbility = container?.get<AbilityOnStackComponent>()
         val kind = when {
-            card?.spellEffect != null -> StackItemKind.SPELL
+            triggered != null -> StackItemKind.TRIGGERED_ABILITY
+            activated != null || legacyAbility != null -> StackItemKind.ACTIVATED_ABILITY
             card != null -> StackItemKind.SPELL
             else -> StackItemKind.OTHER
         }
         return StackItemView(
             entityId = entityId,
-            controllerId = state.projectedState.getController(entityId),
-            name = card?.name ?: "",
+            // A stack object never gets a Layer-4 projection entry, so `projectedState` has no
+            // controller for one. Each stack component carries its own; a spell's is its
+            // ControllerComponent, else the caster — the fallback `ProjectedState` uses too.
+            controllerId = triggered?.controllerId
+                ?: activated?.controllerId
+                ?: legacyAbility?.controllerId
+                ?: container?.get<ControllerComponent>()?.playerId
+                ?: container?.get<SpellOnStackComponent>()?.casterId,
+            name = card?.name ?: triggered?.sourceName ?: activated?.sourceName ?: "",
             kind = kind,
             oracleText = card?.oracleText ?: "",
-            targets = emptyList()
+            targets = container?.get<TargetsComponent>()?.targets.orEmpty().map(::targetEntityId)
         )
+    }
+
+    /**
+     * The entity a chosen target names. A player target contributes the player's own entity id —
+     * players are entities here, so the flattened list stays unambiguous.
+     */
+    private fun targetEntityId(target: ChosenTarget): EntityId = when (target) {
+        is ChosenTarget.Player -> target.playerId
+        is ChosenTarget.Permanent -> target.entityId
+        is ChosenTarget.Card -> target.cardId
+        is ChosenTarget.Spell -> target.spellEntityId
     }
 
     // =========================================================================

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
@@ -60,7 +60,9 @@ object StateDigest {
                 sb.append("Z[").append(z.ownerId.value).append('/').append(z.zoneType.name)
                     .append("]:hidden=").append(z.hidden)
                     .append(":size=").append(z.size)
-                if (!z.hidden) {
+                // A hidden zone may still contain identities this perspective knows. Encode every
+                // supplied card; a completely unknown hidden zone has an empty cards list.
+                if (z.cards.isNotEmpty()) {
                     sb.append(":ids=")
                     z.cards.forEach { c ->
                         sb.append(c.entityId.value).append(',')
@@ -74,7 +76,12 @@ object StateDigest {
         // Stack — order is meaningful (bottom → top).
         obs.stack.forEachIndexed { i, s ->
             sb.append("S[").append(i).append("]=").append(s.entityId.value)
-                .append(':').append(s.kind.name).append('|')
+                .append(":ctl=").append(s.controllerId?.value)
+                .append(":name=").append(s.name)
+                .append(":kind=").append(s.kind.name)
+                .append(":text=").append(s.oracleText)
+                .append(":targets=").append(s.targets.joinToString(",") { it.value })
+                .append("|")
         }
 
         // Pending decision — identity + kind only; per-option IDs are not

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/StateDigest.kt
@@ -14,7 +14,9 @@ import java.security.MessageDigest
  * The canonical encoding sorts all unordered collections (sets, map keys) so
  * iteration-order variations cannot produce different digests for equivalent
  * states. Ordered collections (zone contents, stack) are encoded as-is: their
- * order is semantically meaningful.
+ * order is semantically meaningful. Free-form strings (names, oracle text) are
+ * length-prefixed by [appendText] so a value containing the encoding's own
+ * delimiters cannot make two different observations serialize alike.
  */
 object StateDigest {
 
@@ -60,15 +62,13 @@ object StateDigest {
                 sb.append("Z[").append(z.ownerId.value).append('/').append(z.zoneType.name)
                     .append("]:hidden=").append(z.hidden)
                     .append(":size=").append(z.size)
-                // A hidden zone may still contain identities this perspective knows. Encode every
-                // supplied card; a completely unknown hidden zone has an empty cards list.
-                if (z.cards.isNotEmpty()) {
-                    sb.append(":ids=")
-                    z.cards.forEach { c ->
-                        sb.append(c.entityId.value).append(',')
-                        encodeEntity(sb, c)
-                        sb.append(';')
-                    }
+                    .append(":ids=")
+                // Every card [ZoneView.cards] lists — which for a hidden zone is the subset this
+                // perspective has been shown, and for a fully concealed one is nothing at all.
+                z.cards.forEach { c ->
+                    sb.append(c.entityId.value).append(',')
+                    encodeEntity(sb, c)
+                    sb.append(';')
                 }
                 sb.append('|')
             }
@@ -77,31 +77,32 @@ object StateDigest {
         obs.stack.forEachIndexed { i, s ->
             sb.append("S[").append(i).append("]=").append(s.entityId.value)
                 .append(":ctl=").append(s.controllerId?.value)
-                .append(":name=").append(s.name)
                 .append(":kind=").append(s.kind.name)
-                .append(":text=").append(s.oracleText)
+                .append(":name=").appendText(s.name)
+                .append(":text=").appendText(s.oracleText)
                 .append(":targets=").append(s.targets.joinToString(",") { it.value })
-                .append("|")
+                .append('|')
         }
 
         // Pending decision — identity + kind only; per-option IDs are not
         // part of game identity.
         obs.pendingDecision?.let { d ->
-            sb.append("D=").append(d.decisionId).append(':').append(d.kind.name)
+            sb.append("D=").appendText(d.decisionId)
+                .append(':').append(d.kind.name)
                 .append(':').append(d.requiresStructuredResponse).append('|')
         }
     }
 
     private fun encodeEntity(sb: StringBuilder, e: EntityFeatures) {
-        sb.append("n=").append(e.name)
-            .append(",def=").append(e.cardDefinitionId)
+        sb.append("n=").appendText(e.name)
+            .append(",def=").appendText(e.cardDefinitionId)
             .append(",own=").append(e.ownerId?.value)
             .append(",ctl=").append(e.controllerId?.value)
             .append(",ty=").append(e.types.sorted().joinToString("/"))
             .append(",sub=").append(e.subtypes.sorted().joinToString("/"))
             .append(",col=").append(e.colors.sorted().joinToString("/"))
             .append(",kw=").append(e.keywords.sorted().joinToString("/"))
-            .append(",mc=").append(e.manaCost)
+            .append(",mc=").appendText(e.manaCost)
             .append(",mv=").append(e.manaValue)
             .append(",p=").append(e.power)
             .append(",t=").append(e.toughness)
@@ -115,4 +116,16 @@ object StateDigest {
             .append(",att=").append(e.attachedTo?.value)
             .append(",eqp=").append(e.attachments.joinToString("/") { it.value })
     }
+
+    /**
+     * Append a free-form string as `<length>:<value>`.
+     *
+     * Card names and oracle text are author-supplied and can contain every delimiter this
+     * encoding uses (`|`, `:`, `,`, `;`, newlines), so appending them raw would let two
+     * observations that differ — in how many stack items they hold, say — serialize to the
+     * same bytes. The length prefix makes the field self-delimiting. `null` is a bare `~`,
+     * which no length-prefixed value can spell (those always start with a digit).
+     */
+    private fun StringBuilder.appendText(value: String?): StringBuilder =
+        if (value == null) append('~') else append(value.length).append(':').append(value)
 }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -131,8 +131,11 @@ data class ManaPoolView(
 /**
  * A zone's contents from [TrainingObservation.perspectivePlayerId]'s point of view.
  *
- * When [hidden] is true (opponent's hand, any library), [cards] is empty and
- * only [size] is meaningful. This mirrors real-MTG information hiding.
+ * [hidden] says some identities in the zone are concealed from the perspective player
+ * (an opponent's hand, any library); [size] is then the true count while [cards] carries
+ * only the entries this perspective knows. That subset is usually empty, but a hand-peek
+ * effect leaves the cards it showed visible to the player who saw them, so a two-card
+ * hidden hand can legitimately list one card. This mirrors real-MTG information hiding.
  */
 @Serializable
 data class ZoneView(
@@ -213,6 +216,10 @@ data class StackItemView(
     val kind: StackItemKind,
     /** Printed oracle text of the card backing this stack item — empty for stackless triggers. */
     val oracleText: String = "",
+    /**
+     * The chosen targets, in the order they were chosen, flattened to entity ids. A player
+     * target contributes the player's own entity id.
+     */
     val targets: List<EntityId> = emptyList()
 )
 

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -5,6 +5,15 @@ import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.core.PlayerConfig
 import com.wingedsheep.gym.GameEnvironment
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
@@ -12,12 +21,14 @@ import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotBeEmpty
 import io.kotest.matchers.string.shouldMatch
 import kotlinx.serialization.json.Json
 
@@ -138,70 +149,170 @@ class TrainingObservationTest : FunSpec({
         }
     }
 
-    test("stateDigest includes known card details supplied inside a hidden zone") {
+    test("a card revealed to this perspective is visible inside its still-hidden zone") {
         val env = newEnv()
         val me = env.playerIds[0]
-        val base = ObservationBuilder().build(env.state, me, env.legalActions())
-            .observation as TrainingObservation
+        val opponent = env.playerIds[1]
+        val opponentHand = env.state.getZone(ZoneKey(opponent, Zone.HAND))
+        opponentHand.size shouldBeGreaterThan 1
 
-        val hiddenIndex = base.zones.indexOfFirst {
-            it.hidden && it.zoneType == Zone.HAND
-        }
-        hiddenIndex shouldNotBe -1
+        fun observe(state: GameState) =
+            ObservationBuilder().build(state, me, env.legalActions()).observation as TrainingObservation
 
-        val hidden = base.zones[hiddenIndex]
-        val template = base.zones
-            .first { !it.hidden && it.cards.isNotEmpty() }
-            .cards.first()
+        fun revealing(cardId: EntityId): GameState =
+            env.state.withEntity(
+                cardId,
+                env.state.getEntity(cardId)!!.with(RevealedToComponent.to(me))
+            )
 
-        val knownA = template.copy(
-            entityId = EntityId.of("known-hidden-card"),
-            cardDefinitionId = "known-a",
-            name = "Known A",
-            ownerId = hidden.ownerId,
-        )
-        val knownB = knownA.copy(
-            cardDefinitionId = "known-b",
-            name = "Known B",
-        )
+        fun opponentHandView(obs: TrainingObservation) =
+            obs.zones.first { it.ownerId == opponent && it.zoneType == Zone.HAND }
 
-        fun withKnown(card: EntityFeatures): TrainingObservation {
-            val zones = base.zones.toMutableList()
-            zones[hiddenIndex] = hidden.copy(cards = listOf(card))
-            return base.copy(zones = zones)
-        }
+        opponentHandView(observe(env.state)).cards.shouldBeEmpty()
 
-        StateDigest.compute(withKnown(knownA)) shouldNotBe
-            StateDigest.compute(withKnown(knownB))
+        val revealed = opponentHandView(observe(revealing(opponentHand[0])))
+        // Peeking at one card does not unhide the zone: the rest of the hand is still unknown,
+        // so `size` stays the true count while `cards` holds only what this player has seen.
+        revealed.hidden.shouldBeTrue()
+        revealed.size shouldBe opponentHand.size
+        revealed.cards.map { it.entityId } shouldBe listOf(opponentHand[0])
     }
 
-    test("stateDigest includes observable stack details") {
+    test("stateDigest distinguishes which card is known inside a hidden zone") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val opponent = env.playerIds[1]
+        val opponentHand = env.state.getZone(ZoneKey(opponent, Zone.HAND))
+
+        fun digestRevealing(cardId: EntityId): String =
+            ObservationBuilder().build(
+                env.state.withEntity(
+                    cardId,
+                    env.state.getEntity(cardId)!!.with(RevealedToComponent.to(me))
+                ),
+                me,
+                env.legalActions()
+            ).observation.stateDigest
+
+        val nothingKnown = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation.stateDigest
+
+        digestRevealing(opponentHand[0]) shouldNotBe nothingKnown
+        digestRevealing(opponentHand[0]) shouldNotBe digestRevealing(opponentHand[1])
+    }
+
+    test("a spell on the stack reports its chosen targets, and they reach the digest") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val opponent = env.playerIds[1]
+        val handKey = ZoneKey(me, Zone.HAND)
+        val spellId = env.state.getZone(handKey).first()
+
+        fun casting(target: EntityId): GameState {
+            val hand = env.state.getZone(handKey)
+            return env.state
+                .copy(zones = env.state.zones + (handKey to hand - spellId), stack = listOf(spellId))
+                .withEntity(
+                    spellId,
+                    env.state.getEntity(spellId)!!
+                        // A real cast stamps the caster as controller on the way to the stack.
+                        .with(ControllerComponent(me))
+                        .with(TargetsComponent(listOf(ChosenTarget.Player(target))))
+                )
+        }
+
+        fun observe(state: GameState) =
+            ObservationBuilder().build(state, me, env.legalActions()).observation as TrainingObservation
+
+        val atOpponent = observe(casting(opponent))
+        val item = atOpponent.stack.single()
+        item.name.shouldNotBeEmpty()
+        item.controllerId shouldBe me
+        item.targets shouldBe listOf(opponent)
+
+        // Same spell, other target: an agent that cannot tell these apart cannot search.
+        atOpponent.stateDigest shouldNotBe observe(casting(me)).stateDigest
+    }
+
+    test("a triggered ability on the stack reports its source and controller") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val opponent = env.playerIds[1]
+        val abilityId = EntityId.of("trigger-on-stack")
+        val state = env.state
+            .withEntity(
+                abilityId,
+                ComponentContainer.of(
+                    TriggeredAbilityOnStackComponent(
+                        sourceId = EntityId.of("source"),
+                        sourceName = "Raging Goblin",
+                        controllerId = opponent,
+                        effect = Effects.DrawCards(1),
+                        description = "Draw a card."
+                    )
+                )
+            )
+            .copy(stack = listOf(abilityId))
+
+        val item = (ObservationBuilder().build(state, me, env.legalActions())
+            .observation as TrainingObservation).stack.single()
+
+        // An ability is its own entity with no CardComponent, so it used to arrive unnamed,
+        // uncontrolled and classified OTHER — three fields the digest now hashes.
+        item.kind shouldBe StackItemKind.TRIGGERED_ABILITY
+        item.controllerId shouldBe opponent
+        item.name shouldBe "Raging Goblin"
+    }
+
+    test("stateDigest reflects every observable field of a stack item") {
         val env = newEnv()
         val me = env.playerIds[0]
         val opponent = env.playerIds[1]
         val base = ObservationBuilder().build(env.state, me, env.legalActions())
             .observation as TrainingObservation
 
-        val targetA = EntityId.of("target-a")
-        val targetB = EntityId.of("target-b")
         val stackItem = StackItemView(
             entityId = EntityId.of("stack-item"),
             controllerId = me,
             name = "Visible Spell",
             kind = StackItemKind.SPELL,
             oracleText = "Visible rules text",
-            targets = listOf(targetA),
+            targets = listOf(EntityId.of("target-a")),
         )
         val baseline = StateDigest.compute(base.copy(stack = listOf(stackItem)))
 
         listOf(
             stackItem.copy(controllerId = opponent),
             stackItem.copy(name = "Different Visible Spell"),
+            stackItem.copy(kind = StackItemKind.TRIGGERED_ABILITY),
             stackItem.copy(oracleText = "Different visible rules text"),
-            stackItem.copy(targets = listOf(targetB)),
+            stackItem.copy(targets = listOf(EntityId.of("target-b"))),
         ).forEach { changed ->
             StateDigest.compute(base.copy(stack = listOf(changed))) shouldNotBe baseline
         }
+    }
+
+    test("stateDigest is unambiguous when a card name contains the encoding's delimiters") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation as TrainingObservation
+
+        fun item(id: String, name: String) = StackItemView(
+            entityId = EntityId.of(id),
+            controllerId = null,
+            name = name,
+            kind = StackItemKind.SPELL,
+        )
+
+        // Card names are author-supplied, so a name can spell the digest's own field separators.
+        // This one reproduces the two-item encoding exactly, and collides with it unless the
+        // free-form fields are length-prefixed.
+        val smuggled = item("s", "N:text=:targets=|S[1]=s2:ctl=null:kind=SPELL:name=M")
+        val twoItems = listOf(item("s", "N"), item("s2", "M"))
+
+        StateDigest.compute(base.copy(stack = listOf(smuggled))) shouldNotBe
+            StateDigest.compute(base.copy(stack = twoItems))
     }
 
     test("stateDigest is stable for equivalent observations and changes when state changes") {

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -134,6 +135,72 @@ class TrainingObservationTest : FunSpec({
         decoded.zones.flatMap { it.cards }.forEach { c ->
             // Every serialized card either has empty oracle text or preserves it.
             c.oracleText shouldBe (obs.zones.flatMap { it.cards }.first { it.entityId == c.entityId }.oracleText)
+        }
+    }
+
+    test("stateDigest includes known card details supplied inside a hidden zone") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation as TrainingObservation
+
+        val hiddenIndex = base.zones.indexOfFirst {
+            it.hidden && it.zoneType == Zone.HAND
+        }
+        hiddenIndex shouldNotBe -1
+
+        val hidden = base.zones[hiddenIndex]
+        val template = base.zones
+            .first { !it.hidden && it.cards.isNotEmpty() }
+            .cards.first()
+
+        val knownA = template.copy(
+            entityId = EntityId.of("known-hidden-card"),
+            cardDefinitionId = "known-a",
+            name = "Known A",
+            ownerId = hidden.ownerId,
+        )
+        val knownB = knownA.copy(
+            cardDefinitionId = "known-b",
+            name = "Known B",
+        )
+
+        fun withKnown(card: EntityFeatures): TrainingObservation {
+            val zones = base.zones.toMutableList()
+            zones[hiddenIndex] = hidden.copy(cards = listOf(card))
+            return base.copy(zones = zones)
+        }
+
+        StateDigest.compute(withKnown(knownA)) shouldNotBe
+            StateDigest.compute(withKnown(knownB))
+    }
+
+    test("stateDigest includes observable stack details") {
+        val env = newEnv()
+        val me = env.playerIds[0]
+        val opponent = env.playerIds[1]
+        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+            .observation as TrainingObservation
+
+        val targetA = EntityId.of("target-a")
+        val targetB = EntityId.of("target-b")
+        val stackItem = StackItemView(
+            entityId = EntityId.of("stack-item"),
+            controllerId = me,
+            name = "Visible Spell",
+            kind = StackItemKind.SPELL,
+            oracleText = "Visible rules text",
+            targets = listOf(targetA),
+        )
+        val baseline = StateDigest.compute(base.copy(stack = listOf(stackItem)))
+
+        listOf(
+            stackItem.copy(controllerId = opponent),
+            stackItem.copy(name = "Different Visible Spell"),
+            stackItem.copy(oracleText = "Different visible rules text"),
+            stackItem.copy(targets = listOf(targetB)),
+        ).forEach { changed ->
+            StateDigest.compute(base.copy(stack = listOf(changed))) shouldNotBe baseline
         }
     }
 


### PR DESCRIPTION
Builds on #2148 (its commit is included here, so this supersedes it) and fixes what the review of that PR turned up.

`StateDigest` is meant to identify the information set a `TrainingObservation` represents, and #2148 widened it to cover a hidden zone's known cards and a stack item's controller, name, text and targets. Reviewing it showed the digest was hashing fields `ObservationBuilder` never fills in, so the widening was inert. This makes the producer emit them.

**A hidden zone is not an empty one.** `RevealedToComponent` is how the engine records "you looked at that card" — it is what `Visibility.isCardRevealedTo` consults for the client. The gym builder discarded it: `cards = if (hidden) emptyList() else …`, so an opponent's hand looked identical whether the viewer had been shown a card in it or not. It now lists the subset this perspective knows while `hidden` stays true and `size` stays the true count, and `ZoneView`'s KDoc documents that shape instead of claiming `cards` is empty. The builder deliberately stops at the per-card component; the whole-hand reveal `Visibility` also honours needs a `CardRegistry`, which an observation builder has no other use for.

**Stack items were missing three things.**

- `targets` was hardcoded to `emptyList()`, so what a spell targets never reached an agent at all. It now comes off `TargetsComponent`, flattened to entity ids (a player target contributes the player's entity id).
- `controllerId` was read from `state.projectedState`, which has no entry for a stack object — Layer 4 projects battlefield permanents. It was therefore **null for every stack item ever observed**, including the case #2148 set out to fix. Each stack component carries its own controller; a spell's is its `ControllerComponent`, else the caster, which is the same fallback `ProjectedState` uses for spells.
- `kind` matched on `CardComponent`, but an ability on the stack is its own entity without one, so every triggered and activated ability arrived unnamed and classified `OTHER`. Abilities now report their kind and their source's name.

**The digest's free-form fields are length-prefixed.** Card names are author-supplied (`custom/` cards included) and can contain every delimiter the encoding uses, so a single stack item could serialize byte-for-byte like a two-item stack. `appendText` writes `<length>:<value>`; the regression test constructs exactly that collision.

The zone encoding also drops the conditional #2148 added — `cards` is simply always encoded, and an empty list contributes nothing, which is the same discrimination in one fewer branch.

No `@Serializable` shape changed, so `SchemaHash.CURRENT` stands. Downstream consumers do see more populated data in `ZoneView.cards` and `StackItemView.targets` — that is the fix, not a break.

## Tests

`TrainingObservationTest` gains six, all against the real builder except the two that need a hand-built DTO:

- a card revealed to this perspective is visible inside its still-hidden zone (zone stays hidden, `size` unchanged)
- the digest distinguishes *which* card is known inside a hidden zone
- a spell on the stack reports its chosen targets, and retargeting it changes the digest
- a triggered ability reports its source name, controller and kind
- every observable field of a stack item moves the digest
- a name spelling the encoding's delimiters cannot collide with a different stack

## Verification

- `just test-class TrainingObservationTest` — 11 passed
- `just test-gym` — green
- `just test-gym-server` — green
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShSJP5bSqef2uALqEAAaJ7