### PR TITLE
Add five Lorwyn Treefolk and Elf cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DauntlessDourbark.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DauntlessDourbark.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dauntless Dourbark
+ * {3}{G}
+ * Creature — Treefolk Warrior
+ * Printed power and toughness are both star (a characteristic-defining ability).
+ * Dauntless Dourbark's power and toughness are each equal to the number of Forests you control
+ * plus the number of Treefolk you control.
+ * This creature has trample as long as you control another Treefolk.
+ *
+ * The CDA is a literal [DynamicAmount.Add] of two independent battlefield counts, which is what
+ * the printed "plus" asks for and what the 2007-10-01 rulings require: the Dourbark counts itself
+ * (it is a Treefolk you control), and a permanent that is *both* a Forest and a Treefolk is
+ * counted **twice** — once by each half. Folding the two into one `withAnySubtype` filter would
+ * silently count such a permanent once and get the card wrong.
+ *
+ * "Forests" is a land type, so that half counts lands with the Forest subtype; the bare noun
+ * "Treefolk" counts every Treefolk *permanent* you control, creature or not.
+ *
+ * Trample is a [ConditionalStaticAbility] over `excludeSelf = true` — "another Treefolk" doesn't
+ * see the Dourbark itself, so it stays correct even if the Dourbark stops being a Treefolk.
+ */
+val DauntlessDourbark = card("Dauntless Dourbark") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Warrior"
+    power = 0
+    toughness = 0
+    oracleText = "Dauntless Dourbark's power and toughness are each equal to the number of " +
+        "Forests you control plus the number of Treefolk you control.\n" +
+        "This creature has trample as long as you control another Treefolk."
+
+    dynamicStats(
+        DynamicAmount.Add(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+            ).count(),
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype(Subtype.TREEFOLK)
+            ).count()
+        )
+    )
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.TRAMPLE, GroupFilter.source()),
+            condition = Conditions.YouControl(
+                GameObjectFilter.Permanent.withSubtype(Subtype.TREEFOLK),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "203"
+        artist = "Jeremy Jarvis"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg?1783942866"
+        ruling("2007-10-01", "Dauntless Dourbark counts itself when determining its power and toughness.")
+        ruling("2007-10-01", "A permanent that's both a Forest and a Treefolk will be counted " +
+            "twice when determining Dauntless Dourbark's power and toughness.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ImmaculateMagistrate.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ImmaculateMagistrate.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Immaculate Magistrate
+ * {3}{G}
+ * Creature — Elf Shaman
+ * 2/2
+ * {T}: Put a +1/+1 counter on target creature for each Elf you control.
+ *
+ * The count is a [Effects.AddDynamicCounters] amount, so it is read when the ability *resolves*
+ * (2020-11-10 ruling) rather than on activation — Elves arriving or leaving in response change
+ * how many counters land. The target is any creature, not just an Elf (same ruling), and the
+ * Magistrate itself is an Elf, so it always contributes at least one.
+ */
+val ImmaculateMagistrate = card("Immaculate Magistrate") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Put a +1/+1 counter on target creature for each Elf you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype(Subtype.ELF)
+            ).count(),
+            creature
+        )
+        description = "{T}: Put a +1/+1 counter on target creature for each Elf you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "219"
+        artist = "Jim Nelson"
+        flavorText = "Elves of the immaculate class weave flora into living creatures—sometimes " +
+            "to endorse an elite warrior, sometimes to create a breathing work of art."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg?1783942860"
+        ruling("2020-11-10", "The number of counters to put on the target creature is determined " +
+            "only as Immaculate Magistrate's ability resolves. Elves coming and going later won't " +
+            "cause that creature to gain or lose +1/+1 counters.")
+        ruling("2020-11-10", "The target creature doesn't have to be an Elf.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/JaggedScarArchers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/JaggedScarArchers.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Jagged-Scar Archers
+ * {1}{G}{G}
+ * Creature — Elf Archer
+ * Printed power and toughness are both star (a characteristic-defining ability).
+ * Jagged-Scar Archers's power and toughness are each equal to the number of Elves you control.
+ * {T}: This creature deals damage equal to its power to target creature with flying.
+ *
+ * The bare noun "Elves" counts every Elf *permanent* you control, not only the creatures — and
+ * the Archers is itself an Elf, so it counts itself.
+ *
+ * The damage amount reads the Archers' power off the *source* at resolution, so it sees the CDA
+ * (and anything else in the layer stack) rather than a snapshot taken on activation. Tapping is
+ * the whole cost, so the Archers is already tapped when the ability resolves — that doesn't change
+ * its power. `damageSource` names the Archers so protection, prevention and "damage dealt by"
+ * triggers attribute it correctly.
+ */
+val JaggedScarArchers = card("Jagged-Scar Archers") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Archer"
+    power = 0
+    toughness = 0
+    oracleText = "Jagged-Scar Archers's power and toughness are each equal to the number of " +
+        "Elves you control.\n{T}: This creature deals damage equal to its power to target " +
+        "creature with flying."
+
+    dynamicStats(
+        DynamicAmounts.battlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withSubtype(Subtype.ELF)
+        ).count()
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        val flier = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.DealDamage(
+            DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power),
+            flier,
+            damageSource = EffectTarget.Self,
+        )
+        description = "{T}: This creature deals damage equal to its power to target creature with flying."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg?1783942861"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Lignify.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Lignify.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.TransformPermanent
+
+/**
+ * Lignify
+ * {1}{G}
+ * Kindred Enchantment — Treefolk Aura
+ *
+ * Enchant creature
+ * Enchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.
+ *
+ * Three layered statics over the enchanted creature, matching the printed clause order:
+ *  - [TransformPermanent] with only `setSubtypes` — Layer 4 `SetAllSubtypes` **replaces** every
+ *    creature type with Treefolk (the 2007-10-01 ruling: it overwrites earlier type-changing
+ *    effects, changeling included). `setCardTypes` is left empty on purpose so the card types are
+ *    untouched — "is a Treefolk" changes only the creature type, so an artifact creature stays an
+ *    artifact. Colors and name are untouched for the same reason.
+ *  - [LoseAllAbilities] — Layer 6.
+ *  - [SetBasePowerToughnessStatic] 0/4 — Layer 7b, so it overwrites a CDA (the ruling names
+ *    Dauntless Dourbark) but loses to later +N/+N effects and counters, which apply in 7c/7d.
+ *
+ * Originally printed as a Tribal enchantment; "Tribal" was errata'd to "Kindred" in 2024 with no
+ * gameplay change (2024-06-07 ruling).
+ */
+val Lignify = card("Lignify") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Kindred Enchantment — Treefolk Aura"
+    oracleText = "Enchant creature\nEnchanted creature is a Treefolk with base power and " +
+        "toughness 0/4 and loses all abilities."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = TransformPermanent(setSubtypes = setOf(Subtype.TREEFOLK.value))
+    }
+
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(0, 4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "228"
+        artist = "Jesper Ejsing"
+        flavorText = "Bulgo paused, puzzled. What was that rustling sound, and why did he feel so " +
+            "stiff? And how could his *feet* be so thirsty?"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg?1783942859"
+        ruling("2007-10-01", "Lignify overwrites characteristic-defining abilities that specify " +
+            "the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) " +
+            "or that specify its creature types (such as changeling does).")
+        ruling("2009-10-01", "Lignify will not overwrite effects such as those from Glorious " +
+            "Anthem, counters, or Giant Growth that change the enchanted creature's power or " +
+            "toughness without setting it to a specific value. Apply such effects after applying " +
+            "Lignify.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TimberProtector.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/TimberProtector.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Timber Protector
+ * {4}{G}
+ * Creature — Treefolk Warrior
+ * 4/6
+ * Other Treefolk creatures you control get +1/+1.
+ * Other Treefolk and Forests you control have indestructible.
+ *
+ * The two lines deliberately use different filters, and the printed text is what separates them:
+ * "Treefolk **creatures**" is the adjectival form (creatures only), while the bare "Treefolk and
+ * Forests" names every *permanent* with either subtype — so an animated Forest, or a Treefolk that
+ * isn't a creature, is indestructible but gets no +1/+1.
+ *
+ * `excludeSelf` on both is the "Other" in the text, and it is also what the 2013-07-01 ruling
+ * turns on: if Timber Protector itself somehow becomes a Forest, it still doesn't grant itself
+ * indestructible.
+ */
+val TimberProtector = card("Timber Protector") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Warrior"
+    power = 4
+    toughness = 6
+    oracleText = "Other Treefolk creatures you control get +1/+1.\n" +
+        "Other Treefolk and Forests you control have indestructible."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.youControl().withSubtype(Subtype.TREEFOLK),
+                excludeSelf = true
+            )
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.INDESTRUCTIBLE,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.youControl()
+                    .withAnySubtype(Subtype.TREEFOLK.value, Subtype.FOREST.value),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Terese Nielsen & Philip Tan"
+        flavorText = "In his presence, an ordinary grove becomes a bastion to turn spells and break armies."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg?1783942856"
+        ruling("2013-07-01", "If Timber Protector somehow becomes a Forest, it doesn't give itself indestructible.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ImmaculateMagistrateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ImmaculateMagistrateReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Immaculate Magistrate reprint in Commander 2014 (C14). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn (its earliest printing); this row
+ * contributes only presentation data.
+ */
+val ImmaculateMagistrateReprint = Printing(
+    oracleId = "e6e38bd4-e6dc-400b-8e08-956726842dc4",
+    name = "Immaculate Magistrate",
+    setCode = "C14",
+    collectorNumber = "201",
+    scryfallId = "ecdff8b7-f111-460a-97c7-903225392cd9",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ecdff8b7-f111-460a-97c7-903225392cd9.jpg?1783938830",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ImmaculateMagistrateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ImmaculateMagistrateReprint.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Immaculate Magistrate reprints in Commander Legends (CMR). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn (its earliest printing); these rows
+ * contribute only presentation data. CMR printed two collector numbers: the main #234 and the
+ * extended-art #679.
+ */
+val ImmaculateMagistrateReprint = Printing(
+    oracleId = "e6e38bd4-e6dc-400b-8e08-956726842dc4",
+    name = "Immaculate Magistrate",
+    setCode = "CMR",
+    collectorNumber = "234",
+    scryfallId = "d9208db8-1ba5-4f9c-90a4-03e377ae6f86",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg?1783928793",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)
+
+val ImmaculateMagistrateReprintExtended = Printing(
+    oracleId = "e6e38bd4-e6dc-400b-8e08-956726842dc4",
+    name = "Immaculate Magistrate",
+    setCode = "CMR",
+    collectorNumber = "679",
+    scryfallId = "4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b3ae08c-aa65-441e-a1cd-8bcb8bda5e33.jpg?1783928607",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/JaggedScarArchersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/JaggedScarArchersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jagged-Scar Archers reprint in Kaldheim Commander (KHC). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn (its earliest printing); this row
+ * contributes only presentation data.
+ */
+val JaggedScarArchersReprint = Printing(
+    oracleId = "f7139c70-dfcc-41ae-9d0d-b6e8c07a063d",
+    name = "Jagged-Scar Archers",
+    setCode = "KHC",
+    collectorNumber = "65",
+    scryfallId = "71c4346a-a330-49ca-909e-08fd8aec7b3f",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71c4346a-a330-49ca-909e-08fd8aec7b3f.jpg?1783928313",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1495,6 +1495,89 @@
     ]
 }
 
+// Dauntless Dourbark
+{
+    "name": "Dauntless Dourbark",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Treefolk Warrior",
+    "oracleText": "Dauntless Dourbark's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.\nThis creature has trample as long as you control another Treefolk.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Add",
+                "left": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                },
+                "right": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "permanent Treefolk"
+                }
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Add",
+                "left": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                },
+                "right": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "permanent Treefolk"
+                }
+            }
+        }
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Treefolk",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "RARE",
+        "artist": "Jeremy Jarvis",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg?1783942866",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Dauntless Dourbark counts itself when determining its power and toughness."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "A permanent that's both a Forest and a Treefolk will be counted twice when determining Dauntless Dourbark's power and toughness."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dawnfluke
 {
     "name": "Dawnfluke",
@@ -4196,6 +4279,69 @@
     ]
 }
 
