### PR TITLE
Expand exact structured decisions in tree search

### DIFF
--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -69,6 +69,22 @@ and the engine's `PendingDecision` (non-null when mid-decision). Every SPI
 call receives it so implementations can branch on decision kind (priority
 vs target selection vs yes/no vs …).
 
+Structured decisions have two separate search seams:
+
+```kotlin
+fun interface StructuredDecisionExpander {
+    fun expand(state: GameState, decision: PendingDecision): StructuredDecisionExpansion
+}
+
+fun interface StructuredDecisionResolver {
+    fun resolve(state: GameState, decision: PendingDecision): DecisionResponse
+}
+```
+
+An expander reports either an exact `Complete` response sequence or `Unsupported`.
+Unsupported decisions retain the configured resolver's single policy-selected
+fallback; no partial expansion, search cap, or sampling policy is implied.
+
 ## Design choices worth knowing about
 
 ### Multi-head policy is first-class
@@ -85,6 +101,11 @@ priority-opponent / target / binary). Forcing every project through a
 single flat head would have made them fork, which was the whole problem
 we were trying to solve. The cost for simple users is a one-element
 `listOf(PolicyHead("actions", 128))`.
+
+Concrete actions are tree-edge identity, while `(head, slot)` is neural-policy
+identity. Colliding structured responses remain independent MCTS edges but
+receive the same learned prior; use a discriminating `ActionFeaturizer` when
+response-specific learned priors or training targets are required.
 
 ### Engine-side MCTS, not Python-side
 
@@ -105,9 +126,11 @@ MCTS edges are ordinary `GameAction`s. At a priority state, edges are
 friends), edges are `SubmitDecision(response)` — exactly the set of
 folded responses `:gym`'s `ActionRegistry` produces. At a complex
 pending decision (targets, distribute, order, search, etc.) the
-`StructuredDecisionResolver` returns a single forced edge. The built-in
-resolver samples uniformly; a production project can supply a heuristic
-or learned one.
+`StructuredDecisionExpander` may return a complete response sequence. The
+built-in exact expander covers one required target from an explicit finite legal
+target list; each validator-approved response becomes its own edge. Other
+structured decisions retain one `StructuredDecisionResolver` fallback edge,
+which is policy-selected rather than exhaustive.
 
 ### Outcome-labelled self-play rows
 
