### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -9798,6 +9798,15 @@ answer it and would silently return `false`.
   covers the whole oracle clause; compose `All(WasCast, NoManaSpentToCast)` for the narrower
   "cast, but for free" sense that excludes uncast permanents. Pairs naturally with the conditional
   `EntersWithCounters(..., condition = Conditions.NoManaSpentToCast)`. Resolution-only.
+- `ManaSpentToCastIncludes(requiredWhite, requiredBlue, requiredBlack, requiredRed, requiredGreen)` —
+  "if {U} was spent to cast this spell" / "if {R}{R} was spent to cast it": each pip named must have
+  been among the mana actually paid. A *payment* question, not a colour requirement — casting a
+  mono-black **Ribbons of Night** off a Dimir land turns its blue rider on. Reads through
+  `ManaSpentReader`, so it answers for a **spell still on the stack** (the Ravnica "if {X} was spent"
+  riders, where the spell's own resolution asks the question) as well as for a permanent that has
+  already resolved (the Lorwyn Incarnation cycle's ETB `interveningIf`). A copy of a spell was never
+  cast and so had no mana spent for it — it always reads false, which is the printed ruling.
+  Resolution-only.
 - `NoManaSpentToCastEntered` — the batch-enters variant of `NoManaSpentToCast`: "if none of them were
   cast or no mana was spent to cast them." Evaluated at resolution over the permanents a batch-enters
   trigger captured (the `Triggers.OneOrMorePermanentsEnter` batch, exposed as the `trigger.captured`

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DryadsCaress.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DryadsCaress.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dryad's Caress — Ravnica: City of Guilds #160
+ * {4}{G}{G} · Instant
+ *
+ * You gain 1 life for each creature on the battlefield. If {W} was spent to cast this spell, untap
+ * all creatures you control.
+ *
+ * "Each creature on the battlefield" is every creature, whoever controls it —
+ * `AggregateBattlefield(Player.Each, Creature)`, the same amount Blunt the Assault counts — read on
+ * resolution (CR 608.2).
+ *
+ * The white rider asks what was *paid*, not what colour the spell is: per the Ravnica rulings it
+ * checks only that at least one {W} went into the cost, so one Plains or a Temple Garden is enough
+ * and the amount doesn't matter. A copy of the spell had no mana spent for it and so never untaps.
+ */
+val DryadsCaress = card("Dryad's Caress") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "You gain 1 life for each creature on the battlefield. " +
+        "If {W} was spent to cast this spell, untap all creatures you control."
+
+    spell {
+        effect = Effects.GainLife(
+            DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature)
+        ).then(
+            ConditionalEffect(
+                condition = Conditions.ManaSpentToCastIncludes(requiredWhite = 1),
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    Effects.Untap(EffectTarget.Self),
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Randy Gallegos"
+        flavorText = "\"I awoke to the face of beauty, my body fully healed. In that moment I knew my " +
+            "destiny was the Conclave's to shape.\"\n—Rogad, Selesnya initiate"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg?1783943640"
+        ruling(
+            "2005-10-01",
+            "The spell checks on resolution to see if any mana of the stated color was spent to pay " +
+                "its cost. It doesn't matter how much mana of that color was spent."
+        )
+        ruling(
+            "2005-10-01",
+            "If the spell is copied (such as with Twincast), the copy will never have had mana of the " +
+                "stated color paid for it, no matter what colors were spent on the original spell."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RibbonsOfNight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RibbonsOfNight.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Ribbons of Night — Ravnica: City of Guilds #101
+ * {4}{B} · Sorcery
+ *
+ * Ribbons of Night deals 4 damage to target creature and you gain 4 life. If {U} was spent to cast
+ * this spell, draw a card.
+ *
+ * One of Ravnica's hybrid-flavoured "if {X} was spent" riders: the spell is mono-black and always
+ * does the damage and the lifegain, and the blue clause is a *payment* question, not a colour
+ * requirement — casting it with a Dimir land or an any-colour source turns the extra card on.
+ * `Conditions.ManaSpentToCastIncludes` reads the payment recorded on the spell itself, so the rider
+ * is checked on resolution (CR 608.2) against what was actually paid, and a copy of the spell —
+ * which was never cast and so had no mana spent for it — correctly misses the rider.
+ */
+val RibbonsOfNight = card("Ribbons of Night") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Ribbons of Night deals 4 damage to target creature and you gain 4 life. " +
+        "If {U} was spent to cast this spell, draw a card."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.DealDamage(4, creature)
+            .then(Effects.GainLife(4))
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredBlue = 1),
+                    effect = Effects.DrawCards(1),
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "101"
+        artist = "Ron Spears"
+        flavorText = "\"My favorite meal is angel's flesh, slain in agony and iced with black vinegar.\"\n" +
+            "—Aszala of House Dimir"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg?1783943663"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RollingSpoil.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RollingSpoil.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rolling Spoil — Ravnica: City of Guilds #179
+ * {2}{G}{G} · Sorcery
+ *
+ * Destroy target land. If {B} was spent to cast this spell, all creatures get -1/-1 until end of turn.
+ *
+ * The Golgari entry in Ravnica's "if {X} was spent" rider cycle. "All creatures" is every creature on
+ * the battlefield, yours included, so it is an unfiltered `GroupFilter(Creature)` sweep and not a
+ * `youControl()` one — the group is snapshotted on resolution, which is also why a creature that
+ * enters afterwards is unaffected.
+ *
+ * The rider follows the destruction rather than branching around it: the -1/-1 happens whether or not
+ * the land actually died (a regenerated or indestructible land still leaves the sweep intact), and
+ * both halves are lost together only if the single target is illegal on resolution (CR 608.2b).
+ */
+val RollingSpoil = card("Rolling Spoil") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target land. " +
+        "If {B} was spent to cast this spell, all creatures get -1/-1 until end of turn."
+
+    spell {
+        val land = target("land", Targets.Land)
+        effect = Effects.Move(land, Zone.GRAVEYARD, byDestruction = true)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredBlack = 1),
+                    effect = Effects.ForEachInGroup(
+                        GroupFilter(GameObjectFilter.Creature),
+                        Effects.ModifyStats(-1, -1, EffectTarget.Self),
+                    ),
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Ron Spencer"
+        flavorText = "The shadow that fell over the grove was silent yet horribly alive, roiling with " +
+            "millions of tiny minions dedicated to the process of rot."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg?1783943633"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SeedSpark.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SeedSpark.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Seed Spark — Ravnica: City of Guilds #30
+ * {3}{W} · Instant
+ *
+ * Destroy target artifact or enchantment. If {G} was spent to cast this spell, create two 1/1 green
+ * Saproling creature tokens.
+ *
+ * The Selesnya half of Ravnica's "if {X} was spent" rider cycle. The green clause asks only what was
+ * *paid*, so any source of {G} — a Forest, a Temple Garden, Birds of Paradise — turns the Saprolings
+ * on; it is not a second colour requirement on the spell, which stays mono-white.
+ *
+ * The rider is a plain `ConditionalEffect` **after** the destruction rather than a branch around it,
+ * because the two halves are independent: the tokens arrive even when the destroy half does nothing
+ * (a target that regenerated or is indestructible), and the spell fizzles entirely — tokens included
+ * — only when its single target is illegal on resolution (CR 608.2b).
+ *
+ * Note the earliest printing: Scryfall lists a `psal` (Salvat 2005) box printing three weeks before
+ * Ravnica, but that is not a real expansion, so the canonical definition belongs here.
+ */
+val SeedSpark = card("Seed Spark") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact or enchantment. " +
+        "If {G} was spent to cast this spell, create two 1/1 green Saproling creature tokens."
+
+    spell {
+        val permanent = target("artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Move(permanent, Zone.GRAVEYARD, byDestruction = true)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredGreen = 1),
+                    effect = Effects.CreateToken(
+                        power = 1,
+                        toughness = 1,
+                        colors = setOf(Color.GREEN),
+                        creatureTypes = setOf("Saproling"),
+                        count = 2,
+                    ),
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Jeff Miracola"
+        flavorText = "\"If you ask me, those root-lovers value mindless dogma over progress.\"\n" +
+            "—Trivaz, Izzet mage"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg?1783943695"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VigorMortis.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VigorMortis.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Vigor Mortis — Ravnica: City of Guilds #111
+ * {2}{B}{B} · Sorcery
+ *
+ * Return target creature card from your graveyard to the battlefield. If {G} was spent to cast this
+ * spell, that creature enters with an additional +1/+1 counter on it.
+ *
+ * The rider is spelled "enters **with**", not "then put a counter on it", so the counter has to ride
+ * along with the move rather than follow it — that is `Effects.Move`'s `addCounterType`, the same
+ * spelling Thunderbolts Conspiracy uses for "return it to the battlefield with a finality counter on
+ * it". The counter lands inside the move executor, before the enters-the-battlefield triggers it
+ * caused are put on the stack, so a trigger that reads the creature's counters or its power sees the
+ * counter — the distinction Miraculous Recovery's rulings draw for the *other* wording.
+ *
+ * The gate therefore has to sit around the whole move (two branches of the same reanimation), not
+ * after it: there is no point in the resolution at which the creature is on the battlefield and the
+ * counter is still pending.
+ */
+val VigorMortis = card("Vigor Mortis") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield. " +
+        "If {G} was spent to cast this spell, that creature enters with an additional +1/+1 counter on it."
+
+    spell {
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.ManaSpentToCastIncludes(requiredGreen = 1),
+            effect = Effects.Move(
+                creatureCard,
+                Zone.BATTLEFIELD,
+                fromZone = Zone.GRAVEYARD,
+                addCounterType = CounterType.PLUS_ONE_PLUS_ONE,
+            ),
+            elseEffect = Effects.Move(creatureCard, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "Dan Murayama Scott"
+        flavorText = "After fear and weakness rot away, that which remains is stronger than its living form."
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg?1783943660"
+        ruling(
+            "2005-10-01",
+            "The +1/+1 counter from this ability is in addition to any other counters the creature enters with."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DryadsCaressScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DryadsCaressScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dryad's Caress — life for every creature on the battlefield (not just yours), and an untap of your
+ * own creatures if {W} was among the mana paid.
+ */
+class DryadsCaressScenarioTest : FunSpec({
+
+    test("gains life for every creature on the battlefield and untaps yours when white mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val caress = driver.putCardInHand(caster, "Dryad's Caress")
+
+        val mine = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        val alsoMine = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.tapPermanent(mine)
+        driver.tapPermanent(alsoMine)
+        driver.tapPermanent(theirs)
+
+        // {4}{G}{G} paid as two green plus four white: white covers the generic.
+        driver.giveMana(caster, Color.GREEN, 2)
+        driver.giveMana(caster, Color.WHITE, 4)
+
+        driver.castSpell(caster, caress).error shouldBe null
+        driver.bothPass()
+
+        // Three creatures on the battlefield, whoever controls them.
+        driver.assertLifeTotal(caster, 23)
+        driver.isTapped(mine) shouldBe false
+        driver.isTapped(alsoMine) shouldBe false
+        // "Creatures you control" — the opponent's stays tapped.
+        driver.isTapped(theirs) shouldBe true
+    }
+
+    test("gains the life but untaps nothing when no white mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val caress = driver.putCardInHand(caster, "Dryad's Caress")
+        val mine = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        driver.tapPermanent(mine)
+
+        driver.giveMana(caster, Color.GREEN, 6)
+
+        driver.castSpell(caster, caress).error shouldBe null
+        driver.bothPass()
+
+        driver.assertLifeTotal(caster, 21)
+        driver.isTapped(mine) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RibbonsOfNightScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RibbonsOfNightScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ribbons of Night — 4 damage to a creature plus 4 life, and a card if {U} was among the mana paid.
+ *
+ * The two tests differ only in which mana is in the pool when the spell is cast, so they pin the
+ * rider to the *payment* rather than to the spell's colour.
+ */
+class RibbonsOfNightScenarioTest : FunSpec({
+
+    test("draws a card when blue mana was spent to cast it") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val ribbons = driver.putCardInHand(caster, "Ribbons of Night")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // {4}{B} paid as one black plus four blue: blue covers the generic, so blue was spent.
+        driver.giveMana(caster, Color.BLACK, 1)
+        driver.giveMana(caster, Color.BLUE, 4)
+
+        val handBefore = driver.getHandSize(caster)
+        driver.castSpellWithTargets(caster, ribbons, listOf(ChosenTarget.Permanent(victim)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertLifeTotal(caster, 24)
+        driver.assertInGraveyard(opponent, "Grizzly Bears")
+        // One card leaves the hand (the spell itself) and one is drawn by the rider.
+        driver.getHandSize(caster) shouldBe handBefore
+    }
+
+    test("draws no card when no blue mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val ribbons = driver.putCardInHand(caster, "Ribbons of Night")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.giveMana(caster, Color.BLACK, 5)
+
+        val handBefore = driver.getHandSize(caster)
+        driver.castSpellWithTargets(caster, ribbons, listOf(ChosenTarget.Permanent(victim)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertLifeTotal(caster, 24)
+        driver.assertInGraveyard(opponent, "Grizzly Bears")
+        driver.getHandSize(caster) shouldBe handBefore - 1
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RollingSpoilScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RollingSpoilScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rolling Spoil — land destruction, plus a symmetric -1/-1 sweep if {B} was among the mana paid.
+ */
+class RollingSpoilScenarioTest : FunSpec({
+
+    test("shrinks every creature, both players', when black mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val spoil = driver.putCardInHand(caster, "Rolling Spoil")
+        val theirLand = driver.putLandOnBattlefield(opponent, "Forest")
+        val mine = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // {2}{G}{G} paid as two green plus two black: black covers the generic.
+        driver.giveMana(caster, Color.GREEN, 2)
+        driver.giveMana(caster, Color.BLACK, 2)
+
+        driver.castSpellWithTargets(caster, spoil, listOf(ChosenTarget.Permanent(theirLand)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertInGraveyard(opponent, "Forest")
+        driver.state.projectedState.getPower(mine) shouldBe 1
+        driver.state.projectedState.getToughness(mine) shouldBe 1
+        driver.state.projectedState.getPower(theirs) shouldBe 1
+        driver.state.projectedState.getToughness(theirs) shouldBe 1
+    }
+
+    test("destroys the land but leaves creatures alone when no black mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val spoil = driver.putCardInHand(caster, "Rolling Spoil")
+        val theirLand = driver.putLandOnBattlefield(opponent, "Forest")
+        val mine = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+
+        driver.giveMana(caster, Color.GREEN, 4)
+
+        driver.castSpellWithTargets(caster, spoil, listOf(ChosenTarget.Permanent(theirLand)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertInGraveyard(opponent, "Forest")
+        driver.state.projectedState.getPower(mine) shouldBe 2
+        driver.state.projectedState.getToughness(mine) shouldBe 2
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SeedSparkScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SeedSparkScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Seed Spark — destroys an artifact or enchantment, and adds two Saprolings if {G} was among the
+ * mana paid.
+ */
+class SeedSparkScenarioTest : FunSpec({
+
+    test("creates two Saprolings when green mana was spent to cast it") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val spark = driver.putCardInHand(caster, "Seed Spark")
+        val artifact = driver.putPermanentOnBattlefield(opponent, "Icy Manipulator")
+
+        // {3}{W} paid as one white plus three green: green covers the generic.
+        driver.giveMana(caster, Color.WHITE, 1)
+        driver.giveMana(caster, Color.GREEN, 3)
+
+        driver.castSpellWithTargets(caster, spark, listOf(ChosenTarget.Permanent(artifact)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertInGraveyard(opponent, "Icy Manipulator")
+        // The engine names an unnamed token "<types> Token", so a Saproling is "Saproling Token".
+        withClue("tokens arrived: " + driver.getCreatures(caster).map { driver.getCardName(it) }) {
+            driver.getCreatures(caster).count { driver.getCardName(it) == "Saproling Token" } shouldBe 2
+        }
+    }
+
+    test("creates no Saprolings when no green mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val spark = driver.putCardInHand(caster, "Seed Spark")
+        val artifact = driver.putPermanentOnBattlefield(opponent, "Icy Manipulator")
+
+        driver.giveMana(caster, Color.WHITE, 4)
+
+        driver.castSpellWithTargets(caster, spark, listOf(ChosenTarget.Permanent(artifact)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.assertInGraveyard(opponent, "Icy Manipulator")
+        driver.getCreatures(caster).shouldBe(emptyList())
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VigorMortisScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VigorMortisScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vigor Mortis — reanimation from your own graveyard, with an extra +1/+1 counter if {G} was among
+ * the mana paid.
+ */
+class VigorMortisScenarioTest : FunSpec({
+
+    test("returns the creature with a +1/+1 counter when green mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val mortis = driver.putCardInHand(caster, "Vigor Mortis")
+        val bears = driver.putCardInGraveyard(caster, "Grizzly Bears")
+
+        // {2}{B}{B} paid as two black plus two green: green covers the generic.
+        driver.giveMana(caster, Color.BLACK, 2)
+        driver.giveMana(caster, Color.GREEN, 2)
+
+        driver.castSpellWithTargets(
+            caster,
+            mortis,
+            listOf(ChosenTarget.Card(cardId = bears, ownerId = caster, zone = Zone.GRAVEYARD)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.assertPermanentExists(caster, "Grizzly Bears")
+        val returned = driver.findPermanent(caster, "Grizzly Bears")!!
+        driver.state.getEntity(returned)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        driver.state.projectedState.getPower(returned) shouldBe 3
+        driver.state.projectedState.getToughness(returned) shouldBe 3
+    }
+
+    test("returns the creature with no counter when no green mana was spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val mortis = driver.putCardInHand(caster, "Vigor Mortis")
+        val bears = driver.putCardInGraveyard(caster, "Grizzly Bears")
+
+        driver.giveMana(caster, Color.BLACK, 4)
+
+        driver.castSpellWithTargets(
+            caster,
+            mortis,
+            listOf(ChosenTarget.Card(cardId = bears, ownerId = caster, zone = Zone.GRAVEYARD)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.assertPermanentExists(caster, "Grizzly Bears")
+        val returned = driver.findPermanent(caster, "Grizzly Bears")!!
+        driver.state.getEntity(returned)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0 shouldBe 0
+        driver.state.projectedState.getPower(returned) shouldBe 2
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2396,6 +2396,72 @@
     ]
 }
 
+// Dryad's Caress
+{
+    "name": "Dryad's Caress",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "You gain 1 life for each creature on the battlefield. If {W} was spent to cast this spell, untap all creatures you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "Each",
+                        "filter": "creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredWhite": 1
+                        }
+                    },
+                    "then": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"I awoke to the face of beauty, my body fully healed. In that moment I knew my destiny was the Conclave's to shape.\"\n—Rogad, Selesnya initiate",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cf707f2-1a62-458e-bcc8-8b1cd081f225.jpg?1783943640",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The spell checks on resolution to see if any mana of the stated color was spent to pay its cost. It doesn't matter how much mana of that color was spent."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If the spell is copied (such as with Twincast), the copy will never have had mana of the stated color paid for it, no matter what colors were spent on the original spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Duskmantle, House of Shadow
 {
     "name": "Duskmantle, House of Shadow",
@@ -5854,6 +5920,149 @@
     ]
 }
 
+// Ribbons of Night
+{
+    "name": "Ribbons of Night",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Ribbons of Night deals 4 damage to target creature and you gain 4 life. If {U} was spent to cast this spell, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredBlue": 1
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spears",
+        "flavorText": "\"My favorite meal is angel's flesh, slain in agony and iced with black vinegar.\"\n—Aszala of House Dimir",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7a2e910-5a61-4ca0-8d69-0a6d4ea12ed7.jpg?1783943663"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Rolling Spoil
+{
+    "name": "Rolling Spoil",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target land. If {B} was spent to cast this spell, all creatures get -1/-1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "land"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredBlack": 1
+                        }
+                    },
+                    "then": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "target": "Self"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spencer",
+        "flavorText": "The shadow that fell over the grove was silent yet horribly alive, roiling with millions of tiny minions dedicated to the process of rot.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6c5546f-2429-4099-a9bd-eda3f52779b7.jpg?1783943633"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Roofstalker Wight
 {
     "name": "Roofstalker Wight",
@@ -6286,6 +6495,74 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Seed Spark
+{
+    "name": "Seed Spark",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact or enchantment. If {G} was spent to cast this spell, create two 1/1 green Saproling creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "artifact or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredGreen": 1
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Saproling"
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "artifact or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "\"If you ask me, those root-lovers value mindless dogma over progress.\"\n—Trivaz, Izzet mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33af31cf-d730-4f54-a0be-3229cdccf60c.jpg?1783943695"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -8163,6 +8440,71 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Vigor Mortis
+{
+    "name": "Vigor Mortis",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield. If {G} was spent to cast this spell, that creature enters with an additional +1/+1 counter on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "ManaSpentToCastIncludes",
+                    "requiredGreen": 1
+                }
+            },
+            "then": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target creature card from your graveyard"
+                },
+                "destination": "Battlefield",
+                "fromZone": "Graveyard",
+                "addCounterType": "PLUS_ONE_PLUS_ONE"
+            },
+            "otherwise": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target creature card from your graveyard"
+                },
+                "destination": "Battlefield",
+                "fromZone": "Graveyard"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "After fear and weakness rot away, that which remains is stronger than its living form.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fe06560-bb3f-4f0b-ad3c-7257419eb8ef.jpg?1783943660",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The +1/+1 counter from this ability is in addition to any other counters the creature enters with."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1582,12 +1582,18 @@ class ConditionEvaluator(
         context: EffectContext
     ): Boolean {
         val sourceId = context.sourceId ?: return false
-        val record = state.getEntity(sourceId)?.get<CastRecordComponent>() ?: return false
-        return record.whiteSpent >= condition.requiredWhite &&
-            record.blueSpent >= condition.requiredBlue &&
-            record.blackSpent >= condition.requiredBlack &&
-            record.redSpent >= condition.requiredRed &&
-            record.greenSpent >= condition.requiredGreen
+        // Read through ManaSpentReader rather than CastRecordComponent directly: that snapshot is
+        // only stamped when a *permanent* spell resolves onto the battlefield, so reading it alone
+        // made the condition permanently false for an instant or sorcery whose own resolution asks
+        // the question ("If {U} was spent to cast this spell", the Ravnica hybrid-rider cycle) —
+        // there the source is still a spell on the stack and its payment lives in
+        // SpellOnStackComponent. The reader covers both zones.
+        val spent = ManaSpentReader.coloredBuckets(state, sourceId)
+        return spent[0] >= condition.requiredWhite &&
+            spent[1] >= condition.requiredBlue &&
+            spent[2] >= condition.requiredBlack &&
+            spent[3] >= condition.requiredRed &&
+            spent[4] >= condition.requiredGreen
     }
 
     private fun evaluateIsInPhase(state: GameState, condition: IsInPhase, context: EffectContext): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ManaSpentReader.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ManaSpentReader.kt
@@ -16,14 +16,14 @@ import com.wingedsheep.sdk.model.EntityId
  * onto the battlefield without being cast, or is a copy created on the stack — no mana was
  * spent in either case), which is CR-faithful for "the mana spent to cast it" payoffs.
  *
- * Shared by [PredicateEvaluator] (mana-value-vs-mana-spent predicates) and
- * [DynamicAmountEvaluator] (Converge / total-mana-spent amounts) so the read path can never
- * drift between the two.
+ * Shared by [PredicateEvaluator] (mana-value-vs-mana-spent predicates),
+ * [DynamicAmountEvaluator] (Converge / total-mana-spent amounts) and [ConditionEvaluator]
+ * (`ManaSpentToCastIncludes`) so the read path can never drift between them.
  */
 object ManaSpentReader {
 
     /** The five colored buckets (W, U, B, R, G) spent to cast [entityId]; colorless excluded. */
-    private fun coloredBuckets(state: GameState, entityId: EntityId): IntArray {
+    fun coloredBuckets(state: GameState, entityId: EntityId): IntArray {
         val container = state.getEntity(entityId) ?: return IntArray(5)
         container.get<SpellOnStackComponent>()?.let {
             return intArrayOf(it.manaSpentWhite, it.manaSpentBlue, it.manaSpentBlack, it.manaSpentRed, it.manaSpentGreen)


### PR DESCRIPTION
Five Ravnica: City of Guilds cards, deliberately picked as one cycle: the set's
"If {X} was spent to cast this spell" riders. RAV goes 168 → 173 of 291.

| Card | What it does | Composes |
|---|---|---|
| **Ribbons of Night** {4}{B} | 4 damage to a creature, 4 life; a card if {U} was paid | `DealDamage` + `GainLife` + `ConditionalEffect` |
| **Seed Spark** {3}{W} | Destroy an artifact or enchantment; two Saprolings if {G} was paid | `Move(byDestruction)` + `CreateToken(count = 2)` |
| **Dryad's Caress** {4}{G}{G} | 1 life per creature *on the battlefield*; untap yours if {W} was paid | `AggregateBattlefield(Player.Each, Creature)` + `ForEachInGroup(Untap)` |
| **Vigor Mortis** {2}{B}{B} | Reanimate from your graveyard; enters with a +1/+1 counter if {G} was paid | `Move(addCounterType = PLUS_ONE_PLUS_ONE)` |
| **Rolling Spoil** {2}{G}{G} | Destroy a land; all creatures get -1/-1 if {B} was paid | `Move(byDestruction)` + `ForEachInGroup(ModifyStats)` |

## The engine fix the cycle needed

`Conditions.ManaSpentToCastIncludes` read `CastRecordComponent` directly. That
snapshot is only stamped when a **permanent** spell resolves onto the battlefield,
so the condition was permanently false for an instant or sorcery whose own
resolution asks the question — there the source is still a spell on the stack and
its payment lives in `SpellOnStackComponent`. A fail-closed hole: both branches
were legal, and the rider simply never fired.

The fix routes the evaluator through `ManaSpentReader`, which already reads both
zones and already backs Converge and the mana-value-vs-mana-spent predicates, so
the read path cannot drift between them. The Lorwyn Incarnation cycle
(Vibrance, Catharsis, …), whose ETB triggers read the already-resolved permanent,
is unaffected. `docs/card-sdk-language-reference.md` gains the condition's entry,
which it did not previously have.

## Notes on two of the cards

**Vigor Mortis** is spelled "enters **with** an additional +1/+1 counter", not
"then put a counter on it", so the counter rides along with the move
(`addCounterType`, the spelling Thunderbolts Conspiracy uses) rather than
following it. It lands inside the move executor, before the enters-the-battlefield
triggers it caused go on the stack — which is why the gate wraps both branches of
the reanimation instead of trailing it. Miraculous Recovery's rulings draw exactly
this distinction for the *other* wording.

**Seed Spark**'s earliest Scryfall printing is `psal` (Salvat 2005, three weeks
before Ravnica), but that is a `box` set, not a real expansion, so the canonical
belongs in RAV. `check-card-printing` agrees.

## Dropped from the batch

**Screeching Griffin** ({R}: Target creature can't block *this creature* this
turn). The SDK has `CantBlockEffect` ("can't block at all") and
`GrantCantBeBlockedExceptBy` (a filter over blockers), but no pairwise "X can't
block Y" restriction — a real vocabulary gap, so it is `add-feature` work and its
own PR, not a batch member.

## Verification

- `just build` green (includes `:rules-engine:test` — 546 test classes, 0 failures —
  and every era's scenario suite).
- 10 new scenario tests, two per card, differing only in the mana in the pool so
  they pin each rider to the *payment* rather than the spell's colour. All pass.
- `just rebless-cards`: RAV golden is insertions only, the five new cards; nothing
  existing moved.
- `just assay-differential --set RAV`: 103/103 confirmed, 0 divergent.
- `just check-card-printing` ok for all five.
- Every mechanical field re-verified against Scryfall (mana cost, type line,
  rarity, collector number, artist, image URI, oracle text, flavor text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dZd4daJdu3PzBgzmEDH6v
