### PR TITLE
Add three Innistrad: Crimson Vow cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,13 +2,13 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 267 / 273
+**Implemented:** 270 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
 - [x] Alchemist's Gambit
 - [x] Alchemist's Retrieval
-- [ ] Alluring Suitor
+- [x] Alluring Suitor
 - [x] Ancestral Anger
 - [x] Ancient Lumberknot
 - [x] Angelic Quartermaster
@@ -91,7 +91,7 @@
 - [x] Eruth, Tormented Prophet
 - [x] Estwald Shieldbasher
 - [x] Evolving Wilds
-- [ ] Faithbound Judge
+- [x] Faithbound Judge
 - [x] Falkenrath Celebrants
 - [x] Falkenrath Forebear
 - [x] Fear of Death
@@ -201,7 +201,7 @@
 - [x] Retrieve
 - [x] Rot-Tide Gargantua
 - [x] Runebound Wolf
-- [ ] Runo Stromkirk
+- [x] Runo Stromkirk
 - [x] Rural Recruit
 - [x] Sanctify
 - [x] Sanguine Statuette

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1580,6 +1580,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   three flip it into Shadows' Lair), `Counters.BORE` (Brass's Tunnel-Grinder — three flip it into Tecutlan),
   `Counters.REVIVAL` (Nine-Lives Familiar — a "lives left" counter: it enters with eight if you cast it and its
   dies trigger reads the last-known count to come back with one fewer),
