### PR TITLE
Unify card identity visibility

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -103,24 +103,18 @@ class Determinizer(
         viewerId: EntityId,
     ): List<EntityId> {
         val handKey = ZoneKey(opponentId, Zone.HAND)
-        val handHidden = !visibility.isZoneVisibleTo(state, handKey, viewerId)
-        val candidates = buildList {
-            addAll(state.getLibrary(opponentId))
-            if (handHidden) addAll(state.getHand(opponentId))
-        }
-        val visibleTop = state.getLibrary(opponentId).firstOrNull()?.takeIf {
-            visibility.revealsTopOfLibraryPublicly(state, opponentId) ||
-                (opponentId == viewerId && visibility.hasLookAtTopOfLibrary(state, viewerId))
-        }
+        val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
+        val library = state.getLibrary(opponentId)
+        val candidates = library + state.getHand(opponentId)
         val referencedByStack = HiddenSlotRewrite.stackReferencedEntities(state)
         return candidates.filter { id ->
-            id != visibleTop &&
+            val zoneKey = if (id in library) libraryKey else handKey
+            !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&
                 id !in referencedByStack &&
                 // Continuation frames carry entity references in several different shapes.
                 // Quiet search roots normally have none; pinning while one exists is the safe
                 // fallback until those shapes share a common reference visitor.
                 state.continuationStack.isEmpty() &&
-                !visibility.isCardRevealedTo(state, id, viewerId) &&
                 isSafeToRewrite(state, id)
         }
     }

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -165,12 +165,13 @@ every candidate. Sampling before the one-ply simulation matters because pending 
 by that simulation can inspect hidden zones too. Sharing the world is essential: independently
 sampling candidates would make hidden-information variance look like move quality.
 
-`Visibility` in `rules-engine/view` is the common oracle for both client masking and AI
-determinization. The determinizer rewrites identities, never entities: entity IDs, zone membership,
-pending decisions, targets and continuations remain intact. Individually revealed cards and cards
-carrying runtime state are pinned. With a known decklist it samples from `decklist − seen`;
-otherwise it permutes the existing hidden multiset. That fallback removes exact hand and
-library-order knowledge, but remains “cheating-lite” because it knows which cards exist unseen.
+`Visibility` in `rules-engine/view` is the common identity oracle for client masking, Gym
+observations, and AI determinization. The determinizer rewrites identities, never entities: entity
+IDs, zone membership, pending decisions, targets and continuations remain intact. Individually
+revealed cards and cards carrying runtime state are pinned. With a known decklist it samples from
+`decklist − seen`; otherwise it permutes the existing hidden multiset. That fallback removes exact
+hand and library-order knowledge, but remains “cheating-lite” because it knows which cards exist
+unseen.
 
 Phase 8 starts with one shared determinization per search. More worlds compete directly with rollout
 count, so raising K requires an arena result showing it buys more strength at the same wall-clock

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1202,20 +1202,27 @@ The server's responsibilities are strictly limited to:
 
 ### 3.2 State Masking (Fog of War)
 
-Hidden-zone visibility is centralized in `rules-engine/view/Visibility`. Both
-`ClientStateTransformer` and the engine AI's determinizer consume it, so a reveal effect cannot be
-visible to the client while remaining hidden from the AI (or vice versa). Consumers must not
-reimplement hand, library, teammate, turn-control, or individually-revealed-card rules.
+Card-identity visibility is centralized in `rules-engine/view/Visibility`.
+`ClientStateTransformer`, server decision presentation, the engine AI's determinizer, and Gym
+observations consume it, so a reveal effect cannot be visible to one perspective consumer while
+remaining hidden from another.
+Consumers must not reimplement hand, library, teammate, turn-control, individual-reveal,
+top-of-library, or face-down identity rules. They remain free to encode the shared answer
+differently: for example, the client retains opaque library slots while Gym reports a size plus the
+known subset.
 
 **Principle:** Each player sees a filtered view of the game state.
 
 In Magic, players cannot see each other's hands or libraries. The `ClientStateTransformer` produces a
 per-player view of the state that hides private information:
 
-- **Libraries:** Always hidden — only the count is visible
+- **Libraries:** The zone remains hidden, but an explicitly known top/individual card may have details
 - **Opponent's hand:** Only the count is visible, not the card identities
-- **Face-down cards:** Show as generic "Card back" to all players (even the controller cannot see
-  the identity in the masked view — only when they choose to interact)
+- **Face-down cards:** Show public face-down characteristics while the underlying identity is shown
+  only to a player entitled to look at it. CR 708.5 scopes that entitlement to the two zones it
+  names — you may look at a face-down spell or permanent *you control*, and at face-down cards in no
+  other zone. A face-down card in exile is therefore hidden from its owner as well, and only an
+  effect granting access (foretell, "you may look at and play") opens it
 - **Revealed cards:** `RevealedToComponent` overrides hiding for cards that have been explicitly revealed
 - **Revealed / returned hand cards:** A card revealed *into* a hand, or returned to a hand from a public
   zone (battlefield, graveyard, the stack), stays visible to opponents until its owner *plays* a card with

--- a/docs/gym-self-play-testing.md
+++ b/docs/gym-self-play-testing.md
@@ -64,8 +64,9 @@ Key config fields:
   `{"type":"RandomSealed","setCode":"BLB","boosterCount":8}` (needs the set's basic-land variants
   registered).
 - **`revealAll: true`** — set this for self-play. Normally observations hide the opponent's hand and
-  libraries; since one agent is playing *both* seats, you want to see everything. (Never use it for
-  real RL self-play — it leaks information.)
+  libraries except for identities the current perspective is entitled to know; since one agent is
+  playing *both* seats, you want to see everything. (Never use it for real RL self-play — it leaks
+  information.)
 - **`skipMulligans: true`** — skip the mulligan back-and-forth.
 - `startingPlayerIndex` — pin it for reproducibility (null = random).
 
@@ -150,7 +151,8 @@ The fields that matter most for spotting bugs:
   …), `description`, `affordable`, `manaCost`, target counts, and the combat candidates
   (`validAttackers`, `mandatoryAttackers`, `validAttackTargets`, `validBlockers`,
   `blockerMaxBlockCounts`, `mandatoryBlockerAssignments`).
-- `zones[]` → `cards[]` → `EntityFeatures` — the projected (post-layers) truth about each object:
+- `zones[]` → `cards[]` → `EntityFeatures` — the projected (post-layers) truth about each visible
+  object. A zone can remain `hidden: true` while `cards` contains its individually known subset:
   `oracleText`, `power`/`toughness`, `types`/`subtypes`/`keywords`/`colors`, `tapped`, `counters`,
   `attachedTo`. **`oracleText` is your oracle**: read what the card *says*, then watch whether the
   game state changes the way it says.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
