### PR TITLE
Expand exact structured decisions in tree search (review-fixed)

### DIFF
--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -81,9 +81,11 @@ fun interface StructuredDecisionResolver {
 }
 ```
 
-An expander reports either an exact `Complete` response sequence or `Unsupported`.
+An expander reports either an exact `Complete` response list or `Unsupported`.
 Unsupported decisions retain the configured resolver's single policy-selected
-fallback; no partial expansion, search cap, or sampling policy is implied.
+fallback; no partial expansion, search cap, or sampling policy is implied. A
+supported family with nothing legal to say reports `Unsupported` too — an empty
+`Complete` is unsearchable, so the resolver owns that degenerate case.
 
 ## Design choices worth knowing about
 
@@ -126,11 +128,18 @@ MCTS edges are ordinary `GameAction`s. At a priority state, edges are
 friends), edges are `SubmitDecision(response)` — exactly the set of
 folded responses `:gym`'s `ActionRegistry` produces. At a complex
 pending decision (targets, distribute, order, search, etc.) the
-`StructuredDecisionExpander` may return a complete response sequence. The
-built-in exact expander covers one required target from an explicit finite legal
-target list; each validator-approved response becomes its own edge. Other
-structured decisions retain one `StructuredDecisionResolver` fallback edge,
-which is policy-selected rather than exhaustive.
+`StructuredDecisionExpander` may return a complete response list. The built-in
+exact expander covers one target slot — required or optional — drawn from an
+explicit finite legal target list; each validator-approved response becomes its
+own edge, and declining an optional slot is the empty selection. Other structured
+decisions retain one `StructuredDecisionResolver` fallback edge, which is
+policy-selected rather than exhaustive.
+
+Cancellation is not among the expanded responses. A `CancelDecisionResponse`
+rewinds a cast-time decision to the priority state that offered the cast, so a
+cancel edge is a transposition back onto the node's own ancestor — the "don't
+cast" branch already exists where the cast was chosen, and duplicating it there
+would let search spend its budget on cast/cancel cycles.
 
 ### Outcome-labelled self-play rows
 
@@ -157,8 +166,8 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `ExactStructuredDecisionExpander` | Complete lazy required-single-target response source. |
-| `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions. |
+| `ExactStructuredDecisionExpander` | Complete single-target-slot response source, required or optional. |
+| `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions; redraws until the engine's validator accepts. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended
 to be replaced when a project gets serious.
@@ -241,4 +250,5 @@ The test set covers:
 - Root noise doesn't break the search
 - Exact structured expansion, validator agreement, and unsupported fallback
 - Independent target-response branches through ordinary Gym execution
+- Resolver draws that violate a state-dependent restriction are redrawn
 - End-to-end self-play producing outcome-labelled JSONL (`SelfPlayLoopTest`)

--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -69,6 +69,22 @@ and the engine's `PendingDecision` (non-null when mid-decision). Every SPI
 call receives it so implementations can branch on decision kind (priority
 vs target selection vs yes/no vs …).
 
+Structured decisions have two separate search seams:
+
+```kotlin
+fun interface StructuredDecisionExpander {
+    fun expand(state: GameState, decision: PendingDecision): StructuredDecisionExpansion
+}
+
+fun interface StructuredDecisionResolver {
+    fun resolve(state: GameState, decision: PendingDecision): DecisionResponse
+}
+```
+
+An expander reports either an exact `Complete` response sequence or `Unsupported`.
+Unsupported decisions retain the configured resolver's single policy-selected
+fallback; no partial expansion, search cap, or sampling policy is implied.
+
 ## Design choices worth knowing about
 
 ### Multi-head policy is first-class
@@ -85,6 +101,11 @@ priority-opponent / target / binary). Forcing every project through a
 single flat head would have made them fork, which was the whole problem
 we were trying to solve. The cost for simple users is a one-element
 `listOf(PolicyHead("actions", 128))`.
+
+Concrete actions are tree-edge identity, while `(head, slot)` is neural-policy
+identity. Colliding structured responses remain independent MCTS edges but
+receive the same learned prior; use a discriminating `ActionFeaturizer` when
+response-specific learned priors or training targets are required.
 
 ### Engine-side MCTS, not Python-side
 
@@ -105,9 +126,11 @@ MCTS edges are ordinary `GameAction`s. At a priority state, edges are
 friends), edges are `SubmitDecision(response)` — exactly the set of
 folded responses `:gym`'s `ActionRegistry` produces. At a complex
 pending decision (targets, distribute, order, search, etc.) the
-`StructuredDecisionResolver` returns a single forced edge. The built-in
-resolver samples uniformly; a production project can supply a heuristic
-or learned one.
+`StructuredDecisionExpander` may return a complete response sequence. The
+built-in exact expander covers one required target from an explicit finite legal
+target list; each validator-approved response becomes its own edge. Other
+structured decisions retain one `StructuredDecisionResolver` fallback edge,
+which is policy-selected rather than exhaustive.
 
 ### Outcome-labelled self-play rows
 
@@ -134,7 +157,8 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `RandomStructuredResolver` | Uniform-random response for structured decisions (targets, etc.). |
+| `ExactStructuredDecisionExpander` | Complete lazy required-single-target response source. |
+| `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended
 to be replaced when a project gets serious.
@@ -215,4 +239,6 @@ just test-gym-trainer              # this module only
 The test set covers:
 - PUCT visit accounting (`AlphaZeroSearchTest`)
 - Root noise doesn't break the search
+- Exact structured expansion, validator agreement, and unsupported fallback
+- Independent target-response branches through ordinary Gym execution
 - End-to-end self-play producing outcome-labelled JSONL (`SelfPlayLoopTest`)

--- a/gym-trainer/build.gradle.kts
+++ b/gym-trainer/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(kotlin("reflect"))
 
     testImplementation(project(":mtg-sets"))
+    testImplementation(testFixtures(project(":rules-engine")))
     testImplementation(libs.kotestRunner)
     testImplementation(libs.kotestAssertions)
     testImplementation(libs.kotestProperty)

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.gym.trainer.defaults
+
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Exact, policy-free expansion for structured families whose pending-decision metadata fully
+ * describes a finite response space.
+ *
+ * A target decision with exactly one requirement for exactly one target is finite and described
+ * completely by its pending-decision payload. Every candidate is filtered through
+ * [DecisionValidators] before it is exposed. Variable-cardinality and multi-requirement target
+ * decisions remain unsupported because current MCTS materializes every edge and has no
+ * caller-owned widening or response-budget policy. Other structured families remain unsupported.
+ */
+object ExactStructuredDecisionExpander : StructuredDecisionExpander {
+
+    override fun expand(
+        state: GameState,
+        decision: PendingDecision
+    ): StructuredDecisionExpansion = when (decision) {
+        is ChooseTargetsDecision -> {
+            val requirement = decision.targetRequirements.singleOrNull()
+            val legalTargets = requirement?.let { decision.legalTargets[it.index] }
+            if (
+                requirement == null || legalTargets == null ||
+                requirement.minTargets != 1 || requirement.maxTargets != 1
+            ) {
+                StructuredDecisionExpansion.Unsupported
+            } else {
+                complete(state, decision, targetResponses(decision, requirement.index, legalTargets))
+            }
+        }
+
+        else -> StructuredDecisionExpansion.Unsupported
+    }
+
+    private fun targetResponses(
+        decision: ChooseTargetsDecision,
+        requirementIndex: Int,
+        legalTargets: List<EntityId>
+    ): Sequence<DecisionResponse> =
+        sequence {
+            if (decision.canCancel) {
+                yield(CancelDecisionResponse(decision.id))
+            }
+
+            for (target in legalTargets.distinct()) {
+                yield(
+                    TargetsResponse(
+                        decisionId = decision.id,
+                        selectedTargets = mapOf(requirementIndex to listOf(target))
+                    )
+                )
+            }
+        }
+
+    private fun complete(
+        state: GameState,
+        decision: PendingDecision,
+        candidates: Sequence<DecisionResponse>
+    ): StructuredDecisionExpansion.Complete = StructuredDecisionExpansion.Complete(
+        candidates.filter { DecisionValidators.validate(decision, it, state) == null }
+    )
+}

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.gym.trainer.defaults
 
-import com.wingedsheep.engine.core.CancelDecisionResponse
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.PendingDecision
@@ -15,11 +14,23 @@ import com.wingedsheep.sdk.model.EntityId
  * Exact, policy-free expansion for structured families whose pending-decision metadata fully
  * describes a finite response space.
  *
- * A target decision with exactly one requirement for exactly one target is finite and described
- * completely by its pending-decision payload. Every candidate is filtered through
- * [DecisionValidators] before it is exposed. Variable-cardinality and multi-requirement target
- * decisions remain unsupported because current MCTS materializes every edge and has no
- * caller-owned widening or response-budget policy. Other structured families remain unsupported.
+ * A target decision with one requirement for at most one target is finite and described completely
+ * by its pending-decision payload: one response per legal target, plus the empty selection when the
+ * requirement is optional. Every candidate is filtered through [DecisionValidators] before it is
+ * exposed. Variable-cardinality and multi-requirement target decisions remain unsupported because
+ * current MCTS materializes every edge and has no caller-owned widening or response-budget policy.
+ * Other structured families remain unsupported.
+ *
+ * Cancellation is deliberately not one of the responses. A
+ * [com.wingedsheep.engine.core.CancelDecisionResponse] on a cast-time target decision rewinds to the
+ * priority state that offered the cast, so a cancel edge is a transposition back to the search node's
+ * own ancestor rather than an alternative *within* the decision — the "don't cast" branch already
+ * exists where the cast was chosen. Declining an optional requirement is the empty selection, which
+ * stays inside the decision.
+ *
+ * A supported decision left with no validator-approved response is reported as
+ * [StructuredDecisionExpansion.Unsupported], not as an empty [StructuredDecisionExpansion.Complete]:
+ * an empty complete set is unsearchable, so the caller's resolver fallback owns that degenerate case.
  */
 object ExactStructuredDecisionExpander : StructuredDecisionExpander {
 
@@ -32,11 +43,20 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
             val legalTargets = requirement?.let { decision.legalTargets[it.index] }
             if (
                 requirement == null || legalTargets == null ||
-                requirement.minTargets != 1 || requirement.maxTargets != 1
+                requirement.maxTargets != 1 || requirement.minTargets !in 0..1
             ) {
                 StructuredDecisionExpansion.Unsupported
             } else {
-                complete(state, decision, targetResponses(decision, requirement.index, legalTargets))
+                complete(
+                    state = state,
+                    decision = decision,
+                    candidates = targetResponses(
+                        decision = decision,
+                        requirementIndex = requirement.index,
+                        legalTargets = legalTargets,
+                        optional = requirement.minTargets == 0
+                    )
+                )
             }
         }
 
@@ -46,28 +66,28 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
     private fun targetResponses(
         decision: ChooseTargetsDecision,
         requirementIndex: Int,
-        legalTargets: List<EntityId>
-    ): Sequence<DecisionResponse> =
-        sequence {
-            if (decision.canCancel) {
-                yield(CancelDecisionResponse(decision.id))
-            }
-
-            for (target in legalTargets.distinct()) {
-                yield(
-                    TargetsResponse(
-                        decisionId = decision.id,
-                        selectedTargets = mapOf(requirementIndex to listOf(target))
-                    )
-                )
-            }
+        legalTargets: List<EntityId>,
+        optional: Boolean
+    ): List<DecisionResponse> = buildList {
+        if (optional) {
+            add(TargetsResponse(decision.id, mapOf(requirementIndex to emptyList())))
         }
+
+        for (target in legalTargets.distinct()) {
+            add(TargetsResponse(decision.id, mapOf(requirementIndex to listOf(target))))
+        }
+    }
 
     private fun complete(
         state: GameState,
         decision: PendingDecision,
-        candidates: Sequence<DecisionResponse>
-    ): StructuredDecisionExpansion.Complete = StructuredDecisionExpansion.Complete(
-        candidates.filter { DecisionValidators.validate(decision, it, state) == null }
-    )
+        candidates: List<DecisionResponse>
+    ): StructuredDecisionExpansion {
+        val legal = candidates.filter { DecisionValidators.validate(decision, it, state) == null }
+        return if (legal.isEmpty()) {
+            StructuredDecisionExpansion.Unsupported
+        } else {
+            StructuredDecisionExpansion.Complete(legal)
+        }
+    }
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -29,10 +29,14 @@ import com.wingedsheep.engine.core.BatchYesNoDecision
 import com.wingedsheep.engine.core.BatchYesNoResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
 import com.wingedsheep.gym.GameEnvironment
+import com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander
 import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
 import com.wingedsheep.gym.trainer.spi.Evaluator
 import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
 import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
 import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.engine.legalactions.LegalAction
@@ -59,10 +63,10 @@ import java.util.Random as JavaRandom
  *      - At a simple pending decision (YesNo, ChooseNumber, single-mode
  *        ChooseMode, ChooseColor, ChooseOption, single-select SelectCards)
  *        → every folded [DecisionResponse] becomes an edge.
- *      - At a complex pending decision (ChooseTargets, Distribute, Order,
- *        SplitPiles, Search, Reorder, AssignDamage, SelectManaSources,
- *        multi-select SelectCards, multi-mode ChooseMode, BudgetModal)
- *        → the [StructuredDecisionResolver] returns a *single* forced edge.
+ *      - At a structured pending decision → [StructuredDecisionExpander]
+ *        may expose a complete response set as independent edges. Unsupported
+ *        families retain a single policy-selected [StructuredDecisionResolver]
+ *        fallback edge.
  *    Then call the [Evaluator] to get priors and value.
  * 3. **Simulate (value)** — at terminal, use the game outcome; at an
  *    expanded leaf, use the evaluator's value (from the acting player's
@@ -81,12 +85,14 @@ import java.util.Random as JavaRandom
  * @param actionFeaturizer action → `(head, slot)` policy index
  * @param evaluator priors + value provider; typically a remote NN
  * @param structuredResolver called on complex engine decisions the
- *        folded-action-space can't express
+ *        [structuredExpander] does not support; this is a policy fallback
  * @param cPuct exploration constant; `1.0` is a sensible default
  * @param dirichletAlpha optional Dirichlet noise alpha applied to root
  *        priors only; `null` disables noise
  * @param dirichletWeight `(1-w) * prior + w * dirichlet` mix weight
  * @param rng seed for noise sampling
+ * @param structuredExpander policy-free source of complete structured
+ *        response sets; defaults to exact required-single-target expansion
  */
 class AlphaZeroSearch<T>(
     private val env: GameEnvironment,
@@ -97,7 +103,8 @@ class AlphaZeroSearch<T>(
     private val cPuct: Double = 1.0,
     private val dirichletAlpha: Double? = null,
     private val dirichletWeight: Double = 0.25,
-    private val rng: Random = Random.Default
+    private val rng: Random = Random.Default,
+    private val structuredExpander: StructuredDecisionExpander = ExactStructuredDecisionExpander
 ) {
     private val workingEnv: GameEnvironment = env.fork()
     private val javaRng: JavaRandom = JavaRandom(rng.nextLong())
@@ -181,6 +188,10 @@ class AlphaZeroSearch<T>(
             ?: error("Expanding a terminal node — should be caught earlier")
 
         val edges = enumerateEdges(node, acting)
+        check(edges.isNotEmpty()) {
+            val source = node.pendingDecision?.let { it::class.simpleName } ?: "priority state"
+            "No search edges for $source"
+        }
         node.edges = edges
 
         val ctx = TrainerContext(node.state, acting, node.pendingDecision)
@@ -233,33 +244,89 @@ class AlphaZeroSearch<T>(
 
         val foldedResponses = foldSimpleDecision(pending)
         if (foldedResponses != null) {
-            return foldedResponses.map { response ->
-                val submit = SubmitDecision(pending.playerId, response)
-                MctsEdge(
-                    action = submit,
-                    legalAction = null,
-                    slot = actionFeaturizer.slot(submit, ctx)
+            return foldedResponses.map { response -> responseEdge(pending, response, ctx) }
+        }
+
+        return when (val expansion = structuredExpander.expand(node.state, pending)) {
+            is StructuredDecisionExpansion.Complete -> {
+                val edges = completeStructuredEdges(node.state, pending, expansion.responses, ctx)
+                check(edges.isNotEmpty()) {
+                    "Complete response expansion for ${pending::class.simpleName} was empty " +
+                        "at a non-terminal search node"
+                }
+                edges
+            }
+
+            StructuredDecisionExpansion.Unsupported -> {
+                val response = structuredResolver.resolve(node.state, pending)
+                listOf(
+                    validatedResponseEdge(
+                        state = node.state,
+                        decision = pending,
+                        response = response,
+                        ctx = ctx,
+                        source = "Structured decision resolver"
+                    )
                 )
             }
         }
+    }
 
-        // Complex decision — resolver produces a forced single edge.
-        val response = structuredResolver.resolve(node.state, pending)
-        val submit = SubmitDecision(pending.playerId, response)
-        return listOf(
-            MctsEdge(
-                action = submit,
-                legalAction = null,
-                slot = actionFeaturizer.slot(submit, ctx)
+    private fun completeStructuredEdges(
+        state: GameState,
+        decision: PendingDecision,
+        responses: Sequence<DecisionResponse>,
+        ctx: TrainerContext
+    ): List<MctsEdge> {
+        val seen = mutableSetOf<DecisionResponse>()
+        return responses.map { response ->
+            check(seen.add(response)) {
+                "Structured expander returned duplicate ${response::class.simpleName}: $response"
+            }
+            validatedResponseEdge(
+                state = state,
+                decision = decision,
+                response = response,
+                ctx = ctx,
+                source = "Structured decision expander"
             )
+        }.toList()
+    }
+
+    private fun validatedResponseEdge(
+        state: GameState,
+        decision: PendingDecision,
+        response: DecisionResponse,
+        ctx: TrainerContext,
+        source: String
+    ): MctsEdge {
+        check(response.decisionId == decision.id) {
+            "$source returned response for ${response.decisionId}, expected ${decision.id}"
+        }
+        val validationError = DecisionValidators.validate(decision, response, state)
+        check(validationError == null) {
+            "$source returned an illegal ${response::class.simpleName}: $validationError"
+        }
+        return responseEdge(decision, response, ctx)
+    }
+
+    private fun responseEdge(
+        decision: PendingDecision,
+        response: DecisionResponse,
+        ctx: TrainerContext
+    ): MctsEdge {
+        val submit = SubmitDecision(decision.playerId, response)
+        return MctsEdge(
+            action = submit,
+            legalAction = null,
+            slot = actionFeaturizer.slot(submit, ctx)
         )
     }
 
     /**
      * Returns the list of concrete [DecisionResponse]s when the pending
      * decision folds cleanly into a discrete action space; returns `null`
-     * when the decision requires a structured response (handed to the
-     * [StructuredDecisionResolver]).
+     * when the structured expander or resolver owns it.
      */
     private fun foldSimpleDecision(d: PendingDecision): List<DecisionResponse>? = when (d) {
         is YesNoDecision -> listOf(YesNoResponse(d.id, true), YesNoResponse(d.id, false))
@@ -296,6 +363,11 @@ class AlphaZeroSearch<T>(
     private fun createChild(parent: MctsNode, edge: MctsEdge, rootPlayer: EntityId): MctsNode {
         workingEnv.restore(parent.state, parent.playerIds, 0)
         workingEnv.step(edge.action)
+        if (edge.action is SubmitDecision) {
+            check(workingEnv.lastRejection == null) {
+                "Search decision edge was rejected by the engine: ${workingEnv.lastRejection}"
+            }
+        }
         return buildNode(
             workingEnv.state,
             workingEnv.playerIds,
@@ -400,10 +472,10 @@ class MctsSearchResult(
 }
 
 /**
- * Default [StructuredDecisionResolver] — picks a uniformly-random valid
- * response for any structured decision. Good enough for getting a training
- * loop to run end-to-end; replace with a heuristic or learned resolver for
- * real training runs.
+ * Default [StructuredDecisionResolver] — picks a random minimum-cardinality
+ * response for the target, card-selection, and mode families it supports.
+ * This is a fallback policy, not uniform enumeration of the legal response
+ * space. Replace it with a domain policy when unsupported decisions can occur.
  */
 class RandomStructuredResolver(private val rng: Random = Random.Default) : StructuredDecisionResolver {
     override fun resolve(state: GameState, decision: PendingDecision): DecisionResponse {

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -275,7 +275,7 @@ class AlphaZeroSearch<T>(
     private fun completeStructuredEdges(
         state: GameState,
         decision: PendingDecision,
-        responses: Sequence<DecisionResponse>,
+        responses: List<DecisionResponse>,
         ctx: TrainerContext
     ): List<MctsEdge> {
         val seen = mutableSetOf<DecisionResponse>()
@@ -290,7 +290,7 @@ class AlphaZeroSearch<T>(
                 ctx = ctx,
                 source = "Structured decision expander"
             )
-        }.toList()
+        }
     }
 
     private fun validatedResponseEdge(
@@ -476,35 +476,66 @@ class MctsSearchResult(
  * response for the target, card-selection, and mode families it supports.
  * This is a fallback policy, not uniform enumeration of the legal response
  * space. Replace it with a domain policy when unsupported decisions can occur.
+ *
+ * Minimum cardinality on its own does not satisfy the state-dependent restrictions the engine's
+ * validator enforces — "with different names", "one per card type", a total-mana-value cap. Rather
+ * than re-implement constraint solving here, the resolver draws up to [attempts] random candidates
+ * and returns the first the engine accepts. When none is accepted it returns the last draw, so the
+ * caller fails loudly against the authoritative validator instead of quietly submitting an illegal
+ * response.
+ *
+ * @param attempts how many candidates to draw before giving up; each draw beyond the first costs one
+ *        [DecisionValidators] call
  */
-class RandomStructuredResolver(private val rng: Random = Random.Default) : StructuredDecisionResolver {
+class RandomStructuredResolver(
+    private val rng: Random = Random.Default,
+    private val attempts: Int = 16
+) : StructuredDecisionResolver {
+
+    init {
+        require(attempts >= 1) { "attempts must be positive" }
+    }
+
     override fun resolve(state: GameState, decision: PendingDecision): DecisionResponse {
-        // Minimal coverage — handles the common structured decisions. Unknown
-        // decisions fall through to an exception the caller can see.
-        return when (decision) {
-            is ChooseTargetsDecision -> {
-                val picked = decision.targetRequirements.associate { req ->
-                    val legal = decision.legalTargets[req.index].orEmpty()
-                    val count = req.minTargets.coerceIn(0, legal.size)
-                    req.index to legal.shuffled(rng).take(count)
-                }
-                com.wingedsheep.engine.core.TargetsResponse(decision.id, picked)
-            }
-            is SelectCardsDecision -> {
-                val n = decision.minSelections.coerceAtLeast(1).coerceAtMost(decision.options.size)
-                val picked = decision.options.shuffled(rng).take(n)
-                CardsSelectedResponse(decision.id, picked)
-            }
-            is ChooseModeDecision -> {
-                val available = decision.modes.filter { it.available }
-                val n = decision.minModes.coerceAtLeast(1).coerceAtMost(available.size)
-                val picked = available.shuffled(rng).take(n).map { it.index }
-                ModesChosenResponse(decision.id, picked)
-            }
-            else -> throw UnsupportedOperationException(
-                "RandomStructuredResolver does not yet handle ${decision::class.simpleName}; " +
-                    "provide a custom StructuredDecisionResolver"
-            )
+        var candidate = draw(decision)
+        repeat(attempts - 1) {
+            if (DecisionValidators.validate(decision, candidate, state) == null) return candidate
+            candidate = draw(decision)
         }
+        return candidate
+    }
+
+    /**
+     * One unvalidated minimum-cardinality candidate. Minimal coverage — handles the common
+     * structured decisions. Unknown decisions fall through to an exception the caller can see.
+     */
+    private fun draw(decision: PendingDecision): DecisionResponse = when (decision) {
+        is ChooseTargetsDecision -> {
+            val picked = decision.targetRequirements.associate { req ->
+                val legal = decision.legalTargets[req.index].orEmpty()
+                // `take` clamps on its own; a requirement asking for more targets than are legal is
+                // unsatisfiable, and an under-count that fails validation says so louder than a
+                // silently shrunk selection would.
+                req.index to legal.shuffled(rng).take(req.minTargets)
+            }
+            com.wingedsheep.engine.core.TargetsResponse(decision.id, picked)
+        }
+        is SelectCardsDecision -> {
+            val n = decision.minSelections.coerceAtLeast(1)
+                .coerceAtMost(minOf(decision.maxSelections, decision.options.size))
+            val picked = decision.options.shuffled(rng).take(n)
+            CardsSelectedResponse(decision.id, picked)
+        }
+        is ChooseModeDecision -> {
+            val available = decision.modes.filter { it.available }
+            val n = decision.minModes.coerceAtLeast(1)
+                .coerceAtMost(minOf(decision.maxModes, available.size))
+            val picked = available.shuffled(rng).take(n).map { it.index }
+            ModesChosenResponse(decision.id, picked)
+        }
+        else -> throw UnsupportedOperationException(
+            "RandomStructuredResolver does not yet handle ${decision::class.simpleName}; " +
+                "provide a custom StructuredDecisionResolver"
+        )
     }
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
 import com.wingedsheep.gym.trainer.spi.Evaluator
 import com.wingedsheep.gym.trainer.spi.SelfPlaySink
 import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
 import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
 import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.sdk.model.EntityId
@@ -46,7 +47,9 @@ class SelfPlayLoop<T>(
     private val temperature: Double = 1.0,
     private val temperatureMoves: Int = 30,
     private val maxSteps: Int = 2000,
-    private val rng: Random = Random.Default
+    private val rng: Random = Random.Default,
+    private val structuredExpander: StructuredDecisionExpander =
+        com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander
 ) {
     /** Run one game. Returns the winner (null = draw / truncation). */
     fun playGame(config: GameConfig, gameId: String = UUID.randomUUID().toString()): GameOutcome {
@@ -68,7 +71,8 @@ class SelfPlayLoop<T>(
                 cPuct = cPuct,
                 dirichletAlpha = dirichletAlpha,
                 dirichletWeight = dirichletWeight,
-                rng = rng
+                rng = rng,
+                structuredExpander = structuredExpander
             )
             val result = search.run(simulationsPerMove)
 

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/ActionFeaturizer.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/ActionFeaturizer.kt
@@ -19,6 +19,14 @@ import com.wingedsheep.engine.core.GameAction
  *    [TrainerContext]s — that's how a `PassPriority` can be slot 0 in the
  *    "priority" head when it's an action and unused entirely in the
  *    "target" head when that's the active decision.
+ *
+ * A policy slot is not MCTS edge identity. Search keeps concrete actions as
+ * independent edges even when their slots collide, but colliding responses
+ * receive the same learned prior and cannot produce distinct categorical
+ * training targets. A production featurizer that learns structured choices
+ * should therefore be injective across the responses legal in one state.
+ * The current self-play row has one `headUsed`, so concurrent alternatives
+ * for a decision should also use one policy head.
  */
 interface ActionFeaturizer {
 

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/SelfPlaySink.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/SelfPlaySink.kt
@@ -26,7 +26,7 @@ interface SelfPlaySink<T> : AutoCloseable {
      * @param ctx           the decision context at which this step was made
      * @param actingPlayer  the player who made the move (== `ctx.playerId`)
      * @param headUsed      the policy head active for this decision
-     * @param legalSlots    slot encodings of every legal action at this state
+     * @param legalSlots    slot encodings of the search edges exposed at this state
      * @param visits        MCTS visit counts, parallel to `legalSlots`
      * @param mctsValue     MCTS-estimated value in `[-1, +1]` from
      *                      `actingPlayer`'s perspective; the terminal outcome

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
@@ -10,8 +10,7 @@ import com.wingedsheep.engine.state.GameState
  * select, sample, truncate, or rank responses on behalf of a search algorithm.
  *
  * Every response in a [StructuredDecisionExpansion.Complete] result must be accepted by the
- * engine's authoritative decision validator in [state]. The sequence may be lazy so an expander
- * does not have to materialize a combinatorial response space merely to describe it.
+ * engine's authoritative decision validator in [state].
  */
 fun interface StructuredDecisionExpander {
     fun expand(state: GameState, decision: PendingDecision): StructuredDecisionExpansion
@@ -20,20 +19,24 @@ fun interface StructuredDecisionExpander {
 /**
  * What an expander knows about a structured decision's response space.
  *
- * [Complete] contains a finite, possibly lazy sequence with one canonical response per legal
- * semantic alternative. It may contain zero, one, or many responses. [Unsupported] means the
- * expander makes no completeness claim; callers may fall back to a strategic
- * [StructuredDecisionResolver], but must not describe that selected response as the complete legal
- * response set.
+ * [Complete] is the finite set of legal semantic alternatives, one canonical response each. It is an
+ * ordinary list rather than a lazy sequence: a caller materializes every edge anyway, and the type
+ * admits no partial or bounded variant, so there is nothing for laziness to defer and no way for a
+ * consumer to be surprised by a single-shot source. [Unsupported] means the expander makes no
+ * completeness claim; callers may fall back to a strategic [StructuredDecisionResolver], but must not
+ * describe that selected response as the complete legal response set.
  *
  * There is deliberately no partial result yet. A bounded or sampled source needs an explicit
  * caller-owned policy for how non-exhaustive branches affect search and training.
- * [com.wingedsheep.gym.trainer.search.AlphaZeroSearch] treats a complete empty result at a live,
- * non-terminal node as an engine-state invariant failure: it does not substitute a resolver choice
- * for a response set known to be empty.
+ *
+ * A [Complete] holding no responses is unsearchable, so an expander that finds no legal response for
+ * a family it otherwise supports reports [Unsupported] and lets the caller's resolver own the
+ * degenerate case. [com.wingedsheep.gym.trainer.search.AlphaZeroSearch] rejects an empty [Complete]
+ * at a live, non-terminal node rather than substituting a resolver choice for a response set that
+ * claims to be exhaustive.
  */
 sealed interface StructuredDecisionExpansion {
-    class Complete(val responses: Sequence<DecisionResponse>) : StructuredDecisionExpansion
+    data class Complete(val responses: List<DecisionResponse>) : StructuredDecisionExpansion
 
     data object Unsupported : StructuredDecisionExpansion
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionExpander.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.gym.trainer.spi
+
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.state.GameState
+
+/**
+ * Generates the legal response alternatives that a search may branch over for a structured
+ * [PendingDecision]. This is a legality/enumeration seam, not a policy: implementations must not
+ * select, sample, truncate, or rank responses on behalf of a search algorithm.
+ *
+ * Every response in a [StructuredDecisionExpansion.Complete] result must be accepted by the
+ * engine's authoritative decision validator in [state]. The sequence may be lazy so an expander
+ * does not have to materialize a combinatorial response space merely to describe it.
+ */
+fun interface StructuredDecisionExpander {
+    fun expand(state: GameState, decision: PendingDecision): StructuredDecisionExpansion
+}
+
+/**
+ * What an expander knows about a structured decision's response space.
+ *
+ * [Complete] contains a finite, possibly lazy sequence with one canonical response per legal
+ * semantic alternative. It may contain zero, one, or many responses. [Unsupported] means the
+ * expander makes no completeness claim; callers may fall back to a strategic
+ * [StructuredDecisionResolver], but must not describe that selected response as the complete legal
+ * response set.
+ *
+ * There is deliberately no partial result yet. A bounded or sampled source needs an explicit
+ * caller-owned policy for how non-exhaustive branches affect search and training.
+ * [com.wingedsheep.gym.trainer.search.AlphaZeroSearch] treats a complete empty result at a live,
+ * non-terminal node as an engine-state invariant failure: it does not substitute a resolver choice
+ * for a response set known to be empty.
+ */
+sealed interface StructuredDecisionExpansion {
+    class Complete(val responses: Sequence<DecisionResponse>) : StructuredDecisionExpansion
+
+    data object Unsupported : StructuredDecisionExpansion
+}

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
@@ -12,14 +12,11 @@ import com.wingedsheep.engine.state.GameState
  * multi-mode `ChooseModeDecision` — that the gym can't fold into a single
  * numeric action space.
  *
- * MCTS treats the result as a *forced* single edge (no exploration), which
- * keeps the self-play loop running but does not train the network on
- * structured decisions. A production project can either:
- *
- *  - supply a smarter resolver that samples from a heuristic distribution, or
- *  - pre-flatten structured decisions into the action space via a custom
- *    [ActionFeaturizer] and an `Evaluator` that knows how to emit priors for
- *    them.
+ * This is a strategic policy seam: it chooses one response. It remains the
+ * fallback when [StructuredDecisionExpander] reports a decision family as unsupported; that
+ * resolver-selected edge is not claimed to be the complete legal response set.
+ * Supplying a custom [ActionFeaturizer] cannot expose responses that were
+ * already collapsed here; enumeration belongs in [StructuredDecisionExpander].
  */
 fun interface StructuredDecisionResolver {
     fun resolve(state: GameState, decision: PendingDecision): DecisionResponse

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/spi/StructuredDecisionResolver.kt
@@ -17,6 +17,11 @@ import com.wingedsheep.engine.state.GameState
  * resolver-selected edge is not claimed to be the complete legal response set.
  * Supplying a custom [ActionFeaturizer] cannot expose responses that were
  * already collapsed here; enumeration belongs in [StructuredDecisionExpander].
+ *
+ * The chosen response is checked against the engine's authoritative decision validator before it
+ * becomes a search edge, so a resolver is free to be strategically bad but not illegal: an
+ * unsatisfiable answer fails loudly rather than being submitted and silently rejected, which would
+ * leave the search a child node identical to its parent.
  */
 fun interface StructuredDecisionResolver {
     fun resolve(state: GameState, decision: PendingDecision): DecisionResponse

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -24,66 +24,117 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     val third = EntityId.of("third")
     val state = GameState(turnOrder = listOf(playerId))
 
-    test("single-target expansion is complete") {
-        val decision = ChooseTargetsDecision(
-            id = "targets",
-            playerId = playerId,
-            prompt = "Choose targets",
-            context = DecisionContext(),
-            targetRequirements = listOf(
-                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
-            ),
-            legalTargets = mapOf(0 to listOf(first, second)),
-            canCancel = true
-        )
+    fun targetDecision(
+        id: String,
+        legalTargets: List<EntityId>,
+        minTargets: Int = 1,
+        maxTargets: Int = 1,
+        canCancel: Boolean = false
+    ) = ChooseTargetsDecision(
+        id = id,
+        playerId = playerId,
+        prompt = "Choose targets",
+        context = DecisionContext(),
+        targetRequirements = listOf(
+            TargetRequirementInfo(0, "target", minTargets = minTargets, maxTargets = maxTargets)
+        ),
+        legalTargets = mapOf(0 to legalTargets),
+        canCancel = canCancel
+    )
+
+    test("required single-target expansion is complete") {
+        val decision = targetDecision("targets", listOf(first, second))
 
         val expansion = ExactStructuredDecisionExpander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
-        val responses = expansion.responses.toList()
 
-        responses.shouldContainExactly(
-            CancelDecisionResponse("targets"),
+        expansion.responses.shouldContainExactly(
             TargetsResponse("targets", mapOf(0 to listOf(first))),
             TargetsResponse("targets", mapOf(0 to listOf(second)))
         )
-        responses.forEach { response ->
+        expansion.responses.forEach { response ->
             response.asClue {
                 DecisionValidators.validate(decision, response, state) shouldBe null
             }
         }
     }
 
+    // "Up to one target" is as finite as "exactly one target" — the extra alternative is declining,
+    // which is an empty selection for the requirement, not a cancellation of the whole decision.
+    test("optional single-target expansion offers the empty selection") {
+        val decision = targetDecision("optional", listOf(first, second), minTargets = 0)
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            TargetsResponse("optional", mapOf(0 to emptyList())),
+            TargetsResponse("optional", mapOf(0 to listOf(first))),
+            TargetsResponse("optional", mapOf(0 to listOf(second)))
+        )
+        expansion.responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    // Cancelling a cast-time decision rewinds to the priority state that offered the cast, so a
+    // cancel edge would be a transposition back onto the search node's own ancestor rather than an
+    // alternative within the decision.
+    test("cancellation is never offered as a response") {
+        val decision = targetDecision("cancellable", listOf(first, second), canCancel = true)
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.none { it is CancelDecisionResponse } shouldBe true
+        expansion.responses.size shouldBe 2
+    }
+
+    test("duplicate legal targets collapse to one response each") {
+        val decision = targetDecision("duplicates", listOf(first, second, first))
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            TargetsResponse("duplicates", mapOf(0 to listOf(first))),
+            TargetsResponse("duplicates", mapOf(0 to listOf(second)))
+        )
+    }
+
     test("variable-cardinality target expansion is explicitly unsupported") {
+        val decision = targetDecision("many-targets", listOf(first, second, third), minTargets = 0, maxTargets = 2)
+
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("multi-requirement target expansion is explicitly unsupported") {
         val decision = ChooseTargetsDecision(
-            id = "many-targets",
+            id = "two-requirements",
             playerId = playerId,
             prompt = "Choose targets",
             context = DecisionContext(),
             targetRequirements = listOf(
-                TargetRequirementInfo(0, "up to two", minTargets = 0, maxTargets = 2)
+                TargetRequirementInfo(0, "first target"),
+                TargetRequirementInfo(1, "second target")
             ),
-            legalTargets = mapOf(0 to listOf(first, second, third))
+            legalTargets = mapOf(0 to listOf(first), 1 to listOf(second))
         )
 
         ExactStructuredDecisionExpander.expand(state, decision) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
-    test("supported family with no legal response is a complete empty expansion") {
-        val decision = ChooseTargetsDecision(
-            id = "no-targets",
-            playerId = playerId,
-            prompt = "Choose a target",
-            context = DecisionContext(),
-            targetRequirements = listOf(
-                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
-            ),
-            legalTargets = mapOf(0 to emptyList())
-        )
+    // An empty Complete is unsearchable, so a supported family with nothing legal to say hands the
+    // decision back to the caller's resolver instead of claiming an exhaustive empty response set.
+    test("supported family with no legal response reports unsupported") {
+        val decision = targetDecision("no-targets", emptyList())
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
-            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
-        expansion.responses.toList() shouldBe emptyList()
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
     }
 
     test("unsupported family returns unsupported") {

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.gym.trainer.defaults
+
+import com.wingedsheep.engine.core.CancelDecisionResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.asClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ExactStructuredDecisionExpanderTest : FunSpec({
+
+    val playerId = EntityId.of("player")
+    val first = EntityId.of("first")
+    val second = EntityId.of("second")
+    val third = EntityId.of("third")
+    val state = GameState(turnOrder = listOf(playerId))
+
+    test("single-target expansion is complete") {
+        val decision = ChooseTargetsDecision(
+            id = "targets",
+            playerId = playerId,
+            prompt = "Choose targets",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
+            ),
+            legalTargets = mapOf(0 to listOf(first, second)),
+            canCancel = true
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        val responses = expansion.responses.toList()
+
+        responses.shouldContainExactly(
+            CancelDecisionResponse("targets"),
+            TargetsResponse("targets", mapOf(0 to listOf(first))),
+            TargetsResponse("targets", mapOf(0 to listOf(second)))
+        )
+        responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("variable-cardinality target expansion is explicitly unsupported") {
+        val decision = ChooseTargetsDecision(
+            id = "many-targets",
+            playerId = playerId,
+            prompt = "Choose targets",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "up to two", minTargets = 0, maxTargets = 2)
+            ),
+            legalTargets = mapOf(0 to listOf(first, second, third))
+        )
+
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("supported family with no legal response is a complete empty expansion") {
+        val decision = ChooseTargetsDecision(
+            id = "no-targets",
+            playerId = playerId,
+            prompt = "Choose a target",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(0, "one target", minTargets = 1, maxTargets = 1)
+            ),
+            legalTargets = mapOf(0 to emptyList())
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        expansion.responses.toList() shouldBe emptyList()
+    }
+
+    test("unsupported family returns unsupported") {
+        val decision = OrderObjectsDecision(
+            id = "order",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second)
+        )
+
+        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+})

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/RandomStructuredResolverTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/RandomStructuredResolverTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.gym.trainer.search
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.asClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlin.random.Random
+
+/**
+ * The resolver is a fallback *policy*, but the search now submits its answer through the engine's
+ * authoritative validator. Minimum cardinality alone does not satisfy a decision's state-dependent
+ * restrictions, so the resolver has to check its own draws before handing one back.
+ */
+class RandomStructuredResolverTest : FunSpec({
+
+    test("a draw that violates a state-dependent restriction is redrawn, not submitted") {
+        val driver = GameTestDriver().apply {
+            registerCards(TestCards.all)
+            initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+        val player = driver.activePlayer!!
+        val firstBear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val secondBear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val goblin = driver.putCreatureOnBattlefield(player, "Raging Goblin")
+
+        // "Two target creatures with different names" — the two Bears are a legal *draw* and an
+        // illegal *response*, so a resolver that only counts targets picks it one time in three.
+        val decision = ChooseTargetsDecision(
+            id = "different-names",
+            playerId = player,
+            prompt = "Choose two creatures with different names",
+            context = DecisionContext(),
+            targetRequirements = listOf(
+                TargetRequirementInfo(
+                    index = 0,
+                    description = "two creatures with different names",
+                    minTargets = 2,
+                    maxTargets = 2,
+                    differentNames = true
+                )
+            ),
+            legalTargets = mapOf(0 to listOf(firstBear, secondBear, goblin))
+        )
+
+        // The restriction is real: the same-name pair is rejected, so the test is not vacuous.
+        DecisionValidators.validate(
+            decision,
+            TargetsResponse(decision.id, mapOf(0 to listOf(firstBear, secondBear))),
+            driver.state
+        ) shouldNotBe null
+
+        repeat(50) { seed ->
+            val response = RandomStructuredResolver(Random(seed.toLong()))
+                .resolve(driver.state, decision)
+            response.asClue {
+                DecisionValidators.validate(decision, response, driver.state) shouldBe null
+            }
+        }
+    }
+})

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -205,7 +205,7 @@ class StructuredDecisionSearchTest : FunSpec({
                 evaluator = uniformEvaluator,
                 structuredExpander = StructuredDecisionExpander { _, _ ->
                     StructuredDecisionExpansion.Complete(
-                        sequenceOf(CardsSelectedResponse("wrong-decision", selected))
+                        listOf(CardsSelectedResponse("wrong-decision", selected))
                     )
                 },
                 dirichletAlpha = null
@@ -222,7 +222,7 @@ class StructuredDecisionSearchTest : FunSpec({
                 evaluator = uniformEvaluator,
                 structuredExpander = StructuredDecisionExpander { _, _ ->
                     StructuredDecisionExpansion.Complete(
-                        sequenceOf(CardsSelectedResponse(pending.id, emptyList()))
+                        listOf(CardsSelectedResponse(pending.id, emptyList()))
                     )
                 },
                 dirichletAlpha = null
@@ -242,13 +242,33 @@ class StructuredDecisionSearchTest : FunSpec({
                     CardsSelectedResponse(pending.id, selected)
                 },
                 structuredExpander = StructuredDecisionExpander { _, _ ->
-                    StructuredDecisionExpansion.Complete(emptySequence())
+                    StructuredDecisionExpansion.Complete(emptyList())
                 },
                 dirichletAlpha = null
             ).run(simulations = 1)
         }
         emptyError.message.orEmpty() shouldContain "Complete response expansion"
         emptyResolverCalls shouldBe 0
+
+        val duplicateError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(
+                        listOf(
+                            CardsSelectedResponse(pending.id, selected),
+                            CardsSelectedResponse(pending.id, selected)
+                        )
+                    )
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        duplicateError.message.orEmpty() shouldContain
+            "Structured expander returned duplicate CardsSelectedResponse"
 
         var resolverCalls = 0
         val result = AlphaZeroSearch(

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -1,0 +1,272 @@
+package com.wingedsheep.gym.trainer.search
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.gym.GameEnvironment
+import com.wingedsheep.gym.trainer.spi.ActionFeaturizer
+import com.wingedsheep.gym.trainer.spi.EvaluationResult
+import com.wingedsheep.gym.trainer.spi.Evaluator
+import com.wingedsheep.gym.trainer.spi.PolicyHead
+import com.wingedsheep.gym.trainer.spi.SlotEncoding
+import com.wingedsheep.gym.trainer.spi.StateFeaturizer
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpander
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
+import com.wingedsheep.gym.trainer.spi.StructuredDecisionResolver
+import com.wingedsheep.gym.trainer.spi.TrainerContext
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.floats.shouldBeExactly
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class StructuredDecisionSearchTest : FunSpec({
+
+    val stateFeaturizer = object : StateFeaturizer<Unit> {
+        override fun featurize(ctx: TrainerContext) = Unit
+    }
+    val sharedSlotFeaturizer = object : ActionFeaturizer {
+        override val heads: List<PolicyHead> = listOf(PolicyHead("shared", 1))
+
+        override fun slot(action: GameAction, ctx: TrainerContext): SlotEncoding =
+            SlotEncoding("shared", 0)
+    }
+    val uniformEvaluator = Evaluator<Unit> { _, _, _ ->
+        EvaluationResult(priors = mapOf("shared" to floatArrayOf(1f)), value = 0f)
+    }
+
+    fun newDriver(deckCard: String): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + PredefinedTokens.allTokens)
+        initMirrorMatch(
+            deck = Deck.of(deckCard to 40),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun environment(driver: GameTestDriver): GameEnvironment =
+        GameEnvironment.create(driver.cardRegistry).also {
+            it.restore(driver.state, listOf(driver.player1, driver.player2))
+        }
+
+    test("MCTS exposes exact target responses as independent edges and executes each branch") {
+        val driver = newDriver("Mountain")
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        val ownCreature = driver.putCreatureOnBattlefield(caster, "Raging Goblin")
+        val opposingCreature = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        repeat(5) { driver.putLandOnBattlefield(caster, "Mountain") }
+        val spell = driver.putCardInHand(caster, "Zuko's Exile")
+
+        driver.castSpell(caster, spell).error shouldBe null
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        val pending = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        pending.legalTargets.values.flatten().toSet() shouldBe setOf(ownCreature, opposingCreature)
+        val rootState = driver.state
+        val env = environment(driver)
+
+        val fallback = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                TargetsResponse(decision.id, mapOf(0 to listOf(ownCreature)))
+            },
+            structuredExpander = StructuredDecisionExpander { _, _ ->
+                StructuredDecisionExpansion.Unsupported
+            },
+            dirichletAlpha = null
+        ).run(simulations = 1)
+        fallback.root.edges.size shouldBe 1
+        (fallback.root.edges.single().action as SubmitDecision).response shouldBe
+            TargetsResponse(pending.id, mapOf(0 to listOf(ownCreature)))
+
+        val result = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                error("exact expansion unexpectedly fell back for ${decision::class.simpleName}")
+            },
+            dirichletAlpha = null
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.visits.toList().shouldContainExactly(1, 1)
+        result.root.edges.forEach { edge ->
+            edge.slot shouldBe SlotEncoding("shared", 0)
+            edge.prior.shouldBeExactly(0.5f)
+            edge.child shouldNotBe null
+        }
+
+        val responsesByTarget = result.root.edges.associate { edge ->
+            val response = (edge.action as SubmitDecision).response
+                .shouldBeInstanceOf<TargetsResponse>()
+            DecisionValidators.validate(pending, response, rootState) shouldBe null
+            response.selectedTargets.getValue(0).single() to edge
+        }
+        responsesByTarget.keys shouldBe setOf(ownCreature, opposingCreature)
+
+        for ((chosenTarget, edge) in responsesByTarget) {
+            val branch = GameEnvironment.create(driver.cardRegistry).also {
+                it.restore(rootState, listOf(driver.player1, driver.player2))
+            }
+            branch.step(edge.action)
+
+            branch.lastRejection shouldBe null
+            branch.lastStepEvents.filterIsInstance<ZoneChangeEvent>()
+                .any { it.entityId == chosenTarget } shouldBe true
+            branch.state.getBattlefield().contains(chosenTarget) shouldBe false
+            branch.state.getBattlefield().contains(
+                if (chosenTarget == ownCreature) opposingCreature else ownCreature
+            ) shouldBe true
+        }
+        responsesByTarget.getValue(ownCreature).child!!.state shouldNotBe
+            responsesByTarget.getValue(opposingCreature).child!!.state
+    }
+
+    test("existing yes-no folding remains a complete two-edge decision") {
+        val driver = newDriver("Grizzly Bears")
+        val player = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(player, "Forest")
+        val train = driver.putCardInHand(player, "Subway Train")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.GREEN, 1)
+
+        driver.castSpell(player, train).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+
+        val result = AlphaZeroSearch(
+            env = environment(driver),
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                when (decision) {
+                    is SelectManaSourcesDecision ->
+                        ManaSourcesSelectedResponse(decision.id, autoPay = true)
+                    is SelectCardsDecision ->
+                        CardsSelectedResponse(decision.id, decision.options.take(decision.minSelections))
+                    else -> error("unexpected fallback for ${decision::class.simpleName}")
+                }
+            },
+            dirichletAlpha = null
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.root.edges.map { (it.action as SubmitDecision).response::class }
+            .all { it == com.wingedsheep.engine.core.YesNoResponse::class } shouldBe true
+    }
+
+    test("unsupported multi-card decision keeps one resolver-selected edge") {
+        val driver = newDriver("Island")
+        val player = driver.activePlayer!!
+        val spell = driver.putCardInHand(player, "Thirst for Identity")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.castSpell(player, spell).error shouldBe null
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        val pending = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pending.maxSelections shouldBe 2
+        val selected = pending.options.take(2)
+
+        val wrongIdError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(
+                        sequenceOf(CardsSelectedResponse("wrong-decision", selected))
+                    )
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        wrongIdError.message.orEmpty() shouldContain
+            "Structured decision expander returned response for wrong-decision"
+
+        val invalidError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(
+                        sequenceOf(CardsSelectedResponse(pending.id, emptyList()))
+                    )
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        invalidError.message.orEmpty() shouldContain "Structured decision expander returned an illegal"
+
+        var emptyResolverCalls = 0
+        val emptyError = shouldThrow<IllegalStateException> {
+            AlphaZeroSearch(
+                env = environment(driver),
+                featurizer = stateFeaturizer,
+                actionFeaturizer = sharedSlotFeaturizer,
+                evaluator = uniformEvaluator,
+                structuredResolver = StructuredDecisionResolver { _, _ ->
+                    emptyResolverCalls += 1
+                    CardsSelectedResponse(pending.id, selected)
+                },
+                structuredExpander = StructuredDecisionExpander { _, _ ->
+                    StructuredDecisionExpansion.Complete(emptySequence())
+                },
+                dirichletAlpha = null
+            ).run(simulations = 1)
+        }
+        emptyError.message.orEmpty() shouldContain "Complete response expansion"
+        emptyResolverCalls shouldBe 0
+
+        var resolverCalls = 0
+        val result = AlphaZeroSearch(
+            env = environment(driver),
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, decision ->
+                resolverCalls += 1
+                CardsSelectedResponse(decision.id, selected)
+            },
+            dirichletAlpha = null
+        ).run(simulations = 1)
+
+        resolverCalls shouldBeGreaterThan 0
+        result.root.edges.size shouldBe 1
+        val response: DecisionResponse = (result.root.edges.single().action as SubmitDecision).response
+        response shouldBe CardsSelectedResponse(pending.id, selected)
+        result.root.edges.single().child shouldNotBe null
+    }
+})

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -114,8 +114,9 @@ class GameEnvironment private constructor(
      *
      * An illegal action leaves the state untouched, which on its own is indistinguishable from an
      * action that legitimately changed nothing (declaring no attackers, passing priority). Callers
-     * that must not swallow a rejection — the HTTP transport, which turns it into a 400 — read this;
-     * the trainer SPI, which only ever submits enumerated actions, can keep ignoring it.
+     * that must not swallow a rejection read this: the HTTP transport turns it into a 400, and MCTS
+     * asserts on it, since a rejected decision edge would otherwise become a child node identical to
+     * its parent and be searched as if it were progress.
      */
     var lastRejection: String? = null
         private set


### PR DESCRIPTION
## Summary

This supersedes #2161 (by @huxinq), whose commit it carries unchanged as the first
commit, plus a follow-up commit applying the review findings. Base is `main`.

The underlying change stands: tree search already represents simple pending decisions
as alternatives, but structured pending decisions were reduced to one resolver-selected
edge before MCTS could compare them. #2161 adds a narrow exact-expansion seam so
supported single-target decisions become independent MCTS branches, checked by the
engine's authoritative validator, with unsupported families retaining the configured
resolver fallback. The separation between `StructuredDecisionExpander` (enumeration)
and `StructuredDecisionResolver` (policy) is the right decomposition and is kept intact.

## What the follow-up commit changes

**Cancellation is no longer an expanded response.** The only `canCancel = true`
`ChooseTargetsDecision` in the engine is cast-time modal target selection
(`CastSpellHandler.kt:4639`), and `CastModalContinuationResumer.kt:152` resumes a cancel
as `ExecutionResult.success(state.withPriority(casterId))` — the pre-cast priority state,
before cost payment or stack placement. A cancel edge is therefore a transposition back
onto the search node's own ancestor: MCTS gets `cast → cancel → cast → cancel …`, growing
a node per simulation and inflating the cast edge's statistics, and `SelfPlayLoop` can
sample the cancel at the root and burn a `stepCount` with no state progress.
`RandomStructuredResolver` never emitted a cancel, so this was new behaviour. The
"don't cast" branch already exists at the priority node that offered the cast.

**Optional single-target slots are now supported.** The guard was
`minTargets != 1 || maxTargets != 1`, which excluded `minTargets = 0, maxTargets = 1`
("up to one target") as though it were combinatorial. It isn't — the space is exactly
`legalTargets.size + 1`, and declining is the empty selection for the requirement, which
stays inside the decision rather than aborting it. Now `maxTargets == 1 && minTargets in 0..1`.

**An empty `Complete` is reported as `Unsupported`.** `AlphaZeroSearch` throws on an
empty complete expansion, and the built-in could produce one two ways: a `minTargets = 1`
requirement with no legal targets — `TrivialDecisions.responseFor` requires
`targets.size == 1`, so those are *not* auto-resolved and reach the search intact — and a
`totalManaValueAtMost` cap that no single legal target satisfies, where the validator
filter empties a non-empty `legalTargets`. Both are now handed to the resolver fallback
instead of raising a mid-training-run crash. The search still rejects an empty `Complete`
from a custom expander, and that guard is still tested.

**`StructuredDecisionExpansion.Complete` carries a `List`, not a `Sequence`.**
`completeStructuredEdges` materialized it immediately, and the type deliberately admits
no partial or bounded variant, so there was nothing for laziness to defer. Meanwhile the
built-in constructed its sequence with `sequence { }` — constrained-once, throwing on any
second iteration, with nothing in the signature saying so. `Complete` is now a `data class`,
matching `Unsupported`'s `data object`.

**`RandomStructuredResolver` redraws until the validator accepts.** The new
`check(validationError == null)` on the fallback path applies to a default resolver that
could not satisfy it: minimum cardinality alone ignores `differentNames`,
`onePerCardType`, `onePerColor` and mana-value caps, all of which `DecisionValidators`
enforces. Previously such a response was silently rejected by the engine and the search
limped; without this it would throw. Rather than re-implement constraint solving, the
resolver draws up to `attempts` (default 16) candidates and returns the first the engine
accepts, falling back to the last draw so an unsatisfiable decision still fails loudly.
It also stops clamping `minTargets` down to the legal-target count (an under-count that
fails validation is louder than a silently shrunk selection) and now respects
`maxSelections` / `maxModes` when picking a count.

**Docs.** The `gym-trainer` README's expander description, defaults table and test list
are updated. `StructuredDecisionResolver`'s KDoc now states that the chosen response is
validated before it becomes an edge. `GameEnvironment.lastRejection`'s KDoc no longer
claims the trainer SPI "can keep ignoring it" — #2161 makes MCTS assert on it, correctly.

## Tests

`just test-gym-trainer` — 16/16 pass. `just test-gym` — pass.

New coverage on top of #2161's:

- cancellation is never offered as a response;
- optional single-target expansion offers the empty selection;
- duplicate legal targets collapse to one response each;
- multi-requirement target decisions report `Unsupported`;
- a supported family with no legal response reports `Unsupported`;
- the expander's duplicate-response guard fires (previously the only new `check` without a test);
- a resolver draw violating a `differentNames` restriction is redrawn rather than submitted
  (`RandomStructuredResolverTest`, with a positive check that the restriction really rejects
  the same-name pair so the test isn't vacuous).

## Not changed

The `ActionFeaturizer` slot-collision caveat #2161 documents is left as documentation:
the default `DynamicSlotActionFeaturizer` hashes the whole `GameAction`, so distinct
target responses already get distinct slots, and the caveat only bites a custom
non-injective featurizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxVSRsZ8HXuE7D4BmdN8fp
