### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/EgoErasure.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/EgoErasure.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ego Erasure
+ * {2}{U}
+ * Kindred Instant — Shapeshifter
+ *
+ * Changeling (This card is every creature type.)
+ * Creatures target player controls get -2/-0 and lose all creature types until end of turn.
+ *
+ * The player is the only *target*; the creatures are a group resolved when the spell resolves,
+ * so a creature that arrives after the spell was cast is still hit. `targetPlayerControls` binds
+ * the group's controller predicate to that target rather than to the spell's controller.
+ *
+ * Both riders land on each member with [EffectTarget.Self] inside the iteration — the same shape
+ * Surge of Thoughtweft uses — so a creature that leaves mid-resolution simply drops out.
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val EgoErasure = card("Ego Erasure") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Kindred Instant — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Creatures target player controls get -2/-0 and lose all creature types until end of turn."
+
+    keywords(Keyword.CHANGELING)
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.targetPlayerControls(player)),
+            Effects.Composite(
+                Effects.ModifyStats(-2, 0, EffectTarget.Self),
+                Effects.LoseAllCreatureTypes(EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Steven Belledin"
+        flavorText = "When all is taken away, all are equal."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg?1783942904"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FireBellyChangeling.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FireBellyChangeling.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fire-Belly Changeling
+ * {1}{R}
+ * Creature — Shapeshifter
+ * 1/1
+ * Changeling (This card is every creature type.)
+ * {R}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn.
+ *
+ * The printed cap is [ActivationRestriction.MaxPerTurn] — the counted sibling of `OncePerTurn`,
+ * enforced by the activation-legality check rather than by the effect, so the third activation is
+ * never offered instead of being offered and fizzling.
+ */
+val FireBellyChangeling = card("Fire-Belly Changeling") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "{R}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn."
+
+    keywords(Keyword.CHANGELING)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.MaxPerTurn(2))
+        description = "{R}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Randy Gallegos"
+        flavorText = "\"My ears say it hisses. My fingers say it burns.\"\n—Auntie Wort"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg?1783942877"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FodderLaunch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FodderLaunch.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fodder Launch
+ * {3}{B}
+ * Kindred Sorcery — Goblin
+ *
+ * As an additional cost to cast this spell, sacrifice a Goblin.
+ * Target creature gets -5/-5 until end of turn. Fodder Launch deals 5 damage to that creature's
+ * controller.
+ *
+ * The Goblin is sacrificed on announcement (an additional cost, so it happens whether or not the
+ * spell resolves), which is also what makes this the sacrifice outlet half of the Boggart deck.
+ *
+ * "That creature's controller" is [EffectTarget.TargetController] — read from the *target* rather
+ * than from the spell's controller, so the damage follows a creature that changed hands.
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val FodderLaunch = card("Fodder Launch") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Kindred Sorcery — Goblin"
+    oracleText = "As an additional cost to cast this spell, sacrifice a Goblin.\n" +
+        "Target creature gets -5/-5 until end of turn. Fodder Launch deals 5 damage to that " +
+        "creature's controller."
+
+    additionalCost(
+        Costs.additional.SacrificePermanent(
+            GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN)
+        )
+    )
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-5, -5, creature) then
+            Effects.DealDamage(5, EffectTarget.TargetController)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "114"
+        artist = "Nils Hamm"
+        flavorText = "Leave it to a boggart to come up with a projectile as disgusting as it is deadly."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg?1783942890"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/StreambedAquitects.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/StreambedAquitects.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Streambed Aquitects
+ * {1}{U}{U}
+ * Creature — Merfolk Scout
+ * 2/3
+ * {T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn.
+ * {T}: Target land becomes an Island until end of turn.
+ *
+ * Two independently-targeted tap abilities that read as one plan: the second makes the defender's
+ * land an Island so the first's islandwalk actually turns off blocking. "Becomes an Island"
+ * *replaces* the land's subtypes (CR 305.7), hence [Effects.SetLandType] and not the additive
+ * `AddSubtype` — the same distinction Dream Thrush documents.
+ */
+val StreambedAquitects = card("Streambed Aquitects") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Scout"
+    power = 2
+    toughness = 3
+    oracleText = "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn. " +
+        "(It can't be blocked as long as defending player controls an Island.)\n" +
+        "{T}: Target land becomes an Island until end of turn."
+
+    activatedAbility {
+        val merfolk = target(
+            "target Merfolk creature",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.MERFOLK))
+        )
+        cost = AbilityCost.Tap
+        effect = Effects.ModifyStats(1, 1, merfolk) then
+            Effects.GrantKeyword(Keyword.ISLANDWALK, merfolk)
+        description = "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn."
+    }
+
+    activatedAbility {
+        val land = target("target land", Targets.Land)
+        cost = AbilityCost.Tap
+        effect = Effects.SetLandType(
+            landType = "Island",
+            target = land,
+            duration = Duration.EndOfTurn
+        )
+        description = "{T}: Target land becomes an Island until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "William O'Connor"
+        flavorText = "\"We look in the river and see scattered stones. A merrow looks and sees a " +
+            "map of Lorwyn.\"\n—Illulia, flamekin soulstoke"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg?1783942896"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TideshaperMystic.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TideshaperMystic.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.OptionType
+
+/**
+ * Tideshaper Mystic
+ * {U}
+ * Creature — Merfolk Wizard
+ * 1/1
+ * {T}: Target land becomes the basic land type of your choice until end of turn.
+ * Activate only during your turn.
+ *
+ * Dream Thrush's ability with a timing restriction bolted on: `ChooseOption(BASIC_LAND_TYPE)`
+ * records the pick, then [Effects.SetLandType] installs the Layer-4 (TYPE) effect that *replaces*
+ * the land's existing subtypes (CR 305.7) — so the land loses its old mana abilities and gains the
+ * chosen type's, which is what makes this a Merfolk islandwalk enabler and a colour-screw tool at
+ * once.
+ */
+val TideshaperMystic = card("Tideshaper Mystic") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target land becomes the basic land type of your choice until end of turn. " +
+        "Activate only during your turn."
+
+    val chosenKey = "chosenLandType"
+
+    activatedAbility {
+        val land = target("target land", Targets.Land)
+        cost = AbilityCost.Tap
+        effect = Effects.Composite(
+            Effects.ChooseOption(
+                optionType = OptionType.BASIC_LAND_TYPE,
+                storeAs = chosenKey
+            ),
+            Effects.SetLandType(
+                target = land,
+                duration = Duration.EndOfTurn,
+                fromChosenValueKey = chosenKey
+            )
+        )
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+        description = "{T}: Target land becomes the basic land type of your choice until end of turn. " +
+            "Activate only during your turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Mark Tedin"
+        flavorText = "He paints with drop and shimmer a world that exists only in the wistful heart."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg?1783942896"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1630,6 +1630,76 @@
     ]
 }
 
