### PR TITLE
Add Radiant Grace to Innistrad: Crimson Vow

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 271 / 273
+**Implemented:** 272 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [x] Aim for the Head
@@ -190,7 +190,7 @@
 - [x] Plains
 - [x] Pointed Discussion
 - [x] Pyre Spawn
-- [ ] Radiant Grace
+- [x] Radiant Grace
 - [x] Ragged Recluse
 - [x] Reckless Impulse
 - [x] Reclusive Taxidermist

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1238,7 +1238,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   battlefield attached to a permanent the controller chooses at resolution (default host filter: a creature
   you control). Works for both Auras and Equipment; the host is chosen, not targeted. If no legal host exists,
   an Equipment enters unattached while an Aura can't enter (Rule 303.4g). (One Last Job.)
-- `ReturnSelfToBattlefieldAttached(target)` — return source attached to target (Aura recursion).
+- `ReturnSelfToBattlefieldAttached(target, transformed = false)` — return source attached to target
+  (Aura recursion). [target] may resolve to a **player** as well as a permanent, and the two cases
+  differ in who controls the returned Aura: a *permanent* host hands control to that permanent's
+  controller (the Dragon-aura cycle's "attached to that creature"), a *player* host leaves it under
+  the **ability's** controller — the only reading "under your control attached to target opponent"
+  allows. `transformed = true` returns it back face up (CR 712.8); the face swap happens while the
+  card is still in its old zone, so the entry registers the back face's statics and replacements.
+  A single-faced card told to enter transformed doesn't move at all (standing ruling), so it is a
+  quiet no-op. Radiant Grace: `ReturnSelfToBattlefieldAttached(target = cursed, transformed = true)`.
 - `ReturnSelfFromExileTransformed` — Craft resolution (CR 702.167a). Returns the source from exile to the
   battlefield as its back face, under its owner's control, and re-attaches the source's
   `CraftedFromExiledComponent` recording the exiled materials. Pair with `AbilityCost.Craft`; see the `Craft`
@@ -4084,7 +4092,20 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   controls" (the upkeep player is the active player — Temporal Distortion).
 - `.targetPlayerControls(target)` — controlled by a referenced player. Resolves `EffectTarget`
   bindings/context targets, plus `EffectTarget.ControllerOfTriggeringEntity` (controller of the
-  entity that fired the trigger — e.g. Tectonic Instability "tap all lands its controller controls").
+  entity that fired the trigger — e.g. Tectonic Instability "tap all lands its controller controls"),
+  `PlayerRef(Player.DefendingPlayer)` ("target creature defending player controls" — Necrite) and
+  `PlayerRef(Player.EnchantedPlayer)` (below). The predicate's own description follows the target,
+  so these read as "defending player controls" / "enchanted player controls" rather than the fixed
+  "target player controls" — neither is targeting anyone.
+- `.controlledByEnchantedPlayer()` — controlled by the player the filtering ability's **source Aura
+  is attached to** (CR 303 enchant player): "Creatures enchanted player controls enter tapped"
+  (Radiant Restraints). A named recipe over `.targetPlayerControls(PlayerRef(Player.EnchantedPlayer))`,
+  and the controller-axis sibling of `attackingEnchantedPlayer()` below — every other controller
+  scope here resolves against the *ability's* controller, which for a Curse is the wrong player.
+  Fails closed when the source isn't an Aura attached to a player. Any read site that evaluates a
+  filter on behalf of a granting permanent must pass **that permanent** as the predicate context's
+  `sourceId`, not the object being filtered — that is what `EnterTappedReplacements` /
+  `EnterUntappedReplacements` thread through.
 - `.ownedByYou()` / `.ownedByOpponent()` — owner predicates (for graveyard/exile cards without a
   controller, and "you own" battlefield wordings).
 - `.ownedByTargetPlayer()` (`ControllerPredicate.OwnedByTargetPlayer`, FQL `own:target-player`) —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1542,9 +1542,16 @@ object Effects {
     /**
      * Return this card from its current zone to the battlefield attached to the target.
      * Used by the Dragon aura cycle (Dragon Shadow, Dragon Breath, etc.).
+     *
+     * [target] may name a **player** as well as a permanent — "attached to target opponent" for a
+     * Curse — and [transformed] returns the card back face up (Radiant Grace's
+     * "return this card to the battlefield transformed under your control attached to target
+     * opponent").
      */
-    fun ReturnSelfToBattlefieldAttached(target: EffectTarget = EffectTarget.TriggeringEntity): Effect =
-        ReturnSelfToBattlefieldAttachedEffect(target)
+    fun ReturnSelfToBattlefieldAttached(
+        target: EffectTarget = EffectTarget.TriggeringEntity,
+        transformed: Boolean = false,
+    ): Effect = ReturnSelfToBattlefieldAttachedEffect(target, transformed)
 
     /**
      * Take the top card from the source's linked exile pile and put it into your hand.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
@@ -435,14 +435,29 @@ data class ExileAndGrantOwnerPlayPermissionEffect(
  * which return from the graveyard when a creature with high mana value enters the battlefield.
  *
  * The [target] specifies what the aura attaches to (typically [EffectTarget.TriggeringEntity]).
+ * It may resolve to a **player** as well as a permanent — "attached to target opponent" for a
+ * Curse (Radiant Grace). The two cases differ in who ends up controlling the returned Aura: a
+ * permanent host hands control to *that permanent's* controller (the Dragon cycle's "attached to
+ * that creature" reads as an ordinary Aura following its host), while a player host leaves it
+ * under the **ability's** controller, which is the only reading "under your control attached to
+ * target opponent" allows.
+ *
+ * @property transformed Return the card **transformed** — back face up (CR 712.8). A card in a
+ *   non-battlefield zone is always front-face-up, so "transformed" can only mean the back face.
+ *   Per the standing ruling a single-faced card told to enter transformed doesn't move at all, so
+ *   this is a no-op rather than an error on a card with no back face.
  */
 @SerialName("ReturnSelfToBattlefieldAttached")
 @Serializable
 data class ReturnSelfToBattlefieldAttachedEffect(
-    val target: EffectTarget = EffectTarget.TriggeringEntity
+    val target: EffectTarget = EffectTarget.TriggeringEntity,
+    val transformed: Boolean = false,
 ) : Effect {
-    override val description: String =
-        "Return this card from your graveyard to the battlefield attached to ${target.description}"
+    override val description: String = buildString {
+        append("Return this card from your graveyard to the battlefield")
+        if (transformed) append(" transformed")
+        append(" attached to ${target.description}")
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -1370,6 +1370,25 @@ data class GameObjectFilter(
     /** Controlled by any player (no controller scope) */
     fun anyController() = copy(controllerPredicate = ControllerPredicate.ControlledByAny)
 
+    /**
+     * Controlled by the player the asking ability's *source* Aura is attached to — "creatures
+     * enchanted player controls" (Radiant Restraints). The attachment-scoped controller sibling of
+     * [StatePredicate.IsAttackingEnchantedPlayer]: every other controller scope here resolves
+     * against the ability's own controller, which for a curse is exactly the wrong player.
+     *
+     * A named recipe over [ControllerPredicate.ControlledByReferencedPlayer], not a new predicate —
+     * `PlayerRef(Player.EnchantedPlayer)` already names the player; this only spares every curse
+     * from spelling out the reference and gives the shape a searchable name.
+     *
+     * Fails closed when the source isn't an Aura attached to a player, so a curse that has fallen
+     * off (or a filter asked with no source in scope) matches nothing rather than everything.
+     */
+    fun controlledByEnchantedPlayer() = copy(
+        controllerPredicate = ControllerPredicate.ControlledByReferencedPlayer(
+            EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.EnchantedPlayer)
+        )
+    )
+
     /** Must be controlled by the active player (the player whose turn it is) */
     fun controlledByActivePlayer() = copy(controllerPredicate = ControllerPredicate.ControlledByActivePlayer)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/ControllerPredicate.kt
@@ -89,11 +89,17 @@ sealed interface ControllerPredicate {
      * picked earlier in the same spell or ability — e.g., modal Commands where one
      * mode says "creatures target player controls". Keeps the target→filter wiring
      * explicit instead of relying on implicit "first player target" inference.
+     *
+     * It is also the general escape hatch for a player scope that is neither "you" nor a chosen
+     * target: `PlayerRef(Player.DefendingPlayer)` for "defending player controls" (Necrite),
+     * `PlayerRef(Player.EnchantedPlayer)` for "enchanted player controls" (Radiant Restraints).
+     * The description follows [target] rather than being fixed at "target player" — those two
+     * readings are not targeting anyone, and a filter that says so is the one shown to players.
      */
     @SerialName("ControlledByReferencedPlayer")
     @Serializable
     data class ControlledByReferencedPlayer(val target: EffectTarget) : ControllerPredicate {
-        override val description: String = "target player controls"
+        override val description: String = "${target.description} controls"
     }
 
     // =============================================================================

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RadiantGrace.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RadiantGrace.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Radiant Grace // Radiant Restraints (Innistrad: Crimson Vow #31)
+ * {W} · Enchantment — Aura // Enchantment — Aura Curse
+ *
+ * Front — Radiant Grace
+ *   Enchant creature
+ *   Enchanted creature gets +1/+0 and has vigilance.
+ *   When enchanted creature dies, return this card to the battlefield transformed under your
+ *   control attached to target opponent.
+ *
+ * Back — Radiant Restraints
+ *   Enchant player
+ *   Creatures enchanted player controls enter tapped.
+ *
+ * The corpus's first **transforming** Aura-front / Aura-back DFC — every other double-faced Aura
+ * here is the disturb shape (Twinblade Geist), where the back is cast from the graveyard rather
+ * than returned by a trigger. Two things had to be built, and each is a *scope* the SDK could name
+ * but not yet resolve:
+ *
+ *  - **"return this card to the battlefield transformed … attached to target opponent"** is
+ *    [Effects.ReturnSelfToBattlefieldAttached] with `transformed = true` and a **player** host.
+ *    The Dragon-aura cycle's version of this effect only ever attached to a creature, and handed
+ *    control of the returned Aura to *that creature's* controller — the right reading for "attached
+ *    to that creature", and exactly wrong for a curse, which would arrive under the control of the
+ *    player it curses. A player host now keeps the Aura under the ability's controller, which is
+ *    what "under your control" says. The face swap happens while the card is still in the
+ *    graveyard, so the battlefield entry registers Radiant Restraints' replacement effect and not
+ *    Radiant Grace's statics.
+ *
+ *  - **"Creatures enchanted player controls"** is
+ *    `GameObjectFilter.Creature.controlledByEnchantedPlayer()`, the controller-axis sibling of
+ *    Curse of Hospitality's [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingEnchantedPlayer]
+ *    and the same lesson: every other controller scope in the SDK resolves against the *ability's*
+ *    controller, which for a Curse is the wrong player. It resolves the granting Aura's own
+ *    attachment, so the enters-tapped replacement had to start passing the permanent that grants
+ *    it — not the permanent that is entering — as the filter's source.
+ *
+ * The trigger is `leavesBattlefield(to = GRAVEYARD, binding = ATTACHED)`: "when enchanted creature
+ * dies" fires while the Aura is still on the battlefield, and resolves once the Aura has itself
+ * been put into the graveyard by CR 704.5m — which is the zone the return reads from. A dead
+ * enchanted creature that was exiled or bounced rather than dying doesn't fire it, and a game with
+ * no opponent left to target simply removes the trigger from the stack.
+ */
+private val RadiantGraceFront = card("Radiant Grace") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+0 and has vigilance.\n" +
+        "When enchanted creature dies, return this card to the battlefield transformed under " +
+        "your control attached to target opponent."
+
+    auraTarget = Targets.Creature
+
+    // Enchanted creature gets +1/+0 and has vigilance.
+    staticAbility {
+        ability = ModifyStats(1, 0, GroupFilter.attachedCreature())
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    // When enchanted creature dies, return this card to the battlefield transformed under your
+    // control attached to target opponent.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ATTACHED,
+        )
+        val cursed = target("target opponent", Targets.Opponent)
+        effect = Effects.ReturnSelfToBattlefieldAttached(target = cursed, transformed = true)
+        description = "When enchanted creature dies, return this card to the battlefield " +
+            "transformed under your control attached to target opponent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1783924919"
+    }
+}
+
+private val RadiantRestraints = card("Radiant Restraints") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Enchantment — Aura Curse"
+    oracleText = "Enchant player\n" +
+        "Creatures enchanted player controls enter tapped."
+
+    auraTarget = Targets.Player
+
+    // Creatures enchanted player controls enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.controlledByEnchantedPlayer(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Campbell White"
+        flavorText = "\"Even in times of brutal darkness, never mistake beauty and delicacy for " +
+            "weakness.\"\n—Thalia, Guardian of Thraben"
+        imageUri = "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1783924919"
+    }
+}
+
+val RadiantGrace: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = RadiantGraceFront,
+    backFace = RadiantRestraints,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RadiantGraceScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RadiantGraceScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Radiant Grace // Radiant Restraints (VOW #31).
+ *
+ *   Front — Radiant Grace — Enchant creature. Enchanted creature gets +1/+0 and has vigilance.
+ *           When enchanted creature dies, return this card to the battlefield transformed under
+ *           your control attached to target opponent.
+ *   Back  — Radiant Restraints — Enchant player. Creatures enchanted player controls enter tapped.
+ *
+ * Two things are new here and both are *scopes*, so both tests that matter are negative ones:
+ *
+ *  - The return is transformed **and** attached to a player, and lands **under the trigger's
+ *    controller** rather than under the player it curses — the Dragon-aura cycle's version of this
+ *    effect handed control to the host's controller, which for a Curse gives the card away.
+ *  - "Creatures enchanted player controls" resolves against the *Aura's attachment*, not against
+ *    the ability's controller. The controller's own creatures entering untapped is what separates
+ *    the two readings; a controller-scoped filter would tap the wrong side of the board.
+ */
+class RadiantGraceScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.attachedTo(id: EntityId): EntityId? =
+        state.getEntity(id)?.get<AttachedToComponent>()?.targetId
+
+    private fun TestGame.nameOf(id: EntityId): String? =
+        state.getEntity(id)?.get<CardComponent>()?.name
+
+    private fun TestGame.tapped(id: EntityId): Boolean =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    init {
+        context("Radiant Grace") {
+
+            test("enchanted creature gets +1/+0 and vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Radiant Grace", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state.projectedState.getPower(bears) shouldBe 3
+                game.state.projectedState.getToughness(bears) shouldBe 2
+                game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+            }
+
+            test("when the enchanted creature dies it returns transformed, cursing the chosen opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Radiant Grace", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val aura = game.findPermanent("Radiant Grace")!!
+
+                // 3 damage kills the 3/2; the Aura falls off into the graveyard (CR 704.5m) and its
+                // "when enchanted creature dies" trigger goes on the stack from the battlefield.
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("the same card is back, showing its other face") {
+                    game.nameOf(aura) shouldBe "Radiant Restraints"
+                    game.isOnBattlefield("Radiant Restraints") shouldBe true
+                }
+                withClue("attached to the targeted opponent, not to a permanent") {
+                    game.attachedTo(aura) shouldBe game.player2Id
+                }
+                withClue("'under your control' — the curse is player 1's, on player 2") {
+                    game.state.getEntity(aura)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+            }
+        }
+
+        context("Radiant Restraints") {
+
+            /**
+             * Radiant Restraints on the battlefield under player 1, cursing [cursedPlayer]. Attached
+             * directly: "enchant player" needs an [AttachedToComponent] pointing at a *player* id,
+             * which the builder's permanent-host `withCardAttachedTo` can't produce.
+             */
+            fun cursing(cursedPlayer: Int, activePlayer: Int = 1): TestGame {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Radiant Restraints")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withActivePlayer(activePlayer)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val curse = game.findPermanent("Radiant Restraints")!!
+                val victimId = if (cursedPlayer == 1) game.player1Id else game.player2Id
+                game.state = game.state.updateEntity(curse) { it.with(AttachedToComponent(victimId)) }
+                return game
+            }
+
+            /** Cast Grizzly Bears from [playerNumber]'s hand and return the resulting permanent. */
+            fun TestGame.playBears(playerNumber: Int): EntityId {
+                castSpell(playerNumber, "Grizzly Bears").error shouldBe null
+                if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+                return findPermanent("Grizzly Bears")!!
+            }
+
+            test("a creature the cursed player controls enters tapped") {
+                val game = cursing(cursedPlayer = 2, activePlayer = 2)
+                val bears = game.playBears(2)
+                game.tapped(bears) shouldBe true
+            }
+
+            test("a creature the curse's own controller controls enters untapped") {
+                val game = cursing(cursedPlayer = 2)
+                val bears = game.playBears(1)
+                withClue("the scope is the Aura's attachment, not the ability's controller") {
+                    game.tapped(bears) shouldBe false
+                }
+            }
+
+            test("a curse on its own controller taps that controller's creatures") {
+                // The reading a controller-scoped filter gets exactly backwards.
+                val game = cursing(cursedPlayer = 1)
+                val bears = game.playBears(1)
+                game.tapped(bears) shouldBe true
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -15288,6 +15288,110 @@
     ]
 }
 
+// Radiant Grace
+{
+    "name": "Radiant Grace",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+0 and has vigilance.\nWhen enchanted creature dies, return this card to the battlefield transformed under your control attached to target opponent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "ReturnSelfToBattlefieldAttached",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    },
+                    "transformed": true
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When enchanted creature dies, return this card to the battlefield transformed under your control attached to target opponent."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "backFace": {
+        "name": "Radiant Restraints",
+        "manaCost": "",
+        "typeLine": "Enchantment — Aura Curse",
+        "oracleText": "Enchant player\nCreatures enchanted player controls enter tapped.",
+        "script": {
+            "replacementEffects": [
+                {
+                    "type": "PermanentsEnterTapped",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "controllerPredicate": {
+                                "type": "ControlledByReferencedPlayer",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EnchantedPlayer"
+                                }
+                            }
+                        },
+                        "to": "Battlefield"
+                    }
+                }
+            ],
+            "auraTarget": "TargetPlayer"
+        },
+        "metadata": {
+            "collectorNumber": "31",
+            "rarity": "UNCOMMON",
+            "artist": "Campbell White",
+            "flavorText": "\"Even in times of brutal darkness, never mistake beauty and delicacy for weakness.\"\n—Thalia, Guardian of Thraben",
+            "imageUri": "https://cards.scryfall.io/normal/back/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1783924919"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "UNCOMMON",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a708243-42a1-4fa7-8b0b-9d5163da84bb.jpg?1783924919"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ragged Recluse
 {
     "name": "Ragged Recluse",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1226,6 +1226,16 @@ class PredicateEvaluator {
             // creature's — so the turn-order guard lives here.
             Player.TriggeringPlayer ->
                 context.triggeringEntityId?.takeIf { it in state.turnOrder }
+            // "creatures enchanted player controls" (Radiant Restraints) — the controller scope a
+            // Curse needs, and the only one that reads the *source's* attachment rather than the
+            // ability's controller. Same resolution as StatePredicate.IsAttackingEnchantedPlayer:
+            // the `in state.turnOrder` guard is what keeps a permanent host out, so an Aura on a
+            // creature can never make this match anything.
+            Player.EnchantedPlayer -> context.sourceId
+                ?.let { state.getEntity(it) }
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                ?.targetId
+                ?.takeIf { it in state.turnOrder }
             else -> null
         }
         else -> null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
@@ -48,7 +48,7 @@ object EnterTappedReplacements {
             val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is PermanentsEnterTapped) continue
-                if (matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, state)) {
+                if (matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, state)) {
                     return true
                 }
             }
@@ -91,16 +91,24 @@ object EnterTappedReplacements {
         }
     }
 
+    /**
+     * [replacementSourceId] is the permanent that *grants* the replacement, not the one entering —
+     * the entering permanent is what the filter is evaluated against and is passed separately. The
+     * distinction only shows up for a source-relative predicate: "creatures enchanted player
+     * controls" has to read the granting Aura's own attachment, and would otherwise be asked about
+     * the entering creature's.
+     */
     private fun matchesEnterFilter(
         event: EventPattern,
         enteringEntityId: EntityId,
+        replacementSourceId: EntityId,
         sourceControllerId: EntityId,
         state: GameState,
     ): Boolean {
         if (event !is EventPattern.ZoneChangeEvent) return false
         if (event.to != Zone.BATTLEFIELD) return false
         val predicateContext = PredicateContext(
-            sourceId = enteringEntityId,
+            sourceId = replacementSourceId,
             controllerId = sourceControllerId,
         )
         return predicateEvaluator.matches(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterUntappedReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterUntappedReplacements.kt
@@ -47,7 +47,7 @@ object EnterUntappedReplacements {
             val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is EntersUntapped) continue
-                if (matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, state)) {
+                if (matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, state)) {
                     return true
                 }
             }
@@ -55,16 +55,24 @@ object EnterUntappedReplacements {
         return false
     }
 
+    /**
+     * [replacementSourceId] is the permanent that *grants* the replacement, not the one entering —
+     * the entering permanent is what the filter is evaluated against and is passed separately. The
+     * distinction only shows up for a source-relative predicate: "creatures enchanted player
+     * controls" has to read the granting Aura's own attachment, and would otherwise be asked about
+     * the entering creature's.
+     */
     private fun matchesEnterFilter(
         event: EventPattern,
         enteringEntityId: EntityId,
+        replacementSourceId: EntityId,
         sourceControllerId: EntityId,
         state: GameState,
     ): Boolean {
         if (event !is EventPattern.ZoneChangeEvent) return false
         if (event.to != Zone.BATTLEFIELD) return false
         val predicateContext = PredicateContext(
-            sourceId = enteringEntityId,
+            sourceId = replacementSourceId,
             controllerId = sourceControllerId,
         )
         return predicateEvaluator.matches(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
@@ -39,7 +39,7 @@ class ReturnSelfFromZoneTransformedExecutor(
     ): EffectResult {
         val sourceId = context.sourceId
             ?: return EffectResult.error(state, "ReturnSelfFromZoneTransformed has no source")
-        val container = state.getEntity(sourceId)
+        state.getEntity(sourceId)
             ?: return EffectResult.success(state)
 
         // Fizzle quietly if the card already left the expected zone.
@@ -53,24 +53,8 @@ class ReturnSelfFromZoneTransformedExecutor(
         // card definition, not the component: DoubleFacedComponent is only stamped when a DFC
         // spell resolves onto the battlefield, so a card that was discarded or milled straight
         // into the graveyard doesn't carry one yet.
-        val cardComponent = container.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+        val workingState = ensureDoubleFacedComponent(state, cardRegistry, sourceId)
             ?: return EffectResult.success(state)
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-        val backFace = cardDef?.backFace
-            ?: return EffectResult.success(state)
-
-        var workingState = state
-        if (container.get<DoubleFacedComponent>() == null) {
-            workingState = state.updateEntity(sourceId) { c ->
-                c.with(
-                    DoubleFacedComponent(
-                        frontCardDefinitionId = cardDef.name,
-                        backCardDefinitionId = backFace.name,
-                        currentFace = DoubleFacedComponent.Face.FRONT
-                    )
-                )
-            }
-        }
 
         val transition = returnDfcFace(
             workingState, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK, tapped = effect.tapped

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -418,19 +418,51 @@ internal fun returnDfcFace(
 ): ZoneTransitionResult {
     val container = state.getEntity(entityId)
         ?: return ZoneTransitionResult(state, emptyList())
-    val dfc = container.get<DoubleFacedComponent>()
-        ?: return ZoneTransitionResult(state, emptyList())
     val currentCard = container.get<CardComponent>()
         ?: return ZoneTransitionResult(state, emptyList())
     val ownerId = container.get<OwnerComponent>()?.playerId ?: currentCard.ownerId
         ?: return ZoneTransitionResult(state, emptyList())
+    val prepared = prepareDfcFaceSwap(state, cardRegistry, entityId, destinationFace)
+        ?: return ZoneTransitionResult(state, emptyList())
+    return ZoneTransitionService.moveToZone(
+        prepared,
+        entityId,
+        Zone.BATTLEFIELD,
+        options = ZoneEntryOptions(controllerId = ownerId, tapped = tapped)
+    )
+}
+
+/**
+ * Swap [entityId] to [destinationFace] **in place**, without moving it between zones — the half of
+ * [returnDfcFace] that decides *which face is up*, split out so a caller that owns its own
+ * battlefield-entry path can reuse it (Radiant Grace returns transformed *and* attached, and its
+ * attachment/controller wiring lives in `ReturnSelfToBattlefieldAttachedExecutor`).
+ *
+ * Returns `null` — and leaves the caller's state untouched — when the entity isn't a double-faced
+ * card that can show [destinationFace]. Callers whose card may not carry a [DoubleFacedComponent]
+ * yet (anything reached from a zone the card was discarded or milled into) run
+ * [ensureDoubleFacedComponent] first; this function deliberately does not, so the existing
+ * transform paths keep their "no component, no flip" behavior.
+ *
+ * Per Rule 712.8a the front face's [CardComponent] is stashed on the [DoubleFacedComponent] when
+ * going to the back face, so the restore-on-leave path can swap back without a registry lookup.
+ */
+internal fun prepareDfcFaceSwap(
+    state: GameState,
+    cardRegistry: CardRegistry,
+    entityId: EntityId,
+    destinationFace: DoubleFacedComponent.Face,
+): GameState? {
+    val container = state.getEntity(entityId) ?: return null
+    val dfc = container.get<DoubleFacedComponent>() ?: return null
+    val currentCard = container.get<CardComponent>() ?: return null
 
     val destinationDefinitionId = when (destinationFace) {
         DoubleFacedComponent.Face.FRONT -> dfc.frontCardDefinitionId
         DoubleFacedComponent.Face.BACK -> dfc.backCardDefinitionId
     }
     val destinationDef = cardRegistry.getCard(destinationDefinitionId)
-        ?: return ZoneTransitionResult(state, emptyList())
+        ?: return null
 
     // `currentCard` is the front face here (Rule 712.8a — the entity reverted to it on leaving the
     // battlefield), so it supplies the CR 712.8e mana value a nonmodal back face keeps.
@@ -453,13 +485,38 @@ internal fun returnDfcFace(
         )
     }
 
-    val prepared = state.updateEntity(entityId) { c ->
+    return state.updateEntity(entityId) { c ->
         withDfcFaceSelfRedirects(c.with(destinationCard).with(updatedDfc), destinationDef)
     }
-    return ZoneTransitionService.moveToZone(
-        prepared,
-        entityId,
-        Zone.BATTLEFIELD,
-        options = ZoneEntryOptions(controllerId = ownerId, tapped = tapped)
-    )
+}
+
+/**
+ * Stamp a [DoubleFacedComponent] onto [entityId] when its card definition has a back face but the
+ * entity carries no component yet, and return the updated state; `null` when the card is not
+ * double-faced at all.
+ *
+ * The component is only stamped when a DFC *spell* resolves onto the battlefield, so a card that
+ * was discarded, milled, or (as here) put into the graveyard as a state-based action can reach a
+ * "return it transformed" effect without one. A single-faced card told to enter transformed
+ * doesn't move at all (standing FIN ruling), which is what the `null` return lets callers express.
+ */
+internal fun ensureDoubleFacedComponent(
+    state: GameState,
+    cardRegistry: CardRegistry,
+    entityId: EntityId,
+): GameState? {
+    val container = state.getEntity(entityId) ?: return null
+    val cardComponent = container.get<CardComponent>() ?: return null
+    val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+    val backFace = cardDef?.backFace ?: return null
+    if (container.get<DoubleFacedComponent>() != null) return state
+    return state.updateEntity(entityId) { c ->
+        c.with(
+            DoubleFacedComponent(
+                frontCardDefinitionId = cardDef.name,
+                backCardDefinitionId = backFace.name,
+                currentFace = DoubleFacedComponent.Face.FRONT
+            )
+        )
+    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ReturnSelfToBattlefieldAttachedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ReturnSelfToBattlefieldAttachedExecutor.kt
@@ -4,6 +4,8 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.ensureDoubleFacedComponent
+import com.wingedsheep.engine.handlers.effects.permanent.types.prepareDfcFaceSwap
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.state.GameState
@@ -11,6 +13,7 @@ import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfToBattlefieldAttachedEffect
@@ -20,15 +23,28 @@ import kotlin.reflect.KClass
  * Executor for ReturnSelfToBattlefieldAttachedEffect.
  *
  * Moves the source permanent (typically an Aura in the graveyard) to the battlefield
- * attached to the specified target creature. Used by the Dragon aura cycle
- * (Dragon Shadow, Dragon Breath, etc.).
+ * attached to the effect's target. Used by the Dragon aura cycle (Dragon Shadow, Dragon
+ * Breath, etc.) and — attached to a *player*, and transformed — by Radiant Grace.
  *
  * Steps:
- * 1. Resolve the attachment target (typically the triggering entity)
+ * 1. Resolve the attachment host (a permanent, or a player for a Curse)
  * 2. Verify the source is in a non-battlefield zone (graveyard)
- * 3. Move source to the target creature's controller's battlefield
- * 4. Add AttachedToComponent pointing to the target
- * 5. Set up continuous effects from static abilities
+ * 3. Flip to the back face first when the effect returns the card transformed
+ * 4. Move source to the new controller's battlefield
+ * 5. Add AttachedToComponent pointing to the host
+ * 6. Set up continuous effects from static abilities
+ *
+ * **Who controls the returned Aura** differs by host, and the two readings are printed
+ * differently. A *permanent* host hands control to that permanent's controller — the Dragon
+ * cycle's Aura follows its creature, which is the only sensible reading of "attached to that
+ * creature" with no controller clause. A *player* host leaves it under the ability's controller:
+ * "return this card to the battlefield transformed **under your control** attached to target
+ * opponent" would otherwise hand the curse to the very player it curses.
+ *
+ * The face swap happens **before** the move, so the battlefield entry registers the back face's
+ * static abilities and replacement effects rather than the front's. Per the standing ruling a
+ * single-faced card told to enter transformed doesn't move at all, so a card with no back face is
+ * a quiet no-op, not an error.
  */
 class ReturnSelfToBattlefieldAttachedExecutor(
     private val cardRegistry: CardRegistry
@@ -48,10 +64,13 @@ class ReturnSelfToBattlefieldAttachedExecutor(
         val attachTargetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.error(state, "No valid attachment target")
 
-        // Verify the attachment target is on the battlefield
-        val targetOnBattlefield = state.getBattlefield().contains(attachTargetId)
-        if (!targetOnBattlefield) {
-            return EffectResult.success(state) // Target left battlefield, do nothing
+        // The host is either a player still in the game or a permanent still on the battlefield.
+        // A host that has since left (creature died, player lost) makes the return do nothing —
+        // the Aura stays where it is rather than entering unattached and immediately dying to
+        // CR 704.5m.
+        val hostIsPlayer = attachTargetId in state.turnOrder
+        if (!hostIsPlayer && !state.getBattlefield().contains(attachTargetId)) {
+            return EffectResult.success(state)
         }
 
         val sourceContainer = state.getEntity(sourceId)
@@ -73,23 +92,39 @@ class ReturnSelfToBattlefieldAttachedExecutor(
             return EffectResult.success(state)
         }
 
-        // Determine the controller: use the attachment target's controller
-        val targetController = state.getEntity(attachTargetId)
-            ?.get<ControllerComponent>()?.playerId ?: ownerId
+        // "under your control" for a player host; an Aura on a permanent follows its host.
+        val newControllerId = if (hostIsPlayer) {
+            context.controllerId
+        } else {
+            state.getEntity(attachTargetId)?.get<ControllerComponent>()?.playerId ?: ownerId
+        }
+
+        // Flip to the back face while the card is still in its old zone, so the entry below sees
+        // the face that is actually going to be up.
+        var newState = state
+        if (effect.transformed) {
+            newState = ensureDoubleFacedComponent(newState, cardRegistry, sourceId)
+                ?.let { prepareDfcFaceSwap(it, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK) }
+                ?: return EffectResult.success(state)
+        }
+
+        // The name and definition to stamp are the *entering* face's, which the swap above may
+        // have just changed.
+        val enteringCard = newState.getEntity(sourceId)?.get<CardComponent>() ?: cardComponent
 
         // Move from current zone to battlefield
-        var newState = state.removeFromZone(currentZone, sourceId)
+        newState = newState.removeFromZone(currentZone, sourceId)
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
-            .place(newState, targetController, sourceId)
+            .place(newState, newControllerId, sourceId)
 
         // Add controller and attachment components
         newState = newState.updateEntity(sourceId) { container ->
             var updated = container
-                .with(ControllerComponent(targetController))
+                .with(ControllerComponent(newControllerId))
                 .with(AttachedToComponent(attachTargetId))
 
             // Set up continuous effects from static abilities
-            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+            val cardDef = cardRegistry.getCard(enteringCard.cardDefinitionId)
             if (cardDef != null) {
                 val staticAbilityHandler = StaticAbilityHandler(cardRegistry)
                 updated = staticAbilityHandler.addContinuousEffectComponent(updated, cardDef)
@@ -102,7 +137,7 @@ class ReturnSelfToBattlefieldAttachedExecutor(
         val events = listOf(
             ZoneChangeEvent(
                 entityId = sourceId,
-                entityName = cardComponent.name,
+                entityName = enteringCard.name,
                 fromZone = currentZone.zoneType,
                 toZone = Zone.BATTLEFIELD,
                 ownerId = ownerId


### PR DESCRIPTION
Radiant Grace // Radiant Restraints (VOW #31) — the corpus's first **transforming** Aura-front /
Aura-back DFC. Every other double-faced Aura here is the disturb shape, where the back is cast from
the graveyard rather than returned by a trigger.

> **Radiant Grace** {W} — Enchantment — Aura
> Enchant creature. Enchanted creature gets +1/+0 and has vigilance.
> When enchanted creature dies, return this card to the battlefield transformed under your control
> attached to target opponent.
>
> **Radiant Restraints** — Enchantment — Aura Curse
> Enchant player. Creatures enchanted player controls enter tapped.

Both gaps turned out to be **scopes the SDK could already name but not resolve**, so neither became
a new type.

### Return transformed, attached to a player

`ReturnSelfToBattlefieldAttachedEffect` gains `transformed` and accepts a player host. The
Dragon-aura cycle's version always handed the returned Aura to *the host permanent's* controller —
the right reading for "attached to that creature", and exactly wrong for a curse, which would
otherwise arrive under the control of the player it curses. A permanent host still follows its host;
a player host stays under the ability's controller, which is what "under your control" says.

The face swap runs while the card is still in the graveyard, so the battlefield entry registers the
back face's replacement effect rather than the front's statics. That needed `returnDfcFace` split
into `prepareDfcFaceSwap` (flip in place, no move) plus the move, with `ensureDoubleFacedComponent`
extracted alongside it — deliberately *not* folded into the prepare, so the three existing
transform-return executors keep their "no `DoubleFacedComponent`, no flip" behaviour.

### "Creatures enchanted player controls"

`ControlledByReferencedPlayer(PlayerRef(Player.EnchantedPlayer))` already named this; only
`PredicateEvaluator.resolveReferencedPlayerFromState` lacked the branch.
`GameObjectFilter.controlledByEnchantedPlayer()` is a named recipe over it — the controller-axis
sibling of Curse of Hospitality's `IsAttackingEnchantedPlayer`, and the same lesson: every other
controller scope resolves against the *ability's* controller, which for a curse is the wrong player.

Resolving it exposed a latent bug: `EnterTappedReplacements` / `EnterUntappedReplacements` passed
the **entering** permanent as the predicate context's `sourceId` (the controller was already the
source's). Invisible until a source-relative predicate showed up — then "creatures enchanted player
controls" asks the *entering creature* what it is attached to. Both now pass the permanent that
grants the replacement.

`ControlledByReferencedPlayer`'s description now follows its target instead of the hardcoded
"target player controls" — neither `DefendingPlayer` (Necrite) nor `EnchantedPlayer` is targeting
anyone.

### Tests

`RadiantGraceScenarioTest` — 5 tests, and the ones that matter are negative:

- the enchanted creature gets +1/+0 and vigilance;
- killing it returns the card transformed, attached to the *targeted* opponent, and **under player
  1's control** — the reading the old executor got backwards;
- a creature the cursed player controls enters tapped;
- a creature the curse's *own controller* controls enters **untapped** — the scope is the
  attachment, not the ability's controller;
- a curse on its own controller taps that controller's creatures — the case a controller-scoped
  filter gets exactly backwards.

### Verification

- `just build` — green (12m43s), full suite.
- `just test-class RadiantGraceScenarioTest` — 5/5.
- `CardDefinitionSnapshotTest` re-blessed: the VOW golden diff is **pure addition**, no other card
  moved.
- `just assay-differential --set VOW` — 70/70 confirmed, 0 divergent (Radiant Grace itself is
  multi-face, which Assay does not read).
- `just check-card-printing "Radiant Grace"` — ok; VOW is the earliest real printing, and DBL (the
  only other) isn't scaffolded here, so there is no reprint row to add.
- `docs/card-sdk-language-reference.md` updated for `transformed`, `.controlledByEnchantedPlayer()`,
  and the `sourceId` rule for granting permanents.

VOW's backlog now reads 272 / 273. Jacob Hauken, Inspector is the last card; its two gaps (a
per-turn cap on `GrantMayPlayFromExileEffect`, and look-at-face-down-exile access that isn't a play
permission) are unrelated to anything here and want their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxVSRsZ8HXuE7D4BmdN8fp