### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3738,6 +3738,8 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `TargetFilter.ArtifactInYourGraveyard` — an artifact card in **your** graveyard: the whole "return target artifact card from your graveyard" family (Ritual of Restoration, Myr Retriever, Buried Ruin, Refurbish, Fortuitous Find). Filter-side only — there is no `Targets` alias — so write `TargetObject(filter = TargetFilter.ArtifactInYourGraveyard)`. Its siblings are `TargetFilter.CreatureInYourGraveyard`, `TargetFilter.PermanentInYourGraveyard` (the bare tribal noun — see the table further down) and `TargetFilter.InstantOrSorceryInYourGraveyard`. **Inclusive**, like every card-type filter here: an artifact creature card matches this *and* `CreatureInYourGraveyard`, which is what lets Fortuitous Find's two modes each accept one. Ownership rather than control is the axis because a card in a graveyard has no controller.
 
 **Chained predicates** — `.youControl()`, `.controlledByOpponent()`, `.opponent()`, `.withSubtype(...)`,
+`.notSubtype(...)` (the negation — "target non-Faerie spell", Faerie Trickery; `CardPredicate.NotSubtype`,
+so a changeling object *has* every creature type and is correctly excluded),
 `.withKeyword(...)`, `.ofColor(...)`, `.tapped()`, `.untapped()`, `.power(n)`, `.minPower(n)`, `.maxPower(n)`,
 `.targetsMatching(subfilter)` (a spell/ability on the stack that targets at least one object matching
 `subfilter` — `CardPredicate.TargetsMatching`; e.g. `GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -386,6 +386,9 @@ data class TargetFilter(
     /** Add subtype by string */
     fun withSubtype(subtype: String) = copy(baseFilter = baseFilter.withSubtype(subtype))
 
+    /** Exclude subtype ("target non-Faerie spell", "target non-Elf creature"). */
+    fun notSubtype(subtype: Subtype) = copy(baseFilter = baseFilter.notSubtype(subtype))
+
     /** Add keyword requirement */
     fun withKeyword(keyword: Keyword) = copy(baseFilter = baseFilter.withKeyword(keyword))
 

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FaerieTrickery.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FaerieTrickery.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Faerie Trickery
+ * {1}{U}{U}
+ * Kindred Instant — Faerie
+ * Counter target non-Faerie spell. If that spell is countered this way, exile it instead of
+ * putting it into its owner's graveyard.
+ *
+ * "Non-Faerie" is a targeting restriction, so it is carried by the target filter rather than
+ * checked at resolution: a Faerie spell is never a legal target in the first place. The subtype is
+ * read off the spell on the stack, which means a changeling spell counts as a Faerie and can't be
+ * hit — including Faerie Trickery's own Kindred Faerie siblings.
+ */
+val FaerieTrickery = card("Faerie Trickery") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Kindred Instant — Faerie"
+    oracleText = "Counter target non-Faerie spell. If that spell is countered this way, exile it " +
+        "instead of putting it into its owner's graveyard."
+
+    spell {
+        target = TargetSpell(filter = TargetFilter.SpellOnStack.notSubtype(Subtype.FAERIE))
+        effect = Effects.CounterSpellToExile()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Terese Nielsen"
+        flavorText = "The fae are so quick and their life spans so short that it's difficult to get retribution for their pranks."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg?1783942904"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ForcedFruition.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ForcedFruition.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Forced Fruition
+ * {4}{U}{U}
+ * Enchantment
+ * Whenever an opponent casts a spell, that player draws seven cards.
+ *
+ * The draw lands on the caster, not on Forced Fruition's controller, so the payoff is bound to
+ * [Player.TriggeringPlayer]. The trigger fires on the cast itself — it resolves before the spell
+ * does, and it still resolves if that spell is later countered.
+ */
+val ForcedFruition = card("Forced Fruition") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever an opponent casts a spell, that player draws seven cards."
+
+    triggeredAbility {
+        trigger = Triggers.OpponentCastsSpell
+        effect = Effects.DrawCards(7, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        description = "Whenever an opponent casts a spell, that player draws seven cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        artist = "William O'Connor"
+        flavorText = "\"Petals within petals within petals, tadpole. The truth lurks below an opulence of illusion.\"\n—Neerdiv, fallowsage"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg?1783942903"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/KnuckleboneWitch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/KnuckleboneWitch.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Knucklebone Witch
+ * {B}
+ * Creature — Goblin Shaman
+ * 1/1
+ * Whenever a Goblin you control is put into a graveyard from the battlefield, you may put a
+ * +1/+1 counter on this creature.
+ *
+ * The bare tribal noun "Goblin" names every permanent with the subtype, not only the creatures, so
+ * the filter is [GameObjectFilter.Permanent]. There is no "another" here — the Witch is itself a
+ * Goblin and does trigger on its own death, which is why the binding is [TriggerBinding.ANY]; by
+ * the time that copy of the trigger resolves the Witch is gone and the counter has nowhere to go.
+ *
+ * "A graveyard", not "your graveyard": a Goblin you control but don't own still triggers this on
+ * the way to its owner's graveyard, so the filter reads control and the destination is unqualified.
+ */
+val KnuckleboneWitch = card("Knucklebone Witch") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a Goblin you control is put into a graveyard from the battlefield, " +
+        "you may put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN).youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        optional = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "you may put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Jim Pavelec"
+        flavorText = "Each bone honors its owner's best pranks."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg?1783942889"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MarshFlitter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MarshFlitter.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Marsh Flitter
+ * {3}{B}
+ * Creature — Faerie Rogue
+ * 1/1
+ * Flying
+ * When this creature enters, create two 1/1 black Goblin Rogue creature tokens.
+ * Sacrifice a Goblin: This creature has base power and toughness 3/3 until end of turn.
+ *
+ * The two Goblins it brings are the fodder for its own ability, but the cost is any Goblin — and
+ * the bare tribal noun means any Goblin *permanent* you control, not just creatures.
+ *
+ * "Has base power and toughness 3/3" *sets* the base (layer 7b) rather than pumping, so a second
+ * activation is redundant while the first is still in effect, and +1/+1 counters still apply on top
+ * of it. The Flitter is a Faerie, never a Goblin, so it can't feed itself.
+ */
+val MarshFlitter = card("Marsh Flitter") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nWhen this creature enters, create two 1/1 black Goblin Rogue creature " +
+        "tokens.\nSacrifice a Goblin: This creature has base power and toughness 3/3 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Goblin", "Rogue"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1783942839",
+        )
+        description = "create two 1/1 black Goblin Rogue creature tokens."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN))
+        effect = Effects.SetBasePowerAndToughness(
+            power = 3,
+            toughness = 3,
+            target = EffectTarget.Self,
+            duration = Duration.EndOfTurn,
+        )
+        description = "Sacrifice a Goblin: This creature has base power and toughness 3/3 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg?1783942888"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThundercloudShaman.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThundercloudShaman.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thundercloud Shaman
+ * {3}{R}{R}
+ * Creature — Giant Shaman
+ * 4/4
+ * When this creature enters, it deals damage equal to the number of Giants you control to each
+ * non-Giant creature.
+ *
+ * Two different readings of "Giant" in one line, and they are not the same set. The *amount* is the
+ * bare tribal noun — every Giant permanent you control, the Shaman itself included, so the sweep is
+ * at least 1. The *victims* are "each non-Giant creature", which is creatures only and spans every
+ * player's battlefield: the Shaman burns its controller's own non-Giants too.
+ *
+ * The count is read once as the ability resolves, before any damage is dealt, and state-based
+ * actions aren't checked mid-resolution — so a Giant dying to this sweep can't shrink it.
+ */
+val ThundercloudShaman = card("Thundercloud Shaman") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Shaman"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, it deals damage equal to the number of Giants you " +
+        "control to each non-Giant creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.GIANT)),
+            DealDamageEffect(
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Permanent.withSubtype(Subtype.GIANT)
+                ).count(),
+                EffectTarget.Self,
+            )
+        )
+        description = "it deals damage equal to the number of Giants you control to each non-Giant creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Greg Staples"
+        flavorText = "He cares not for the disasters his storm brings as long as his path ahead is clear."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg?1783942868"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieTrickeryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieTrickeryScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Faerie Trickery (LRW #62, {1}{U}{U}, Kindred Instant — Faerie).
+ *
+ *   Counter target non-Faerie spell. If that spell is countered this way, exile it instead of
+ *   putting it into its owner's graveyard.
+ *
+ * Two things are worth proving. The exile rider — a countered spell must land in exile, not in its
+ * owner's graveyard — and the "non-Faerie" restriction, which lives in the *target filter* rather
+ * than in a resolution-time check, so a Faerie spell is simply not a legal target. A changeling
+ * spell is every creature type, Faerie included, so it is off limits too.
+ */
+class FaerieTrickeryScenarioTest : ScenarioTestBase() {
+
+    private fun trickery(opponentSpell: String) = scenario()
+        .withPlayers("Alice", "Bob")
+        .withCardInHand(1, "Faerie Trickery")
+        .withLandsOnBattlefield(1, "Island", 3)
+        .withCardInHand(2, opponentSpell)
+        .withLandsOnBattlefield(2, "Swamp", 2)
+        .withLandsOnBattlefield(2, "Forest", 2)
+        .withLandsOnBattlefield(2, "Plains", 3)
+        .withCardInLibrary(1, "Island")
+        .withCardInLibrary(2, "Swamp")
+        .withActivePlayer(2)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Faerie Trickery") {
+
+            test("counters a non-Faerie spell and exiles it instead of binning it") {
+                val game = trickery("Grizzly Bears")
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Faerie Trickery", "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                withClue("The rider replaces the graveyard destination with exile") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a Faerie spell is not a legal target") {
+                val game = trickery("Nightshade Stinger") // {B} Creature — Faerie Rogue
+                game.castSpell(2, "Nightshade Stinger").error shouldBe null
+                game.passPriority()
+
+                withClue("\"non-Faerie\" is a targeting restriction, so the cast must be rejected") {
+                    game.castSpellTargetingStackSpell(1, "Faerie Trickery", "Nightshade Stinger")
+                        .error shouldNotBe null
+                }
+            }
+
+            test("a changeling spell counts as a Faerie and is off limits") {
+                val game = trickery("Avian Changeling") // {2}{W} Creature — Shapeshifter, changeling
+                game.castSpell(2, "Avian Changeling").error shouldBe null
+                game.passPriority()
+
+                withClue("Changeling makes the spell every creature type, Faerie included") {
+                    game.castSpellTargetingStackSpell(1, "Faerie Trickery", "Avian Changeling")
+                        .error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ThundercloudShamanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ThundercloudShamanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thundercloud Shaman reprint in C15. Canonical CardDefinition lives in its earliest set (LRW).
+ */
+val ThundercloudShamanReprint = Printing(
+    oracleId = "eb812ea7-3301-4774-86a2-64c4ed6766fc",
+    name = "Thundercloud Shaman",
+    setCode = "C15",
+    collectorNumber = "168",
+    scryfallId = "e5535949-44e7-45b4-94b1-b752e4d17861",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5535949-44e7-45b4-94b1-b752e4d17861.jpg?1783938073",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -2571,6 +2571,45 @@
     ]
 }
 
+// Faerie Trickery
+{
+    "name": "Faerie Trickery",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Kindred Instant — Faerie",
+    "oracleText": "Counter target non-Faerie spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "counterDestination": "CounterDestination.Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Faerie"
+                            }
+                        ]
+                    },
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Terese Nielsen",
+        "flavorText": "The fae are so quick and their life spans so short that it's difficult to get retribution for their pranks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/defb9f0b-195e-4aeb-92c1-8f827ad6724b.jpg?1783942904"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Fallowsage
 {
     "name": "Fallowsage",
@@ -3076,6 +3115,48 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Forced Fruition
+{
+    "name": "Forced Fruition",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever an opponent casts a spell, that player draws seven cards.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 7
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent casts a spell, that player draws seven cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "William O'Connor",
+        "flavorText": "\"Petals within petals within petals, tadpole. The truth lurks below an opulence of illusion.\"\n—Neerdiv, fallowsage",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg?1783942903"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5212,6 +5293,54 @@
     ]
 }
 
+// Knucklebone Witch
+{
+    "name": "Knucklebone Witch",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "Whenever a Goblin you control is put into a graveyard from the battlefield, you may put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Goblin ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "you may put a +1/+1 counter on this creature."
+                },
+                "descriptionOverride": "you may put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Jim Pavelec",
+        "flavorText": "Each bone honors its owner's best pranks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg?1783942889"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Lace with Moonglove
 {
     "name": "Lace with Moonglove",
@@ -5549,6 +5678,85 @@
                 "text": "The second ability can target any Goblin permanent except the Mad Auntie whose ability is being activated. It can target a different Mad Auntie."
             }
         ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Marsh Flitter
+{
+    "name": "Marsh Flitter",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nWhen this creature enters, create two 1/1 black Goblin Rogue creature tokens.\nSacrifice a Goblin: This creature has base power and toughness 3/3 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Goblin",
+                        "Rogue"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/4/f44d5271-5d10-46b2-9ba2-5788d99de2e6.jpg?1783942839"
+                },
+                "descriptionOverride": "create two 1/1 black Goblin Rogue creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Goblin"
+                    }
+                },
+                "effect": {
+                    "type": "SetBaseStats",
+                    "target": "Self",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "duration": "EndOfTurn"
+                },
+                "descriptionOverride": "Sacrifice a Goblin: This creature has base power and toughness 3/3 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/040e1039-1943-4c2d-aa98-b7f9519de321.jpg?1783942888"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -8447,6 +8655,66 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Thundercloud Shaman
+{
+    "name": "Thundercloud Shaman",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Giant Shaman",
+    "oracleText": "When this creature enters, it deals damage equal to the number of Giants you control to each non-Giant creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Giant"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "permanent Giant"
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "it deals damage equal to the number of Giants you control to each non-Giant creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "He cares not for the disasters his storm brings as long as his path ahead is clear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/5864f207-2878-461b-8ff6-76475abc324d.jpg?1783942868"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, all composed from existing primitives. One SDK addition, and it is a pass-through rather than new vocabulary.

- **Forced Fruition** ({4}{U}{U} Enchantment) — `Triggers.OpponentCastsSpell` + `Effects.DrawCards(7, …)` bound to `Player.TriggeringPlayer`, so the seven cards land on the caster, not on the enchantment's controller.
- **Faerie Trickery** ({1}{U}{U} Kindred Instant — Faerie) — `Effects.CounterSpellToExile()` over a spell target carrying the "non-Faerie" restriction in the *filter*, so a Faerie spell is never a legal target rather than being checked at resolution.
- **Knucklebone Witch** ({B} Goblin Shaman 1/1) — `Triggers.leavesBattlefield` to the graveyard over Goblin *permanents* you control (the bare tribal noun, not just creatures), `TriggerBinding.ANY` because the Witch is itself a Goblin and does trigger on its own death.
- **Thundercloud Shaman** ({3}{R}{R} Giant Shaman 4/4) — `Effects.ForEachInGroup` over non-Giant creatures, each taking `DynamicAmounts.battlefield(You, Permanent Giants).count()` damage. The two readings of "Giant" in the line are different sets on purpose: the amount is every Giant permanent you control (the Shaman included, so the sweep is at least 1); the victims are creatures only, across every battlefield.
- **Marsh Flitter** ({3}{B} Faerie Rogue 1/1) — enters trigger creating two 1/1 black Goblin Rogue tokens (LRW token art), plus `Costs.Sacrifice` over Goblin permanents feeding `Effects.SetBasePowerAndToughness`. It *sets* the base at layer 7b rather than pumping, so +1/+1 counters still apply on top and a second activation is redundant while the first stands.

### SDK

`TargetFilter.notSubtype(subtype)` — the chainer that spells Faerie Trickery's restriction. It delegates to the `notSubtype` that `GameObjectFilter` already had, over the existing `CardPredicate.NotSubtype`; no new predicate, executor, or engine behaviour. Because that predicate reads projected subtypes, a changeling spell counts as a Faerie and is correctly off limits. `docs/card-sdk-language-reference.md` updated in the same change.

### Reprints

Thundercloud Shaman is also in C15, which is scaffolded, so it gets a `Printing` row there; the canonical stays in LRW, its earliest printing. `just check-card-printing` is clean for all five.

### Cards considered and dropped

Nova Chaser and Changeling Berserker were in the original batch and left it: **champion does not exist anywhere in the SDK or engine** — no keyword, no static ability, no grep hit. That is `add-feature` work (it blocks the whole LRW champion cycle plus Mistbind Clique, Thoughtweft Trio, Wanderwine Prophets, Boggart Mob and Wren's Run Packmaster), not something to fake with a sacrifice-and-exile lookalike. Worth noting because a memory note claimed champion was already present; it is not.

### Verification

- `just build` — green (full build, all module test suites).
- `just test-class FaerieTrickeryScenarioTest` — 3/3 pass: the exile rider, a Faerie spell rejected as a target, and a changeling spell rejected as a target.
- `just rebless-cards` — only the five new cards move in `snapshots/cards/LRW.json`.
- `just assay-differential --set LRW` — 10 DIVERGENT, all pre-existing (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). None of the five new cards diverges; Assay declines all five at parse time, so they are outside its covered class.
- All six image URIs (five cards + the Goblin Rogue token) verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6