@@ -2,29 +2,26 @@ package com.wingedsheep.gameserver.session
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
 class DecisionEnricher(private val cardRegistry: CardRegistry) {
-
-    private companion object {
-        /** Generic label for a face-down (morph / manifest) creature; mirrors the client state transformer. */
-        const val FACE_DOWN_CREATURE_NAME = "Face-down creature"
-    }
+    private val visibility = Visibility(cardRegistry)
 
     /**
-     * Whether [entityId]'s real name must be hidden from [viewerId]. A face-down permanent's identity
-     * is known only to the player who controls it (they may look at their own face-down creatures);
-     * everyone else sees the generic label. Mirrors the battlefield masking in ClientStateTransformer
-     * (`isFaceDown && controllerId != viewingPlayerId`). It intentionally does not honour
-     * Lens-of-Clarity-style reveals — omitting them only ever over-masks, so it can't leak.
+     * Whether [entityId]'s real name must be hidden from [viewerId]. The engine visibility authority
+     * combines controller access with explicit reveals and effect-granted access; this presenter only
+     * chooses the generic label once that semantic answer is known.
      */
     private fun isHiddenFrom(state: GameState, entityId: EntityId, viewerId: EntityId): Boolean =
         state.getEntity(entityId)?.has<FaceDownComponent>() == true &&
-            state.projectedState.getController(entityId) != viewerId
+            !visibility.isCardIdentityVisibleTo(state, Zone.BATTLEFIELD, entityId, viewerId)
 
     /**
      * The source name to display for [decision] to [viewerId]. The combat board copies the (single)
@@ -51,7 +48,7 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
         val sourceName = decision.context.sourceName ?: return null
         if (decision is CombatResolutionDecision) {
             val single = decision.attackers.singleOrNull() ?: return sourceName
-            if (single.name == sourceName && isHiddenFrom(state, single.id, viewerId)) return FACE_DOWN_CREATURE_NAME
+            if (single.name == sourceName && isHiddenFrom(state, single.id, viewerId)) return FACE_DOWN_DISPLAY_NAME
         }
         return sourceName
     }
@@ -91,15 +88,15 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
                 // leak to the opponent through a shared node. Mask per viewer: the controller keeps
                 // its own creature's name, everyone else sees the generic label.
                 val maskedAttackers = decision.attackers.map {
-                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_DISPLAY_NAME) else it
                 }
                 val maskedBlockers = decision.blockers.map {
-                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_DISPLAY_NAME) else it
                 }
                 // The single-attacker prompt embeds that attacker's name; mask it in lockstep.
                 val single = decision.attackers.singleOrNull()
                 val maskedPrompt = if (single != null && isHiddenFrom(state, single.id, viewerId)) {
-                    decision.prompt.replaceFirst(single.name, FACE_DOWN_CREATURE_NAME)
+                    decision.prompt.replaceFirst(single.name, FACE_DOWN_DISPLAY_NAME)
                 } else {
                     decision.prompt
                 }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Step
@@ -114,5 +115,14 @@ class CombatDamageMaskingEnricherTest : FunSpec({
         // The opponent-decision status shown to the defender also masks the attacker's real name.
         val status = enricher.createOpponentDecisionStatus(decision, driver.state, defender)
         (status.sourceName ?: "") shouldNotContain "Centaur Courser"
+
+        // The same presenter must stop masking when the engine's shared identity authority says
+        // this viewer has learned the face-down blocker. The decision DTO stays unchanged; only
+        // the semantic visibility fact in state changes.
+        driver.replaceState(driver.state.updateEntity(manifestBlocker) { container ->
+            container.with(RevealedToComponent.to(attacker))
+        })
+        val afterReveal = enricher.enrich(decision, driver.state, attacker) as CombatResolutionDecision
+        afterReveal.blockers.single { it.id == manifestBlocker }.name shouldBe "Savannah Lions"
     }
 })

--- a/gym/README.md
+++ b/gym/README.md
@@ -106,8 +106,13 @@ multi-mode `ChooseModeDecision`, `BudgetModalDecision`) flag
 
 ### Information hiding by default
 
-`ObservationBuilder` hides opponent hand and every library when building
-a `TrainingObservation`. Only zone sizes are reported for hidden zones.
+`ObservationBuilder` delegates identity knowledge to the rules engine's `Visibility` authority.
+For a fully hidden opponent hand or library, only the zone size is reported. If one card is
+individually revealed or the top card is legitimately visible, that known card appears while the
+zone stays marked hidden — `hidden` reports the structural fact that the zone is not wholly public,
+not "something here is unknown", so it stays a stable feature as reveals come and go. Public
+face-down objects expose their public projected characteristics but not the underlying card
+identity.
 A `revealAll = true` flag is available for debug tooling and must not be
 enabled in real self-play (the agent would be training on leaked
 information).

--- a/gym/build.gradle.kts
+++ b/gym/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     runtimeOnly(libs.slf4jApi)
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -79,7 +79,7 @@ import com.wingedsheep.sdk.model.EntityId
  * ```
  */
 class GameEnvironment private constructor(
-    private val cardRegistry: CardRegistry,
+    internal val cardRegistry: CardRegistry,
     private val processor: ActionProcessor,
     private val enumerator: LegalActionEnumerator,
     private val evaluator: BoardEvaluator,

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameGymEnv.kt
@@ -25,7 +25,7 @@ class GameGymEnv(
     val environment: GameEnvironment,
     private val perspectivePlayerIndex: Int,
     private val defaultRevealAll: Boolean,
-    private val observationBuilder: ObservationBuilder = ObservationBuilder()
+    private val observationBuilder: ObservationBuilder = ObservationBuilder(environment.cardRegistry)
 ) : GymEnv {
 
     @Volatile

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -29,7 +29,10 @@ import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -42,7 +45,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
-import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
@@ -53,6 +55,7 @@ import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
@@ -61,13 +64,13 @@ import com.wingedsheep.sdk.model.EntityId
  *
  * ## Information hiding
  *
- * By default, opponent hand and everyone's library are hidden
- * ([ZoneView.hidden] = true). A hidden zone is not necessarily an empty one:
- * a card a hand-peek effect has shown this perspective stays visible to it
- * (`RevealedToComponent`), so [ZoneView.cards] carries the subset this player
- * knows while [ZoneView.size] stays the true count. Set [revealAll] to `true`
- * to disable masking — only appropriate for debug scripts; never for real
- * self-play training.
+ * Identity visibility comes from the engine's [Visibility] authority, so a hidden zone is not
+ * necessarily an empty one. A card a hand-peek effect has shown this perspective stays visible to
+ * it, and so does a top card the perspective may legitimately see, which means [ZoneView.cards]
+ * carries the subset this player knows while [ZoneView.size] stays the true count and
+ * [ZoneView.hidden] stays true. Public face-down objects retain their public projected
+ * characteristics but never expose the underlying card identity. Set [revealAll] to `true` to
+ * disable masking — only appropriate for debug scripts; never for real self-play training.
  *
  * ## Projected vs. base state
  *
@@ -78,8 +81,11 @@ import com.wingedsheep.sdk.model.EntityId
  * zones — see `GameState.getBattlefield`).
  */
 class ObservationBuilder(
+    cardRegistry: CardRegistry,
     private val schemaHash: String = SchemaHash.CURRENT
 ) {
+    private val visibility = Visibility(cardRegistry)
+
     fun build(
         state: GameState,
         perspectivePlayerId: EntityId,
@@ -92,7 +98,9 @@ class ObservationBuilder(
 
         val zones = buildZones(state, perspectivePlayerId, revealAll)
 
-        val stack = state.stack.map { entityId -> buildStackItem(state, entityId) }
+        val stack = state.stack.map { entityId ->
+            buildStackItem(state, entityId, perspectivePlayerId, revealAll)
+        }
 
         val pendingDecisionAndRegistry = state.pendingDecision
             ?.let { buildPendingDecision(it) }
@@ -194,15 +202,25 @@ class ObservationBuilder(
             for (zone in perPlayerZones) {
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
-                val hidden = !revealAll && isHiddenFrom(zone, playerId, perspectivePlayerId)
-                // A hidden zone still exposes what this perspective has already been shown —
-                // "look at target opponent's hand" leaves those cards visible to the viewer.
-                val knownIds = if (hidden) ids.filter { isRevealedTo(state, it, perspectivePlayerId) } else ids
-                val cards = knownIds.map { buildEntityFeatures(state, it, zone) }
+                val wholeZoneVisible = revealAll ||
+                    visibility.isZoneVisibleTo(state, key, perspectivePlayerId)
+                // A hidden zone still exposes what this perspective may know — a card a hand-peek
+                // effect showed it, or a top card it is entitled to see. Which of those apply is
+                // the engine's question, not this builder's.
+                val cards = ids.mapNotNull { entityId ->
+                    val identityVisible = revealAll || visibility.isCardIdentityVisibleTo(
+                        state,
+                        key,
+                        entityId,
+                        perspectivePlayerId,
+                    )
+                    if (!wholeZoneVisible && !identityVisible) null
+                    else buildEntityFeatures(state, entityId, zone, identityVisible)
+                }
                 views += ZoneView(
                     ownerId = playerId,
                     zoneType = zone,
-                    hidden = hidden,
+                    hidden = !wholeZoneVisible,
                     size = ids.size,
                     cards = cards
                 )
@@ -211,20 +229,6 @@ class ObservationBuilder(
         return views
     }
 
-    private fun isHiddenFrom(zone: Zone, owner: EntityId, perspective: EntityId): Boolean = when (zone) {
-        Zone.LIBRARY -> true
-        Zone.HAND -> owner != perspective
-        else -> false
-    }
-
-    /**
-     * Mirrors `Visibility.isCardRevealedTo`. The gym builder deliberately stops at the per-card
-     * component: the whole-hand reveal that class also honours needs a `CardRegistry` to find the
-     * granting static ability, which an observation builder has no other use for.
-     */
-    private fun isRevealedTo(state: GameState, entityId: EntityId, perspective: EntityId): Boolean =
-        state.getEntity(entityId)?.get<RevealedToComponent>()?.isRevealedTo(perspective) == true
-
     // =========================================================================
     // Entities
     // =========================================================================
@@ -232,7 +236,8 @@ class ObservationBuilder(
     private fun buildEntityFeatures(
         state: GameState,
         entityId: EntityId,
-        zone: Zone
+        zone: Zone,
+        identityVisible: Boolean,
     ): EntityFeatures {
         val container = state.getEntity(entityId) ?: ComponentContainer.EMPTY
         val card = container.get<CardComponent>()
@@ -243,29 +248,39 @@ class ObservationBuilder(
 
         val types: Set<String> = when {
             pv != null -> pv.types.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.typeLine.cardTypes.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val subtypes: Set<String> = when {
             pv != null -> pv.subtypes.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.typeLine.subtypes.mapTo(mutableSetOf()) { it.value }
             else -> emptySet()
         }
         val colors: Set<String> = when {
             pv != null -> pv.colors.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.colors.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
         val keywords: Set<String> = when {
             pv != null -> pv.keywords.toSet()
+            !identityVisible -> emptySet()
             card != null -> card.baseKeywords.mapTo(mutableSetOf()) { it.name }
             else -> emptySet()
         }
 
+        val maskedName = if (zone == Zone.EXILE) {
+            FACE_DOWN_CARD_DISPLAY_NAME
+        } else {
+            FACE_DOWN_DISPLAY_NAME
+        }
+
         return EntityFeatures(
             entityId = entityId,
-            cardDefinitionId = card?.cardDefinitionId,
-            name = card?.name ?: "",
+            cardDefinitionId = card?.cardDefinitionId.takeIf { identityVisible },
+            name = if (identityVisible) card?.name ?: "" else maskedName,
             zone = zone,
             ownerId = container.get<OwnerComponent>()?.playerId ?: card?.ownerId,
             controllerId = if (onBattlefield) projected.getController(entityId) else null,
@@ -273,9 +288,9 @@ class ObservationBuilder(
             subtypes = subtypes,
             colors = colors,
             keywords = keywords,
-            manaCost = card?.manaCost?.toString() ?: "",
-            manaValue = card?.manaValue ?: 0,
-            oracleText = card?.oracleText ?: "",
+            manaCost = if (identityVisible) card?.manaCost?.toString() ?: "" else "",
+            manaValue = if (identityVisible) card?.manaValue ?: 0 else 0,
+            oracleText = if (identityVisible) card?.oracleText ?: "" else "",
             power = if (onBattlefield) projected.getPower(entityId) else null,
             toughness = if (onBattlefield) projected.getToughness(entityId) else null,
             tapped = onBattlefield && container.get<TappedComponent>() != null,
@@ -300,12 +315,27 @@ class ObservationBuilder(
     // Stack
     // =========================================================================
 
-    private fun buildStackItem(state: GameState, entityId: EntityId): StackItemView {
+    private fun buildStackItem(
+        state: GameState,
+        entityId: EntityId,
+        perspectivePlayerId: EntityId,
+        revealAll: Boolean,
+    ): StackItemView {
         val container = state.getEntity(entityId)
         val card = container?.get<CardComponent>()
         val triggered = container?.get<TriggeredAbilityOnStackComponent>()
         val activated = container?.get<ActivatedAbilityOnStackComponent>()
         val legacyAbility = container?.get<AbilityOnStackComponent>()
+        // The stack is not part of `state.zones`, so there is no key to pass here — the visibility
+        // authority derives one from the spell's caster rather than us inventing an owner.
+        val identityVisible = revealAll || visibility.isCardIdentityVisibleTo(
+            state,
+            Zone.STACK,
+            entityId,
+            perspectivePlayerId,
+        )
+        // Stack kind inference — fall back to OTHER. A more precise classification
+        // can be added once the stack carries explicit metadata.
         val kind = when {
             triggered != null -> StackItemKind.TRIGGERED_ABILITY
             activated != null || legacyAbility != null -> StackItemKind.ACTIVATED_ABILITY
@@ -322,9 +352,15 @@ class ObservationBuilder(
                 ?: legacyAbility?.controllerId
                 ?: container?.get<ControllerComponent>()?.playerId
                 ?: container?.get<SpellOnStackComponent>()?.casterId,
-            name = card?.name ?: triggered?.sourceName ?: activated?.sourceName ?: "",
+            // An ability on the stack is never face down, so it keeps its source name; only a
+            // spell cast face down loses its identity here.
+            name = if (identityVisible) {
+                card?.name ?: triggered?.sourceName ?: activated?.sourceName ?: ""
+            } else {
+                FACE_DOWN_DISPLAY_NAME
+            },
             kind = kind,
-            oracleText = card?.oracleText ?: "",
+            oracleText = if (identityVisible) card?.oracleText ?: "" else "",
             targets = container?.get<TargetsComponent>()?.targets.orEmpty().map(::targetEntityId)
         )
     }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -72,8 +72,9 @@ data class TrainingObservation(
 
     /**
      * Per-zone entity views. A `(ownerId, zoneType)` pair appears at most once.
-     * Hidden zones (opponent hand, libraries) expose [ZoneView.hidden] = true
-     * and [ZoneView.cards] is empty (only [ZoneView.size] is populated).
+     * [ZoneView.hidden] means the zone is not wholly public to this perspective. [ZoneView.cards]
+     * contains only the identities this perspective may know, so an individually revealed card can
+     * appear while the zone remains hidden and [ZoneView.size] still reports its true size.
      */
     val zones: List<ZoneView>,
 
@@ -131,11 +132,14 @@ data class ManaPoolView(
 /**
  * A zone's contents from [TrainingObservation.perspectivePlayerId]'s point of view.
  *
- * [hidden] says some identities in the zone are concealed from the perspective player
- * (an opponent's hand, any library); [size] is then the true count while [cards] carries
- * only the entries this perspective knows. That subset is usually empty, but a hand-peek
- * effect leaves the cards it showed visible to the player who saw them, so a two-card
- * hidden hand can legitimately list one card. This mirrors real-MTG information hiding.
+ * [hidden] reports the structural fact that the zone is not wholly public to this perspective (an
+ * opponent's hand, any library) — a stable feature, so an agent's input distribution does not shift
+ * as reveals come and go. It is deliberately not "something here is unknown": [size] is the true
+ * count while [cards] carries only the entries this perspective knows, and that subset can be the
+ * whole zone. A hand-peek effect leaves the cards it showed visible to the player who saw them, so
+ * a two-card hidden hand can legitimately list one card — or, for a one-card library under a public
+ * top-card reveal, all of it. Hidden-zone slot IDs and the positions of known cards among unknown
+ * ones are intentionally not part of this schema.
  */
 @Serializable
 data class ZoneView(

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
@@ -1,0 +1,231 @@
+package com.wingedsheep.gym.contract
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+/**
+ * How a `TrainingObservation` encodes the identity answers `Visibility` gives.
+ *
+ * The answers themselves are the engine's, and `CardIdentityVisibilityTest` in `rules-engine`
+ * asserts them there. What belongs here is Gym's *representation* of them, which is deliberately
+ * unlike the client's: a hidden zone reports its true size and carries only the identities this
+ * perspective may know, never an opaque slot per unknown card.
+ */
+class ObservationVisibilityTest : ScenarioTestBase() {
+
+    private val openThoughts = card("Open Thoughts") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = OpponentsPlayWithHandsRevealed }
+    }
+
+    private val publicTop = card("Public Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = RevealTopOfLibrary }
+    }
+
+    private val privateTop = card("Private Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = LookAtTopOfLibrary }
+    }
+
+    init {
+        cardRegistry.register(listOf(openThoughts, publicTop, privateTop))
+
+        test("a hidden hand reports its size and none of its cards") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .build()
+            val view = observe(game.state, game.player1Id)
+
+            zone(view, game.player1Id, Zone.HAND).let {
+                it.hidden shouldBe false
+                it.cards.size shouldBe it.size
+            }
+            zone(view, game.player2Id, Zone.HAND).let {
+                it.hidden shouldBe true
+                it.size shouldBe 1
+                it.cards shouldBe emptyList()
+            }
+        }
+
+        test("a whole-hand reveal drops the hidden flag for the entitled perspective") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, openThoughts.name)
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+
+            zone(observe(game.state, game.player1Id), game.player2Id, Zone.HAND).let {
+                it.hidden shouldBe false
+                it.cards.size shouldBe it.size
+            }
+            zone(observe(game.state, game.player2Id), game.player1Id, Zone.HAND).let {
+                it.hidden shouldBe true
+                it.cards shouldBe emptyList()
+            }
+        }
+
+        // The representation this whole change exists for: a zone stays hidden while carrying the
+        // one identity the perspective legitimately knows. The unknown slot is not emitted at all,
+        // so nothing in the schema says *where* among the unknowns the known card sits.
+        test("a hidden zone carries its known subset while still reporting its full size") {
+            val base = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val bystander = EntityId.of("player-3")
+            val withBystander = addBystander(base.state, bystander)
+            val known = withBystander.getHand(base.player2Id).first { id ->
+                withBystander.getEntity(id)?.get<CardComponent>()?.name == "Mountain"
+            }
+            val state = withBystander.updateEntity(known) {
+                it.with(RevealedToComponent.to(base.player1Id))
+            }
+
+            zone(observe(state, base.player1Id), base.player2Id, Zone.HAND).let {
+                it.hidden shouldBe true
+                it.size shouldBe 2
+                it.cards.map { card -> card.entityId } shouldContainExactly listOf(known)
+            }
+            zone(observe(state, bystander), base.player2Id, Zone.HAND).cards shouldBe emptyList()
+        }
+
+        test("a known top card is the library's only entry, public or private") {
+            val privateGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, privateTop.name)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Hill Giant")
+                .build()
+            val privateKnown = privateGame.state.getLibrary(privateGame.player1Id).first()
+
+            zone(observe(privateGame.state, privateGame.player1Id), privateGame.player1Id, Zone.LIBRARY)
+                .let {
+                    it.hidden shouldBe true
+                    it.size shouldBe 2
+                    it.cards.map { card -> card.entityId } shouldContainExactly listOf(privateKnown)
+                }
+            zone(observe(privateGame.state, privateGame.player2Id), privateGame.player1Id, Zone.LIBRARY)
+                .cards shouldBe emptyList()
+
+            val publicGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, publicTop.name)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .build()
+            val publicKnown = publicGame.state.getLibrary(publicGame.player1Id).first()
+            listOf(publicGame.player1Id, publicGame.player2Id).forEach { viewer ->
+                zone(observe(publicGame.state, viewer), publicGame.player1Id, Zone.LIBRARY)
+                    .cards.map { it.entityId } shouldContainExactly listOf(publicKnown)
+            }
+        }
+
+        test("a face-down object keeps its public characteristics and loses its identity") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Craw Wurm")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val permanent = game.state.getBattlefield().single()
+            val spell = game.state.getHand(game.player2Id).single()
+            val hiddenState = game.state
+                .updateEntity(permanent) { it.with(FaceDownComponent) }
+                .removeFromZone(ZoneKey(game.player2Id, Zone.HAND), spell)
+                .updateEntity(spell) {
+                    it.with(SpellOnStackComponent(casterId = game.player2Id, castFaceDown = true))
+                }
+                .copy(stack = listOf(spell))
+
+            val opponentView = observe(hiddenState, game.player1Id)
+            zone(opponentView, game.player2Id, Zone.BATTLEFIELD).cards.single().let {
+                it.entityId shouldBe permanent
+                it.name shouldBe FACE_DOWN_DISPLAY_NAME
+                it.cardDefinitionId shouldBe null
+                it.oracleText shouldBe ""
+                withClue("the public face-down characteristics survive — it is a 2/2 creature") {
+                    it.types shouldBe setOf("CREATURE")
+                    it.power shouldBe 2
+                    it.toughness shouldBe 2
+                }
+            }
+            opponentView.stack.single().let {
+                it.name shouldBe FACE_DOWN_DISPLAY_NAME
+                it.oracleText shouldBe ""
+            }
+
+            // Independent boundary check: neither zone features nor the sibling stack/action/
+            // decision fields can recover the forbidden printed identities in this ordinary state.
+            val serialized = Json.encodeToString(TrainingObservation.serializer(), opponentView)
+            serialized.contains("Craw Wurm") shouldBe false
+            serialized.contains("Hill Giant") shouldBe false
+
+            val controllerView = observe(hiddenState, game.player2Id)
+            zone(controllerView, game.player2Id, Zone.BATTLEFIELD).cards.single().name shouldBe "Craw Wurm"
+            controllerView.stack.single().name shouldBe "Hill Giant"
+
+            val debugView = observe(hiddenState, game.player1Id, revealAll = true)
+            zone(debugView, game.player2Id, Zone.BATTLEFIELD).cards.single().name shouldBe "Craw Wurm"
+            debugView.stack.single().name shouldBe "Hill Giant"
+        }
+
+    }
+
+    private fun observe(
+        state: GameState,
+        viewer: EntityId,
+        revealAll: Boolean = false,
+    ): TrainingObservation = ObservationBuilder(cardRegistry)
+        .build(state, viewer, legalActions = emptyList(), revealAll = revealAll)
+        .observation as TrainingObservation
+
+    private fun zone(
+        observation: TrainingObservation,
+        gameOwner: EntityId,
+        zone: Zone,
+    ): ZoneView = observation.zones.single { it.ownerId == gameOwner && it.zoneType == zone }
+
+    /** A third seat, so "revealed to a player" can be told apart from "revealed to everyone". */
+    private fun addBystander(state: GameState, playerId: EntityId): GameState {
+        var result = state.withEntity(
+            playerId,
+            ComponentContainer.of(
+                PlayerComponent("Bystander"),
+                LifeTotalComponent(20),
+                ManaPoolComponent(),
+            ),
+        ).copy(turnOrder = state.turnOrder + playerId)
+        for (zone in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD)) {
+            result = result.copy(zones = result.zones + (ZoneKey(playerId, zone) to emptyList()))
+        }
+        return result
+    }
+}

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -63,7 +63,7 @@ class TrainingObservationTest : FunSpec({
     test("observation includes all basic state fields and round-trips through JSON") {
         val env = newEnv()
         val perspective = env.playerIds[0]
-        val result = ObservationBuilder().build(env.state, perspective, env.legalActions())
+        val result = ObservationBuilder(env.cardRegistry).build(env.state, perspective, env.legalActions())
 
         val obs = result.observation as TrainingObservation
         obs.perspectivePlayerId shouldBe perspective
@@ -85,7 +85,7 @@ class TrainingObservationTest : FunSpec({
     test("an actionId from the observation resolves to a steppable action") {
         val env = newEnv()
         val perspective = env.playerIds[0]
-        val result = ObservationBuilder().build(env.state, perspective, env.legalActions())
+        val result = ObservationBuilder(env.cardRegistry).build(env.state, perspective, env.legalActions())
 
         val passView = result.observation.legalActions.first { it.description.contains("Pass", ignoreCase = true) || it.kind.contains("Pass", ignoreCase = true) }
         val resolved = result.registry.resolve(passView.actionId)
@@ -104,7 +104,7 @@ class TrainingObservationTest : FunSpec({
         val me = env.playerIds[0]
         val opponent = env.playerIds[1]
 
-        val masked = ObservationBuilder().build(env.state, me, env.legalActions())
+        val masked = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions())
             .observation as TrainingObservation
         val myHand = masked.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
         val theirHand = masked.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
@@ -117,7 +117,12 @@ class TrainingObservationTest : FunSpec({
         // Every library is hidden regardless of perspective.
         masked.zones.filter { it.zoneType == Zone.LIBRARY }.forEach { it.hidden.shouldBeTrue() }
 
-        val revealed = ObservationBuilder().build(env.state, me, env.legalActions(), revealAll = true)
+        val revealed = ObservationBuilder(env.cardRegistry).build(
+            env.state,
+            me,
+            env.legalActions(),
+            revealAll = true,
+        )
             .observation as TrainingObservation
         val theirHandRevealed = revealed.zones.single { it.ownerId == opponent && it.zoneType == Zone.HAND }
         theirHandRevealed.hidden.shouldBeFalse()
@@ -130,7 +135,11 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
 
-        val obs = ObservationBuilder().build(env.state, me, env.legalActions()).observation as TrainingObservation
+        val obs = ObservationBuilder(env.cardRegistry).build(
+            env.state,
+            me,
+            env.legalActions(),
+        ).observation as TrainingObservation
         val myHand = obs.zones.single { it.ownerId == me && it.zoneType == Zone.HAND }
 
         // At least one card should be in the opening hand; every card there
@@ -319,14 +328,14 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
 
-        val a = ObservationBuilder().build(env.state, me, env.legalActions()).observation
-        val b = ObservationBuilder().build(env.state, me, env.legalActions()).observation
+        val a = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
+        val b = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
         a.stateDigest shouldBe b.stateDigest
 
         // Advance a step and verify the digest changes.
         val pass = env.legalActions().first { it.action is PassPriority }
         env.step(pass.action)
-        val c = ObservationBuilder().build(env.state, me, env.legalActions()).observation
+        val c = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions()).observation
         c.stateDigest shouldNotBe a.stateDigest
     }
 })

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -166,7 +166,7 @@ class TrainingObservationTest : FunSpec({
         opponentHand.size shouldBeGreaterThan 1
 
         fun observe(state: GameState) =
-            ObservationBuilder().build(state, me, env.legalActions()).observation as TrainingObservation
+            ObservationBuilder(env.cardRegistry).build(state, me, env.legalActions()).observation as TrainingObservation
 
         fun revealing(cardId: EntityId): GameState =
             env.state.withEntity(
@@ -194,7 +194,7 @@ class TrainingObservationTest : FunSpec({
         val opponentHand = env.state.getZone(ZoneKey(opponent, Zone.HAND))
 
         fun digestRevealing(cardId: EntityId): String =
-            ObservationBuilder().build(
+            ObservationBuilder(env.cardRegistry).build(
                 env.state.withEntity(
                     cardId,
                     env.state.getEntity(cardId)!!.with(RevealedToComponent.to(me))
@@ -203,7 +203,7 @@ class TrainingObservationTest : FunSpec({
                 env.legalActions()
             ).observation.stateDigest
 
-        val nothingKnown = ObservationBuilder().build(env.state, me, env.legalActions())
+        val nothingKnown = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions())
             .observation.stateDigest
 
         digestRevealing(opponentHand[0]) shouldNotBe nothingKnown
@@ -231,7 +231,7 @@ class TrainingObservationTest : FunSpec({
         }
 
         fun observe(state: GameState) =
-            ObservationBuilder().build(state, me, env.legalActions()).observation as TrainingObservation
+            ObservationBuilder(env.cardRegistry).build(state, me, env.legalActions()).observation as TrainingObservation
 
         val atOpponent = observe(casting(opponent))
         val item = atOpponent.stack.single()
@@ -263,7 +263,7 @@ class TrainingObservationTest : FunSpec({
             )
             .copy(stack = listOf(abilityId))
 
-        val item = (ObservationBuilder().build(state, me, env.legalActions())
+        val item = (ObservationBuilder(env.cardRegistry).build(state, me, env.legalActions())
             .observation as TrainingObservation).stack.single()
 
         // An ability is its own entity with no CardComponent, so it used to arrive unnamed,
@@ -277,7 +277,7 @@ class TrainingObservationTest : FunSpec({
         val env = newEnv()
         val me = env.playerIds[0]
         val opponent = env.playerIds[1]
-        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+        val base = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions())
             .observation as TrainingObservation
 
         val stackItem = StackItemView(
@@ -304,7 +304,7 @@ class TrainingObservationTest : FunSpec({
     test("stateDigest is unambiguous when a card name contains the encoding's delimiters") {
         val env = newEnv()
         val me = env.playerIds[0]
-        val base = ObservationBuilder().build(env.state, me, env.legalActions())
+        val base = ObservationBuilder(env.cardRegistry).build(env.state, me, env.legalActions())
             .observation as TrainingObservation
 
         fun item(id: String, name: String) = StackItemView(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -32,31 +32,13 @@ const val FACE_DOWN_CARD_DISPLAY_NAME: String = "Face-down card"
  * downstream: it maps engine events to text with no `GameState` in hand, so it cannot tell a
  * face-down object from a face-up one. The decision has to be made where the event is emitted.
  *
- * Where the text *does* have an audience, prefer [nameVisibleTo] — a player may look at a
- * face-down object they control (CR 708.5).
+ * Where the text *does* have an audience, ask
+ * [com.wingedsheep.engine.view.Visibility.isCardIdentityVisibleTo] instead and pick the label from
+ * its answer. That query knows what this file cannot: explicit reveals, effect-granted access, and
+ * the zones CR 708.5 does and does not let a controller look in.
  */
 fun nameVisibleToAll(state: GameState, entityId: EntityId, fallback: String): String =
     faceDownDisplayName(state, entityId) ?: fallback
-
-/**
- * The name [entityId] may be shown under to [viewingPlayerId] specifically.
- *
- * Same masking as [nameVisibleToAll], except that a player may look at a face-down object they
- * control (CR 708.5) and so keeps [fallback] for their own. A spectator never may — matching the
- * gate [com.wingedsheep.engine.view.ClientStateTransformer] applies to card views, so a per-viewer
- * label and the card it labels always agree.
- */
-fun nameVisibleTo(
-    state: GameState,
-    entityId: EntityId,
-    fallback: String,
-    viewingPlayerId: EntityId,
-    isSpectator: Boolean = false,
-): String {
-    val masked = faceDownDisplayName(state, entityId) ?: return fallback
-    val mayLook = !isSpectator && viewingPlayerId == playerWhoMayLookAt(state, entityId)
-    return if (mayLook) fallback else masked
-}
 
 /**
  * The masked name for [entityId] if it is a face-down object in a zone where its identity is
@@ -76,7 +58,7 @@ fun nameVisibleTo(
  * Anything else keeps its name, including a face-down object that has already left all three: its
  * owner reveals it to every player as it goes (CR 708.9).
  */
-private fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
+internal fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
     val container = state.getEntity(entityId) ?: return null
 
     if (entityId in state.stack) {
@@ -100,8 +82,16 @@ private fun faceDownDisplayName(state: GameState, entityId: EntityId): String? {
     return null
 }
 
-/** The one player entitled to read [entityId]'s real name off the table (CR 708.5). */
-private fun playerWhoMayLookAt(state: GameState, entityId: EntityId): EntityId? {
+/**
+ * The one player entitled to look at [entityId] merely because they control the face-down object.
+ *
+ * This is only the *controller* baseline, and CR 708.5 scopes it to the stack and the battlefield —
+ * "you can't look at face-down cards in any other zone", their owner included. Applying that scope,
+ * and combining this with explicit reveals and effect-granted access, is
+ * [com.wingedsheep.engine.view.Visibility]'s job; this function does not know which zone it is
+ * being asked about.
+ */
+internal fun playerWhoMayLookAtFaceDown(state: GameState, entityId: EntityId): EntityId? {
     val container = state.getEntity(entityId) ?: return null
     return state.projectedState.getController(entityId)
         ?: container.get<SpellOnStackComponent>()?.casterId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -23,7 +23,6 @@ import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.engine.state.FACE_DOWN_CARD_DISPLAY_NAME
 import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.nameVisibleTo
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.*
 import com.wingedsheep.engine.state.components.battlefield.*
@@ -128,7 +127,13 @@ class ClientStateTransformer(
                 entityIds
             } else {
                 entityIds.filter { entityId ->
-                    visibility.isCardRevealedTo(state, entityId, viewingPlayerId)
+                    visibility.isCardIdentityVisibleTo(
+                        state,
+                        zoneKey,
+                        entityId,
+                        viewingPlayerId,
+                        isSpectator,
+                    )
                 }
             }
             val zoneCardIds = if (isLibrary) entityIds else cardsWithDetails
@@ -201,73 +206,6 @@ class ClientStateTransformer(
             }
         }
         // --- FIX END ---
-
-        // Reveal top library card for players who "play with the top card revealed"
-        // (PlayFromTopOfLibrary, e.g. Future Sight; or RevealTopOfLibrary, e.g. Goblin Spy).
-        // The top card is revealed to ALL players per the card's oracle text. The two abilities
-        // differ only in play permission (handled elsewhere); the public reveal is identical.
-        for (ownerId in state.turnOrder) {
-            if (revealsTopOfLibraryPublicly(state, ownerId)) {
-                val library = state.getLibrary(ownerId)
-                if (library.isNotEmpty()) {
-                    val topCardId = library.first()
-                    if (topCardId !in cards) {
-                        val libraryZoneKey = ZoneKey(ownerId, Zone.LIBRARY)
-                        val clientCard = transformCard(state, topCardId, libraryZoneKey, projectedState, viewingPlayerId)
-                        if (clientCard != null) {
-                            cards[topCardId] = clientCard
-                            // Update the library zone entry to include this card as visible
-                            val zoneIndex = zones.indexOfFirst {
-                                it.zoneId.ownerId == ownerId && it.zoneId.zoneType == Zone.LIBRARY
-                            }
-                            if (zoneIndex >= 0) {
-                                val existingZone = zones[zoneIndex]
-                                val newCardIds = if (existingZone.cardIds.contains(topCardId)) {
-                                    existingZone.cardIds
-                                } else {
-                                    listOf(topCardId) + existingZone.cardIds
-                                }
-                                zones[zoneIndex] = existingZone.copy(
-                                    cardIds = newCardIds,
-                                    isVisible = true
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Reveal top library card privately for players with LookAtTopOfLibrary (e.g., Lens of Clarity)
-        // Unlike PlayFromTopOfLibrary, this only reveals to the controller, not all players.
-        if (!isSpectator && hasLookAtTopOfLibrary(state, viewingPlayerId)) {
-            val library = state.getLibrary(viewingPlayerId)
-            if (library.isNotEmpty()) {
-                val topCardId = library.first()
-                if (topCardId !in cards) {
-                    val libraryZoneKey = ZoneKey(viewingPlayerId, Zone.LIBRARY)
-                    val clientCard = transformCard(state, topCardId, libraryZoneKey, projectedState, viewingPlayerId)
-                    if (clientCard != null) {
-                        cards[topCardId] = clientCard
-                        val zoneIndex = zones.indexOfFirst {
-                            it.zoneId.ownerId == viewingPlayerId && it.zoneId.zoneType == Zone.LIBRARY
-                        }
-                        if (zoneIndex >= 0) {
-                            val existingZone = zones[zoneIndex]
-                            val newCardIds = if (existingZone.cardIds.contains(topCardId)) {
-                                existingZone.cardIds
-                            } else {
-                                listOf(topCardId) + existingZone.cardIds
-                            }
-                            zones[zoneIndex] = existingZone.copy(
-                                cardIds = newCardIds,
-                                isVisible = true
-                            )
-                        }
-                    }
-                }
-            }
-        }
 
         // Build player information
         val players = state.turnOrder.map { playerId ->
@@ -372,7 +310,12 @@ class ClientStateTransformer(
 
             val tally = tallies.getOrPut(definitionId) { Tally() }
             tally.copies++
-            if (!ownerKnowsIdentity(state, entityId, zoneType, viewingPlayerId)) tally.remaining++
+            // The zone walk below has a real key to hand and the stack has none, so let the
+            // visibility authority derive it either way rather than assuming every zone is
+            // owner-keyed — the battlefield is not.
+            if (!visibility.isCardIdentityVisibleTo(state, zoneType, entityId, viewingPlayerId)) {
+                tally.remaining++
+            }
             if (copyOf == null && tally.printingImageUri == null) {
                 tally.printingImageUri = cardComponent.imageUri
             }
@@ -396,31 +339,6 @@ class ClientStateTransformer(
                 imageUri = tally.printingImageUri ?: definition.metadata.imageUri
             )
         }.sortedWith(compareBy({ it.cmc }, { it.cardName }))
-    }
-
-    /**
-     * Whether the owner of [entityId] can currently tell *which* of their cards this one is.
-     *
-     * False for anything in their library (that's the whole point — you know what's in your deck,
-     * not where), and for a card of theirs that is face down somewhere they can't look: exiled face
-     * down, or a face-down permanent an opponent controls. Mirrors the face-down masking in
-     * [transformCard] so the tracker never claims knowledge the client wasn't sent.
-     */
-    private fun ownerKnowsIdentity(
-        state: GameState,
-        entityId: EntityId,
-        zoneType: Zone,
-        viewingPlayerId: EntityId
-    ): Boolean {
-        if (zoneType == Zone.LIBRARY) return false
-        val container = state.getEntity(entityId) ?: return false
-        val isInFaceDownZone =
-            zoneType == Zone.BATTLEFIELD || zoneType == Zone.STACK || zoneType == Zone.EXILE
-        if (!isInFaceDownZone || !container.has<FaceDownComponent>()) return true
-        val controllerId = container.get<ControllerComponent>()?.playerId
-        return controllerId == viewingPlayerId ||
-            visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
-            (zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
     }
 
     /**
@@ -521,12 +439,6 @@ class ClientStateTransformer(
      * This is used for "look at hand" or "reveal hand" effects where the viewing player
      * can see specific cards in an otherwise hidden zone.
      */
-    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
-        visibility.revealsTopOfLibraryPublicly(state, playerId)
-
-    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
-        visibility.hasLookAtTopOfLibrary(state, playerId)
-
     /**
      * Transform an activated or triggered ability on the stack into a ClientCard DTO.
      * These don't have CardComponent, so we create a synthetic card representation.
@@ -849,9 +761,12 @@ class ClientStateTransformer(
             // Check if the face-down card has been revealed to the viewing player (e.g., via Spy Network)
             // Also check LookAtFaceDownCreatures (e.g., Lens of Clarity) — only for battlefield creatures,
             // not face-down spells on the stack (per ruling).
-            val isRevealedToViewer = !isSpectator && (
-                visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
-                (zoneKey.zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
+            val isRevealedToViewer = visibility.isCardIdentityVisibleTo(
+                state,
+                zoneKey,
+                entityId,
+                viewingPlayerId,
+                isSpectator,
             )
 
             // Face-down exiled cards show minimal info (not creatures, no P/T)
@@ -1758,8 +1673,8 @@ class ClientStateTransformer(
     /**
      * Build per-mode target groups for a modal spell on the stack, aligned with
      * [SpellOnStackComponent.modeTargetsOrdered]. Hidden-zone targets are redacted to a generic
-     * "a card in X's hand/library" string when the viewer does not own the zone, and a face-down
-     * object is redacted for every viewer but the one who may look at it (see
+     * "a card in X's hand/library" string, and a face-down object gets its generic public name,
+     * whenever the shared identity authority says this viewer may not know it (see
      * [resolveTargetDisplayName]).
      */
     private fun buildPerModeTargetGroups(
@@ -1794,8 +1709,8 @@ class ClientStateTransformer(
     }
 
     /**
-     * Resolve a [ChosenTarget] to a human-readable display name for the stack view. Cards in
-     * hidden zones are redacted unless the viewing player owns the zone.
+     * Resolve a [ChosenTarget] to a human-readable display name for the stack view. The engine's
+     * [Visibility] authority decides identity; this method owns only the client-facing placeholder.
      */
     private fun resolveTargetDisplayName(
         state: GameState,
@@ -1805,29 +1720,55 @@ class ClientStateTransformer(
     ): String = when (target) {
         is ChosenTarget.Player -> state.getEntity(target.playerId)
             ?.get<PlayerComponent>()?.name ?: "a player"
-        // A face-down object is nameless (CR 708.2a / 708.4), but this label has an audience, so
-        // it is masked per viewer rather than for everyone: a player may look at a face-down
-        // object they control (CR 708.5). That also keeps modal spells consistent with non-modal
-        // ones, whose targets ship as bare entity ids and are named client-side from the card
-        // view — which applies exactly this gate.
-        is ChosenTarget.Permanent -> state.getEntity(target.entityId)
-            ?.get<CardComponent>()?.name
-            ?.let { nameVisibleTo(state, target.entityId, it, viewingPlayerId, isSpectator) }
-            ?: "a permanent"
-        is ChosenTarget.Spell -> state.getEntity(target.spellEntityId)
-            ?.get<CardComponent>()?.name
-            ?.let { nameVisibleTo(state, target.spellEntityId, it, viewingPlayerId, isSpectator) }
-            ?: "a spell"
+        is ChosenTarget.Permanent -> {
+            if (visibility.isCardIdentityVisibleTo(
+                    state,
+                    Zone.BATTLEFIELD,
+                    target.entityId,
+                    viewingPlayerId,
+                    isSpectator,
+                )
+            ) {
+                state.getEntity(target.entityId)?.get<CardComponent>()?.name ?: "a permanent"
+            } else {
+                FACE_DOWN_DISPLAY_NAME
+            }
+        }
+        is ChosenTarget.Spell -> {
+            if (visibility.isCardIdentityVisibleTo(
+                    state,
+                    Zone.STACK,
+                    target.spellEntityId,
+                    viewingPlayerId,
+                    isSpectator,
+                )
+            ) {
+                state.getEntity(target.spellEntityId)?.get<CardComponent>()?.name ?: "a spell"
+            } else {
+                FACE_DOWN_DISPLAY_NAME
+            }
+        }
         is ChosenTarget.Card -> {
-            val hiddenZone = target.zone == Zone.HAND || target.zone == Zone.LIBRARY
-            if (hiddenZone && target.ownerId != viewingPlayerId) {
+            val identityVisible = visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(target.ownerId, target.zone),
+                target.cardId,
+                viewingPlayerId,
+                isSpectator,
+            )
+            if (identityVisible) {
+                state.getEntity(target.cardId)?.get<CardComponent>()?.name ?: "a card"
+            } else if (target.zone == Zone.HAND ||
+                target.zone == Zone.LIBRARY ||
+                target.zone == Zone.SIDEBOARD
+            ) {
                 val ownerName = state.getEntity(target.ownerId)
                     ?.get<PlayerComponent>()?.name ?: "opponent"
                 "a card in ${ownerName}'s ${target.zone.name.lowercase()}"
+            } else if (target.zone == Zone.EXILE) {
+                FACE_DOWN_CARD_DISPLAY_NAME
             } else {
-                state.getEntity(target.cardId)?.get<CardComponent>()?.name
-                    ?.let { nameVisibleTo(state, target.cardId, it, viewingPlayerId, isSpectator) }
-                    ?: "a card"
+                "a card"
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -3,11 +3,16 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.faceDownDisplayName
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.playerWhoMayLookAtFaceDown
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.permissions.hasMayPlayFor
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
@@ -19,11 +24,14 @@ import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.StaticAbility
 
 /**
- * The engine's single source of truth for which hidden-zone identities a player may see.
+ * The engine's single source of truth for which card identities a player may see.
  *
- * Client masking and AI determinization deliberately share this service. Adding a reveal rule to
- * one without the other would either leak information to the AI or hide information it is legally
- * entitled to use.
+ * This covers both identities in hidden zones and face-down objects in otherwise public zones.
+ * Client state and decision masking, AI determinization, and Gym observations deliberately share
+ * this service. Adding a reveal rule to one without the others would either leak information or
+ * hide information a perspective is legally entitled to use. Consumers still own their
+ * representations: knowing an identity does not prescribe a client card DTO, a Gym feature vector,
+ * or opaque zone slots.
  */
 class Visibility(
     private val cardRegistry: CardRegistry,
@@ -38,13 +46,16 @@ class Visibility(
         isSpectator: Boolean = false,
     ): Boolean = when (zoneKey.zoneType) {
         Zone.LIBRARY -> false
-        Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
-            (!isSpectator && zoneKey.ownerId in state.teammatesOf(viewingPlayerId)) ||
-            (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
-                revealsOpponentHandsTo(state, viewingPlayerId))
-        Zone.SIDEBOARD -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
+        Zone.HAND -> debugMode || (!isSpectator && (
+            zoneKey.ownerId == viewingPlayerId ||
+                state.actorFor(zoneKey.ownerId) == viewingPlayerId ||
+                zoneKey.ownerId in state.teammatesOf(viewingPlayerId) ||
+                (zoneKey.ownerId != viewingPlayerId && revealsOpponentHandsTo(state, viewingPlayerId))
+            ))
+        Zone.SIDEBOARD -> debugMode || (!isSpectator && (
+            zoneKey.ownerId == viewingPlayerId ||
+                state.actorFor(zoneKey.ownerId) == viewingPlayerId
+            ))
         Zone.BATTLEFIELD,
         Zone.GRAVEYARD,
         Zone.STACK,
@@ -52,7 +63,107 @@ class Visibility(
         Zone.COMMAND -> true
     }
 
-    fun isCardRevealedTo(
+    /**
+     * Whether [viewingPlayerId] may know the identity of [entityId], which sits in [zoneType].
+     *
+     * Use this where the caller has an entity but no honest [ZoneKey] to pass: the stack is not
+     * part of [GameState.zones] at all, and a battlefield key names the *controller*, not the
+     * owner. Deriving the key here keeps those callers from inventing one — defaulting the owner
+     * to the viewer reads as "my own zone", and is only ever harmless because the public zones
+     * where it happens ignore the owner entirely.
+     */
+    fun isCardIdentityVisibleTo(
+        state: GameState,
+        zoneType: Zone,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean = isCardIdentityVisibleTo(
+        state,
+        // A dangling reference — a target whose object has already left — has no zone to key on.
+        // The viewer's own key is the harmless choice: it can only make a public zone public.
+        ZoneKey(zoneOwnerOf(state, entityId, zoneType) ?: viewingPlayerId, zoneType),
+        entityId,
+        viewingPlayerId,
+        isSpectator,
+    )
+
+    /**
+     * Whether [viewingPlayerId] may know the identity of [entityId] in [zoneKey].
+     *
+     * A hidden zone is not all-or-nothing: [RevealedToComponent] and top-of-library effects can
+     * expose one card while the rest stays hidden. Conversely, a public zone does not make the
+     * identity under a face-down object public. This query combines those identity facts while
+     * leaving ordered hidden-zone structure and consumer-specific presentation to the caller.
+     */
+    fun isCardIdentityVisibleTo(
+        state: GameState,
+        zoneKey: ZoneKey,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean {
+        // Public-zone visibility does not reveal what is underneath a face-down object.
+        if (faceDownDisplayName(state, entityId) != null) {
+            if (debugMode) return true
+            if (isSpectator) return false
+            // CR 708.5: "At any time, you may look at a face-down spell you control on the stack or
+            // a face-down permanent you control … You can't look at face-down cards in any other
+            // zone." Exile therefore gets no controller baseline — a face-down exiled card is
+            // hidden from its owner too, and the *only* way under it is an effect that grants
+            // access (foretell, Gonti's "you may look at and play"), checked below.
+            if (zoneKey.zoneType != Zone.EXILE &&
+                playerWhoMayLookAtFaceDown(state, entityId) == viewingPlayerId
+            ) return true
+            if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
+            if (zoneKey.zoneType == Zone.BATTLEFIELD &&
+                hasLookAtFaceDownCreatures(state, viewingPlayerId)
+            ) return true
+            if (zoneKey.zoneType == Zone.EXILE &&
+                state.hasMayPlayFor(entityId, viewingPlayerId, conditionEvaluator, cardRegistry)
+            ) return true
+            return false
+        }
+
+        if (isZoneVisibleTo(state, zoneKey, viewingPlayerId, isSpectator)) return true
+
+        // A spectator receives public reveals but never a player's private reveal memory.
+        val isTopCard = zoneKey.zoneType == Zone.LIBRARY &&
+            state.getLibrary(zoneKey.ownerId).firstOrNull() == entityId
+        if (isTopCard && revealsTopOfLibraryPublicly(state, zoneKey.ownerId)) return true
+        if (isSpectator) return false
+
+        if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
+        return isTopCard && zoneKey.ownerId == viewingPlayerId &&
+            hasLookAtTopOfLibrary(state, viewingPlayerId)
+    }
+
+    /**
+     * Which player's [ZoneKey] holds [entityId] while it is in [zoneType].
+     *
+     * The battlefield is keyed by controller and the stack — which lives outside
+     * [GameState.zones] — by caster. Every other zone is keyed by owner: CR 401.1 and 402.1 give
+     * each player their own library and hand, and a card can only ever be in its owner's.
+     */
+    private fun zoneOwnerOf(state: GameState, entityId: EntityId, zoneType: Zone): EntityId? {
+        val container = state.getEntity(entityId) ?: return null
+        val keyedByController = when (zoneType) {
+            Zone.BATTLEFIELD -> state.projectedState.getController(entityId)
+                ?: container.get<ControllerComponent>()?.playerId
+            Zone.STACK -> container.get<SpellOnStackComponent>()?.casterId
+            else -> null
+        }
+        return keyedByController
+            ?: container.get<CardComponent>()?.ownerId
+            ?: container.get<OwnerComponent>()?.playerId
+    }
+
+    // The ingredients below are deliberately private. This class exists because four subsystems
+    // each grew their own answer to "may this perspective know this identity?"; handing those
+    // ingredients back out is how a fifth local approximation gets built. Consumers ask
+    // [isCardIdentityVisibleTo] or [isZoneVisibleTo] and encode the answer however they like.
+
+    private fun isCardRevealedTo(
         state: GameState,
         entityId: EntityId,
         viewingPlayerId: EntityId,
@@ -60,15 +171,15 @@ class Visibility(
         ?.get<RevealedToComponent>()
         ?.isRevealedTo(viewingPlayerId) == true
 
-    fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
+    private fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) { it is LookAtFaceDownCreatures }
 
-    fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
+    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) {
             it is PlayFromTopOfLibrary || it is RevealTopOfLibrary
         }
 
-    fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
+    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) { it is LookAtTopOfLibrary }
 
     private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean =

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.state.playerWhoMayLookAtFaceDown
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ForetoldComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -109,9 +111,9 @@ class Visibility(
             if (isSpectator) return false
             // CR 708.5: "At any time, you may look at a face-down spell you control on the stack or
             // a face-down permanent you control … You can't look at face-down cards in any other
-            // zone." Exile therefore gets no controller baseline — a face-down exiled card is
-            // hidden from its owner too, and the *only* way under it is an effect that grants
-            // access (foretell, Gonti's "you may look at and play"), checked below.
+            // zone." Exile therefore gets no controller baseline: a card put there by a plain
+            // "exile face down" rider is hidden from its owner too. Only an effect that grants
+            // access opens one, and every such effect names its grantee — see below.
             if (zoneKey.zoneType != Zone.EXILE &&
                 playerWhoMayLookAtFaceDown(state, entityId) == viewingPlayerId
             ) return true
@@ -120,7 +122,7 @@ class Visibility(
                 hasLookAtFaceDownCreatures(state, viewingPlayerId)
             ) return true
             if (zoneKey.zoneType == Zone.EXILE &&
-                state.hasMayPlayFor(entityId, viewingPlayerId, conditionEvaluator, cardRegistry)
+                grantsFaceDownExileAccessTo(state, entityId, viewingPlayerId)
             ) return true
             return false
         }
@@ -136,6 +138,31 @@ class Visibility(
         if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
         return isTopCard && zoneKey.ownerId == viewingPlayerId &&
             hasLookAtTopOfLibrary(state, viewingPlayerId)
+    }
+
+    /**
+     * Whether an effect entitles [viewingPlayerId] to look under face-down [entityId] in exile.
+     *
+     * CR 708.5 grants nothing here, so this is the whole permission, and each granting effect
+     * names the player it grants to:
+     *
+     * - **Foretell** (CR 702.143a) — "That player may look at that card as long as it remains in
+     *   exile." The engine stamps [FaceDownComponent] on a foretold card purely to mask it from
+     *   *opponents*, so reading [ForetoldComponent] is what keeps the foreteller's own view.
+     * - **May-play grants** — Gonti's "you may look at that card for as long as it remains
+     *   exiled", and the filter-defined grants [hasMayPlayFor] derives. Keyed on the same check
+     *   that drives castability, so a card the viewer may cast is never one they cannot see.
+     *
+     * A card exiled face down by a plain rider grants neither, and stays hidden from everyone.
+     */
+    private fun grantsFaceDownExileAccessTo(
+        state: GameState,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+    ): Boolean {
+        val foretoldBy = state.getEntity(entityId)?.get<ForetoldComponent>()?.controllerId
+        if (foretoldBy == viewingPlayerId) return true
+        return state.hasMayPlayFor(entityId, viewingPlayerId, conditionEvaluator, cardRegistry)
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.engine.view.ClientDeckCard
 import com.wingedsheep.engine.view.ClientStateTransformer
@@ -180,6 +181,24 @@ class DeckListClientViewTest : ScenarioTestBase() {
             val row = row(faceDown, "Grizzly Bears")
             row.shouldNotBeNull()
             row.remaining shouldBe 0
+        }
+
+        test("an individually known library card is accounted for without treating the zone as public") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .build()
+
+            val known = game.state.getLibrary(p1).first()
+            val withKnownTop = game.state.updateEntity(known) {
+                it.with(RevealedToComponent.to(p1))
+            }
+
+            val bolt = row(withKnownTop, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.copies shouldBe 2
+            bolt.remaining shouldBe 1
         }
 
         test("spectators are told nothing about anyone's deck") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ForetoldComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
@@ -221,6 +222,27 @@ class CardIdentityVisibilityTest : ScenarioTestBase() {
 
             visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player1Id) shouldBe false
             visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player2Id) shouldBe false
+        }
+
+        // CR 702.143a: "That player may look at that card as long as it remains in exile." The
+        // engine stamps FaceDownComponent on a foretold card to mask it from opponents, so the
+        // CR 708.5 scoping above must not take the foreteller's own view away with it.
+        test("a foretold card stays visible to the player who foretold it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInExile(1, "Craw Wurm")
+                .build()
+            val exiled = game.state.getExile(game.player1Id).single()
+            val exileKey = ZoneKey(game.player1Id, Zone.EXILE)
+            val state = game.state.updateEntity(exiled) {
+                it.with(FaceDownComponent)
+                    .with(ForetoldComponent(controllerId = game.player1Id, turnForetold = 1))
+            }
+
+            visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player1Id) shouldBe true
+            withClue("the opponent never gets to look") {
+                visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player2Id) shouldBe false
+            }
         }
 
         // The other half of the same rule: an effect that says you may look *does* entitle you, and

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
@@ -1,0 +1,318 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.permissions.MayPlayPermission
+import com.wingedsheep.engine.state.permissions.addMayPlayPermission
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * What [Visibility] answers about a single card's identity, and that the client view agrees.
+ *
+ * These are the *engine* propositions. The Gym module asserts the same states through
+ * `ObservationVisibilityTest`, which is the point of routing every consumer through one query:
+ * two representations, one semantic answer. When a case here and a case there disagree, one of
+ * the consumers has grown a local approximation again.
+ */
+class CardIdentityVisibilityTest : ScenarioTestBase() {
+
+    private val openThoughts = card("Open Thoughts") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = OpponentsPlayWithHandsRevealed }
+    }
+
+    private val publicTop = card("Public Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = RevealTopOfLibrary }
+    }
+
+    private val privateTop = card("Private Top") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = LookAtTopOfLibrary }
+    }
+
+    private val visibility: Visibility
+        get() = Visibility(cardRegistry)
+
+    init {
+        cardRegistry.register(listOf(openThoughts, publicTop, privateTop))
+
+        test("a player knows their own hand and not an opponent's") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .build()
+            val state = game.state
+            val ownCard = state.getHand(game.player1Id).single()
+            val opposingCard = state.getHand(game.player2Id).single()
+
+            visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(game.player1Id, Zone.HAND),
+                ownCard,
+                game.player1Id,
+            ) shouldBe true
+            visibility.isCardIdentityVisibleTo(
+                state,
+                ZoneKey(game.player2Id, Zone.HAND),
+                opposingCard,
+                game.player1Id,
+            ) shouldBe false
+
+            val clientView = ClientStateTransformer(cardRegistry).transform(state, game.player1Id)
+            clientView.cards.keys shouldContain ownCard
+            clientView.cards.keys shouldNotContain opposingCard
+        }
+
+        test("an individual reveal exposes that card and no other, and only to the entitled player") {
+            val base = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+            val bystander = EntityId.of("player-3")
+            val withBystander = addBystander(base.state, bystander)
+            val known = withBystander.getHand(base.player2Id).first { id ->
+                withBystander.getEntity(id)?.get<CardComponent>()?.name == "Mountain"
+            }
+            val unknown = withBystander.getHand(base.player2Id).single { it != known }
+            val state = withBystander.updateEntity(known) {
+                it.with(RevealedToComponent.to(base.player1Id))
+            }
+            val player2Hand = ZoneKey(base.player2Id, Zone.HAND)
+
+            withClue("the reveal is per card, not per zone") {
+                visibility.isZoneVisibleTo(state, player2Hand, base.player1Id) shouldBe false
+                visibility.isCardIdentityVisibleTo(state, player2Hand, known, base.player1Id) shouldBe true
+                visibility.isCardIdentityVisibleTo(state, player2Hand, unknown, base.player1Id) shouldBe false
+            }
+            withClue("a third player was not shown it") {
+                visibility.isCardIdentityVisibleTo(state, player2Hand, known, bystander) shouldBe false
+            }
+
+            val client = ClientStateTransformer(cardRegistry)
+            client.transform(state, base.player1Id).cards.keys.let {
+                it shouldContain known
+                it shouldNotContain unknown
+            }
+            client.transform(state, bystander).cards.keys shouldNotContain known
+        }
+
+        test("a whole-hand reveal is zone visibility for its controller alone") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, openThoughts.name)
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .build()
+
+            visibility.isZoneVisibleTo(
+                game.state,
+                ZoneKey(game.player2Id, Zone.HAND),
+                game.player1Id,
+            ) shouldBe true
+            visibility.isZoneVisibleTo(
+                game.state,
+                ZoneKey(game.player1Id, Zone.HAND),
+                game.player2Id,
+            ) shouldBe false
+        }
+
+        test("a private top-card effect tells only its controller; a public one tells everyone") {
+            val privateGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, privateTop.name)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Hill Giant")
+                .build()
+            val privateLibrary = ZoneKey(privateGame.player1Id, Zone.LIBRARY)
+            val privateTopCard = privateGame.state.getLibrary(privateGame.player1Id).first()
+            val privateSecond = privateGame.state.getLibrary(privateGame.player1Id)[1]
+
+            visibility.isCardIdentityVisibleTo(
+                privateGame.state, privateLibrary, privateTopCard, privateGame.player1Id,
+            ) shouldBe true
+            withClue("only the top card, not the one under it") {
+                visibility.isCardIdentityVisibleTo(
+                    privateGame.state, privateLibrary, privateSecond, privateGame.player1Id,
+                ) shouldBe false
+            }
+            visibility.isCardIdentityVisibleTo(
+                privateGame.state, privateLibrary, privateTopCard, privateGame.player2Id,
+            ) shouldBe false
+
+            val publicGame = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, publicTop.name)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .build()
+            val publicLibrary = ZoneKey(publicGame.player1Id, Zone.LIBRARY)
+            val publicTopCard = publicGame.state.getLibrary(publicGame.player1Id).first()
+
+            listOf(publicGame.player1Id, publicGame.player2Id).forEach { viewer ->
+                visibility.isCardIdentityVisibleTo(
+                    publicGame.state, publicLibrary, publicTopCard, viewer,
+                ) shouldBe true
+            }
+            withClue("a public reveal reaches a spectator; a private one never does") {
+                visibility.isCardIdentityVisibleTo(
+                    publicGame.state, publicLibrary, publicTopCard, publicGame.player1Id,
+                    isSpectator = true,
+                ) shouldBe true
+                visibility.isCardIdentityVisibleTo(
+                    privateGame.state, privateLibrary, privateTopCard, privateGame.player1Id,
+                    isSpectator = true,
+                ) shouldBe false
+            }
+        }
+
+        test("a face-down object on the battlefield or stack is known only to the player who may look") {
+            val game = faceDownGame()
+
+            visibility.isCardIdentityVisibleTo(
+                game.state, Zone.BATTLEFIELD, game.permanent, game.controller,
+            ) shouldBe true
+            visibility.isCardIdentityVisibleTo(
+                game.state, Zone.BATTLEFIELD, game.permanent, game.opponent,
+            ) shouldBe false
+            visibility.isCardIdentityVisibleTo(
+                game.state, Zone.STACK, game.spell, game.controller,
+            ) shouldBe true
+            visibility.isCardIdentityVisibleTo(
+                game.state, Zone.STACK, game.spell, game.opponent,
+            ) shouldBe false
+        }
+
+        // CR 708.5: "At any time, you may look at a face-down spell you control on the stack or a
+        // face-down permanent you control … You can't look at face-down cards in any other zone."
+        // Exile is one of those other zones, so ownership alone entitles nobody — this was the
+        // controller/caster baseline leaking past the two zones the rule scopes it to.
+        test("a face-down card in exile is hidden from its owner too") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInExile(1, "Craw Wurm")
+                .build()
+            val exiled = game.state.getExile(game.player1Id).single()
+            val state = game.state.updateEntity(exiled) { it.with(FaceDownComponent) }
+            val exileKey = ZoneKey(game.player1Id, Zone.EXILE)
+
+            visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player1Id) shouldBe false
+            visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player2Id) shouldBe false
+        }
+
+        // The other half of the same rule: an effect that says you may look *does* entitle you, and
+        // that permission is the only way under a face-down exiled card.
+        test("a may-play grant is what opens a face-down exiled card, for the granted player only") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInExile(1, "Craw Wurm")
+                .build()
+            val exiled = game.state.getExile(game.player1Id).single()
+            val exileKey = ZoneKey(game.player1Id, Zone.EXILE)
+            val state = game.state
+                .updateEntity(exiled) { it.with(FaceDownComponent) }
+                .addMayPlayPermission(
+                    MayPlayPermission(
+                        id = EntityId.of("test-may-play"),
+                        cardIds = setOf(exiled),
+                        controllerId = game.player2Id,
+                        permanent = true,
+                    )
+                )
+
+            visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player2Id) shouldBe true
+            withClue("the owner still may not look — the grant went to the other player") {
+                visibility.isCardIdentityVisibleTo(state, exileKey, exiled, game.player1Id) shouldBe false
+            }
+        }
+
+        // A spectator's transform runs from a seat's perspective (SpectatorStateBuilder passes the
+        // first seat), so every private answer has to be gated on the spectator flag rather than on
+        // "is this the viewer's own zone" — otherwise watching a game shows you that seat's hand.
+        test("a spectator is told nothing private about the seat they view from") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Forest")
+                .build()
+            val state = game.state
+            val ownHand = ZoneKey(game.player1Id, Zone.HAND)
+            val ownSideboard = ZoneKey(game.player1Id, Zone.SIDEBOARD)
+            val card = state.getHand(game.player1Id).single()
+
+            visibility.isZoneVisibleTo(state, ownHand, game.player1Id, isSpectator = true) shouldBe false
+            visibility.isZoneVisibleTo(state, ownSideboard, game.player1Id, isSpectator = true) shouldBe false
+            visibility.isCardIdentityVisibleTo(
+                state, ownHand, card, game.player1Id, isSpectator = true,
+            ) shouldBe false
+            withClue("the same seat, viewed as a player, still sees its own hand") {
+                visibility.isZoneVisibleTo(state, ownHand, game.player1Id) shouldBe true
+            }
+        }
+    }
+
+    private class FaceDownGame(
+        val state: GameState,
+        val permanent: EntityId,
+        val spell: EntityId,
+        val controller: EntityId,
+        val opponent: EntityId,
+    )
+
+    /** Player 2 controls a face-down Craw Wurm and has a face-down Hill Giant on the stack. */
+    private fun faceDownGame(): FaceDownGame {
+        val game = scenario()
+            .withPlayers()
+            .withCardOnBattlefield(2, "Craw Wurm")
+            .withCardInHand(2, "Hill Giant")
+            .build()
+        val permanent = game.state.getBattlefield().single()
+        val spell = game.state.getHand(game.player2Id).single()
+        val state = game.state
+            .updateEntity(permanent) { it.with(FaceDownComponent) }
+            .removeFromZone(ZoneKey(game.player2Id, Zone.HAND), spell)
+            .updateEntity(spell) {
+                it.with(SpellOnStackComponent(casterId = game.player2Id, castFaceDown = true))
+            }
+            .copy(stack = listOf(spell))
+        return FaceDownGame(state, permanent, spell, game.player2Id, game.player1Id)
+    }
+
+    /** A third seat, so "revealed to a player" can be told apart from "revealed to everyone". */
+    private fun addBystander(state: GameState, playerId: EntityId): GameState {
+        var result = state.withEntity(
+            playerId,
+            ComponentContainer.of(
+                PlayerComponent("Bystander"),
+                LifeTotalComponent(20),
+                ManaPoolComponent(),
+            ),
+        ).copy(turnOrder = state.turnOrder + playerId)
+        for (zone in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD)) {
+            result = result.copy(zones = result.zones + (ZoneKey(playerId, zone) to emptyList()))
+        }
+        return result
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
@@ -240,6 +240,7 @@ class CardIdentityVisibilityTest : ScenarioTestBase() {
                         cardIds = setOf(exiled),
                         controllerId = game.player2Id,
                         permanent = true,
+                        timestamp = 0L,
                     )
                 )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -7,12 +7,12 @@ import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
-import com.wingedsheep.engine.state.nameVisibleTo
 import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
@@ -244,14 +244,24 @@ class FaceDownGameLogMaskingTest : FunSpec({
         val controller = d.activePlayer!!
         val opponent = d.getOpponent(controller)
         val hidden = d.putFaceDown(controller, "Disguised Angel", FaceDownMode.DISGUISE)
+        val visibility = Visibility(d.cardRegistry)
 
-        // CR 708.5 — you may look at a face-down permanent you control. Per-viewer text honours
-        // that; the flat game-log strings cannot and mask for everyone.
-        nameVisibleTo(d.state, hidden, "Disguised Angel", controller) shouldBe "Disguised Angel"
-        nameVisibleTo(d.state, hidden, "Disguised Angel", opponent) shouldBe "Face-down creature"
+        // CR 708.5 — you may look at a face-down permanent you control. Text with an audience asks
+        // the shared identity authority and picks its label from that answer; the flat game-log
+        // strings have no audience to ask about and mask for everyone.
+        visibility.isCardIdentityVisibleTo(d.state, Zone.BATTLEFIELD, hidden, controller) shouldBe true
+        visibility.isCardIdentityVisibleTo(d.state, Zone.BATTLEFIELD, hidden, opponent) shouldBe false
         withClue("a spectator is never the player who may look") {
-            nameVisibleTo(d.state, hidden, "Disguised Angel", controller, isSpectator = true) shouldBe
-                "Face-down creature"
+            visibility.isCardIdentityVisibleTo(
+                d.state,
+                Zone.BATTLEFIELD,
+                hidden,
+                controller,
+                isSpectator = true,
+            ) shouldBe false
+        }
+        withClue("the flat game-log string masks for everyone, controller included") {
+            nameVisibleToAll(d.state, hidden, "Disguised Angel") shouldBe "Face-down creature"
         }
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/ModalSpellStackVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/ModalSpellStackVisibilityTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.support.GameTestDriver
@@ -233,6 +234,19 @@ class ModalSpellStackVisibilityTest : FunSpec({
         redactedName shouldNotContain "Savannah Lions"
         redactedName.lowercase() shouldContain "card in"
         redactedName.lowercase() shouldContain "hand"
+
+        // A per-card reveal changes the semantic identity answer without making the whole hand
+        // public. Stack target presentation must follow that answer rather than the old owner-only
+        // shortcut.
+        d.replaceState(d.state.updateEntity(secret) { container ->
+            container.with(RevealedToComponent.to(p2))
+        })
+        val revealedOpponentGroups = transformer(d)
+            .transform(d.state, viewingPlayerId = p2)
+            .cards[stackSpellId]
+            ?.perModeTargets
+        revealedOpponentGroups.shouldNotBeNull()
+        revealedOpponentGroups[1].targetNames shouldBe listOf("Savannah Lions")
 
         // Mode descriptions are still public to the opponent — only the card identity is hidden.
         opponentView.cards[stackSpellId]?.chosenModeDescriptions?.size shouldBe 2


### PR DESCRIPTION
Supersedes #2146 (by @huxinq), rebased onto current `main` with the review findings from that PR applied.

## What it does

Several consumers each answered "may this perspective know this card's identity?" on their own, and disagreed in real states.

Gym is the clearest case. Its observation builder treated visibility as a whole-zone property: your hand visible, an opponent's hidden, libraries hidden. But Magic allows partial knowledge — if one card in an opponent's two-card hand has been individually revealed to you, the hand is still a hidden zone and you still know one identity. The opposite problem appeared with face-down objects: the battlefield is public, but that does not make the identity *under* a face-down permanent public, so an observation could expose `"Craw Wurm"` simply because the object lived in an otherwise public zone.

`Visibility.isCardIdentityVisibleTo` is now the single answer. It composes whole-zone access, `RevealedToComponent`, public and private top-of-library access, who may look at a face-down object, effect-granted face-down access in exile, and spectator restrictions. AI determinization, client modal-target presentation, the deck tracker, and server combat-decision masking all delegate to it.

Consumers keep their own representations. Gym reports an opponent hand with one revealed card as a hidden zone of size two whose `cards` holds only the identity it knows; the client keeps opaque library slots. A face-down permanent still exposes its public projected characteristics (its 2/2), but not its `cardDefinitionId`, name, mana cost, or oracle text. `revealAll` remains the debug escape hatch.

This deliberately does not create a shared client/Gym DTO or move presentation policy into the rules engine.

## Changes on top of #2146

Each of these came out of reviewing that PR.

**CR 708.5 is scoped to the two zones it names.** The rule reads: "At any time, you may look at a face-down spell you control on the stack or a face-down permanent you control … You can't look at face-down cards in any other zone." `playerWhoMayLookAtFaceDown` falls back through owner, so in exile it resolved to the owner and returned true — I confirmed with a probe that the owner saw the identity of their own face-down exiled card. That also made the `Zone.EXILE && hasMayPlayFor` branch dead for owned cards. The baseline is now skipped for exile, so a may-play grant (foretell, Gonti) is the only way under a face-down exiled card. Two tests cover both halves.

**A `Zone`-keyed overload, so callers stop inventing zone keys.** Three sites built a `ZoneKey` whose owner defaulted to the *viewer* — which reads as "my own zone" and was only harmless because the public zones where it happened ignore the owner. `isCardIdentityVisibleTo(state, zoneType, …)` derives the key instead: controller for the battlefield, caster for the stack (which isn't in `state.zones` at all), owner elsewhere.

**The ingredient queries are private.** `isCardRevealedTo`, `hasLookAtFaceDownCreatures`, `revealsTopOfLibraryPublicly`, and `hasLookAtTopOfLibrary` had no production caller outside `Visibility` after this change. This class exists because four subsystems grew their own answer; handing the ingredients back out is how a fifth gets built.

**`nameVisibleTo` is deleted.** It had one caller left and it was a test. Its own KDoc advised preferring it for audience-bearing text — advice nothing followed. `nameVisibleToAll` (16 callers) stays and now points at `Visibility` for the per-viewer question.

**`debugMode` reaches the face-down branch**, which it previously short-circuited past.

**Tests split by layer.** The engine propositions live in `rules-engine`'s new `CardIdentityVisibilityTest`; `ObservationVisibilityTest` in `gym` keeps the Gym representation assertions. Two tests were added for behavior #2146 changed without covering: the spectator gating in `isZoneVisibleTo` (a spectator's transform runs from a seat's perspective, so "is this my own zone" had to become spectator-gated or watching a game showed you that seat's hand), and the CR 708.5 exile pair above.

## Merge notes

`main` moved twice under #2146 and both required real resolution:

- **#2153** extracted `HiddenSlotRewrite` and rewrote the same `Determinizer.hiddenCards` body. Resolved onto main's structure — `isCardIdentityVisibleTo` subsumes main's `visibleTop`, `handHidden`, and `!isCardRevealedTo` clauses exactly, so it is a strict simplification. Main's `runtimeBlockers` also pins any slot carrying `RevealedToComponent`, which makes #2146's reveal-preservation hack unnecessary; it is gone.
- **#2154** independently implemented "a hidden zone carries its revealed subset" via `RevealedToComponent` alone. This PR's `Visibility`-driven version is a superset (it also covers top-of-library and face-down), so the resolution keeps this one and drops main's now-unused `isHiddenFrom` / `isRevealedTo` helpers, while keeping every field #2154 added to `StackItemView` and `StateDigest`. Main's digest work also made a fix I had staged redundant, so it was dropped.

## Verification

**Not yet run against this final merged tree** — the suites below were green on the pre-#2154 merge, and everything since is the resolution above plus the review fixes. Please let CI confirm before merging.

- `just test-rules`, `just test-ai`, `just test-server`, `just test-gym` (green on the earlier merge; `ObservationVisibilityTest` 5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkXNxEYvWntTmbq8guuWvs
