### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FaithsFetters.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FaithsFetters.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Faith's Fetters
+ * {3}{W}
+ * Enchantment — Aura
+ *
+ * Enchant permanent
+ * When this Aura enters, you gain 4 life.
+ * Enchanted permanent can't attack or block, and its activated abilities can't be activated
+ * unless they're mana abilities.
+ *
+ * Arrest's three-static shape widened one step in each direction: it enchants any *permanent*
+ * rather than a creature, and the activation lock spares mana abilities. Both are expressible
+ * as-is — [GroupFilter.attachedCreature] is scope-based (`GameObjectFilter.Permanent` scoped to
+ * the attachment) despite the name, so it already covers a non-creature host, and
+ * [PreventActivatedAbilities] carries the `nonManaAbilitiesOnly` flag for the
+ * "… unless they're mana abilities" wording.
+ *
+ * The combat halves are inert on a non-creature host rather than wrong: a Fettered land was
+ * never going to attack or block, and if it later animates the statics are already on it.
+ */
+val FaithsFetters = card("Faith's Fetters") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant permanent\n" +
+        "When this Aura enters, you gain 4 life.\n" +
+        "Enchanted permanent can't attack or block, and its activated abilities can't be " +
+        "activated unless they're mana abilities."
+
+    auraTarget = Targets.Permanent
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Permanent.attachedToBySource(),
+            nonManaAbilitiesOnly = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg?1783943702"
+        ruling(
+            "2020-11-10",
+            "If the target permanent is an illegal target by the time Faith's Fetters tries to " +
+                "resolve, it doesn't resolve. It won't enter the battlefield, so its " +
+                "enters-the-battlefield ability won't trigger."
+        )
+        ruling(
+            "2020-11-10",
+            "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana " +
+                "abilities from working. A mana ability is an ability that produces mana, not " +
+                "an ability that costs mana."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NecromanticThirst.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NecromanticThirst.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Necromantic Thirst
+ * {2}{B}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Whenever enchanted creature deals combat damage to a player, you may return target creature
+ * card from your graveyard to your hand.
+ *
+ * The trigger reads one object further out than the Aura itself — [TriggerBinding.ATTACHED] hangs
+ * the damage watcher on the enchanted creature rather than on the enchantment, so an unattached
+ * Aura never fires. The target is mandatory (chosen as the ability goes on the stack, which per
+ * the printed ruling is *after* creatures dealt lethal damage in the same combat have hit the
+ * graveyard, so the enchanted creature itself can be the target); only the return is optional.
+ */
+val NecromanticThirst = card("Necromantic Thirst") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Whenever enchanted creature deals combat damage to a player, you may return target " +
+        "creature card from your graveyard to your hand."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED,
+        )
+        val t = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = MayEffect(Effects.ReturnToHandFromGraveyard(t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Brandon Kitkouski"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg?1783943667"
+        ruling(
+            "2005-10-01",
+            "The target is chosen just after any creatures dealt lethal damage at the same time " +
+                "that the enchanted creature dealt damage have been put into the graveyard. That " +
+                "might include the enchanted creature itself, if it had trample and was blocked, " +
+                "for example."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StrandsOfUndeath.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StrandsOfUndeath.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Strands of Undeath
+ * {3}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, target player discards two cards.
+ * {B}: Regenerate enchanted creature.
+ *
+ * The enters trigger targets independently of the Aura's own enchant target — the discard can be
+ * pointed at any player, including the Aura's own controller, exactly as Galvanic Arc's damage
+ * can. The activated ability has no mana-ability shape and no tap, so it can be activated any
+ * number of times to stack regeneration shields.
+ */
+val StrandsOfUndeath = card("Strands of Undeath") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, target player discards two cards.\n" +
+        "{B}: Regenerate enchanted creature."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target player", Targets.Player)
+        effect = Effects.Discard(count = 2, target = t)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.EnchantedCreature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Dave Allsop"
+        flavorText = "\"Why limit yourself to mortal law when you can outlive those who enforce " +
+            "it?\"\n—Czaric, Orzhov prelate"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg?1783943661"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Transluminant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Transluminant.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+
+/**
+ * Transluminant
+ * {1}{G}
+ * Creature — Dryad Shaman
+ * 2/2
+ *
+ * {W}, Sacrifice this creature: Create a 1/1 white Spirit creature token with flying at the
+ * beginning of the next end step.
+ *
+ * The token is not created on resolution — the ability schedules a step-based delayed trigger for
+ * the next beginning-of-end-step, which is what makes the printed ruling true: activating during
+ * a turn's end step has already missed that step's trigger window, so the Spirit arrives at the
+ * *following* turn's end step. `fireOnPlayer` stays null because the text says "the next end
+ * step", not "your next end step".
+ *
+ * Ravnica predates token *cards* (Scryfall has no `trav` set), and the set self-hosts art only
+ * for its Saproling, so this token falls through to the engine-wide generic Spirit art.
+ */
+val Transluminant = card("Transluminant") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{W}, Sacrifice this creature: Create a 1/1 white Spirit creature token with " +
+        "flying at the beginning of the next end step."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.SacrificeSelf)
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END,
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Spirit"),
+                keywords = setOf(Keyword.FLYING),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Greg Hildebrandt"
+        flavorText = "\"Forget yourself. Forget your city. Forget your homes, your families, the " +
+            "debts and obligations that hold you to this world.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg?1783943629"
+        ruling(
+            "2005-10-01",
+            "If you use this ability during a turn's end phase, the chance to put \"at end of " +
+                "turn\"-triggered abilities on the stack has passed. You won't get the Spirit " +
+                "creature token until the beginning of the next end step."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VoyagerStaff.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/VoyagerStaff.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voyager Staff
+ * {1}
+ * Artifact
+ *
+ * {2}, Sacrifice this artifact: Exile target creature. Return the exiled card to the battlefield
+ * under its owner's control at the beginning of the next end step.
+ *
+ * The plain blink pattern — [Patterns.Exile.exileUntilEndStep] moves the target to exile and
+ * schedules the step-based delayed return under its owner's control, the same primitive
+ * Transluminant uses for its delayed token. A token exiled this way simply ceases to exist, per
+ * the printed ruling; that falls out of the move rather than needing a special case.
+ */
+val VoyagerStaff = card("Voyager Staff") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "{2}, Sacrifice this artifact: Exile target creature. Return the exiled card to " +
+        "the battlefield under its owner's control at the beginning of the next end step."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        val t = target("target creature", Targets.Creature)
+        effect = Patterns.Exile.exileUntilEndStep(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "274"
+        artist = "Tsutomu Kawade"
+        flavorText = "Voyager staffs are sought by those hoping to find an escape from the " +
+            "sprawling glut of Ravnica."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg?1783943594"
+        ruling(
+            "2024-01-12",
+            "If a creature token is exiled by Voyager Staff's ability, it will cease to exist. " +
+                "It won't return to the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/FaithsFettersReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/FaithsFettersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faith's Fetters reprint in Commander 2015. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ravnica: City of Guilds, the card's earliest
+ * real printing; this file contributes only presentation data.
+ */
+val FaithsFettersReprint = Printing(
+    oracleId = "2b2d76f5-4c9b-49dc-b202-68095e2d9b29",
+    name = "Faith's Fetters",
+    setCode = "C15",
+    collectorNumber = "69",
+    scryfallId = "fe653236-c5c1-4dcd-95cd-3c53f1e256ef",
+    artist = "Brian Despain",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe653236-c5c1-4dcd-95cd-3c53f1e256ef.jpg?1783938101",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/FaithsFettersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/FaithsFettersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faith's Fetters reprint in Commander Legends. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ravnica: City of Guilds, the card's earliest
+ * real printing; this file contributes only presentation data.
+ */
+val FaithsFettersReprint = Printing(
+    oracleId = "2b2d76f5-4c9b-49dc-b202-68095e2d9b29",
+    name = "Faith's Fetters",
+    setCode = "CMR",
+    collectorNumber = "20",
+    scryfallId = "04a7da8c-a444-4deb-89b9-2fc9e5475bff",
+    artist = "Brian Despain",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04a7da8c-a444-4deb-89b9-2fc9e5475bff.jpg?1783928885",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaithsFettersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaithsFettersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faith's Fetters reprint in Jumpstart 2022. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ravnica: City of Guilds, the card's earliest
+ * real printing; this file contributes only presentation data.
+ */
+val FaithsFettersReprint = Printing(
+    oracleId = "2b2d76f5-4c9b-49dc-b202-68095e2d9b29",
+    name = "Faith's Fetters",
+    setCode = "J22",
+    collectorNumber = "181",
+    scryfallId = "dc226022-c422-4e9d-a359-5c2104e0a5f2",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc226022-c422-4e9d-a359-5c2104e0a5f2.jpg?1783919116",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/FaithsFettersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/FaithsFettersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faith's Fetters reprint in Core Set 2021. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ravnica: City of Guilds, the card's earliest
+ * real printing; this file contributes only presentation data.
+ */
+val FaithsFettersReprint = Printing(
+    oracleId = "2b2d76f5-4c9b-49dc-b202-68095e2d9b29",
+    name = "Faith's Fetters",
+    setCode = "M21",
+    collectorNumber = "17",
+    scryfallId = "8e742d49-e6f0-4016-ba4c-11878fad89cb",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e742d49-e6f0-4016-ba4c-11878fad89cb.jpg?1783930744",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2661,6 +2661,84 @@
     ]
 }
 
+// Faith's Fetters
+{
+    "name": "Faith's Fetters",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant permanent\nWhen this Aura enters, you gain 4 life.\nEnchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "CantBlock",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": {
+                    "cardPredicates": [
+                        "IsPermanent"
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToBySource"
+                    ]
+                },
+                "nonManaAbilitiesOnly": true
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "permanent"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Chippy",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b8ffba3-44a9-41ce-a5a1-37413346db2f.jpg?1783943702",
+        "rulings": [
+            {
+                "date": "2020-11-10",
+                "text": "If the target permanent is an illegal target by the time Faith's Fetters tries to resolve, it doesn't resolve. It won't enter the battlefield, so its enters-the-battlefield ability won't trigger."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "Faith's Fetters doesn't stop static abilities, triggered abilities, or mana abilities from working. A mana ability is an ability that produces mana, not an ability that costs mana."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Farseek
 {
     "name": "Farseek",
@@ -5178,6 +5256,68 @@
     ]
 }
 
+// Necromantic Thirst
+{
+    "name": "Necromantic Thirst",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhenever enchanted creature deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card in your graveyard"
+                        },
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Brandon Kitkouski",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a46880c-a9f4-452d-8b91-51d8aa97cbd2.jpg?1783943667",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The target is chosen just after any creatures dealt lethal damage at the same time that the enchanted creature dealt damage have been put into the graveyard. That might include the enchanted creature itself, if it had trample and was blocked, for example."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nightguard Patrol
 {
     "name": "Nightguard Patrol",
@@ -7320,6 +7460,104 @@
     ]
 }
 
+// Strands of Undeath
+{
+    "name": "Strands of Undeath",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, target player discards two cards.\n{B}: Regenerate enchanted creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 2 cards to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "EnchantedCreature"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Dave Allsop",
+        "flavorText": "\"Why limit yourself to mortal law when you can outlive those who enforce it?\"\n—Czaric, Orzhov prelate",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93ced365-f445-4a4a-b33f-986279404fde.jpg?1783943661"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Sundering Vitae
 {
     "name": "Sundering Vitae",
@@ -8077,6 +8315,71 @@
     ]
 }
 
+// Transluminant
+{
+    "name": "Transluminant",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Dryad Shaman",
+    "oracleText": "{W}, Sacrifice this creature: Create a 1/1 white Spirit creature token with flying at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "\"Forget yourself. Forget your city. Forget your homes, your families, the debts and obligations that hold you to this world.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/318ce4ef-38bd-4360-895f-457587164197.jpg?1783943629",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If you use this ability during a turn's end phase, the chance to put \"at end of turn\"-triggered abilities on the stack has passed. You won't get the Spirit creature token until the beginning of the next end step."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Undercity Shade
 {
     "name": "Undercity Shade",
@@ -8701,6 +9004,81 @@
         "WHITE",
         "GREEN"
     ]
+}
+
+// Voyager Staff
+{
+    "name": "Voyager Staff",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, Sacrifice this artifact: Exile target creature. Return the exiled card to the battlefield under its owner's control at the beginning of the next end step.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "rarity": "UNCOMMON",
+        "artist": "Tsutomu Kawade",
+        "flavorText": "Voyager staffs are sought by those hoping to find an escape from the sprawling glut of Ravnica.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76554c65-edea-48b0-b3a5-483dfe80eaac.jpg?1783943594",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "If a creature token is exiled by Voyager Staff's ability, it will cease to exist. It won't return to the battlefield."
+            }
+        ]
+    }
 }
 
 // War-Torch Goblin


### PR DESCRIPTION
Five RAV cards, each built entirely from existing `Effects.*` / `Patterns.*` / static-ability vocabulary — no new SDK types.

| Card | What it does | Composed from |
|---|---|---|
| **Faith's Fetters** `{3}{W}` | Enchant permanent; gain 4 life on entry; enchanted permanent can't attack or block and its non-mana activated abilities are locked | `CantAttack` + `CantBlock` over `GroupFilter.attachedCreature()`, `PreventActivatedAbilities(attachedToBySource(), nonManaAbilitiesOnly = true)`, `Effects.GainLife(4)` |
| **Transluminant** `{1}{G}` | `{W}`, Sac: 1/1 white Spirit flier at the beginning of the next end step | `Costs.Composite(Mana, SacrificeSelf)` → `CreateDelayedTriggerEffect(step = Step.END, …CreateToken)` |
| **Voyager Staff** `{1}` | `{2}`, Sac: exile target creature, return it at the beginning of the next end step | `Patterns.Exile.exileUntilEndStep` |
| **Strands of Undeath** `{3}{B}` | Enchant creature; on entry target player discards two; `{B}`: regenerate enchanted creature | `Effects.Discard(2, target)`, `RegenerateEffect(EffectTarget.EnchantedCreature)` |
| **Necromantic Thirst** `{2}{B}{B}` | Enchant creature; on combat damage to a player, may return target creature card from your graveyard | `Triggers.dealsDamage(binding = TriggerBinding.ATTACHED)`, `MayEffect(Effects.ReturnToHandFromGraveyard)` |

### Notes worth a reviewer's eye

- **Faith's Fetters is Arrest widened at both ends.** It enchants any *permanent*, not a creature, and the activation lock spares mana abilities. Both were already expressible: `GroupFilter.attachedCreature()` is scope-based (`GameObjectFilter.Permanent` scoped to the attachment) despite its name, and `PreventActivatedAbilities` already carries `nonManaAbilitiesOnly`. The combat halves are inert rather than wrong on a non-creature host, and are already in place if it later animates.
- **Both delayed triggers leave `fireOnPlayer` null**, because the printed text is "the next end step", not "your next end step". That is also what makes Transluminant's ruling true: activating during a turn's end step has missed that step's window, so the Spirit arrives at the following turn's end step.
- **Necromantic Thirst's target is mandatory, the return is optional** — the target is chosen as the ability goes on the stack, which per its ruling is *after* creatures dealt lethal damage in the same combat have hit the graveyard, so the enchanted creature itself can be the target.
- **Faith's Fetters also gets `Printing` rows** in the four scaffolded sets that reprint it (C15, M21, CMR, J22); `just check-card-printing` was red without them.
- **Transluminant's Spirit token has no art.** Ravnica predates token cards (Scryfall has no `trav` set) and the set self-hosts art only for its Saproling, so the token falls through to the engine-wide generic art. Fixing that needs a self-hosted image under `web-client/public/images/tokens/` plus a `tokenArt` row, which is out of scope here.

### Dropped from the batch

**Drake Familiar** — "sacrifice it unless you return an enchantment to its owner's hand". Its ruling is explicit that you may return *any* enchantment on the battlefield, including an opponent's, but `CostAtom.ReturnToHand` is hardcoded to permanents you control (`CostPaymentService.domain` → `controlledMatching`). Widening it means threading a flag through the cost enumerators, which is new vocabulary and belongs in its own PR rather than being faked with a you-control-only cost that is wrong in exactly the case the ruling calls out.

### Verification

- `just build` — green (Kotlin compile + `:mtg-sets:test`, second run after the reprint rows).
- `just rebless-cards` — only `snapshots/cards/RAV.json` moved, and only for these five names.
- `just check-card-printing` — ok for all five.
- `just assay-differential --set RAV` — 103 compared, 103 confirmed, **0 divergent**.
- All 50 mechanical fields (mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor, image) re-diffed against Scryfall; all nine image URIs return HTTP 200.

No new SDK vocabulary, so no scenario tests, no engine tracing, and no e2e — the snapshot, lint, facade-boundary and differential nets cover these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6