+  `Counters.JUDGMENT` (Faithbound Judge // Sinner's Judgment — both faces count to three, the
+  creature face to shed defender and the Aura face to make the enchanted player lose the game),
   `Counters.NET`, `Counters.FIRE`, `Counters.CONQUEROR`, `Counters.POINT` (Contested Game Ball — its
   `{2}, {T}` ability adds one per activation and, when five or more are present, sacrifices the artifact and
   creates a Treasure), `Counters.WISH` (Wishclaw Talisman — see below), `Counters.INGENUITY` (Lady Octopus,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -173,7 +173,10 @@ enum class CounterType {
     CUBE,
 
     /** Tide counter (FEM — Homarid, Tidal Influence). See [Counters.TIDE]. */
-    TIDE;
+    TIDE,
+
+    /** Judgment counter (VOW — Faithbound Judge // Sinner's Judgment). See [Counters.JUDGMENT]. */
+    JUDGMENT;
 
     companion object {
         /**
@@ -683,6 +686,18 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val UNLOCK = "unlock"
+
+    /**
+     * Judgment counter (VOW — Faithbound Judge // Sinner's Judgment). A passive
+     * accumulate-then-threshold counter with no inherent rule of its own, the same shape as
+     * [PLAN] and [UNLOCK]: each face's own upkeep trigger adds one, and a second ability gated on
+     * `Conditions.SourceCounterCountAtLeast(Counters.JUDGMENT, 3)` reads the tally back — the
+     * creature face to shed its defender restriction, the Aura face to make the enchanted player
+     * lose the game. The two faces do *not* share a tally: they are different objects (CR 400.7),
+     * so a disturbed Sinner's Judgment starts at zero.
+     * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val JUDGMENT = "judgment"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AlluringSuitor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AlluringSuitor.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.YouAttackEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Alluring Suitor // Deadly Dancer — Innistrad: Crimson Vow #141
+ * {2}{R} · Creature — Vampire 2/3 // Creature — Vampire 3/3
+ *
+ * Front — Alluring Suitor
+ *   When you attack with exactly two creatures, transform this creature.
+ *
+ * Back — Deadly Dancer
+ *   Trample
+ *   When this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't
+ *   lose this mana as steps and phases end.
+ *   {R}{R}: This creature and another target creature each get +1/+0 until end of turn.
+ *
+ * Modeling notes:
+ *
+ *  - **"Exactly two" is the attackers-declared event plus a CR 603.2 restriction, not a new
+ *    event.** [YouAttackEvent] carries a `minAttackers` floor only — it is a "two or more" shape —
+ *    so the upper bound rides `triggerRestriction`, which CR 603.2 checks *when the trigger would
+ *    fire and never again*. That timing is what makes the printed ruling fall out for free: a
+ *    creature **put onto the battlefield attacking** never "attacked", and it can only arrive
+ *    *after* declare-attackers triggers have been put on the stack, so it is not on the board when
+ *    the restriction counts. Using `interveningIf` here would be wrong twice over — it would
+ *    re-check on resolution, by which point such a token *is* attacking.
+ *  - The count itself is [DynamicAmounts.attackingCreaturesYouControl], the same battlefield tally
+ *    Wingmate Roc reads, compared with [ComparisonOperator.EQ].
+ *  - **The mana is added by a normal triggered ability, not a mana ability** — it uses the stack
+ *    (CR 605.1b: an ability that triggers is never a mana ability), which is exactly what the
+ *    printed "When this creature transforms into Deadly Dancer, add {R}{R}" means. The trigger is
+ *    [Triggers.TransformsToBack], so it fires on the flip the front face just caused and *not* on
+ *    a disturb-style cast onto the back face.
+ *  - **"You don't lose this mana as steps and phases end" is its own effect**, not a mana expiry:
+ *    [Effects.RetainUnspentMana] tags the controller's red mana as surviving every step/phase
+ *    boundary until cleanup. Sequenced after the add so it covers the mana just produced.
+ *  - **"This creature and another target creature"** is one target slot, excluding the source —
+ *    [TargetFilter.OtherCreature] — plus an untargeted pump of the Dancer itself. Two
+ *    [Effects.ModifyStats] rather than a group effect, because only one of the two is a target and
+ *    the Dancer's own +1/+0 lands even if the target is removed in response.
+ */
+private val AlluringSuitorFront = card("Alluring Suitor") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 3
+    oracleText = "When you attack with exactly two creatures, transform this creature."
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = YouAttackEvent(minAttackers = 2),
+            binding = TriggerBinding.ANY,
+        )
+        triggerRestriction = Conditions.CompareAmounts(
+            DynamicAmounts.attackingCreaturesYouControl(),
+            ComparisonOperator.EQ,
+            DynamicAmount.Fixed(2),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+        description = "When you attack with exactly two creatures, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Justine Cruz"
+        flavorText = "\"May I have this dance?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1783924853"
+
+        ruling(
+            "2021-11-19",
+            "A creature put onto the battlefield attacking didn't \"attack\" and won't be counted " +
+                "to determine whether Alluring Suitor's ability should trigger."
+        )
+    }
+}
+
+private val DeadlyDancer = card("Deadly Dancer") {
+    manaCost = ""
+    colorIdentity = "R"
+    colorIndicator = "R" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\n" +
+        "When this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you " +
+        "don't lose this mana as steps and phases end.\n" +
+        "{R}{R}: This creature and another target creature each get +1/+0 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Effects.Composite(
+            Effects.AddMana(Color.RED, 2),
+            Effects.RetainUnspentMana(Color.RED),
+        )
+        description = "When this creature transforms into Deadly Dancer, add {R}{R}. Until end of " +
+            "turn, you don't lose this mana as steps and phases end."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}{R}")
+        val partner = target(
+            "another target creature",
+            TargetCreature(filter = TargetFilter.OtherCreature)
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, EffectTarget.Self),
+            Effects.ModifyStats(1, 0, partner),
+        )
+        description = "This creature and another target creature each get +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1783924853"
+    }
+}
+
+val AlluringSuitor: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = AlluringSuitorFront,
+    backFace = DeadlyDancer,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FaithboundJudge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FaithboundJudge.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.disturb
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Faithbound Judge // Sinner's Judgment — Innistrad: Crimson Vow #12
+ * {1}{W}{W} · Creature — Spirit Soldier 4/4 // Enchantment — Aura Curse
+ *
+ * Front — Faithbound Judge
+ *   Defender, flying, vigilance
+ *   At the beginning of your upkeep, if this creature has two or fewer judgment counters on it,
+ *   put a judgment counter on it.
+ *   As long as this creature has three or more judgment counters on it, it can attack as though it
+ *   didn't have defender.
+ *   Disturb {5}{W}{W}
+ *
+ * Back — Sinner's Judgment
+ *   Enchant player
+ *   At the beginning of your upkeep, put a judgment counter on this Aura. Then if there are three
+ *   or more judgment counters on it, enchanted player loses the game.
+ *   If Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.
+ *
+ * Modeling notes:
+ *
+ *  - **The two faces do not share a tally.** They are different objects (CR 400.7): a Judge that
+ *    died with three judgment counters comes back from the graveyard as a fresh Sinner's Judgment
+ *    with none, and has to count to three again. Nothing in the model carries the count across —
+ *    each face reads counters off *itself* — so that falls out for free.
+ *  - **Front: a true intervening "if" (CR 603.4), back: a resolution-time "then if".** The
+ *    difference is printed. The Judge's clause gates the trigger *and* is rechecked on resolution,
+ *    so it rides `interveningIf`; a fourth counter can therefore never land. The Aura's clause is
+ *    the word "Then", which is checked only while the ability resolves and *after* the counter has
+ *    been added — so it is a [ConditionalEffect] sequenced behind the add, and the third counter
+ *    kills the enchanted player on the very upkeep it lands.
+ *  - **"three or more"/"two or fewer" are counter-count conditions on the source**, not board
+ *    conditions: [Conditions.SourceCounterCountAtLeast] and its downward twin
+ *    [Conditions.SourceCounterCountAtMost].
+ *  - **The defender bypass is a *conditional static*, not a one-shot grant.** Per the printed
+ *    ruling, removing judgment counters after the Judge has attacked won't remove it from combat —
+ *    which is exactly what a static ability checked at attack declaration does.
+ *  - **The Aura enchants a player**, so `auraTarget = Targets.Player` (Curse of Hospitality's slot
+ *    in this same set) and the loser is [Player.EnchantedPlayer], not the controller — the Curse
+ *    kills whoever it is attached to, and its controller is the one asking for that.
+ *  - **The exile-instead clause is [RedirectZoneChange] with `selfOnly = true`** so it functions
+ *    in every zone (CR 614.12) — the same shape Spectral Binding uses. Without it the Curse would
+ *    return to the graveyard and be disturbable again, which is the whole point of the clause.
+ */
+private val FaithboundJudgeFront = card("Faithbound Judge") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Defender, flying, vigilance\n" +
+        "At the beginning of your upkeep, if this creature has two or fewer judgment counters on " +
+        "it, put a judgment counter on it.\n" +
+        "As long as this creature has three or more judgment counters on it, it can attack as " +
+        "though it didn't have defender.\n" +
+        "Disturb {5}{W}{W} (You may cast this card from your graveyard transformed for its " +
+        "disturb cost.)"
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING, Keyword.VIGILANCE)
+
+    // At the beginning of your upkeep, if this creature has two or fewer judgment counters on it,
+    // put a judgment counter on it.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        interveningIf = Conditions.SourceCounterCountAtMost(Counters.JUDGMENT, 2)
+        effect = Effects.AddCounters(Counters.JUDGMENT, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, if this creature has two or fewer " +
+            "judgment counters on it, put a judgment counter on it."
+    }
+
+    // As long as this creature has three or more judgment counters on it, it can attack as though
+    // it didn't have defender.
+    staticAbility {
+        ability = CanAttackDespiteDefender(
+            condition = Conditions.SourceCounterCountAtLeast(Counters.JUDGMENT, 3)
+        )
+    }
+
+    disturb("{5}{W}{W}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "12"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1783951787"
+
+        ruling(
+            "2021-11-19",
+            "Removing judgment counters from Faithbound Judge after it has attacked won't remove " +
+                "it from combat."
+        )
+    }
+}
+
+private val SinnersJudgment = card("Sinner's Judgment") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Enchantment — Aura Curse"
+    oracleText = "Enchant player\n" +
+        "At the beginning of your upkeep, put a judgment counter on this Aura. Then if there are " +
+        "three or more judgment counters on it, enchanted player loses the game.\n" +
+        "If Sinner's Judgment would be put into a graveyard from anywhere, exile it instead."
+
+    auraTarget = Targets.Player
+
+    // At the beginning of your upkeep, put a judgment counter on this Aura. Then if there are
+    // three or more judgment counters on it, enchanted player loses the game.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.JUDGMENT, 1, EffectTarget.Self),
+            ConditionalEffect(
+                condition = Conditions.SourceCounterCountAtLeast(Counters.JUDGMENT, 3),
+                effect = Effects.LoseGame(
+                    target = EffectTarget.PlayerRef(Player.EnchantedPlayer),
+                    message = "Sinner's Judgment"
+                ),
+            ),
+        )
+        description = "At the beginning of your upkeep, put a judgment counter on this Aura. Then " +
+            "if there are three or more judgment counters on it, enchanted player loses the game."
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "12"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1783951787"
+    }
+}
+
+val FaithboundJudge: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = FaithboundJudgeFront,
+    backFace = SinnersJudgment,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RunoStromkirk.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RunoStromkirk.kt
@@ -1,0 +1,220 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Runo Stromkirk // Krothuss, Lord of the Deep — Innistrad: Crimson Vow #246
+ * {1}{U}{B} · Legendary Creature — Vampire Cleric 1/4 // Legendary Creature — Kraken Horror 3/5
+ *
+ * Front — Runo Stromkirk
+ *   Flying
+ *   When Runo enters, put up to one target creature card from your graveyard on top of your
+ *   library.
+ *   At the beginning of your upkeep, look at the top card of your library. You may reveal that
+ *   card. If a creature card with mana value 6 or greater is revealed this way, transform Runo.
+ *
+ * Back — Krothuss, Lord of the Deep
+ *   Flying
+ *   Whenever Krothuss attacks, create a tapped and attacking token that's a copy of another target
+ *   attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of
+ *   those tokens instead.
+ *
+ * Modeling notes:
+ *
+ *  - **The upkeep trigger is Delver of Secrets' sentence with a different filter.** Nothing moves
+ *    zones — the card is looked at and stays on top whether or not it is revealed — so the pipeline
+ *    is gather-only, and the "you may reveal" is a `ChooseUpTo(1)` over the looked-at collection
+ *    (`showAllCards = true` makes the overlay the *look*, selecting is the *reveal*). The transform
+ *    is gated on the **revealed** collection, not the looked-at one: declining to reveal a
+ *    six-drop must not flip Runo, and the printed text says "revealed this way".
+ *  - **"a creature card with mana value 6 or greater"** is one filter,
+ *    `GameObjectFilter.Creature.manaValueAtLeast(6)`, not two clauses — the card must satisfy both
+ *    to flip.
+ *  - **The ETB target is `optional = true`, not a separate "you may".** "Up to one target" is a
+ *    target-count shape (CR 115.2c): casting Runo with an empty graveyard is legal and the trigger
+ *    simply chooses nothing. `TargetFilter.CreatureInYourGraveyard` is the same slot Retrieve uses.
+ *  - **Krothuss targets "another" attacking creature**, so the requirement is wrapped in
+ *    [TargetOther] — Krothuss is itself an attacking creature and would otherwise be a legal
+ *    choice for its own trigger.
+ *  - **The doubled count is a property of the *target*, read at resolution.**
+ *    [CreateTokenCopyOfTargetEffect.count] takes a [DynamicAmount], so the "if that creature is a
+ *    Kraken, Leviathan, Octopus, or Serpent" rider is `DynamicAmount.Conditional` over
+ *    [Conditions.TargetMatchesFilter] at target index 0 rather than two branches of a
+ *    [ConditionalEffect] — one effect, one token template, two possible counts. The subtype test
+ *    is a single `withAnySubtype` (an OR), which is what the printed comma list means.
+ *  - Per its own ruling the token is *put onto the battlefield* attacking rather than declared as
+ *    an attacker, which is exactly what `attacking = true` models — it emits no "attacks" trigger.
+ *    The token is **not** sacrificed at end of turn: unlike Calamity, Krothuss prints no such
+ *    clause, so `sacrificeAtStep` stays null.
+ */
+private val RunoStromkirkFront = card("Runo Stromkirk") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Vampire Cleric"
+    power = 1
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When Runo enters, put up to one target creature card from your graveyard on top of your " +
+        "library.\n" +
+        "At the beginning of your upkeep, look at the top card of your library. You may reveal " +
+        "that card. If a creature card with mana value 6 or greater is revealed this way, " +
+        "transform Runo."
+
+    keywords(Keyword.FLYING)
+
+    // When Runo enters, put up to one target creature card from your graveyard on top of your library.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val fromGraveyard = target(
+            "creature card from your graveyard",
+            TargetObject(optional = true, filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        effect = Effects.Move(
+            target = fromGraveyard,
+            destination = Zone.LIBRARY,
+            placement = ZonePlacement.Top,
+        )
+        description = "When Runo enters, put up to one target creature card from your graveyard " +
+            "on top of your library."
+    }
+
+    // At the beginning of your upkeep, look at the top card of your library. You may reveal that
+    // card. If a creature card with mana value 6 or greater is revealed this way, transform Runo.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "runoLooked",
+            ),
+            SelectFromCollectionEffect(
+                from = "runoLooked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "runoRevealed",
+                showAllCards = true,
+                prompt = "You may reveal the top card of your library",
+                selectedLabel = "Reveal",
+            ),
+            RevealCollectionEffect(from = "runoRevealed", revealToSelf = false),
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch(
+                    "runoRevealed",
+                    GameObjectFilter.Creature.manaValueAtLeast(6),
+                ),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "At the beginning of your upkeep, look at the top card of your library. You " +
+            "may reveal that card. If a creature card with mana value 6 or greater is revealed " +
+            "this way, transform Runo."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "246"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1783924792"
+    }
+}
+
+private val KrothussLordOfTheDeep = card("Krothuss, Lord of the Deep") {
+    manaCost = ""
+    colorIdentity = "UB"
+    colorIndicator = "UB" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Legendary Creature — Kraken Horror"
+    power = 3
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Whenever Krothuss attacks, create a tapped and attacking token that's a copy of another " +
+        "target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, " +
+        "create two of those tokens instead."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val copied = target(
+            "another attacking creature",
+            TargetOther(baseRequirement = Targets.AttackingCreature)
+        )
+        effect = CreateTokenCopyOfTargetEffect(
+            target = copied,
+            count = DynamicAmount.Conditional(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Creature.withAnySubtype(
+                        "Kraken", "Leviathan", "Octopus", "Serpent"
+                    ),
+                    targetIndex = 0,
+                ),
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+            tapped = true,
+            attacking = true,
+        )
+        description = "Whenever Krothuss attacks, create a tapped and attacking token that's a " +
+            "copy of another target attacking creature. If that creature is a Kraken, Leviathan, " +
+            "Octopus, or Serpent, create two of those tokens instead."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "246"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1783924792"
+
+        ruling(
+            "2021-11-19",
+            "You choose which opponent or opposing planeswalker the token is attacking as you put " +
+                "it onto the battlefield. It doesn't have to be the same player or planeswalker " +
+                "Krothuss, Lord of the Deep is attacking."
+        )
+        ruling(
+            "2021-11-19",
+            "Although the token is attacking, it was never declared as an attacking creature (for " +
+                "purposes of abilities that trigger whenever a creature attacks, for example, " +
+                "like training)."
+        )
+        ruling(
+            "2021-11-19",
+            "The token copies exactly what was printed on the original creature and nothing else " +
+                "(unless that permanent is copying something else or is a token). It doesn't copy " +
+                "whether that creature has any counters on it or Auras and/or Equipment attached " +
+                "to it, or any non-copy effects that changed its power, toughness, types, color, " +
+                "and so on."
+        )
+        ruling(
+            "2021-11-19",
+            "Any enters-the-battlefield abilities of the copied creature will trigger when the " +
+                "token enters the battlefield."
+        )
+    }
+}
+
+val RunoStromkirk: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = RunoStromkirkFront,
+    backFace = KrothussLordOfTheDeep,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AlluringSuitorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AlluringSuitorScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alluring Suitor // Deadly Dancer (VOW #141).
+ *
+ *   Front — Alluring Suitor (2/3) — When you attack with exactly two creatures, transform this
+ *           creature.
+ *   Back  — Deadly Dancer (3/3) — Trample. When this transforms into Deadly Dancer, add {R}{R};
+ *           until end of turn you don't lose that mana as steps and phases end.
+ *
+ * "Exactly two" is the whole point of the front face: the underlying event is a *two or more*
+ * attackers-declared pattern, and the upper bound rides a CR 603.2 `triggerRestriction`. So the
+ * tests bracket it on both sides — one attacker (no trigger), two (flip), three (no trigger) — and
+ * then check that the flip's mana actually survives the step boundary out of combat.
+ */
+class AlluringSuitorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Alluring Suitor") {
+
+            /** Suitor plus [extraAttackers] vanilla creatures, ready to attack. */
+            fun board(extraAttackers: Int): TestGame {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Alluring Suitor", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(extraAttackers) {
+                    builder = builder.withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+                return builder.build()
+            }
+
+            fun attackWith(game: TestGame, names: List<String>) {
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(names.associateWith { 2 }).error shouldBe null
+                game.resolveStack()
+            }
+
+            fun manaTotal(game: TestGame): Int {
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                    ?: ManaPoolComponent()
+                return pool.white + pool.blue + pool.black + pool.red + pool.green + pool.colorless
+            }
+
+            fun faceOf(game: TestGame): String =
+                game.state.getEntity(game.findPermanent("Alluring Suitor") ?: game.findPermanent("Deadly Dancer")!!)!!
+                    .get<CardComponent>()!!.name
+
+            test("attacking with exactly two creatures transforms the Suitor") {
+                val game = board(extraAttackers = 1)
+                attackWith(game, listOf("Alluring Suitor", "Grizzly Bears"))
+                withClue("two attackers — the trigger's restriction is met") {
+                    faceOf(game) shouldBe "Deadly Dancer"
+                }
+            }
+
+            test("attacking alone does not transform it") {
+                val game = board(extraAttackers = 0)
+                attackWith(game, listOf("Alluring Suitor"))
+                withClue("one attacker is below the event's own two-attacker floor") {
+                    faceOf(game) shouldBe "Alluring Suitor"
+                }
+            }
+
+            test("attacking with three creatures does not transform it") {
+                val game = board(extraAttackers = 2)
+                // Two distinct Bears exist; declareAttackers resolves by name, so attack with the
+                // Suitor and both of them by declaring each Bears entity directly.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val suitor = game.findPermanent("Alluring Suitor")!!
+                val bears = game.findAllPermanents("Grizzly Bears")
+                bears.size shouldBe 2
+                game.execute(
+                    DeclareAttackers(
+                        game.state.activePlayerId!!,
+                        (listOf(suitor) + bears).associateWith { game.player2Id }
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                withClue("the event fires at two-or-more, but 'exactly two' rejects three") {
+                    faceOf(game) shouldBe "Alluring Suitor"
+                }
+            }
+
+            test("the transform trigger's {R}{R} survives the end of the combat phase") {
+                val game = board(extraAttackers = 1)
+                attackWith(game, listOf("Alluring Suitor", "Grizzly Bears"))
+                faceOf(game) shouldBe "Deadly Dancer"
+
+                withClue("the trigger added {R}{R} to its controller's pool") {
+                    manaTotal(game) shouldBe 2
+                }
+
+                game.advanceToPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                withClue("'you don't lose this mana as steps and phases end' — it is still there") {
+                    manaTotal(game) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FaithboundJudgeScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FaithboundJudgeScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Faithbound Judge // Sinner's Judgment (VOW #12).
+ *
+ *   Front — Faithbound Judge (4/4) — Defender, flying, vigilance. At the beginning of your upkeep,
+ *           if it has two or fewer judgment counters on it, put a judgment counter on it. As long
+ *           as it has three or more judgment counters on it, it can attack as though it didn't have
+ *           defender. Disturb {5}{W}{W}.
+ *   Back  — Sinner's Judgment — Enchant player. At the beginning of your upkeep, put a judgment
+ *           counter on this Aura. Then if there are three or more judgment counters on it,
+ *           enchanted player loses the game.
+ *
+ * The two faces differ in exactly the way their printed text does, and that is what these tests
+ * pin down: the creature's clause is an intervening "if" that **caps** the tally at three, while
+ * the Aura's is a resolution-time "Then if" with no cap — and, being on the *Aura*, it kills the
+ * player it is attached to rather than its own controller.
+ */
+class FaithboundJudgeScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.judgmentCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.JUDGMENT) ?: 0
+
+    /** Advance from the controller's upkeep to their *next* upkeep, resolving each one. */
+    private fun TestGame.toNextOwnUpkeep() {
+        passUntilPhase(Phase.ENDING, Step.END)
+        passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // opponent's upkeep — no accrual
+        passUntilPhase(Phase.ENDING, Step.END)
+        passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // ours again
+        resolveStack()
+    }
+
+    init {
+        context("Faithbound Judge") {
+
+            test("your upkeep adds a judgment counter, and the intervening if caps the tally at three") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Faithbound Judge", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                repeat(20) { builder = builder.withCardInLibrary(1, "Plains") }
+                repeat(20) { builder = builder.withCardInLibrary(2, "Plains") }
+                val game = builder.build()
+
+                val judge = game.findPermanent("Faithbound Judge")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                withClue("first upkeep") { game.judgmentCounters(judge) shouldBe 1 }
+
+                game.toNextOwnUpkeep()
+                withClue("second upkeep") { game.judgmentCounters(judge) shouldBe 2 }
+
+                game.toNextOwnUpkeep()
+                withClue("third upkeep") { game.judgmentCounters(judge) shouldBe 3 }
+
+                game.toNextOwnUpkeep()
+                withClue("the intervening 'if' fails at three, so a fourth counter never lands") {
+                    game.judgmentCounters(judge) shouldBe 3
+                }
+            }
+
+            test("three judgment counters let it attack despite defender; two do not") {
+                fun judgeWith(counters: Int): Pair<TestGame, EntityId> {
+                    val game = scenario()
+                        .withPlayers("Player1", "Player2")
+                        .withCardOnBattlefield(1, "Faithbound Judge", summoningSickness = false)
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+                    val judge = game.findPermanent("Faithbound Judge")!!
+                    game.state = game.state.updateEntity(judge) {
+                        it.with(CountersComponent(mapOf(CounterType.JUDGMENT to counters)))
+                    }
+                    return game to judge
+                }
+
+                val (blocked, _) = judgeWith(2)
+                blocked.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("two counters — defender still applies") {
+                    (blocked.declareAttackers(mapOf("Faithbound Judge" to 2)).error != null) shouldBe true
+                }
+
+                val (freed, judge) = judgeWith(3)
+                freed.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("three counters — it can attack as though it didn't have defender") {
+                    freed.declareAttackers(mapOf("Faithbound Judge" to 2)).error shouldBe null
+                }
+                withClue("and it really is attacking") {
+                    freed.state.getEntity(judge)?.has<AttackingComponent>() shouldBe true
+                }
+            }
+        }
+
+        context("Sinner's Judgment") {
+
+            test("the third judgment counter makes the enchanted player — not the controller — lose the game") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sinner's Judgment")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                repeat(20) { builder = builder.withCardInLibrary(1, "Plains") }
+                repeat(20) { builder = builder.withCardInLibrary(2, "Plains") }
+                val game = builder.build()
+
+                // "Enchant player" needs an AttachedToComponent pointing at a *player* id, which the
+                // builder's permanent-host `withCardAttachedTo` can't produce.
+                val curse = game.findPermanent("Sinner's Judgment")!!
+                game.state = game.state.updateEntity(curse) {
+                    it.with(AttachedToComponent(game.player2Id))
+                }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                withClue("one counter — nobody has lost") {
+                    game.judgmentCounters(curse) shouldBe 1
+                    game.state.gameOver shouldBe false
+                }
+
+                game.toNextOwnUpkeep()
+                withClue("two counters — still nobody") {
+                    game.judgmentCounters(curse) shouldBe 2
+                    game.state.gameOver shouldBe false
+                }
+
+                game.toNextOwnUpkeep()
+                game.checkStateBasedActions()
+                withClue("the third counter landed") { game.judgmentCounters(curse) shouldBe 3 }
+                withClue("the third counter kills the enchanted player, leaving its controller the winner") {
+                    game.state.gameOver shouldBe true
+                    game.state.winnerId shouldBe game.player1Id
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RunoStromkirkScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RunoStromkirkScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Runo Stromkirk // Krothuss, Lord of the Deep (VOW #246).
+ *
+ *   Front — Runo Stromkirk (1/4) — Flying. When Runo enters, put up to one target creature card
+ *           from your graveyard on top of your library. At the beginning of your upkeep, look at
+ *           the top card of your library; you may reveal it, and if a creature card with mana value
+ *           6 or greater is revealed this way, transform Runo.
+ *   Back  — Krothuss, Lord of the Deep (3/5) — Flying. Whenever Krothuss attacks, create a tapped
+ *           and attacking token that's a copy of another target attacking creature. If that creature
+ *           is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.
+ *
+ * The interesting pieces are the two conditionals. The upkeep flip is gated on the *revealed*
+ * card's type **and** mana value, so a revealed cheap creature must not flip it; and Krothuss's
+ * token count is a `DynamicAmount.Conditional` over the target's subtypes, so the same effect makes
+ * one token or two depending purely on what it copied.
+ */
+class RunoStromkirkScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Runo Stromkirk") {
+
+            /** Runo on the battlefield with [topOfLibrary] as the only card in the library. */
+            fun runoWithTop(topOfLibrary: String): TestGame =
+                scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Runo Stromkirk", summoningSickness = false)
+                    .withCardInLibrary(1, topOfLibrary)
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+            fun faceName(game: TestGame): String =
+                game.state.getEntity(
+                    game.findPermanent("Runo Stromkirk") ?: game.findPermanent("Krothuss, Lord of the Deep")!!
+                )!!.get<CardComponent>()!!.name
+
+            /** Run the upkeep trigger, revealing the looked-at card when offered the choice. */
+            fun runUpkeepRevealing(game: TestGame) {
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                var guard = 0
+                while (guard++ < 20) {
+                    val decision = game.getPendingDecision()
+                    when {
+                        decision is com.wingedsheep.engine.core.SelectCardsDecision ->
+                            game.selectCards(listOf(decision.options.first()))
+                        game.state.stack.isNotEmpty() -> game.resolveStack()
+                        else -> break
+                    }
+                }
+            }
+
+            test("revealing a creature with mana value 6 or greater transforms Runo") {
+                val game = runoWithTop("Colossal Dreadmaw") // {4}{G}{G} — mana value 6
+                runUpkeepRevealing(game)
+                withClue("a six-drop creature was revealed") {
+                    faceName(game) shouldBe "Krothuss, Lord of the Deep"
+                }
+            }
+
+            test("revealing a cheap creature does not transform Runo") {
+                val game = runoWithTop("Grizzly Bears") // mana value 2
+                runUpkeepRevealing(game)
+                withClue("the filter tests mana value as well as card type") {
+                    faceName(game) shouldBe "Runo Stromkirk"
+                }
+            }
+
+            test("the enters trigger tucks a chosen creature card from your graveyard on top") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Runo Stromkirk")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInGraveyard(1, "Colossal Dreadmaw")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dreadmaw = game.findCardsInGraveyard(1, "Colossal Dreadmaw").single()
+
+                game.castSpell(1, "Runo Stromkirk").error shouldBe null
+                var guard = 0
+                while (guard++ < 20) {
+                    when {
+                        game.getPendingDecision() is SelectManaSourcesDecision -> game.submitManaSourcesAutoPay()
+                        game.hasPendingDecision() -> game.selectTargets(listOf(dreadmaw))
+                        game.state.stack.isNotEmpty() -> game.resolveStack()
+                        else -> break
+                    }
+                }
+
+                withClue("the Dreadmaw left the graveyard for the top of the library") {
+                    game.isInGraveyard(1, "Colossal Dreadmaw") shouldBe false
+                    game.state.getLibrary(game.player1Id).first() shouldBe dreadmaw
+                }
+            }
+
+            test("declining the reveal leaves Runo on its front face") {
+                val game = runoWithTop("Colossal Dreadmaw")
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                var guard = 0
+                while (guard++ < 20) {
+                    val decision = game.getPendingDecision()
+                    when {
+                        decision is com.wingedsheep.engine.core.SelectCardsDecision -> game.skipSelection()
+                        game.state.stack.isNotEmpty() -> game.resolveStack()
+                        else -> break
+                    }
+                }
+                withClue("the transform reads the *revealed* collection, which stayed empty") {
+                    faceName(game) shouldBe "Runo Stromkirk"
+                }
+            }
+        }
+
+        context("Krothuss, Lord of the Deep") {
+
+            /** Krothuss plus one other creature of the caller's choosing, ready to attack. */
+            fun krothussWith(partner: String): TestGame =
+                scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Krothuss, Lord of the Deep", summoningSickness = false)
+                    .withCardOnBattlefield(1, partner, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+            fun attackAndCopy(game: TestGame, partner: String) {
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Krothuss, Lord of the Deep" to 2, partner to 2)
+                ).error shouldBe null
+                var guard = 0
+                while (guard++ < 20) {
+                    when {
+                        game.hasPendingDecision() -> {
+                            val partnerId = game.findPermanent(partner)!!
+                            game.selectTargets(listOf(partnerId))
+                        }
+                        game.state.stack.isNotEmpty() -> game.resolveStack()
+                        else -> break
+                    }
+                }
+            }
+
+            test("copying a non-Kraken attacker makes one token") {
+                val partner = "Grizzly Bears"
+                val game = krothussWith(partner)
+                attackAndCopy(game, partner)
+                withClue("one original plus one token copy") {
+                    game.findAllPermanents(partner).size shouldBe 2
+                }
+            }
+
+            test("copying an Octopus attacker makes two tokens") {
+                val partner = "Giant Octopus" // Creature — Octopus
+                val game = krothussWith(partner)
+                attackAndCopy(game, partner)
+                withClue("the subtype rider doubles the count: one original plus two token copies") {
+                    game.findAllPermanents(partner).size shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -227,6 +227,173 @@
     ]
 }
 
+// Alluring Suitor
+{
+    "name": "Alluring Suitor",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "When you attack with exactly two creatures, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "minAttackers": 2
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerRestriction": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature attacking"
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When you attack with exactly two creatures, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Deadly Dancer",
+        "manaCost": "",
+        "typeLine": "Creature — Vampire",
+        "oracleText": "Trample\nWhen this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end.\n{R}{R}: This creature and another target creature each get +1/+0 until end of turn.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "TRAMPLE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddMana",
+                                "color": "RED",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "RetainUnspentMana",
+                                "colors": [
+                                    "RED"
+                                ]
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "When this creature transforms into Deadly Dancer, add {R}{R}. Until end of turn, you don't lose this mana as steps and phases end."
+                }
+            ],
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{R}{R}"
+                        }
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target creature"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature",
+                                "excludeSelf": true
+                            },
+                            "id": "another target creature"
+                        }
+                    ],
+                    "descriptionOverride": "This creature and another target creature each get +1/+0 until end of turn."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "141",
+            "rarity": "UNCOMMON",
+            "artist": "Justine Cruz",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1783924853"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "Justine Cruz",
+        "flavorText": "\"May I have this dance?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/397ffd01-c090-4233-9f5a-5f765886d498.jpg?1783924853",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "A creature put onto the battlefield attacking didn't \"attack\" and won't be counted to determine whether Alluring Suitor's ability should trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ancestral Anger
 {
     "name": "Ancestral Anger",
@@ -7157,6 +7324,195 @@
         "artist": "Wayne Reynolds",
         "flavorText": "The door to her home survived the fires of the Malignus. Now it's her greatest weapon.",
         "imageUri": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg?1782703190"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Faithbound Judge
+{
+    "name": "Faithbound Judge",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Spirit Soldier",
+    "oracleText": "Defender, flying, vigilance\nAt the beginning of your upkeep, if this creature has two or fewer judgment counters on it, put a judgment counter on it.\nAs long as this creature has three or more judgment counters on it, it can attack as though it didn't have defender.\nDisturb {5}{W}{W} (You may cast this card from your graveyard transformed for its disturb cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING",
+        "VIGILANCE",
+        "DISTURB"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disturb",
+            "cost": "{5}{W}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "judgment",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "judgment"
+                            }
+                        }
+                    },
+                    "operator": "LTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, if this creature has two or fewer judgment counters on it, put a judgment counter on it."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CanAttackDespiteDefender",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "judgment"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Sinner's Judgment",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura Curse",
+        "oracleText": "Enchant player\nAt the beginning of your upkeep, put a judgment counter on this Aura. Then if there are three or more judgment counters on it, enchanted player loses the game.\nIf Sinner's Judgment would be put into a graveyard from anywhere, exile it instead.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "judgment",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "judgment"
+                                                }
+                                            }
+                                        },
+                                        "operator": "GTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "type": "LoseGame",
+                                    "target": {
+                                        "type": "PlayerRef",
+                                        "player": "EnchantedPlayer"
+                                    },
+                                    "message": "Sinner's Judgment"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "At the beginning of your upkeep, put a judgment counter on this Aura. Then if there are three or more judgment counters on it, enchanted player loses the game."
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Graveyard"
+                    },
+                    "selfOnly": true
+                }
+            ],
+            "auraTarget": "TargetPlayer"
+        },
+        "metadata": {
+            "collectorNumber": "12",
+            "rarity": "MYTHIC",
+            "artist": "Svetlin Velinov",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1783951787"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "MYTHIC",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db791fb6-b0ff-4ded-bd3d-9447cf398312.jpg?1783951787",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "Removing judgment counters from Faithbound Judge after it has attacked won't remove it from combat."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -15527,6 +15883,211 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Runo Stromkirk
+{
+    "name": "Runo Stromkirk",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Legendary Creature — Vampire Cleric",
+    "oracleText": "Flying\nWhen Runo enters, put up to one target creature card from your graveyard on top of your library.\nAt the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature card from your graveyard"
+                    },
+                    "destination": "Library",
+                    "placement": "Top"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "creature card from your graveyard"
+                },
+                "descriptionOverride": "When Runo enters, put up to one target creature card from your graveyard on top of your library."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "runoLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "runoLooked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "runoRevealed",
+                            "prompt": "You may reveal the top card of your library",
+                            "selectedLabel": "Reveal",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "runoRevealed",
+                            "revealToSelf": false
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "runoRevealed",
+                                    "filter": "creature mv>=6"
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If a creature card with mana value 6 or greater is revealed this way, transform Runo."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Krothuss, Lord of the Deep",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Kraken Horror",
+        "oracleText": "Flying\nWhenever Krothuss attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 5
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "CreateTokenCopyOfTarget",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "another attacking creature"
+                        },
+                        "count": {
+                            "type": "Conditional",
+                            "condition": {
+                                "type": "EntityMatches",
+                                "entity": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "filter": "creature Kraken|Leviathan|Octopus|Serpent"
+                            },
+                            "ifTrue": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "ifFalse": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "tapped": true,
+                        "attacking": true
+                    },
+                    "targetRequirement": {
+                        "type": "TargetOther",
+                        "baseRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature attacking"
+                            }
+                        },
+                        "id": "another attacking creature"
+                    },
+                    "descriptionOverride": "Whenever Krothuss attacks, create a tapped and attacking token that's a copy of another target attacking creature. If that creature is a Kraken, Leviathan, Octopus, or Serpent, create two of those tokens instead."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "246",
+            "rarity": "RARE",
+            "artist": "Matt Stewart",
+            "imageUri": "https://cards.scryfall.io/normal/back/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1783924792",
+            "rulings": [
+                {
+                    "date": "2021-11-19",
+                    "text": "You choose which opponent or opposing planeswalker the token is attacking as you put it onto the battlefield. It doesn't have to be the same player or planeswalker Krothuss, Lord of the Deep is attacking."
+                },
+                {
+                    "date": "2021-11-19",
+                    "text": "Although the token is attacking, it was never declared as an attacking creature (for purposes of abilities that trigger whenever a creature attacks, for example, like training)."
+                },
+                {
+                    "date": "2021-11-19",
+                    "text": "The token copies exactly what was printed on the original creature and nothing else (unless that permanent is copying something else or is a token). It doesn't copy whether that creature has any counters on it or Auras and/or Equipment attached to it, or any non-copy effects that changed its power, toughness, types, color, and so on."
+                },
+                {
+                    "date": "2021-11-19",
+                    "text": "Any enters-the-battlefield abilities of the copied creature will trigger when the token enters the battlefield."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "BLUE",
+            "BLACK"
+        ],
+        "colorIndicator": [
+            "BLUE",
+            "BLACK"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6c0fca5-b759-4543-95e2-8d712aae5281.jpg?1783924792"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LoseGameExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LoseGameExecutor.kt
@@ -26,7 +26,11 @@ class LoseGameExecutor : EffectExecutor<LoseGameEffect> {
         effect: LoseGameEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolvePlayerTarget(effect.target)
+        // State-aware resolution: the stateless overload only knows the four "chosen target"
+        // references, so an attachment- or relation-derived player (Sinner's Judgment's
+        // `Player.EnchantedPlayer`, `ChosenOpponent`, `OwnerOf`, …) silently resolved to null and
+        // the loss never happened. `resolvePlayerRef` is the switch that knows all of them.
+        val targetId = context.resolvePlayerTarget(effect.target, state)
             ?: return EffectResult.error(state, "No target player for LoseGameEffect")
 
         // Check if player has already lost

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -186,4 +186,5 @@ export const counterManaClass: Record<string, string> = {
   JAVELIN: 'counter-arrow',
   CREDIT: 'counter-gold',
   CUBE: 'counter-charge',
+  JUDGMENT: 'counter-shield',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -787,6 +787,10 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.JAVELIN,
   CounterType.CREDIT,
   CounterType.CUBE,
+  // Innistrad: Crimson Vow. Faithbound Judge // Sinner's Judgment counts to three on both
+  // faces, and on the Aura face the third counter *ends the game* — a tally a player has to be
+  // able to read off the board.
+  CounterType.JUDGMENT,
   CounterType.PLUS_ONE_PLUS_TWO,
   CounterType.PLUS_TWO_PLUS_TWO,
   CounterType.MINUS_TWO_MINUS_TWO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2339,6 +2339,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   JAVELIN: { bg: 'rgba(44, 38, 26, 0.95)', border: 'rgba(210, 180, 120, 0.7)', color: '#e0cba0' },
   CREDIT: { bg: 'rgba(48, 42, 18, 0.95)', border: 'rgba(226, 196, 96, 0.7)', color: '#ecd98a' },
   CUBE: { bg: 'rgba(34, 30, 52, 0.95)', border: 'rgba(168, 150, 220, 0.7)', color: '#c6b6ea' },
+  JUDGMENT: { bg: 'rgba(52, 46, 24, 0.95)', border: 'rgba(232, 208, 132, 0.75)', color: '#f2e2a4', glow: 'rgba(232, 208, 132, 0.6)' },
   MINUS_ZERO_MINUS_ONE: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },
 }
 

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -512,6 +512,7 @@ export enum CounterType {
   CREDIT = 'CREDIT',
   CUBE = 'CUBE',
   TIDE = 'TIDE',
+  JUDGMENT = 'JUDGMENT',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -615,6 +616,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.CREDIT]: 'Credit',
   [CounterType.CUBE]: 'Cube',
   [CounterType.TIDE]: 'Tide',
+  [CounterType.JUDGMENT]: 'Judgment',
 }
 
 /**


### PR DESCRIPTION
The VOW tail, minus the three cards that genuinely need new engine vocabulary. 270 / 273.

## Cards

- **Alluring Suitor // Deadly Dancer** (#141) — "When you attack with **exactly two** creatures, transform this creature." The back has trample, a transforms-into trigger adding `{R}{R}` that survives step and phase boundaries, and a `{R}{R}` pump of itself plus another target creature.
  Composes `YouAttackEvent(minAttackers = 2)` with a CR 603.2 `triggerRestriction` (`attackingCreaturesYouControl` `EQ` 2), `Triggers.TransformsToBack`, `Effects.AddMana` + `Effects.RetainUnspentMana`, and `TargetFilter.OtherCreature`.
- **Runo Stromkirk // Krothuss, Lord of the Deep** (#246) — enters tucking up to one target creature card from your graveyard; flips on an upkeep reveal of a creature with mana value 6+; the back copies another target attacking creature, tapped and attacking, twice over for a Kraken/Leviathan/Octopus/Serpent.
  The upkeep trigger is Delver of Secrets' shape with a different filter. The doubled count is `DynamicAmount.Conditional` over `Conditions.TargetMatchesFilter` feeding `CreateTokenCopyOfTargetEffect.count`, so it stays one effect with two possible counts rather than two branches.
- **Faithbound Judge // Sinner's Judgment** (#12) — defender/flying/vigilance 4/4 that sheds defender at three judgment counters, disturb `{5}{W}{W}`, and an Aura Curse whose third judgment counter makes the enchanted player lose the game.
  `CanAttackDespiteDefender`, `auraTarget = Targets.Player`, `Effects.LoseGame(PlayerRef(EnchantedPlayer))`, `RedirectZoneChange(selfOnly = true)`.

The two Faithbound faces differ exactly as printed: the creature's clause is a true intervening "if" that caps the tally at three, the Aura's is a resolution-time "Then if" with no cap. They share no tally (CR 400.7), so a disturbed Curse starts at zero.

## Supporting changes

- **`Counters.JUDGMENT`** — a passive named counter, wired through the SDK enum/constants and the client's `PASSIVE_COUNTER_TYPES`, badge palette and icon class, per the language reference's catalog-addition checklist.
- **Engine fix: `LoseGameExecutor` used the stateless player resolver.** Its `PlayerRef` arm knows only You / TargetPlayer / TargetOpponent / Any / TriggeringPlayer, so `Player.EnchantedPlayer` — and `ChosenOpponent`, `DefendingPlayer`, `AnOpponent`, `OwnerOf`, `ControllerOf` — resolved to `null` and the loss silently never happened. Switched to the state-aware overload that delegates to `resolvePlayerRef`, which is what every other attachment-scoped payoff already uses.

## Not in this PR

Three VOW cards remain, each blocked on real `add-feature` work rather than authoring:

| Card | What it needs |
|---|---|
| Kaya, Geist Hunter | `TokenCreationReplacementHelper.applyCountReplacements` only walks battlefield permanents' printed replacements, so a floating until-EOT `MultiplyTokenCreation` granted by the −2 is inert |
| Radiant Grace // Radiant Restraints | A return-from-graveyard that is both *transformed* and *attached to a target player* (the two effects are disjoint today, and the attach executor rejects non-battlefield hosts), plus a `ControlledByEnchantedPlayer` controller scope |
| Jacob Hauken, Inspector | A per-turn use cap on `GrantMayPlayFromExileEffect` (`oncePerTurn` exists only on the cast-grant statics, which exclude lands), and a look-at-face-down-exile grant independent of a play permission |

## Verification

- `just build` and `just test` — green.
- 15 new scenario tests across three files (one per card), all passing.
- `just assay-differential --set VOW` — 70/70 confirmed, 0 divergent.
- `just check-card-printing` — clean for all three; VOW is the canonical printing for each.
- Every field re-verified against Scryfall: name, mana cost, type line, P/T, oracle text, rarity, collector number, artist, image URI.
- `tsc --noEmit` and the client's passive-counter wiring test (111 assertions) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCfUksnRx8VT364fCpU3qw