+// Immaculate Magistrate
+{
+    "name": "Immaculate Magistrate",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{T}: Put a +1/+1 counter on target creature for each Elf you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Elf"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{T}: Put a +1/+1 counter on target creature for each Elf you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "RARE",
+        "artist": "Jim Nelson",
+        "flavorText": "Elves of the immaculate class weave flora into living creatures—sometimes to endorse an elite warrior, sometimes to create a breathing work of art.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3bbf6137-4f50-4915-b608-7a03512476a2.jpg?1783942860",
+        "rulings": [
+            {
+                "date": "2020-11-10",
+                "text": "The number of counters to put on the target creature is determined only as Immaculate Magistrate's ability resolves. Elves coming and going later won't cause that creature to gain or lose +1/+1 counters."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "The target creature doesn't have to be an Elf."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Imperious Perfect
 {
     "name": "Imperious Perfect",
@@ -4528,6 +4674,72 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Jagged-Scar Archers
+{
+    "name": "Jagged-Scar Archers",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Jagged-Scar Archers's power and toughness are each equal to the number of Elves you control.\n{T}: This creature deals damage equal to its power to target creature with flying.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent Elf"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent Elf"
+            }
+        }
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with flying"
+                    },
+                    "damageSource": "Self"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature kw:flying"
+                        },
+                        "id": "target creature with flying"
+                    }
+                ],
+                "descriptionOverride": "{T}: This creature deals damage equal to its power to target creature with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75fd5232-2dac-4bd9-a1f6-eb1a40154367.jpg?1783942861"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -5077,6 +5289,55 @@
         "artist": "Quinton Hoover",
         "flavorText": "Eidren, perfect of Lys Alana, ordered hundreds of trees uprooted and rearranged into a pattern he deemed beautiful. Thus the Gilt-Leaf Wood was born.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1783942859"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Lignify