+// Ego Erasure
+{
+    "name": "Ego Erasure",
+    "manaCost": "{2}{U}",
+    "typeLine": "Kindred Instant — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nCreatures target player controls get -2/-0 and lose all creature types until end of turn.",
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "controllerPredicate": {
+                            "type": "ControlledByReferencedPlayer",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        }
+                    }
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "LoseAllCreatureTypes",
+                        "target": "Self"
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "When all is taken away, all are equal.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f577831b-2aa2-44a1-bd6b-ef111bc2e211.jpg?1783942904"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Elvish Eulogist
 {
     "name": "Elvish Eulogist",
@@ -2495,6 +2565,63 @@
     ]
 }
 
+// Fire-Belly Changeling
+{
+    "name": "Fire-Belly Changeling",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\n{R}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    {
+                        "type": "MaxPerTurn",
+                        "count": 2
+                    }
+                ],
+                "descriptionOverride": "{R}: This creature gets +1/+0 until end of turn. Activate no more than twice each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"My ears say it hisses. My fingers say it burns.\"\n—Auntie Wort",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4732342-71a4-4079-b549-f4454945273a.jpg?1783942877"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flamekin Brawler
 {
     "name": "Flamekin Brawler",
@@ -2665,6 +2792,72 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Fodder Launch
+{
+    "name": "Fodder Launch",
+    "manaCost": "{3}{B}",
+    "typeLine": "Kindred Sorcery — Goblin",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a Goblin.\nTarget creature gets -5/-5 until end of turn. Fodder Launch deals 5 damage to that creature's controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -5
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": "TargetController"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "permanent Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "Leave it to a boggart to come up with a projectile as disgusting as it is deadly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d000670f-1151-4abf-a7ec-b35a6e587183.jpg?1783942890"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -6985,6 +7178,95 @@
     ]
 }
 