@@ -134,7 +157,8 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `RandomStructuredResolver` | Uniform-random response for structured decisions (targets, etc.). |
+| `ExactStructuredDecisionExpander` | Complete lazy required-single-target response source. |
+| `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended
 to be replaced when a project gets serious.
@@ -215,4 +239,6 @@ just test-gym-trainer              # this module only
 The test set covers:
 - PUCT visit accounting (`AlphaZeroSearchTest`)
 - Root noise doesn't break the search
+- Exact structured expansion, validator agreement, and unsupported fallback
+- Independent target-response branches through ordinary Gym execution
 - End-to-end self-play producing outcome-labelled JSONL (`SelfPlayLoopTest`)

--- a/gym-trainer/build.gradle.kts
+++ b/gym-trainer/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(kotlin("reflect"))
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.gym.trainer.defaults
+
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Exact, policy-free expansion for structured families whose pending-decision metadata fully
+ * describes a finite response space.
+ *
+ * A target decision with exactly one requirement for exactly one target is finite and described
+ * completely by its pending-decision payload. Every candidate is filtered through
+ * [DecisionValidators] before it is exposed. Variable-cardinality and multi-requirement target
+ * decisions remain unsupported because current MCTS materializes every edge and has no
+ * caller-owned widening or response-budget policy. Other structured families remain unsupported.
+ */
+object ExactStructuredDecisionExpander : StructuredDecisionExpander {
+
+    override fun expand(
+        state: GameState,
+        decision: PendingDecision
+    ): StructuredDecisionExpansion = when (decision) {
+        is ChooseTargetsDecision -> {
+            val requirement = decision.targetRequirements.singleOrNull()
+            val legalTargets = requirement?.let { decision.legalTargets[it.index] }
+            if (
+                requirement == null || legalTargets == null ||
+                requirement.minTargets != 1 || requirement.maxTargets != 1
+            ) {
+                StructuredDecisionExpansion.Unsupported
+            } else {
+                complete(state, decision, targetResponses(decision, requirement.index, legalTargets))
+            }
+        }
+
+        else -> StructuredDecisionExpansion.Unsupported
+    }
+
+    private fun targetResponses(
+        decision: ChooseTargetsDecision,
+        requirementIndex: Int,
+        legalTargets: List<EntityId>
+    ): Sequence<DecisionResponse> =
+        sequence {
+            if (decision.canCancel) {
+                yield(CancelDecisionResponse(decision.id))
+            }
+
+            for (target in legalTargets.distinct()) {
+                yield(
+                    TargetsResponse(
+                        decisionId = decision.id,
+                        selectedTargets = mapOf(requirementIndex to listOf(target))
+                    )
+                )
+            }
+        }
+
+    private fun complete(
+        state: GameState,
+        decision: PendingDecision,
+        candidates: Sequence<DecisionResponse>
+    ): StructuredDecisionExpansion.Complete = StructuredDecisionExpansion.Complete(
+        candidates.filter { DecisionValidators.validate(decision, it, state) == null }
+    )
+}

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -29,10 +29,14 @@ import com.wingedsheep.engine.core.BatchYesNoDecision
 import com.wingedsheep.engine.core.BatchYesNoResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
 import com.wingedsheep.gym.GameEnvironment
+import com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander
 import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
 import com.wingedsheep.gym.trainer.spi.Evaluator
 import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
 import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
 import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.engine.legalactions.LegalAction
@@ -59,10 +63,10 @@ import java.util.Random as JavaRandom
  *      - At a simple pending decision (YesNo, ChooseNumber, single-mode
  *        ChooseMode, ChooseColor, ChooseOption, single-select SelectCards)
  *        → every folded [DecisionResponse] becomes an edge.
- *      - At a complex pending decision (ChooseTargets, Distribute, Order,
- *        SplitPiles, Search, Reorder, AssignDamage, SelectManaSources,
- *        multi-select SelectCards, multi-mode ChooseMode, BudgetModal)
- *        → the [StructuredDecisionResolver] returns a *single* forced edge.
+ *      - At a structured pending decision → [StructuredDecisionExpander]
+ *        may expose a complete response set as independent edges. Unsupported
+ *        families retain a single policy-selected [StructuredDecisionResolver]
+ *        fallback edge.
  *    Then call the [Evaluator] to get priors and value.
  * 3. **Simulate (value)** — at terminal, use the game outcome; at an
  *    expanded leaf, use the evaluator's value (from the acting player's
@@ -81,12 +85,14 @@ import java.util.Random as JavaRandom
  * @param actionFeaturizer action → `(head, slot)` policy index
  * @param evaluator priors + value provider; typically a remote NN
  * @param structuredResolver called on complex engine decisions the
- *        folded-action-space can't express
+ *        [structuredExpander] does not support; this is a policy fallback
  * @param cPuct exploration constant; `1.0` is a sensible default
  * @param dirichletAlpha optional Dirichlet noise alpha applied to root
  *        priors only; `null` disables noise
  * @param dirichletWeight `(1-w) * prior + w * dirichlet` mix weight
  * @param rng seed for noise sampling
+ * @param structuredExpander policy-free source of complete structured
+ *        response sets; defaults to exact required-single-target expansion
  */
 class AlphaZeroSearch<T>(
     private val env: GameEnvironment,
@@ -97,7 +103,8 @@ class AlphaZeroSearch<T>(
     private val cPuct: Double = 1.0,
     private val dirichletAlpha: Double? = null,
     private val dirichletWeight: Double = 0.25,
-    private val rng: Random = Random.Default
+    private val rng: Random = Random.Default,
+    private val structuredExpander: StructuredDecisionExpander = ExactStructuredDecisionExpander
 ) {
     private val workingEnv: GameEnvironment = env.fork()
     private val javaRng: JavaRandom = JavaRandom(rng.nextLong())
@@ -181,6 +188,10 @@ class AlphaZeroSearch<T>(
             ?: error("Expanding a terminal node — should be caught earlier")
 
         val edges = enumerateEdges(node, acting)
+        check(edges.isNotEmpty()) {
+            val source = node.pendingDecision?.let { it::class.simpleName } ?: "priority state"
+            "No search edges for $source"
+        }
         node.edges = edges
 
         val ctx = TrainerContext(node.state, acting, node.pendingDecision)
@@ -233,33 +244,89 @@ class AlphaZeroSearch<T>(
 
         val foldedResponses = foldSimpleDecision(pending)
         if (foldedResponses != null) {
-            return foldedResponses.map { response ->
-                val submit = SubmitDecision(pending.playerId, response)
-                MctsEdge(
-                    action = submit,
-                    legalAction = null,
-                    slot = actionFeaturizer.slot(submit, ctx)
+            return foldedResponses.map { response -> responseEdge(pending, response, ctx) }
+        }
+
+        return when (val expansion = structuredExpander.expand(node.state, pending)) {
+            is StructuredDecisionExpansion.Complete -> {
+                val edges = completeStructuredEdges(node.state, pending, expansion.responses, ctx)
+                check(edges.isNotEmpty()) {
+                    "Complete response expansion for ${pending::class.simpleName} was empty " +
+                        "at a non-terminal search node"
+                }
+                edges
+            }
+
+            StructuredDecisionExpansion.Unsupported -> {
+                val response = structuredResolver.resolve(node.state, pending)
+                listOf(
+                    validatedResponseEdge(
+                        state = node.state,
+                        decision = pending,
+                        response = response,
+                        ctx = ctx,
+                        source = "Structured decision resolver"
+                    )
                 )
             }
         }
+    }
 
-        // Complex decision — resolver produces a forced single edge.
-        val response = structuredResolver.resolve(node.state, pending)
-        val submit = SubmitDecision(pending.playerId, response)
-        return listOf(
-            MctsEdge(
-                action = submit,
-                legalAction = null,
-                slot = actionFeaturizer.slot(submit, ctx)
+    private fun completeStructuredEdges(
+        state: GameState,
+        decision: PendingDecision,
+        responses: Sequence<DecisionResponse>,
+        ctx: TrainerContext
+    ): List<MctsEdge> {
+        val seen = mutableSetOf<DecisionResponse>()
+        return responses.map { response ->
+            check(seen.add(response)) {
+                "Structured expander returned duplicate ${response::class.simpleName}: $response"
+            }
+            validatedResponseEdge(
+                state = state,
+                decision = decision,
+                response = response,
+                ctx = ctx,
+                source = "Structured decision expander"
             )
+        }.toList()
+    }
+
+    private fun validatedResponseEdge(
+        state: GameState,
+        decision: PendingDecision,
+        response: DecisionResponse,
+        ctx: TrainerContext,
+        source: String
+    ): MctsEdge {
+        check(response.decisionId == decision.id) {
+            "$source returned response for ${response.decisionId}, expected ${decision.id}"
+        }
+        val validationError = DecisionValidators.validate(decision, response, state)
+        check(validationError == null) {
+            "$source returned an illegal ${response::class.simpleName}: $validationError"
+        }
+        return responseEdge(decision, response, ctx)
+    }
+
+    private fun responseEdge(
+        decision: PendingDecision,
+        response: DecisionResponse,
+        ctx: TrainerContext
+    ): MctsEdge {
+        val submit = SubmitDecision(decision.playerId, response)
+        return MctsEdge(
+            action = submit,
+            legalAction = null,
+            slot = actionFeaturizer.slot(submit, ctx)
         )
     }
 
     /**
      * Returns the list of concrete [DecisionResponse]s when the pending
      * decision folds cleanly into a discrete action space; returns `null`
-     * when the decision requires a structured response (handed to the
-     * [StructuredDecisionResolver]).
+     * when the structured expander or resolver owns it.
      */
     private fun foldSimpleDecision(d: PendingDecision): List<DecisionResponse>? = when (d) {
         is YesNoDecision -> listOf(YesNoResponse(d.id, true), YesNoResponse(d.id, false))
@@ -296,6 +363,11 @@ class AlphaZeroSearch<T>(
     private fun createChild(parent: MctsNode, edge: MctsEdge, rootPlayer: EntityId): MctsNode {
         workingEnv.restore(parent.state, parent.playerIds, 0)
         workingEnv.step(edge.action)
+        if (edge.action is SubmitDecision) {
+            check(workingEnv.lastRejection == null) {
+                "Search decision edge was rejected by the engine: ${workingEnv.lastRejection}"
+            }
+        }
         return buildNode(
             workingEnv.state,
             workingEnv.playerIds,
@@ -400,10 +472,10 @@ class MctsSearchResult(
 }
 
 /**
- * Default [StructuredDecisionResolver] — picks a uniformly-random valid
- * response for any structured decision. Good enough for getting a training
- * loop to run end-to-end; replace with a heuristic or learned resolver for
- * real training runs.
+ * Default [StructuredDecisionResolver] — picks a random minimum-cardinality
+ * response for the target, card-selection, and mode families it supports.
+ * This is a fallback policy, not uniform enumeration of the legal response
+ * space. Replace it with a domain policy when unsupported decisions can occur.
  */
 class RandomStructuredResolver(private val rng: Random = Random.Default) : StructuredDecisionResolver {
     override fun resolve(state: GameState, decision: PendingDecision): DecisionResponse {

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
 import com.wingedsheep.gym.trainer.spi.Evaluator
 import com.wingedsheep.gym.trainer.spi.SelfPlaySink
 import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
 import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
 import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.sdk.model.EntityId
@@ -46,7 +47,9 @@ class SelfPlayLoop<T>(
     private val temperature: Double = 1.0,
     private val temperatureMoves: Int = 30,
     private val maxSteps: Int = 2000,
-    private val rng: Random = Random.Default
+    private val rng: Random = Random.Default,
+    private val structuredExpander: StructuredDecisionExpander =
+        com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander
 ) {
     /** Run one game. Returns the winner (null = draw / truncation). */
     fun playGame(config: GameConfig, gameId: String = UUID.randomUUID().toString()): GameOutcome {
@@ -68,7 +71,8 @@ class SelfPlayLoop<T>(
                 cPuct = cPuct,
                 dirichletAlpha = dirichletAlpha,
                 dirichletWeight = dirichletWeight,
-                rng = rng
+                rng = rng,
+                structuredExpander = structuredExpander
             )
             val result = search.run(simulationsPerMove)
 

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/ActionFeaturizer.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/ActionFeaturizer.kt
@@ -19,6 +19,14 @@ import com.wingedsheep.engine.core.GameAction
  *    [TrainerContext]s — that's how a `PassPriority` can be slot 0 in the
  *    "priority" head when it's an action and unused entirely in the
  *    "target" head when that's the active decision.
+ *
+ * A policy slot is not MCTS edge identity. Search keeps concrete actions as
+ * independent edges even when their slots collide, but colliding responses
+ * receive the same learned prior and cannot produce distinct categorical
+ * training targets. A production featurizer that learns structured choices
+ * should therefore be injective across the responses legal in one state.
+ * The current self-play row has one `headUsed`, so concurrent alternatives
+ * for a decision should also use one policy head.
  */
 interface ActionFeaturizer {
 

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/SelfPlaySink.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/SelfPlaySink.kt
@@ -26,7 +26,7 @@ interface SelfPlaySink<T> : AutoCloseable {
      * @param ctx           the decision context at which this step was made
      * @param actingPlayer  the player who made the move (== `ctx.playerId`)
      * @param headUsed      the policy head active for this decision
-     * @param legalSlots    slot encodings of every legal action at this state
+     * @param legalSlots    slot encodings of the search edges exposed at this state
      * @param visits        MCTS visit counts, parallel to `legalSlots`
      * @param mctsValue     MCTS-estimated value in `[-1, +1]` from
      *                      `actingPlayer`'s perspective; the terminal outcome

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.gym.trainer.spi
+
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.state.GameState
+
+/**
+ * Generates the legal response alternatives that a search may branch over for a structured
+ * [PendingDecision]. This is a legality/enumeration seam, not a policy: implementations must not
+ * select, sample, truncate, or rank responses on behalf of a search algorithm.
+ *
+ * Every response in a [StructuredDecisionExpansion.Complete] result must be accepted by the
+ * engine's authoritative decision validator in [state]. The sequence may be lazy so an expander
+ * does not have to materialize a combinatorial response space merely to describe it.
+ */
+fun interface StructuredDecisionExpander {
+    fun expand(state: GameState, decision: PendingDecision): StructuredDecisionExpansion
+}
+
+/**
+ * What an expander knows about a structured decision's response space.
+ *
+ * [Complete] contains a finite, possibly lazy sequence with one canonical response per legal
+ * semantic alternative. It may contain zero, one, or many responses. [Unsupported] means the
+ * expander makes no completeness claim; callers may fall back to a strategic
+ * [StructuredDecisionResolver], but must not describe that selected response as the complete legal
+ * response set.
+ *
+ * There is deliberately no partial result yet. A bounded or sampled source needs an explicit
+ * caller-owned policy for how non-exhaustive branches affect search and training.
+ * [com.wingedsheep.gym.trainer.search.AlphaZeroSearch] treats a complete empty result at a live,
+ * non-terminal node as an engine-state invariant failure: it does not substitute a resolver choice
+ * for a response set known to be empty.
+ */
+sealed interface StructuredDecisionExpansion {
+    class Complete(val responses: Sequence<DecisionResponse>) : StructuredDecisionExpansion
+
+    data object Unsupported : StructuredDecisionExpansion
+}

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
@@ -12,14 +12,11 @@ import com.wingedsheep.engine.state.GameState
  * multi-mode `ChooseModeDecision` — that the gym can't fold into a single
  * numeric action space.
  *
- * MCTS treats the result as a *forced* single edge (no exploration), which
- * keeps the self-play loop running but does not train the network on
- * structured decisions. A production project can either:
- *
- *  - supply a smarter resolver that samples from a heuristic distribution, or
- *  - pre-flatten structured decisions into the action space via a custom
- *    [ActionFeaturizer] and an `Evaluator` that knows how to emit priors for
- *    them.
+ * This is a strategic policy seam: it chooses one response. It remains the
+ * fallback when [StructuredDecisionExpander] reports a decision family as unsupported; that
+ * resolver-selected edge is not claimed to be the complete legal response set.
+ * Supplying a custom [ActionFeaturizer] cannot expose responses that were
+ * already collapsed here; enumeration belongs in [StructuredDecisionExpander].
  */
 fun interface StructuredDecisionResolver {
     fun resolve(state: GameState, decision: PendingDecision): DecisionResponse

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gym.trainer.defaults
+
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.asClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ExactStructuredDecisionExpanderTest : FunSpec({
+
+    val playerId = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val third = EntityId.of("third")
+    val state = GameState(turnOrder = listOf(playerId))
+
+    test("single-target expansion is complete") {
+        val decision = ChooseTargetsDecision(
+            id = "targets",
+            playerId = playerId,
+            prompt = "Choose targets",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
+            ),
+            legalTargets = mapOf(0 to listOf(first, second)),
+            canCancel = true
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        val responses = expansion.responses.toList()
+
+        responses.shouldContainExactly(
+            CancelDecisionResponse("targets"),
+            TargetsResponse("targets", mapOf(0 to listOf(first))),
+            TargetsResponse("targets", mapOf(0 to listOf(second)))
+        )
+        responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("variable-cardinality target expansion is explicitly unsupported") {
+        val decision = ChooseTargetsDecision(
+            id = "many-targets",
+            playerId = playerId,
+            prompt = "Choose targets",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "up to two", minTargets = 0, maxTargets = 2)
+            ),
+            legalTargets = mapOf(0 to listOf(first, second, third))
+        )
+
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("supported family with no legal response is a complete empty expansion") {
+        val decision = ChooseTargetsDecision(
+            id = "no-targets",
+            playerId = playerId,
+            prompt = "Choose a target",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
+            ),
+            legalTargets = mapOf(0 to emptyList())
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        expansion.responses.toList() shouldBe emptyList()
+    }
+
+    test("unsupported family returns unsupported") {
+        val decision = OrderObjectsDecision(
+            id = "order",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second)
+        )
+
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+})

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -1,0 +1,272 @@
+package com.wingedsheep.gym.trainer.search
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.gym.GameEnvironment
+import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
+import com.wingedsheep.gym.trainer.spi.EvaluationResult
+import com.wingedsheep.gym.trainer.spi.Evaluator
+import com.wingedsheep.gym.trainer.spi.PolicyHead
+import com.wingedsheep.gym.trainer.spi.SlotEncoding
+import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
+import com.wingedsheep.gym.trainer.spi.TrainerContext
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.floats.shouldBeExactly
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class StructuredDecisionSearchTest : FunSpec({
+
+    val stateFeaturizer = object : StateFeaturizer<Unit> {
+        override fun featurize(ctx: TrainerContext) = Unit
+    }
+    val sharedSlotFeaturizer = object : ActionFeaturizer {
+        override val heads: List<PolicyHead> = listOf(PolicyHead("shared", 1))
+
+        override fun slot(action: GameAction, ctx: TrainerContext): SlotEncoding =
+            SlotEncoding("shared", 0)
+    }
+    val uniformEvaluator = Evaluator<Unit> { _, _, _ ->
+        EvaluationResult(priors = mapOf("shared" to floatArrayOf(1f)), value = 0f)
+    }
+
+    fun newDriver(deckCard: String): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + PredefinedTokens.allTokens)
+        initMirrorMatch(
+            deck = Deck.of(deckCard to 40),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun environment(driver: GameTestDriver): GameEnvironment =
+        GameEnvironment.create(driver.cardRegistry).also {
+            it.restore(driver.state, listOf(driver.player1, driver.player2))
+        }
+
+    test("MCTS exposes exact target responses as independent edges and executes each branch") {
+        val driver = newDriver("Mountain")
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val ownCreature = driver.putCreatureOnBattlefield(caster, "Raging Goblin")
+        val opposingCreature = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        repeat(5) { driver.putLandOnBattlefield(caster, "Mountain") }
+        val spell = driver.putCardInHand(caster, "Zuko's Exile")
+
+        driver.castSpell(caster, spell).error shouldBe null
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        val pending = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        pending.legalTargets.values.flatten().toSet() shouldBe setOf(ownCreature, opposingCreature)
+        val rootState = driver.state
+        val env = environment(driver)
+
+        val fallback = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                TargetsResponse(decision.id, mapOf(0 to listOf(ownCreature)))
+            },
+            structuredExpander = StructuredDecisionExpander { _, _ ->
+                StructuredDecisionExpansion.Unsupported
+            },
+            dirichletAlpha = null
+        ).run(simulations = 1)
+        fallback.root.edges.size shouldBe 1
+        (fallback.root.edges.single().action as SubmitDecision).response shouldBe
+            TargetsResponse(pending.id, mapOf(0 to listOf(ownCreature)))
+
+        val result = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                error("exact expansion unexpectedly fell back for ${decision::class.simpleName}")
+            },
+            dirichletAlpha = null
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.visits.toList().shouldContainExactly(1, 1)
+        result.root.edges.forEach { edge ->
+            edge.slot shouldBe SlotEncoding("shared", 0)
+            edge.prior.shouldBeExactly(0.5f)
+            edge.child shouldNotBe null
+        }
+
+        val responsesByTarget = result.root.edges.associate { edge ->
+            val response = (edge.action as SubmitDecision).response
+                .shouldBeInstanceOf<TargetsResponse>()
+            DecisionValidators.validate(pending, response, rootState) shouldBe null
+            response.selectedTargets.getValue(0).single() to edge
+        }
+        responsesByTarget.keys shouldBe setOf(ownCreature, opposingCreature)
+
+        for ((chosenTarget, edge) in responsesByTarget) {
+            val branch = GameEnvironment.create(driver.cardRegistry).also {
+                it.restore(rootState, listOf(driver.player1, driver.player2))
+            }
+            branch.step(edge.action)
+
+            branch.lastRejection shouldBe null
+            branch.lastStepEvents.filterIsInstance<ZoneChangeEvent>()
+                .any { it.entityId == chosenTarget } shouldBe true
+            branch.state.getBattlefield().contains(chosenTarget) shouldBe false
+            branch.state.getBattlefield().contains(
+                if (chosenTarget == ownCreature) opposingCreature else ownCreature
+            ) shouldBe true
+        }
+        responsesByTarget.getValue(ownCreature).child!!.state shouldNotBe
+            responsesByTarget.getValue(opposingCreature).child!!.state
+    }
+
+    test("existing yes-no folding remains a complete two-edge decision") {
+        val driver = newDriver("Grizzly Bears")
+        val player = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(player, "Forest")
+        val train = driver.putCardInHand(player, "Subway Train")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.GREEN, 1)
+
+        driver.castSpell(player, train).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+
+        val result = AlphaZeroSearch(
+            env = environment(driver),
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                when (decision) {
+                    is SelectManaSourcesDecision ->
+                        ManaSourcesSelectedResponse(decision.id, autoPay = true)
+                    is SelectCardsDecision ->
+                        CardsSelectedResponse(decision.id, decision.options.take(decision.minSelections))
+                    else -> error("unexpected fallback for ${decision::class.simpleName}")
+                }
+            },
+            dirichletAlpha = null
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.root.edges.map { (it.action as SubmitDecision).response::class }
+            .all { it == com.wingedsheep.engine.core.YesNoResponse::class } shouldBe true
+    }
+
+    test("unsupported multi-card decision keeps one resolver-selected edge") {
+        val driver = newDriver("Island")
+        val player = driver.activePlayer!!
+        val spell = driver.putCardInHand(player, "Thirst for Identity")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.castSpell(player, spell).error shouldBe null
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        val pending = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pending.maxSelections shouldBe 2
+        val selected = pending.options.take(2)
+
+        val wrongIdError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(
+                        sequenceOf(CardsSelectedResponse("wrong-decision", selected))
+                    )
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        wrongIdError.message.orEmpty() shouldContain
+            "Structured decision expander returned response for wrong-decision"
+
+        val invalidError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(
+                        sequenceOf(CardsSelectedResponse(pending.id, emptyList()))
+                    )
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        invalidError.message.orEmpty() shouldContain "Structured decision expander returned an illegal"
+
+        var emptyResolverCalls = 0
+        val emptyError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredResolver = StructuredDecisionResolver { _, _ ->
+                    emptyResolverCalls += 1
+                    CardsSelectedResponse(pending.id, selected)
+                },
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(emptySequence())
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        emptyError.message.orEmpty() shouldContain "Complete response expansion"
+        emptyResolverCalls shouldBe 0
+
+        var resolverCalls = 0
+        val result = AlphaZeroSearch(
+            env = environment(driver),
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                resolverCalls += 1
+                CardsSelectedResponse(decision.id, selected)
+            },
+            dirichletAlpha = null
+        ).run(simulations = 1)
+
+        resolverCalls shouldBeGreaterThan 0
+        result.root.edges.size shouldBe 1
+        val response: DecisionResponse = (result.root.edges.single().action as SubmitDecision).response
+        response shouldBe CardsSelectedResponse(pending.id, selected)
+        result.root.edges.single().child shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Summary

Tree search already represents simple pending decisions as alternatives, but structured pending decisions are reduced to one resolver-selected edge before MCTS can compare them.

This adds a narrow exact-expansion seam for structured decisions:

- supported single-target decisions become independent MCTS branches;
- expanded responses are checked by the engine's authoritative validator;
- unsupported structured decisions retain the configured resolver fallback;
- expansion is considered exhaustive only when the expander explicitly returns `Complete`.

## Why this matters

Target selection can itself be the strategic decision.

For example, if a spell may legally target either creature A or creature B, the current structured resolver chooses one target before MCTS sees the position. Search can evaluate the continuation after A **or** the continuation after B, but not compare them—the unchosen target never becomes a tree edge.

The integration test exercises this with **Zuko's Exile** and two legal creature targets. With expansion disabled, the resolver produces one target edge. With exact expansion enabled, both legal target responses become independent MCTS branches, execute through the normal Gym/rules path, produce different resulting states, and receive separate visits.

This separation also matters independently of neural action encoding: the test deliberately maps both target responses to the same policy slot, and MCTS still keeps them as distinct edges with independent visit/Q/child state.

## Scope

The built-in expander deliberately supports only a `ChooseTargetsDecision` with:

- exactly one target requirement;
- exactly one required target;
- an explicit finite legal-target list.

If the decision can be cancelled, cancellation is included as another legal response. A simple case with two legal targets and cancellation therefore expands to three responses: cancel, target A, and target B.

More complicated structured decisions—multi-target combinations, distributions, ordering, card selections, mana-source choices, and similar combinatorial spaces—remain unsupported and continue through the existing resolver fallback.

No partial expansion, search cap, policy heuristic, widening strategy, or neural action-space redesign is introduced.

Concrete responses remain distinct tree edges even if an `ActionFeaturizer` maps them to the same policy slot. Callers that need response-specific learned priors or training targets must provide sufficiently discriminating slots.

## Tests

- `just test-class ExactStructuredDecisionExpanderTest`
- `just test-class StructuredDecisionSearchTest`
- `just test-class AlphaZeroSearchTest`
- `just test-gym-trainer`

Coverage includes:

- exact single-target expansion;
- validator-approved and executable alternatives;
- distinct target-specific child states and independent MCTS visits;
- same-slot responses remaining separate tree edges;
- unsupported structured decisions retaining resolver fallback;
- `Complete(empty)` remaining distinct from `Unsupported`;
- existing simple decision folding remaining unchanged.