+{
+    "name": "Lignify",
+    "manaCost": "{1}{G}",
+    "typeLine": "Kindred Enchantment — Treefolk Aura",
+    "oracleText": "Enchant creature\nEnchanted creature is a Treefolk with base power and toughness 0/4 and loses all abilities.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "TransformPermanent",
+                "setSubtypes": [
+                    "Treefolk"
+                ]
+            },
+            "LoseAllAbilities",
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 0,
+                "toughness": 4
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Bulgo paused, puzzled. What was that rustling sound, and why did he feel so stiff? And how could his *feet* be so thirsty?",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/264fd6c5-8d73-4928-aed7-5ed637426780.jpg?1783942859",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Lignify overwrites characteristic-defining abilities that specify the enchanted creature's power or toughness (such as the one Dauntless Dourbark has) or that specify its creature types (such as changeling does)."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "Lignify will not overwrite effects such as those from Glorious Anthem, counters, or Giant Growth that change the enchanted creature's power or toughness without setting it to a specific value. Apply such effects after applying Lignify."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -8246,6 +8507,55 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Timber Protector
+{
+    "name": "Timber Protector",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Treefolk Warrior",
+    "oracleText": "Other Treefolk creatures you control get +1/+1.\nOther Treefolk and Forests you control have indestructible.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Treefolk ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "INDESTRUCTIBLE",
+                "filter": {
+                    "baseFilter": "permanent Treefolk|Forest ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Terese Nielsen & Philip Tan",
+        "flavorText": "In his presence, an ordinary grove becomes a bastion to turn spells and break armies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg?1783942856",
+        "rulings": [
+            {
+                "date": "2013-07-01",
+                "text": "If Timber Protector somehow becomes a Forest, it doesn't give itself indestructible."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Five green Lorwyn cards, all composed from existing SDK primitives — no new engine vocabulary. The batch is one tribal idea seen five ways: the Treefolk half (Lignify, Timber Protector, Dauntless Dourbark) and the Elf half (Immaculate Magistrate, Jagged-Scar Archers).

## Cards

- **Lignify** `{1}{G}` — Kindred Enchantment — Treefolk Aura. Three layered statics: `TransformPermanent(setSubtypes = Treefolk)` (Layer 4 — replaces every creature type but leaves card types and colors alone, so an artifact creature stays an artifact), `LoseAllAbilities` (Layer 6), `SetBasePowerToughnessStatic(0, 4)` (Layer 7b — beats a CDA, loses to later +N/+N and counters, per the 2007/2009 rulings).
- **Timber Protector** `{4}{G}` 4/6 — `ModifyStats(1, 1)` over Treefolk *creatures* you control, and `GrantKeyword(INDESTRUCTIBLE)` over the bare-noun "Treefolk and Forests", i.e. `Permanent.withAnySubtype("Treefolk", "Forest")`. `excludeSelf` on both is the printed "Other" — and is what the 2013-07-01 ruling turns on.
- **Dauntless Dourbark** `{3}{G}` \*/\* — CDA is a literal `DynamicAmount.Add` of two independent battlefield counts. That is what the printed "plus" asks for and what the rulings require: the Dourbark counts itself, and a permanent that is both a Forest and a Treefolk is counted **twice**. Folding the halves into one `withAnySubtype` filter would count it once and get the card wrong. Trample is a `ConditionalStaticAbility` over `Conditions.YouControl(..., excludeSelf = true)`.
- **Immaculate Magistrate** `{3}{G}` 2/2 — `{T}`: `Effects.AddDynamicCounters` over a battlefield count of Elf *permanents* you control, read at resolution (2020-11-10 ruling). Target is any creature, not just an Elf.
- **Jagged-Scar Archers** `{1}{G}{G}` \*/\* — CDA over Elf permanents you control; `{T}` deals damage read off the source with `EntityProperty(Source, Power)`, so it sees the CDA and the whole layer stack rather than an activation-time snapshot, with `damageSource = Self` so protection and prevention attribute it correctly.

Every "number of Elves / Treefolk you control" is a **bare tribal noun**, so all of them count permanents rather than creatures.

## Reprint rows

Canonical placement put all five in LRW (their earliest real printing). Three scaffolded reprint sets needed rows: **C14** #201 and **CMR** #234 + extended-art #679 for Immaculate Magistrate, **KHC** #65 for Jagged-Scar Archers. `just check-card-printing` is clean for all five.

## Cards considered and dropped

Six cards were picked first and ejected at Step 4 — each needs new engine vocabulary and belongs in its own `add-feature` PR:

- **Oaken Brawler, Paperfin Rascal, Bog Hoodlums, Lash Out** — **clash** is entirely unimplemented; there is no keyword action, no "if you win" gate, and no post-clash trigger anywhere in the SDK or the engine. Roughly 25 of Lorwyn's remaining cards are blocked on it.
- **Wren's Run Vanquisher, Silvergill Adept** — "reveal a \<type\> card from your hand or pay {3}" needs a reveal-from-hand `AdditionalCost` leg for `OrPay`. `OrPay` currently only accepts a selection-carrying leg (Behold, or an atom over Sacrifice / Discard / ExileFrom / TapPermanents / ReturnToHand). Substituting `BeholdOrPay` would wrongly let the caster satisfy it with a battlefield permanent, so it was not faked.

## Verification

- `just build` — **BUILD SUCCESSFUL** (full compile + tests).
- `just rebless-cards` — the LRW golden is **310 lines, all insertions**; only the five new cards moved.
- `just assay-differential --set LRW` — 101 confirmed, 10 divergent, and all 10 are pre-existing cards (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). None of the five new cards divergent.
- `just check-card-printing` — ok for all five.
- Step 9 re-fetched each card from Scryfall and diffed mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavour and image URI against the blessed golden: all match. All nine image URLs return HTTP 200.

No scenario tests: no new SDK vocabulary was added, so the snapshot and lint nets cover these. `DynamicAmount.Add` inside `dynamicStats` already has precedent (Soulless One, Multani).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw