### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AustereCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AustereCommand.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Austere Command
+ * {4}{W}{W}
+ * Sorcery
+ * Choose two —
+ * • Destroy all artifacts.
+ * • Destroy all enchantments.
+ * • Destroy all creatures with mana value 3 or less.
+ * • Destroy all creatures with mana value 4 or greater.
+ *
+ * The four modes are four independent `Effects.DestroyAll` gathers, so each resolves against the
+ * battlefield as it stands when *that* mode runs — the sequential resolution the 2020-11-10 rulings
+ * describe, not one simultaneous sweep. That's why an artifact creature caught by both creature
+ * modes has to be regenerated twice, and why a card exiled "until ~ leaves the battlefield" can
+ * return between modes and be destroyed by a later one.
+ */
+val AustereCommand = card("Austere Command") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Choose two —\n" +
+        "• Destroy all artifacts.\n" +
+        "• Destroy all enchantments.\n" +
+        "• Destroy all creatures with mana value 3 or less.\n" +
+        "• Destroy all creatures with mana value 4 or greater."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Destroy all artifacts") {
+                effect = Effects.DestroyAll(GameObjectFilter.Artifact)
+            }
+            mode("Destroy all enchantments") {
+                effect = Effects.DestroyAll(GameObjectFilter.Enchantment)
+            }
+            mode("Destroy all creatures with mana value 3 or less") {
+                effect = Effects.DestroyAll(GameObjectFilter.Creature.manaValueAtMost(3))
+            }
+            mode("Destroy all creatures with mana value 4 or greater") {
+                effect = Effects.DestroyAll(GameObjectFilter.Creature.manaValueAtLeast(4))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg?1783942918"
+        ruling("2020-11-10", "Each of the chosen modes happens sequentially. If a permanent has an ability that triggers whenever it or another permanent is destroyed, it will see permanents destroyed at the same time as it or before it, but not permanents destroyed by later modes.")
+        ruling("2020-11-10", "If the first and last modes are chosen, an artifact creature with mana value 4 or greater will have to be regenerated twice to survive. This is because the modes happen sequentially, and the regeneration \"shield\" is used up by the first one. The same is true with any other combination of modes that covers one permanent twice.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HunterOfEyeblights.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HunterOfEyeblights.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Hunter of Eyeblights
+ * {3}{B}{B}
+ * Creature — Elf Assassin
+ * 3/3
+ * When this creature enters, put a +1/+1 counter on target creature you don't control.
+ * {2}{B}, {T}: Destroy target creature with a counter on it.
+ *
+ * The ETB gift is how the Hunter marks its own prey — but per the 2007-10-01 ruling the activated
+ * ability targets a creature with *any* kind of counter, not just the +1/+1 it just handed out, so
+ * the removal filter is `withAnyCounter()` rather than a `+1/+1`-specific one.
+ */
+val HunterOfEyeblights = card("Hunter of Eyeblights") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elf Assassin"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature you don't control.\n" +
+        "{2}{B}, {T}: Destroy target creature with a counter on it."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val marked = target(
+            "creature you don't control",
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, marked)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap)
+        val prey = target(
+            "creature with a counter on it",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withAnyCounter())),
+        )
+        effect = Effects.Destroy(prey)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Jesper Ejsing"
+        flavorText = "Snokk ran as fast as he could, but the sound of hooves grew ever louder in his ears."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg?1783942889"
+        ruling("2007-10-01", "The activated ability can target a creature with any kind of counter on it, not just a +1/+1 counter.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LysAlanaScarblade.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LysAlanaScarblade.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lys Alana Scarblade
+ * {2}{B}
+ * Creature — Elf Assassin
+ * 1/1
+ * {T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of
+ * Elves you control.
+ *
+ * X is an `AggregateBattlefield` tally read on resolution, not on activation — the 2016-06-08 ruling
+ * is explicit that a Scarblade still on the battlefield counts itself, and that the count is taken
+ * as the ability resolves. `Multiply(…, -1)` is how the SDK spells a shrink; the same amount serves
+ * both halves because the card shrinks power and toughness equally.
+ *
+ * The two filters deliberately differ. The cost discards an Elf *card* from hand, so it is
+ * `GameObjectFilter.Any` — that admits the Kindred noncreature Elf cards (Gilt-Leaf Ambush, Elvish
+ * Promenade) alongside Elf creatures. The tally counts Elves on the battlefield, so it is
+ * `GameObjectFilter.Permanent`.
+ */
+val LysAlanaScarblade = card("Lys Alana Scarblade") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elf Assassin"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.Discard(filter = GameObjectFilter.Any.withSubtype(Subtype.ELF)),
+        )
+        val victim = target("target creature", Targets.Creature)
+        val shrink = DynamicAmount.Multiply(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Permanent.withSubtype(Subtype.ELF),
+            ),
+            -1,
+        )
+        effect = Effects.ModifyStats(shrink, shrink, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Christopher Moeller"
+        flavorText = "In beauty-obsessed Lys Alana, one cut of her blade means the difference between a high society feast and raking through the dungheap for scraps."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg?1783942889"
+        ruling("2016-06-08", "The number of Elves you control is counted only as Lys Alana Scarblade's ability resolves. If Lys Alana Scarblade is still on the battlefield, it'll count itself.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/OblivionRing.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/OblivionRing.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Oblivion Ring
+ * {2}{W}
+ * Enchantment
+ * When this enchantment enters, exile another target nonland permanent.
+ * When this enchantment leaves the battlefield, return the exiled card to the battlefield under its
+ * owner's control.
+ *
+ * Two *separate* triggers, not one "exile until ~ leaves" — that's the whole point of the 2007-10-01
+ * ruling: if the Ring leaves before its ETB trigger resolves, the leaves trigger fires first and
+ * finds nothing, and the ETB then exiles its target permanently. Modelling this as `ExileUntilLeaves`
+ * plus a linked return (rather than a duration-scoped exile) keeps that ordering honest.
+ *
+ * "another target nonland permanent" is [TargetFilter.OtherNonlandPermanent] — any controller's, but
+ * never the Ring itself.
+ */
+val OblivionRing = card("Oblivion Ring") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, exile another target nonland permanent.\n" +
+        "When this enchantment leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target(
+            "another target nonland permanent",
+            TargetPermanent(filter = TargetFilter.OtherNonlandPermanent),
+        )
+        effect = Effects.ExileUntilLeaves(exiled)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Wayne England"
+        flavorText = "A circle of sugar and a word of forbiddance."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg?1783942910"
+        ruling("2007-10-01", "If Oblivion Ring leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and exile the targeted nonland permanent forever.")
+        ruling("2012-07-01", "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SummonTheSchool.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SummonTheSchool.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Summon the School
+ * {3}{W}
+ * Kindred Sorcery — Merfolk
+ * Create two 1/1 blue Merfolk Wizard creature tokens.
+ * Tap four untapped Merfolk you control: Return this card from your graveyard to your hand.
+ *
+ * The recursion is an activated ability of a card in the graveyard (`activateFromZone`), and its
+ * only cost is the tap — `Costs.TapPermanents` already means "untapped ~ you control", so the
+ * Merfolk it taps include the two Wizards this spell just made.
+ *
+ * Ruling (2024-06-07): the card was printed as "Tribal"; that type is now spelled "Kindred" with no
+ * change in function. That matters here — the card is a Merfolk in the graveyard too, though
+ * nothing on it counts itself.
+ */
+val SummonTheSchool = card("Summon the School") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Kindred Sorcery — Merfolk"
+    oracleText = "Create two 1/1 blue Merfolk Wizard creature tokens.\n" +
+        "Tap four untapped Merfolk you control: Return this card from your graveyard to your hand."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Merfolk", "Wizard"),
+            imageUri = "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg?1783942838",
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 4,
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK),
+        )
+        effect = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "42"
+        artist = "Dave Dorman"
+        flavorText = "\"When merrows talk, listeners grow fins.\"\n—Kithkin saying"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg?1783942909"
+        ruling("2024-06-07", "This cards was originally printed with the \"tribal\" card type. That card type has been replaced with \"kindred\". This change does not affect the gameplay function of this card.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AustereCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AustereCommandScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AustereCommand
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Austere Command (LRW #3) — {4}{W}{W} Sorcery.
+ *
+ * Choose two —
+ * • Destroy all artifacts. • Destroy all enchantments.
+ * • Destroy all creatures with mana value 3 or less.
+ * • Destroy all creatures with mana value 4 or greater.
+ *
+ * The whole card is two boundaries and a choose-two. Both boundaries are inclusive on their own
+ * side and exclusive on the other — a mana value 3 creature dies to the third mode and survives the
+ * fourth, a mana value 4 creature does the reverse — and getting either `manaValueAtMost` /
+ * `manaValueAtLeast` off by one is silent. So each band is exercised alone, against creatures
+ * sitting exactly on 3 and exactly on 4.
+ */
+class AustereCommandScenarioTest : FunSpec({
+
+    // Mode order follows the printed bullets.
+    val artifacts = 0
+    val enchantments = 1
+    val cheapCreatures = 2
+    val expensiveCreatures = 3
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AustereCommand))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCommand(caster: EntityId, modes: List<Int>) {
+        giveMana(caster, Color.WHITE, 6)
+        val spell = putCardInHand(caster, "Austere Command")
+        submit(CastSpell(playerId = caster, cardId = spell, chosenModes = modes)).error shouldBe null
+        bothPass()
+    }
+
+    test("'mana value 3 or less' takes the 3-drop and spares the 4-drop") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Savannah Lions")   // mana value 1
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")  // mana value 3 — on the boundary
+        driver.putCreatureOnBattlefield(me, "Frogmite")         // mana value 4 — on the boundary
+        driver.putCreatureOnBattlefield(me, "Force of Nature")  // mana value 5
+
+        driver.castCommand(me, listOf(cheapCreatures, enchantments))
+
+        driver.getCreatures(me).map { driver.getCardName(it) }.toSet() shouldBe
+            setOf("Frogmite", "Force of Nature")
+    }
+
+    test("'mana value 4 or greater' takes the 4-drop and spares the 3-drop") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.putCreatureOnBattlefield(me, "Frogmite")
+        driver.putCreatureOnBattlefield(me, "Force of Nature")
+
+        driver.castCommand(me, listOf(expensiveCreatures, enchantments))
+
+        driver.getCreatures(me).map { driver.getCardName(it) }.toSet() shouldBe
+            setOf("Savannah Lions", "Centaur Courser")
+    }
+
+    test("both creature modes leave nothing behind — the two bands cover every mana value") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.putCreatureOnBattlefield(opponent, "Frogmite")
+        driver.putCreatureOnBattlefield(opponent, "Force of Nature")
+
+        driver.castCommand(me, listOf(cheapCreatures, expensiveCreatures))
+
+        // "Destroy all creatures" is symmetric — the caster's board goes too.
+        driver.getCreatures(me).size shouldBe 0
+        driver.getCreatures(opponent).size shouldBe 0
+    }
+
+    test("artifacts and enchantments go, and a plain creature is untouched") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Test Enchantment")
+        driver.putCreatureOnBattlefield(me, "Artifact Creature")  // artifact *and* a creature
+        driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        driver.castCommand(me, listOf(artifacts, enchantments))
+
+        driver.findPermanent(me, "Test Enchantment") shouldBe null
+        driver.findPermanent(me, "Artifact Creature") shouldBe null
+        driver.getCreatures(me).map { driver.getCardName(it) } shouldBe listOf("Savannah Lions")
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonTheSchoolScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonTheSchoolScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.InkfathomDivers
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SummonTheSchool
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Summon the School (LRW #42) — {3}{W} Kindred Sorcery — Merfolk.
+ *
+ * "Create two 1/1 blue Merfolk Wizard creature tokens.
+ *  Tap four untapped Merfolk you control: Return this card from your graveyard to your hand."
+ *
+ * The recursion is the part worth pinning: it is an activated ability of a card in the *graveyard*
+ * whose only cost is a tap-four-permanents cost. That combination — `activateFromZone = GRAVEYARD`
+ * with a non-mana selection cost — has no other card in the corpus, so both halves are checked
+ * here: the enumerator must surface the ability while the card sits in the graveyard, and the
+ * payment must actually demand four *untapped* Merfolk before the card comes back.
+ */
+class SummonTheSchoolScenarioTest : FunSpec({
+
+    val abilityId = SummonTheSchool.activatedAbilities.first().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonTheSchool, InkfathomDivers))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun canActivate(driver: GameTestDriver, player: EntityId, source: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        return enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .any { (it.action as? ActivateAbility)?.sourceId == source }
+    }
+
+    fun activate(driver: GameTestDriver, player: EntityId, source: EntityId, tapping: List<EntityId>) =
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = source,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = tapping),
+            )
+        )
+
+    test("the spell makes two 1/1 blue Merfolk Wizard tokens") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val spell = driver.putCardInHand(me, "Summon the School")
+        driver.giveMana(me, Color.WHITE, 4)
+        driver.castSpell(me, spell).isSuccess shouldBe true
+        driver.bothPass()
+
+        val tokens = driver.getCreatures(me)
+        tokens.size shouldBe 2
+        tokens.forEach { token ->
+            driver.state.projectedState.getPower(token) shouldBe 1
+            driver.state.projectedState.getToughness(token) shouldBe 1
+            driver.getCardName(token) shouldBe "Merfolk Wizard Token"
+        }
+
+        // The sorcery itself is now in the graveyard, where its recursion lives.
+        driver.getGraveyardCardNames(me) shouldBe listOf("Summon the School")
+    }
+
+    test("the recursion is offered while the card sits in the graveyard") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val card = driver.putCardInGraveyard(me, "Summon the School")
+        repeat(4) { driver.putCreatureOnBattlefield(me, "Inkfathom Divers") }
+
+        canActivate(driver, me, card) shouldBe true
+    }
+
+    test("three Merfolk can't pay a cost that asks for four") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val card = driver.putCardInGraveyard(me, "Summon the School")
+        val divers = List(3) { driver.putCreatureOnBattlefield(me, "Inkfathom Divers") }
+
+        activate(driver, me, card, divers).isSuccess shouldBe false
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(card) shouldBe true
+    }
+
+    test("an already-tapped Merfolk doesn't count toward the four") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val card = driver.putCardInGraveyard(me, "Summon the School")
+        val divers = List(4) { driver.putCreatureOnBattlefield(me, "Inkfathom Divers") }
+        driver.tapPermanent(divers.first())
+
+        activate(driver, me, card, divers).isSuccess shouldBe false
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(card) shouldBe true
+    }
+
+    test("four untapped Merfolk return the card from the graveyard to hand, and are tapped for it") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val card = driver.putCardInGraveyard(me, "Summon the School")
+        val divers = List(4) { driver.putCreatureOnBattlefield(me, "Inkfathom Divers") }
+
+        activate(driver, me, card, divers).isSuccess shouldBe true
+        var guard = 0
+        while (driver.isPaused && guard++ < 20) driver.autoResolveDecision()
+        driver.bothPass()
+
+        divers.forEach { driver.isTapped(it) shouldBe true }
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(card) shouldBe false
+        driver.state.getZone(ZoneKey(me, Zone.HAND)).contains(card) shouldBe true
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in ALA. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "ALA",
+    collectorNumber = "20",
+    scryfallId = "895c270d-84d8-4c7f-9df3-5a595e113dd7",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/895c270d-84d8-4c7f-9df3-5a595e113dd7.jpg?1783942580",
+    releaseDate = "2008-10-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in ARC. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "ARC",
+    collectorNumber = "3",
+    scryfallId = "e2083354-a406-42c8-991a-27cc37d18694",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e2083354-a406-42c8-991a-27cc37d18694.jpg?1783941917",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AustereCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AustereCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Austere Command reprint in CMD. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val AustereCommandReprint = Printing(
+    oracleId = "09cc8709-fe10-472a-b05c-e89f3523018d",
+    name = "Austere Command",
+    setCode = "CMD",
+    collectorNumber = "8",
+    scryfallId = "45000021-a6d9-4f86-a92e-3e52d1000c20",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45000021-a6d9-4f86-a92e-3e52d1000c20.jpg?1783941257",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in CMD. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "CMD",
+    collectorNumber = "23",
+    scryfallId = "892cf23c-e215-4978-b9b6-ef6e337f88be",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/892cf23c-e215-4978-b9b6-ef6e337f88be.jpg?1783941249",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.hop.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in HOP. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "HOP",
+    collectorNumber = "4",
+    scryfallId = "fbb74aec-2cf1-431d-ae28-ed1e6bae4f5e",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbb74aec-2cf1-431d-ae28-ed1e6bae4f5e.jpg?1783942336",
+    releaseDate = "2009-09-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in M12. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "M12",
+    collectorNumber = "27",
+    scryfallId = "9efc5a2a-eb76-410d-98e6-1455108faa52",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9efc5a2a-eb76-410d-98e6-1455108faa52.jpg?1783941100",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/OblivionRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/OblivionRingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oblivion Ring reprint in M13. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val OblivionRingReprint = Printing(
+    oracleId = "bd9b9772-f5f9-4c6b-913e-7193bea5d0a7",
+    name = "Oblivion Ring",
+    setCode = "M13",
+    collectorNumber = "22",
+    scryfallId = "1e2a73ec-39be-4d23-8c25-17d7c174dcee",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e2a73ec-39be-4d23-8c25-17d7c174dcee.jpg?1783940516",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/AustereCommandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/AustereCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Austere Command reprint in CLB. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val AustereCommandReprint = Printing(
+    oracleId = "09cc8709-fe10-472a-b05c-e89f3523018d",
+    name = "Austere Command",
+    setCode = "CLB",
+    collectorNumber = "687",
+    scryfallId = "3d24036e-075f-4991-a740-a9d943722ad2",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d24036e-075f-4991-a740-a9d943722ad2.jpg?1783922495",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/AustereCommandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/AustereCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Austere Command reprint in CMR. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val AustereCommandReprint = Printing(
+    oracleId = "09cc8709-fe10-472a-b05c-e89f3523018d",
+    name = "Austere Command",
+    setCode = "CMR",
+    collectorNumber = "12",
+    scryfallId = "ce4ec853-411d-40a3-84a7-a62b3cb57cb3",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce4ec853-411d-40a3-84a7-a62b3cb57cb3.jpg?1783928889",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/LysAlanaScarbladeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/LysAlanaScarbladeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lys Alana Scarblade reprint in KHC. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val LysAlanaScarbladeReprint = Printing(
+    oracleId = "b7ebd207-43e3-49eb-86ca-b5987ef9e22f",
+    name = "Lys Alana Scarblade",
+    setCode = "KHC",
+    collectorNumber = "50",
+    scryfallId = "58b3b63d-fabb-46ad-aabe-1e9fb34b4f8c",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58b3b63d-fabb-46ad-aabe-1e9fb34b4f8c.jpg?1783928319",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/AustereCommandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/AustereCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Austere Command reprint in NCC. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val AustereCommandReprint = Printing(
+    oracleId = "09cc8709-fe10-472a-b05c-e89f3523018d",
+    name = "Austere Command",
+    setCode = "NCC",
+    collectorNumber = "193",
+    scryfallId = "a12ce59c-4b72-45a9-91df-5966d3a81f3a",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a12ce59c-4b72-45a9-91df-5966d3a81f3a.jpg?1783923295",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/AustereCommandReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/AustereCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Austere Command reprint in MSC. The canonical CardDefinition lives in Lorwyn (`lrw`), the card's
+ * earliest real printing; this file contributes only per-printing presentation data.
+ */
+val AustereCommandReprint = Printing(
+    oracleId = "09cc8709-fe10-472a-b05c-e89f3523018d",
+    name = "Austere Command",
+    setCode = "MSC",
+    collectorNumber = "121",
+    scryfallId = "a8bc7912-e201-468a-b251-140205cb741c",
+    artist = "Taurin Clarke",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a8bc7912-e201-468a-b251-140205cb741c.jpg?1783903253",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -166,6 +166,141 @@
     ]
 }
 
+// Austere Command
+{
+    "name": "Austere Command",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose two —\n• Destroy all artifacts.\n• Destroy all enchantments.\n• Destroy all creatures with mana value 3 or less.\n• Destroy all creatures with mana value 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "artifact"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all artifacts"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "enchantment"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all enchantments"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature mv<=3"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all creatures with mana value 3 or less"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature mv>=4"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all creatures with mana value 4 or greater"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ee73fe8-d52b-43bb-ab91-5545192be676.jpg?1783942918",
+        "rulings": [
+            {
+                "date": "2020-11-10",
+                "text": "Each of the chosen modes happens sequentially. If a permanent has an ability that triggers whenever it or another permanent is destroyed, it will see permanents destroyed at the same time as it or before it, but not permanents destroyed by later modes."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "If the first and last modes are chosen, an artifact creature with mana value 4 or greater will have to be regenerated twice to survive. This is because the modes happen sequentially, and the regeneration \"shield\" is used up by the first one. The same is true with any other combination of modes that covers one permanent twice."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Avian Changeling
 {
     "name": "Avian Changeling",
@@ -3891,6 +4026,104 @@
     ]
 }
 
+// Hunter of Eyeblights
+{
+    "name": "Hunter of Eyeblights",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Elf Assassin",
+    "oracleText": "When this creature enters, put a +1/+1 counter on target creature you don't control.\n{2}{B}, {T}: Destroy target creature with a counter on it.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you don't control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature you don't control"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature with a counter on it"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "HasAnyCounter"
+                                ]
+                            }
+                        },
+                        "id": "creature with a counter on it"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Snokk ran as fast as he could, but the sound of hooves grew ever louder in his ears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbd5b8db-4a56-45bd-9704-a1316016ec5b.jpg?1783942889",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The activated ability can target a creature with any kind of counter on it, not just a +1/+1 counter."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hurly-Burly
 {
     "name": "Hurly-Burly",
@@ -4912,6 +5145,88 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lys Alana Scarblade
+{
+    "name": "Lys Alana Scarblade",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Elf Assassin",
+    "oracleText": "{T}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "Elf"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "permanent Elf"
+                        },
+                        "multiplier": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "permanent Elf"
+                        },
+                        "multiplier": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Moeller",
+        "flavorText": "In beauty-obsessed Lys Alana, one cut of her blade means the difference between a high society feast and raking through the dungheap for scraps.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7614e3e7-708f-4717-b798-97f0c391a673.jpg?1783942889",
+        "rulings": [
+            {
+                "date": "2016-06-08",
+                "text": "The number of Elves you control is counted only as Lys Alana Scarblade's ability resolves. If Lys Alana Scarblade is still on the battlefield, it'll count itself."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -5941,6 +6256,85 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Oblivion Ring
+{
+    "name": "Oblivion Ring",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, exile another target nonland permanent.\nWhen this enchantment leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target nonland permanent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent",
+                        "excludeSelf": true
+                    },
+                    "id": "another target nonland permanent"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Wayne England",
+        "flavorText": "A circle of sugar and a word of forbiddance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c7fffe8-709c-4cb4-bbad-e4a0c35b616a.jpg?1783942910",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "If Oblivion Ring leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and exile the targeted nonland permanent forever."
+            },
+            {
+                "date": "2012-07-01",
+                "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Equipment attached to the exiled permanent will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -7264,6 +7658,69 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Summon the School
+{
+    "name": "Summon the School",
+    "manaCost": "{3}{W}",
+    "typeLine": "Kindred Sorcery — Merfolk",
+    "oracleText": "Create two 1/1 blue Merfolk Wizard creature tokens.\nTap four untapped Merfolk you control: Return this card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "BLUE"
+            ],
+            "creatureTypes": [
+                "Merfolk",
+                "Wizard"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/5/2/526da544-23dd-42b8-8c00-c3609eea4489.jpg?1783942838"
+        },
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 4,
+                        "filter": "permanent Merfolk"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Dorman",
+        "flavorText": "\"When merrows talk, listeners grow fins.\"\n—Kithkin saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13a4c124-216b-44b1-b49a-3db3f033e4cd.jpg?1783942909",
+        "rulings": [
+            {
+                "date": "2024-06-07",
+                "text": "This cards was originally printed with the \"tribal\" card type. That card type has been replaced with \"kindred\". This change does not affect the gameplay function of this card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, all built from existing `Effects.*` / `Patterns.*` — no new SDK vocabulary. Canonical `CardDefinition`s all land in LRW (the earliest real printing for each), with `Printing` rows for every scaffolded reprint.

| Card | What it does | Composed from |
|---|---|---|
| **Austere Command** `{4}{W}{W}` | Choose two of four board wipes | `modal(chooseCount = 2)` over four `Effects.DestroyAll`; the creature bands are `Creature.manaValueAtMost(3)` / `.manaValueAtLeast(4)` |
| **Summon the School** `{3}{W}` | Two Merfolk Wizard tokens; recur itself by tapping four Merfolk | `Effects.CreateToken` + an `activateFromZone = GRAVEYARD` ability with `Costs.TapPermanents(4, …)` and `Effects.ReturnToHandFromGraveyard` |
| **Oblivion Ring** `{2}{W}` | Exile another nonland permanent until it leaves | `Effects.ExileUntilLeaves` on ETB + `Effects.ReturnLinkedExileUnderOwnersControl()` on LTB, over `TargetFilter.OtherNonlandPermanent` |
| **Hunter of Eyeblights** `{3}{B}{B}` | ETB counter on an opponent's creature; `{2}{B}, {T}` destroy a countered creature | `Effects.AddCounters` + `Effects.Destroy` over `Creature.withAnyCounter()` |
| **Lys Alana Scarblade** `{2}{B}` | `{T}`, discard an Elf: -X/-X where X = Elves you control | `Costs.Discard(filter = …)` + `Effects.ModifyStats` with `Multiply(AggregateBattlefield(…), -1)` |

### Three details the oracle text turns on

- **Austere Command's modes resolve sequentially**, each with its own gather. That is what the 2020-11-10 rulings describe: an artifact creature caught by two chosen modes has to be regenerated twice, and a card exiled "until ~ leaves" can return between modes and be destroyed by a later one.
- **Oblivion Ring is two independent triggers**, not a duration-scoped exile. Per the 2007-10-01 ruling, if the Ring leaves before its ETB resolves, the leaves trigger fires first and finds nothing, and the ETB then exiles its target permanently.
- **Hunter of Eyeblights takes *any* counter**, not just the +1/+1 it handed out (2007-10-01 ruling) — hence `withAnyCounter()` rather than a `+1/+1`-specific filter.

### Tests

Two scenario tests, one file per card, for the two shapes with real silent-failure risk:

- `SummonTheSchoolScenarioTest` — a graveyard activation whose only cost is a non-mana *selection* cost has no other card in the corpus. Pins that the enumerator surfaces the ability from the graveyard, and that payment really demands four **untapped** Merfolk (three, or four with one already tapped, is refused and the card stays put).
- `AustereCommandScenarioTest` — both mana-value boundaries, with creatures sitting exactly on 3 and exactly on 4, where an off-by-one in `manaValueAtMost`/`manaValueAtLeast` would be silent.

The other three compose primitives with several corpus precedents each, so they rely on the snapshot and lint nets per `add-card` Step 5.

### Verification

- `just build` green.
- `just test-class SummonTheSchoolScenarioTest` — 5/5. `just test-class AustereCommandScenarioTest` — 4/4.
- `just check-card-printing` clean for all five.
- `just rebless-cards` — only `snapshots/cards/LRW.json` moved.
- `just assay-differential --set LRW` — 111 compared, 10 DIVERGENT, **none of them these cards**. All ten are pre-existing (the Harbinger cycle, Kithkin Greatheart, Epic Proportions, Boggart Sprite-Chaser) and untouched here.
- Every `imageUri` (cards and reprint rows) verified HTTP 200.

### Considered and dropped

Lorwyn's missing pool is dominated by **clash**, which has no SDK vocabulary — that is `add-feature` work, so every clash card was excluded. Also dropped after probing:

- **Silvergill Adept / Wren's Run Vanquisher / Goldmeadow Stalwart** — "reveal a &lt;type&gt; card from your hand or pay {3}". `AdditionalCost.OrPay` exists but its non-mana leg must be a selection-carrying cost; `CostAtom.RevealFromHand` is explicitly a no-op on the spell additional-cost path (`CastSpellHandler`). Needs engine work, not a Behold approximation.
- **Turtleshell Changeling** — "switch this creature's power and toughness" has no SDK spelling at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aTsiHBo78PUW7woF7ySfC
