### PR TITLE
Finish the Gym observation semantics: close the face-down leak, name the abilities on the stack

### DIFF
--- a/gym/build.gradle.kts
+++ b/gym/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     runtimeOnly(libs.slf4jApi)
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -39,12 +39,17 @@ import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
@@ -243,7 +248,7 @@ class ObservationBuilder(
         return EntityFeatures(
             entityId = entityId,
             cardDefinitionId = card?.cardDefinitionId,
-            name = card?.name ?: "",
+            name = pv?.name ?: card?.name ?: "",
             zone = zone,
             ownerId = container.get<OwnerComponent>()?.playerId ?: card?.ownerId,
             controllerId = if (onBattlefield) projected.getController(entityId) else null,
@@ -254,8 +259,16 @@ class ObservationBuilder(
             manaCost = card?.manaCost?.toString() ?: "",
             manaValue = card?.manaValue ?: 0,
             oracleText = card?.oracleText ?: "",
-            power = if (onBattlefield) projected.getPower(entityId) else null,
-            toughness = if (onBattlefield) projected.getToughness(entityId) else null,
+            power = if (onBattlefield && projected.isCreature(entityId)) {
+                projected.getPower(entityId)
+            } else {
+                null
+            },
+            toughness = if (onBattlefield && projected.isCreature(entityId)) {
+                projected.getToughness(entityId)
+            } else {
+                null
+            },
             tapped = onBattlefield && container.get<TappedComponent>() != null,
             // Only creatures meaningfully suffer summoning sickness — the engine attaches the
             // marker to every entering permanent so Vehicles / animated lands inherit the
@@ -264,7 +277,8 @@ class ObservationBuilder(
             // played Mountain would mislead the agent into thinking it can't tap for mana.
             summoningSick = onBattlefield
                 && container.get<SummoningSicknessComponent>() != null
-                && projected.isCreature(entityId),
+                && projected.isCreature(entityId)
+                && Keyword.HASTE.name !in keywords,
             faceDown = container.get<FaceDownComponent>() != null,
             damageMarked = container.get<DamageComponent>()?.amount ?: 0,
             counters = container.get<CountersComponent>()?.counters
@@ -281,16 +295,23 @@ class ObservationBuilder(
     private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
-        // Stack kind inference — fall back to OTHER. A more precise classification
-        // can be added once the stack carries explicit metadata.
+        val spell = container?.get<SpellOnStackComponent>()
+        val triggeredAbility = container?.get<TriggeredAbilityOnStackComponent>()
+        val activatedAbility = container?.get<ActivatedAbilityOnStackComponent>()
         val kind = when {
-            card?.spellEffect != null -> StackItemKind.SPELL
-            card != null -> StackItemKind.SPELL
+            spell != null || card != null -> StackItemKind.SPELL
+            triggeredAbility != null -> StackItemKind.TRIGGERED_ABILITY
+            activatedAbility != null -> StackItemKind.ACTIVATED_ABILITY
             else -> StackItemKind.OTHER
         }
         return StackItemView(
             entityId = entityId,
-            controllerId = state.projectedState.getController(entityId),
+            // Battlefield projection deliberately has no entries for stack objects. Stack
+            // components are the engine authority for the caster/controller of each kind.
+            controllerId = spell?.casterId
+                ?: triggeredAbility?.controllerId
+                ?: activatedAbility?.controllerId
+                ?: container?.get<ControllerComponent>()?.playerId,
             name = card?.name ?: "",
             kind = kind,
             oracleText = card?.oracleText ?: "",

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -39,7 +39,6 @@ import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -49,6 +48,8 @@ import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.state.identityVisibleTo
+import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -59,9 +60,10 @@ import com.wingedsheep.sdk.model.EntityId
  * ## Information hiding
  *
  * By default, opponent hand and everyone's library are hidden
- * ([ZoneView.hidden] = true, [ZoneView.cards] empty). Set [revealAll] to
- * `true` to disable masking — only appropriate for debug scripts; never
- * for real self-play training.
+ * ([ZoneView.hidden] = true, [ZoneView.cards] empty), and a face-down object
+ * reports only what the player looking at it may know (CR 708.5 — see
+ * `identityVisibleTo`). Set [revealAll] to `true` to disable masking — only
+ * appropriate for debug scripts; never for real self-play training.
  *
  * ## Projected vs. base state
  *
@@ -86,7 +88,9 @@ class ObservationBuilder(
 
         val zones = buildZones(state, perspectivePlayerId, revealAll)
 
-        val stack = state.stack.map { entityId -> buildStackItem(state, entityId) }
+        val stack = state.stack.map { entityId ->
+            buildStackItem(state, entityId, perspectivePlayerId, revealAll)
+        }
 
         val pendingDecisionAndRegistry = state.pendingDecision
             ?.let { buildPendingDecision(it) }
@@ -189,7 +193,11 @@ class ObservationBuilder(
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
                 val hidden = !revealAll && isHiddenFrom(zone, playerId, perspectivePlayerId)
-                val cards = if (hidden) emptyList() else ids.map { buildEntityFeatures(state, it, zone) }
+                val cards = if (hidden) {
+                    emptyList()
+                } else {
+                    ids.map { buildEntityFeatures(state, it, zone, perspectivePlayerId, revealAll) }
+                }
                 views += ZoneView(
                     ownerId = playerId,
                     zoneType = zone,
@@ -215,7 +223,9 @@ class ObservationBuilder(
     private fun buildEntityFeatures(
         state: GameState,
         entityId: EntityId,
-        zone: Zone
+        zone: Zone,
+        perspectivePlayerId: EntityId,
+        revealAll: Boolean
     ): EntityFeatures {
         val container = state.getEntity(entityId) ?: ComponentContainer.EMPTY
         val card = container.get<CardComponent>()
@@ -224,31 +234,47 @@ class ObservationBuilder(
 
         val onBattlefield = zone == Zone.BATTLEFIELD
 
+        // CR 708.5 — only the player who may look at a face-down object learns which card it is.
+        // Projection already masks a face-down permanent's characteristics down to the 2/2 with no
+        // name of CR 708.2a, but the printed fields below read the card underneath directly and
+        // have no projection entry to hide behind, so they are gated here. A face-down card in
+        // exile has no projection entry at all — hence the gate on the base-state fallbacks too.
+        val identityHidden = !revealAll &&
+            !identityVisibleTo(state, entityId, perspectivePlayerId)
+
         val types: Set<String> = when {
             pv != null -> pv.types.toSet()
+            identityHidden -> emptySet()
             card != null -> card.typeLine.cardTypes.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val subtypes: Set<String> = when {
             pv != null -> pv.subtypes.toSet()
+            identityHidden -> emptySet()
             card != null -> card.typeLine.subtypes.mapTo(mutableSetOf()) { it.value }
             else -> emptySet()
         }
         val colors: Set<String> = when {
             pv != null -> pv.colors.toSet()
+            identityHidden -> emptySet()
             card != null -> card.colors.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val keywords: Set<String> = when {
             pv != null -> pv.keywords.toSet()
+            identityHidden -> emptySet()
             card != null -> card.baseKeywords.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
 
         return EntityFeatures(
             entityId = entityId,
-            cardDefinitionId = card?.cardDefinitionId,
-            name = pv?.name ?: card?.name ?: "",
+            cardDefinitionId = if (identityHidden) null else card?.cardDefinitionId,
+            name = if (identityHidden) {
+                nameVisibleToAll(state, entityId, "")
+            } else {
+                pv?.name ?: card?.name ?: ""
+            },
             zone = zone,
             ownerId = container.get<OwnerComponent>()?.playerId ?: card?.ownerId,
             controllerId = if (onBattlefield) projected.getController(entityId) else null,
@@ -256,9 +282,9 @@ class ObservationBuilder(
             subtypes = subtypes,
             colors = colors,
             keywords = keywords,
-            manaCost = card?.manaCost?.toString() ?: "",
-            manaValue = card?.manaValue ?: 0,
-            oracleText = card?.oracleText ?: "",
+            manaCost = if (identityHidden) "" else card?.manaCost?.toString() ?: "",
+            manaValue = if (identityHidden) 0 else card?.manaValue ?: 0,
+            oracleText = if (identityHidden) "" else card?.oracleText ?: "",
             power = if (onBattlefield && projected.isCreature(entityId)) {
                 projected.getPower(entityId)
             } else {
@@ -278,7 +304,7 @@ class ObservationBuilder(
             summoningSick = onBattlefield
                 && container.get<SummoningSicknessComponent>() != null
                 && projected.isCreature(entityId)
-                && Keyword.HASTE.name !in keywords,
+                && !projected.hasKeyword(entityId, Keyword.HASTE),
             faceDown = container.get<FaceDownComponent>() != null,
             damageMarked = container.get<DamageComponent>()?.amount ?: 0,
             counters = container.get<CountersComponent>()?.counters
@@ -292,29 +318,50 @@ class ObservationBuilder(
     // Stack
     // =========================================================================
 
-    private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
+    private fun buildStackItem(
+        state: GameState,
+        entityId: EntityId,
+        perspectivePlayerId: EntityId,
+        revealAll: Boolean
+    ): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
         val spell = container?.get<SpellOnStackComponent>()
         val triggeredAbility = container?.get<TriggeredAbilityOnStackComponent>()
         val activatedAbility = container?.get<ActivatedAbilityOnStackComponent>()
+        // Abilities first: a spell copy carries both a CardComponent and a SpellOnStackComponent,
+        // but nothing that is an ability carries a card, so the ability branches are the specific
+        // ones and must win if that ever stops being true.
         val kind = when {
-            spell != null || card != null -> StackItemKind.SPELL
             triggeredAbility != null -> StackItemKind.TRIGGERED_ABILITY
             activatedAbility != null -> StackItemKind.ACTIVATED_ABILITY
+            spell != null || card != null -> StackItemKind.SPELL
             else -> StackItemKind.OTHER
         }
+        // An ability's entity holds only its stack component — `StackResolver` builds it from that
+        // alone, with no CardComponent — so the source name and description are the only identity
+        // an agent can read for it.
+        val name = card?.name
+            ?: triggeredAbility?.sourceName
+            ?: activatedAbility?.sourceName
+            ?: ""
+        val text = card?.oracleText
+            ?: triggeredAbility?.let { it.descriptionOverride ?: it.description }
+            ?: activatedAbility?.descriptionOverride
+            ?: ""
+        // A spell cast face down is one its opponents may not read either (CR 708.4/708.5).
+        val identityHidden = !revealAll &&
+            !identityVisibleTo(state, entityId, perspectivePlayerId)
         return StackItemView(
             entityId = entityId,
             // Battlefield projection deliberately has no entries for stack objects. Stack
             // components are the engine authority for the caster/controller of each kind.
             controllerId = spell?.casterId
                 ?: triggeredAbility?.controllerId
-                ?: activatedAbility?.controllerId
-                ?: container?.get<ControllerComponent>()?.playerId,
-            name = card?.name ?: "",
+                ?: activatedAbility?.controllerId,
+            name = if (identityHidden) nameVisibleToAll(state, entityId, name) else name,
             kind = kind,
-            oracleText = card?.oracleText ?: "",
+            oracleText = if (identityHidden) "" else text,
             targets = emptyList()
         )
     }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
@@ -6,9 +6,10 @@ package com.wingedsheep.gym.contract
  * DTO shape has drifted.
  *
  * Bump [CURRENT] whenever any `@Serializable` data class in this package
- * changes shape in a way that would break a downstream consumer. The value
- * itself is arbitrary; uniqueness is what matters.
+ * changes shape — or a field changes what it means — in a way that would
+ * break a downstream consumer. The value itself is arbitrary; uniqueness is
+ * what matters.
  */
 object SchemaHash {
-    const val CURRENT: String = "argentum-gym-contract@v1.3-action-params"
+    const val CURRENT: String = "argentum-gym-contract@v1.4-object-semantics"
 }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -156,7 +156,14 @@ data class ZoneView(
 @Serializable
 data class EntityFeatures(
     val entityId: EntityId,
+    /** Null for a face-down object the perspective player may not look at. */
     val cardDefinitionId: String?,
+    /**
+     * The projected name — what Layer 3 renamed the object to (Witness Protection), else the
+     * printed one. `"Face-down creature"` / `"Face-down card"` for a face-down object the
+     * perspective player may not look at, whose [oracleText], [manaCost] and [manaValue] are
+     * blanked to match.
+     */
     val name: String,
     val zone: Zone,
     val ownerId: EntityId?,
@@ -194,6 +201,12 @@ data class EntityFeatures(
     val toughness: Int?,
 
     val tapped: Boolean = false,
+    /**
+     * The restriction actually in force: the object entered under this controller too recently,
+     * it is currently a creature, and it has no haste. Not the raw engine marker — a creature
+     * with projected haste reports `false` even though the marker is still on it, and reverts to
+     * `true` if the haste goes away while the marker stands.
+     */
     val summoningSick: Boolean = false,
     val faceDown: Boolean = false,
     val damageMarked: Int = 0,
@@ -208,10 +221,12 @@ data class EntityFeatures(
 @Serializable
 data class StackItemView(
     val entityId: EntityId,
+    /** The caster of a spell, or the controller of an ability. */
     val controllerId: EntityId?,
+    /** The spell's card name, or the source name of an ability. */
     val name: String,
     val kind: StackItemKind,
-    /** Printed oracle text of the card backing this stack item — empty for stackless triggers. */
+    /** Printed oracle text of the card, or an ability's description. */
     val oracleText: String = "",
     val targets: List<EntityId> = emptyList()
 )

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.gym.contract
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.blc.cards.RollingHamsphere
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.dsl.Effects
+import io.kotest.matchers.shouldBe
+
+/** Public Gym fields must read the engine semantic authority for the object kind in question. */
+class ObservationProjectedStateTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(RollingHamsphere)
+
+        test("battlefield names follow the layer projection") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Test Hasty Prospector")
+                .withCardOnBattlefield(1, "Witness Protection")
+                .build()
+            val creature = permanentNamed(game.state, "Test Hasty Prospector")
+            val aura = permanentNamed(game.state, "Witness Protection")
+            val enchanted = game.state.updateEntity(aura) { it.with(AttachedToComponent(creature)) }
+
+            enchanted.projectedState.getName(creature) shouldBe "Legitimate Businessperson"
+            entity(observe(enchanted, game.player1Id), creature).name shouldBe
+                "Legitimate Businessperson"
+        }
+
+        test("an uncrewed Vehicle has no public power or toughness") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, RollingHamsphere.name)
+                .build()
+            val vehicle = permanentNamed(game.state, RollingHamsphere.name)
+
+            game.state.projectedState.isCreature(vehicle) shouldBe false
+            // Projection retains the printed values for a later animation, but public P/T is
+            // conditional on the object currently being a creature.
+            game.state.projectedState.getPower(vehicle) shouldBe 4
+            entity(observe(game.state, game.player1Id), vehicle).let {
+                it.power shouldBe null
+                it.toughness shouldBe null
+            }
+        }
+
+        test("haste suppresses effective summoning sickness in the observation") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(
+                    1,
+                    "Test Hasty Prospector",
+                    summoningSickness = true,
+                )
+                .build()
+            val creature = permanentNamed(game.state, "Test Hasty Prospector")
+
+            game.state.projectedState.hasKeyword(creature, Keyword.HASTE) shouldBe true
+            entity(observe(game.state, game.player1Id), creature).summoningSick shouldBe false
+        }
+
+        test("stack controller and kind come from stack components rather than battlefield projection") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val spell = game.state.getHand(game.player2Id).single()
+            val trigger = EntityId.of("trigger-on-stack")
+            val activation = EntityId.of("activation-on-stack")
+            val state = game.state
+                .removeFromZone(ZoneKey(game.player2Id, Zone.HAND), spell)
+                .updateEntity(spell) { it.with(SpellOnStackComponent(casterId = game.player2Id)) }
+                .withEntity(
+                    trigger,
+                    ComponentContainer.of(
+                        TriggeredAbilityOnStackComponent(
+                            sourceId = EntityId.of("trigger-source"),
+                            sourceName = "Trigger Source",
+                            controllerId = game.player1Id,
+                            effect = Effects.DrawCards(1),
+                            description = "Draw a card",
+                        ),
+                    ),
+                )
+                .withEntity(
+                    activation,
+                    ComponentContainer.of(
+                        ActivatedAbilityOnStackComponent(
+                            sourceId = EntityId.of("activation-source"),
+                            sourceName = "Activation Source",
+                            controllerId = game.player2Id,
+                            effect = Effects.DrawCards(1),
+                        ),
+                    ),
+                )
+                .copy(stack = listOf(spell, trigger, activation))
+
+            val stack = observe(state, game.player1Id).stack.associateBy { it.entityId }
+            stack.getValue(spell).let {
+                it.kind shouldBe StackItemKind.SPELL
+                it.controllerId shouldBe game.player2Id
+            }
+            stack.getValue(trigger).let {
+                it.kind shouldBe StackItemKind.TRIGGERED_ABILITY
+                it.controllerId shouldBe game.player1Id
+            }
+            stack.getValue(activation).let {
+                it.kind shouldBe StackItemKind.ACTIVATED_ABILITY
+                it.controllerId shouldBe game.player2Id
+            }
+        }
+    }
+
+    private fun observe(
+        state: com.wingedsheep.engine.state.GameState,
+        viewer: EntityId,
+    ): TrainingObservation = ObservationBuilder()
+        .build(state, viewer, legalActions = emptyList())
+        .observation as TrainingObservation
+
+    private fun entity(observation: TrainingObservation, entityId: EntityId): EntityFeatures =
+        observation.zones.flatMap { it.cards }.single { it.entityId == entityId }
+
+    private fun permanentNamed(
+        state: com.wingedsheep.engine.state.GameState,
+        name: String,
+    ): EntityId = state.getBattlefield().single { id ->
+        state.getEntity(id)?.get<CardComponent>()?.name == name
+    }
+}

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationProjectedStateTest.kt
@@ -1,9 +1,13 @@
 package com.wingedsheep.gym.contract
 
+import com.wingedsheep.engine.core.CrewVehicle
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
@@ -11,8 +15,8 @@ import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.mtg.sets.definitions.blc.cards.RollingHamsphere
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.EntityId
 import io.kotest.matchers.shouldBe
 
 /** Public Gym fields must read the engine semantic authority for the object kind in question. */
@@ -29,6 +33,12 @@ class ObservationProjectedStateTest : ScenarioTestBase() {
                 .build()
             val creature = permanentNamed(game.state, "Test Hasty Prospector")
             val aura = permanentNamed(game.state, "Witness Protection")
+
+            // Nothing has renamed it yet: projection carries no name and the printed one stands.
+            game.state.projectedState.getName(creature) shouldBe null
+            entity(observe(game.state, game.player1Id), creature).name shouldBe
+                "Test Hasty Prospector"
+
             val enchanted = game.state.updateEntity(aura) { it.with(AttachedToComponent(creature)) }
 
             enchanted.projectedState.getName(creature) shouldBe "Legitimate Businessperson"
@@ -40,16 +50,43 @@ class ObservationProjectedStateTest : ScenarioTestBase() {
             val game = scenario()
                 .withPlayers()
                 .withCardOnBattlefield(1, RollingHamsphere.name)
+                .withCardOnBattlefield(1, "Hill Giant")
                 .build()
             val vehicle = permanentNamed(game.state, RollingHamsphere.name)
+            val creature = permanentNamed(game.state, "Hill Giant")
 
             game.state.projectedState.isCreature(vehicle) shouldBe false
             // Projection retains the printed values for a later animation, but public P/T is
             // conditional on the object currently being a creature.
             game.state.projectedState.getPower(vehicle) shouldBe 4
-            entity(observe(game.state, game.player1Id), vehicle).let {
+            val observation = observe(game.state, game.player1Id)
+            entity(observation, vehicle).let {
                 it.power shouldBe null
                 it.toughness shouldBe null
+            }
+            // The gate hides P/T for non-creatures only — a creature beside it still reports its.
+            entity(observation, creature).let {
+                it.power shouldBe 3
+                it.toughness shouldBe 3
+            }
+        }
+
+        test("crewing a Vehicle makes its power and toughness public") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, RollingHamsphere.name)
+                .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                .build()
+            val vehicle = permanentNamed(game.state, RollingHamsphere.name)
+            val crew = permanentNamed(game.state, "Hill Giant")
+
+            game.execute(CrewVehicle(game.player1Id, vehicle, listOf(crew))).error shouldBe null
+            game.resolveStack()
+
+            game.state.projectedState.isCreature(vehicle) shouldBe true
+            entity(observe(game.state, game.player1Id), vehicle).let {
+                it.power shouldBe 4
+                it.toughness shouldBe 4
             }
         }
 
@@ -64,8 +101,48 @@ class ObservationProjectedStateTest : ScenarioTestBase() {
                 .build()
             val creature = permanentNamed(game.state, "Test Hasty Prospector")
 
+            // The engine marker is what makes this a real suppression rather than an absent flag.
+            game.state.getEntity(creature)!!.has<SummoningSicknessComponent>() shouldBe true
             game.state.projectedState.hasKeyword(creature, Keyword.HASTE) shouldBe true
             entity(observe(game.state, game.player1Id), creature).summoningSick shouldBe false
+        }
+
+        test("a creature without haste still reports the restriction") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hill Giant", summoningSickness = true)
+                .build()
+            val creature = permanentNamed(game.state, "Hill Giant")
+
+            game.state.projectedState.hasKeyword(creature, Keyword.HASTE) shouldBe false
+            entity(observe(game.state, game.player1Id), creature).summoningSick shouldBe true
+        }
+
+        test("a face-down permanent reveals its card only to the player who may look") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Hill Giant")
+                .build()
+            val morph = permanentNamed(game.state, "Hill Giant")
+            val state = game.state.updateEntity(morph) { it.with(FaceDownComponent) }
+
+            entity(observe(state, game.player1Id), morph).let {
+                // CR 708.2a — a 2/2 creature with no name, no subtypes and no mana cost.
+                it.name shouldBe "Face-down creature"
+                it.cardDefinitionId shouldBe null
+                it.oracleText shouldBe ""
+                it.manaCost shouldBe ""
+                it.manaValue shouldBe 0
+                it.types shouldBe setOf("CREATURE")
+                it.subtypes shouldBe emptySet()
+                it.power shouldBe 2
+                it.toughness shouldBe 2
+            }
+            // CR 708.5 — its controller may look at it.
+            entity(observe(state, game.player2Id), morph).let {
+                it.name shouldBe "Hill Giant"
+                it.cardDefinitionId shouldBe "Hill Giant"
+            }
         }
 
         test("stack controller and kind come from stack components rather than battlefield projection") {
@@ -108,32 +185,54 @@ class ObservationProjectedStateTest : ScenarioTestBase() {
             stack.getValue(spell).let {
                 it.kind shouldBe StackItemKind.SPELL
                 it.controllerId shouldBe game.player2Id
+                it.name shouldBe "Hill Giant"
             }
+            // An ability carries no CardComponent, so its source name and description are the
+            // only identity the observation can offer.
             stack.getValue(trigger).let {
                 it.kind shouldBe StackItemKind.TRIGGERED_ABILITY
                 it.controllerId shouldBe game.player1Id
+                it.name shouldBe "Trigger Source"
+                it.oracleText shouldBe "Draw a card"
             }
             stack.getValue(activation).let {
                 it.kind shouldBe StackItemKind.ACTIVATED_ABILITY
                 it.controllerId shouldBe game.player2Id
+                it.name shouldBe "Activation Source"
             }
+        }
+
+        test("a face-down spell on the stack is nameless to its opponent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val spell = game.state.getHand(game.player2Id).single()
+            val state = game.state
+                .removeFromZone(ZoneKey(game.player2Id, Zone.HAND), spell)
+                .updateEntity(spell) {
+                    it.with(SpellOnStackComponent(casterId = game.player2Id, castFaceDown = true))
+                }
+                .copy(stack = listOf(spell))
+
+            observe(state, game.player1Id).stack.single().let {
+                it.name shouldBe "Face-down creature"
+                it.oracleText shouldBe ""
+            }
+            observe(state, game.player2Id).stack.single().name shouldBe "Hill Giant"
         }
     }
 
-    private fun observe(
-        state: com.wingedsheep.engine.state.GameState,
-        viewer: EntityId,
-    ): TrainingObservation = ObservationBuilder()
-        .build(state, viewer, legalActions = emptyList())
-        .observation as TrainingObservation
+    private fun observe(state: GameState, viewer: EntityId): TrainingObservation =
+        ObservationBuilder()
+            .build(state, viewer, legalActions = emptyList())
+            .observation as TrainingObservation
 
     private fun entity(observation: TrainingObservation, entityId: EntityId): EntityFeatures =
         observation.zones.flatMap { it.cards }.single { it.entityId == entityId }
 
-    private fun permanentNamed(
-        state: com.wingedsheep.engine.state.GameState,
-        name: String,
-    ): EntityId = state.getBattlefield().single { id ->
-        state.getEntity(id)?.get<CardComponent>()?.name == name
-    }
+    private fun permanentNamed(state: GameState, name: String): EntityId =
+        state.getBattlefield().single { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -54,8 +54,30 @@ fun nameVisibleTo(
     isSpectator: Boolean = false,
 ): String {
     val masked = faceDownDisplayName(state, entityId) ?: return fallback
-    val mayLook = !isSpectator && viewingPlayerId == playerWhoMayLookAt(state, entityId)
-    return if (mayLook) fallback else masked
+    return if (identityVisibleTo(state, entityId, viewingPlayerId, isSpectator)) fallback else masked
+}
+
+/**
+ * Whether [viewingPlayerId] may read [entityId]'s *printed* identity — the name, rules text, mana
+ * cost and card definition of the card underneath.
+ *
+ * True for everything except a face-down object another player controls (CR 708.5). Use it to gate
+ * the printed fields that no other layer masks: a face-down permanent's projected characteristics
+ * are already the 2/2 with no name that CR 708.2a describes, but the card's own printed text has no
+ * projection entry to hide behind.
+ *
+ * Controller-only, matching the rule. A grant that widens it (Lens of Clarity's "you may look at
+ * face-down creatures") is layered on top by the caller that supports it — see
+ * [com.wingedsheep.engine.view.ClientStateTransformer].
+ */
+fun identityVisibleTo(
+    state: GameState,
+    entityId: EntityId,
+    viewingPlayerId: EntityId,
+    isSpectator: Boolean = false,
+): Boolean {
+    faceDownDisplayName(state, entityId) ?: return true
+    return !isSpectator && viewingPlayerId == playerWhoMayLookAt(state, entityId)
 }
 
 /**


### PR DESCRIPTION
Builds on #2147 (included here, so this PR supersedes it — merging this closes both). That PR pointed
`ObservationBuilder` at the right authority for each field: `ProjectedState` for battlefield
characteristics, the stack components for stack metadata. This finishes the job — the review of it
turned up one leak, two half-tested gates, and a contract that no longer described itself.

### Face-down objects no longer leak the card underneath (CR 708.5)

The projected-name fix walked past a real hole. `StateProjector` deliberately gives a face-down
permanent no name, no subtypes and no colors (CR 708.2a), so those fields were already masked — but
`name`, `oracleText`, `manaCost`, `manaValue` and `cardDefinitionId` read the `CardComponent`
directly, which has no projection entry to hide behind. Every face-down permanent therefore reported
its real card name and rules text to **both** players' observations, and a face-down card in exile
(a foretold card) leaked its types and colors too, having no projection entry at all. A self-play
agent could read morphs.

The engine already owns this question: `FaceDownNaming` knows which zones hide an identity and which
single player may look at it. It only exposed the *name* half, so this adds `identityVisibleTo`
beside `nameVisibleTo` — the same gate, asked about the whole printed identity rather than one
string — and re-expresses `nameVisibleTo` in terms of it. Gym now gates the printed fields on it, and
the masked name comes back from `nameVisibleToAll`, so a face-down card in exile is labelled
"Face-down card" and a face-down permanent "Face-down creature", each per its own zone.

Stack items get the same gate: a spell cast face down is one its opponents may not read either
(CR 708.4).

The gate is controller-only, as the rule is. A grant that widens it (Lens of Clarity) is layered on
by `ClientStateTransformer` for the client views; Gym does not read it, so a Lens controller sees
less than they are entitled to rather than more — the conservative direction, and no leak.

### An ability on the stack now says which ability it is

#2147 taught `buildStackItem` to read the caster/controller and kind off
`TriggeredAbilityOnStackComponent` / `ActivatedAbilityOnStackComponent`, but left `name` reading
`card?.name`. An ability's stack entity has no `CardComponent` at all — `StackResolver` builds it
from the ability component alone — so every ability on the stack reported `name = ""`. An agent
learned that *an* ability was on the stack and whose it was, but never which one. Both components
carry `sourceName`, and the descriptions are right there next to them.

The `kind` branches are also reordered to test the ability components before the card one. It is
unreachable today, but `spell != null || card != null -> SPELL` sitting first means the general
branch wins over the specific ones, which is backwards for the one shape that would break it.

The dead `ControllerComponent` fallback on `controllerId` is dropped: every stack object goes on
through one of the three `StackResolver` paths, all of which attach one of the three components, and
a base-state controller read is exactly what the comment above it says not to do.

### The two new gates get their positive side tested

Both of #2147's new conditions were tested only where they suppress a value. A regression that made
`power` unconditionally null, or `summoningSick` unconditionally false, passed the whole suite.

- The uncrewed Vehicle now has a creature beside it that still reports 3/3, and a sibling test crews
  the Vehicle for real (`CrewVehicle` + `resolveStack`) and watches its P/T go from null to 4/4.
- The haste test asserts the engine's `SummoningSicknessComponent` is actually present, so it can no
  longer pass because the marker was never attached in the first place, and a non-hasty creature
  under the same marker is asserted to still report `true`.
- The name test asserts the printed-name fallback (projection carries no name until something sets
  one) before enchanting with Witness Protection.

### Contract docs and schema hash

`summoningSick` changed meaning in #2147 — from "the engine marker is present" to "the restriction
is actually in force" — and had no KDoc at all. It has one now, including the part that surprises:
the value reverts to `true` if the haste goes away while the marker stands. `EntityFeatures.name`,
`cardDefinitionId` and the `StackItemView` fields document their masking and their new sources.

`SchemaHash` goes to `v1.4-object-semantics`. The shape is unchanged, so its own KDoc did not
strictly demand a bump — but a consumer that assumed a battlefield permanent's `power` is an int now
gets `null` for Vehicles, and every observation's `stateDigest` changes, so the KDoc is widened to
cover a field changing what it means. No in-repo Python client pins the old value.

### Verification

- `just test-class ObservationProjectedStateTest` — 8/8
- `just test-gym`
- `just test-rules` (`FaceDownNaming` is shared with `ClientStateTransformer`)
- `git diff --check`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rfrULSePQdBYHntY2Yf7R