+// Streambed Aquitects
+{
+    "name": "Streambed Aquitects",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)\n{T}: Target land becomes an Island until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Merfolk creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "ISLANDWALK",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Merfolk creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Merfolk"
+                        },
+                        "id": "target Merfolk creature"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target Merfolk creature gets +1/+1 and gains islandwalk until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "SetLandType",
+                    "landType": "Island",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target land"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target land becomes an Island until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "William O'Connor",
+        "flavorText": "\"We look in the river and see scattered stones. A merrow looks and sees a map of Lorwyn.\"\n—Illulia, flamekin soulstoke",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aed908f4-630c-4f3c-9e61-4725b88b93ff.jpg?1783942896"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sunrise Sovereign
 {
     "name": "Sunrise Sovereign",
@@ -7447,6 +7729,66 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Tideshaper Mystic
+{
+    "name": "Tideshaper Mystic",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{T}: Target land becomes the basic land type of your choice until end of turn. Activate only during your turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ChooseOption",
+                            "optionType": "BASIC_LAND_TYPE",
+                            "storeAs": "chosenLandType"
+                        },
+                        {
+                            "type": "SetLandType",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land"
+                            },
+                            "fromChosenValueKey": "chosenLandType"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target land"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ],
+                "descriptionOverride": "{T}: Target land becomes the basic land type of your choice until end of turn. Activate only during your turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Mark Tedin",
+        "flavorText": "He paints with drop and shimmer a world that exists only in the wistful heart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e526ebbf-2041-4c3e-9a20-73bbf6f90251.jpg?1783942896"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, all built from existing `Effects.*` / `Costs.*` primitives — no new SDK vocabulary. LRW is each card's earliest real printing, so all five are canonical `card(...)` definitions; no `Printing` rows owed elsewhere.

| Card | What it does | Composed from |
|---|---|---|
| **Ego Erasure** `{2}{U}` | Changeling. Creatures target player controls get -2/-0 and lose all creature types until end of turn. | `ForEachInGroup(GameObjectFilter.Creature.targetPlayerControls(player))` over `ModifyStats(-2, 0, Self)` + `LoseAllCreatureTypes(Self)` — the player is the only target; the creatures are a resolution-time group |
| **Tideshaper Mystic** `{U}` | `{T}`: Target land becomes the basic land type of your choice until end of turn. Activate only during your turn. | Dream Thrush's `ChooseOption(BASIC_LAND_TYPE)` → `SetLandType(fromChosenValueKey)`, plus `ActivationRestriction.OnlyDuringYourTurn` |
| **Streambed Aquitects** `{1}{U}{U}` | `{T}`: Target Merfolk gets +1/+1 and gains islandwalk UEOT. `{T}`: Target land becomes an Island UEOT. | `ModifyStats` + `GrantKeyword(ISLANDWALK)`; `SetLandType("Island")`. Two independently-targeted tap abilities with distinct `description`s so the action menu reads clearly |
| **Fodder Launch** `{3}{B}` | Additional cost: sacrifice a Goblin. Target creature gets -5/-5; deals 5 damage to that creature's controller. | `Costs.additional.SacrificePermanent(Goblin)`, `ModifyStats(-5, -5)` + `DealDamage(5, EffectTarget.TargetController)` |
| **Fire-Belly Changeling** `{1}{R}` | Changeling. `{R}`: +1/+0 UEOT. Activate no more than twice each turn. | `ActivationRestriction.MaxPerTurn(2)` — enforced by the activation-legality check, so the third activation is never offered |

`SetLandType` (not `AddSubtype`) is the right primitive for both "becomes" lines: CR 305.7 *replaces* the land's existing subtypes, which is what makes Tideshaper Mystic a colour-screw tool and what makes Streambed Aquitects' two abilities combine (turn their land into an Island, then islandwalk past it).

### Dropped from the batch

**Crush Underfoot** — "Choose a Giant creature you control. It deals damage equal to its power to target creature." The chosen Giant is a resolution-time pick stored by `Effects.SelectTarget`, but `DynamicAmount.EntityProperty` has no `EntityReference` variant that reads a pipeline slot (`IterationEntity` is `ForEachInGroup`-only, and a group iteration would hit *every* Giant rather than one). That's new SDK vocabulary, so per the batching rule it gets its own PR. Fire-Belly Changeling took its place.

### Verification

- `just build` — **BUILD SUCCESSFUL**.
- `CardDefinitionSnapshotTest` — re-blessed with `just rebless-cards`. The golden diff is **342 lines, all insertions**, covering exactly these five cards; no existing card moved.
- `just check-card-printing` — ok for all five ("canonical is in the card's earliest real printing and all scaffolded reprints have rows"). Streambed Aquitects' DDT reprint and Fire-Belly Changeling's DDG/PLST reprints are in unscaffolded sets, so no rows are owed.
- `just assay-differential --set LRW` — 109 compared, 96 confirmed, **13 divergent, none of them these five** (the 13 are the pre-existing Harbinger-cycle target-id fold plus Boggart Birth Rite / Epic Proportions / Kithkin Greatheart / Scarred Vinebreeder / Wort, untouched by this PR). All five of these cards land in Assay's "not yet covered by the grammar" bucket — a decline, not a pass, so the differential is silent on them either way.

No new SDK vocabulary means no scenario tests are required (AGENTS.md / the `add-card` skill: a card built purely from existing primitives is covered by the snapshot and lint nets), and no new visual mechanic means no e2e spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjbh7kf6RCpCp3mjfurysE