### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GateHound.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GateHound.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gate Hound — Ravnica: City of Guilds #19 (canonical printing, only printing)
+ * {2}{W} · Creature — Dog · 1/1
+ *
+ * Creatures you control have vigilance as long as this creature is enchanted.
+ *
+ * Printed as "Creature — Hound"; the type line here is the modern Hound→Dog errata Scryfall
+ * serves.
+ *
+ * A lord effect behind a gate, so it is one `staticAbility` with both halves filled in rather
+ * than anything bespoke:
+ *
+ * - The gate is `Conditions.SourceMatches(GameObjectFilter.Any.enchanted())` — "as long as *this
+ *   creature* is enchanted", i.e. it has at least one Aura attached (CR 303.4). `enchanted()`
+ *   deliberately ignores who controls the Aura, which is right: an opponent's Aura on the Hound
+ *   still turns the vigilance on, and that is the printed behaviour.
+ * - The grant is `GroupFilter.AllCreaturesYouControl`, not "other creatures" — the Hound is one
+ *   of the creatures you control, so it gains vigilance too.
+ *
+ * Both halves are continuous and re-read every projection pass, so attaching or removing the Aura
+ * flips the whole team's vigilance on and off with no event of its own.
+ */
+val GateHound = card("Gate Hound") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    power = 1
+    toughness = 1
+    oracleText = "Creatures you control have vigilance as long as this creature is enchanted."
+
+    staticAbility {
+        condition = Conditions.SourceMatches(GameObjectFilter.Any.enchanted())
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Ralph Horsley"
+        flavorText = "\"Ditri, I leave this checkpoint in your capable teeth.\"\n—Kitov, nightguard patrol"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg?1783943700"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GlareOfSubdual.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GlareOfSubdual.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Glare of Subdual — Ravnica: City of Guilds #207 (canonical printing; reprinted in EMA and GK1)
+ * {2}{G}{W} · Enchantment
+ *
+ * Tap an untapped creature you control: Tap target artifact or creature.
+ *
+ * A repeatable tapper whose only cost is a creature tap, so it is one `activatedAbility` with
+ * `Costs.TapPermanents(1, Creature)` and nothing else — no mana, and no `{T}` of its own (the
+ * enchantment never taps).
+ *
+ * The cost atom already carries the two restrictions the printed cost states: the creature must be
+ * **untapped** and **yours**, both intrinsic to `CostAtom.TapPermanents`. Summoning sickness does
+ * *not* apply — this is not a `{T}` cost of the creature's own ability, so a creature that came
+ * down this turn can pay (the Convoke rule). The ability has no activation restriction, so it works
+ * at instant speed and any number of times, once per untapped creature.
+ */
+val GlareOfSubdual = card("Glare of Subdual") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment"
+    oracleText = "Tap an untapped creature you control: Tap target artifact or creature."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(1, GameObjectFilter.Creature)
+        val t = target(
+            "target artifact or creature",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Creature)),
+        )
+        effect = TapUntapEffect(target = t, tap = true)
+        description = "Tap an untapped creature you control: Tap target artifact or creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "207"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "The righteous light of Selesnya is channeled through the devout, striking out to blind the nonbelievers."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg?1783943621"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InstillFuror.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InstillFuror.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Instill Furor — Ravnica: City of Guilds #134 (canonical printing, only printing)
+ * {1}{R} · Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "At the beginning of your end step, sacrifice this creature unless it
+ * attacked this turn."
+ *
+ * The printed text grants the ability rather than printing it on the Aura, and that distinction is
+ * the whole card, so it is a [GrantTriggeredAbility] over [GroupFilter.attachedCreature] (the Relic
+ * Bane shape) rather than a trigger on the Aura itself. Two rulings depend on it:
+ *
+ * - "Instill Furor grants a triggered ability that triggers at the end of the *creature's
+ *   controller's* turn" (2005-10-01). The granted ability is controlled by whoever controls the
+ *   creature, so `Triggers.YourEndStep` reads that player's end step — not the Aura controller's.
+ *   Stealing the creature moves the clock with it.
+ * - "Once the ability triggers, nothing that happens to Instill Furor can prevent the ability from
+ *   resolving" (2005-10-01). The ability is an independent object on the stack once it triggers;
+ *   nothing here re-reads the Aura at resolution.
+ *
+ * "Sacrifice … **unless** it attacked this turn" is a resolution-time test, not an intervening "if"
+ * (CR 603.4 vs 608.2), so it is a [ConditionalEffect] inside the effect rather than an
+ * `interveningIf` on the trigger: the ability always triggers and always goes on the stack, and the
+ * attack check happens as it resolves. `Conditions.SourceAttackedThisTurn` reads the *granted*
+ * ability's source, which is the enchanted creature, exactly as the printed "it" demands.
+ */
+val InstillFuror = card("Instill Furor") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"At the beginning of your end step, sacrifice this creature " +
+        "unless it attacked this turn.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YourEndStep.event,
+                binding = Triggers.YourEndStep.binding,
+                effect = ConditionalEffect(
+                    condition = Conditions.Not(Conditions.SourceAttackedThisTurn),
+                    effect = Effects.SacrificeTarget(EffectTarget.Self),
+                ),
+                descriptionOverride = "At the beginning of your end step, sacrifice this creature " +
+                    "unless it attacked this turn.",
+            ),
+            filter = GroupFilter.attachedCreature(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Jim Nelson"
+        flavorText = "\"The Rakdos know little of technology, but they definitely know how to push buttons.\"\n—Trivaz, Izzet mage"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg?1783943651"
+        ruling("2005-10-01", "Instill Furor grants a triggered ability that triggers at the end of the creature's controller's turn.")
+        ruling("2005-10-01", "Once the ability triggers, nothing that happens to Instill Furor can prevent the ability from resolving.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Phytohydra.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Phytohydra.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Phytohydra — Ravnica: City of Guilds #218 (canonical printing; reprinted in RVR)
+ * {2}{G}{W}{W} · Creature — Plant Hydra · 1/1
+ *
+ * If damage would be dealt to this creature, put that many +1/+1 counters on it instead.
+ *
+ * One [ReplaceDamageWithCounters] with `RecipientFilter.Self` — the Anti-Venom clause, unchanged.
+ * The "instead" matters and the primitive already gets it right (CR 614.1a): the damage is
+ * *replaced*, never dealt and never prevented. Two rulings fall out of that for free:
+ *
+ * - "Phytohydra's ability doesn't prevent damage. Damage that can't be prevented will still be
+ *   replaced by +1/+1 counters" (2024-01-12) — a replacement, not a prevention shield, so
+ *   Excruciator-style unpreventable damage still turns into counters.
+ * - First strike gets the counters in the first-strike damage step, before Phytohydra deals its own
+ *   damage in the second (2005-10-01) — nothing special-cased; the replacement runs per damage
+ *   event on whichever step deals it.
+ *
+ * The counter recipient defaults to the replacement's own host, which here is also the damaged
+ * permanent, so the default is the printed "on it".
+ */
+val Phytohydra = card("Phytohydra") {
+    manaCost = "{2}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Plant Hydra"
+    power = 1
+    toughness = 1
+    oracleText = "If damage would be dealt to this creature, put that many +1/+1 counters on it instead."
+
+    replacementEffect(
+        ReplaceDamageWithCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.Self),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "218"
+        artist = "Jim Murray"
+        flavorText = "\"Look at this creature, so like the Conclave it serves. Cut one head and it grows two. Damage it and it flourishes.\"\n—Veszka, Selesnya evangel"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg?1783943615"
+        ruling("2024-01-12", "Phytohydra's ability doesn't prevent damage. Damage that can't be prevented will still be replaced by +1/+1 counters being put on Phytohydra.")
+        ruling("2005-10-01", "If another effect would prevent damage from being dealt to Phytohydra or replace it with something else, Phytohydra's controller chooses which effect to apply first.")
+        ruling("2005-10-01", "If Phytohydra blocks or is blocked by a creature with first strike or double strike, Phytohydra will get the counters during the first-strike combat damage step before it deals its own combat damage during the second combat damage step.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TwistedJustice.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TwistedJustice.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Twisted Justice — Ravnica: City of Guilds #237 (canonical printing, only printing)
+ * {4}{U}{B} · Sorcery
+ *
+ * Target player sacrifices a creature of their choice. You draw cards equal to that creature's
+ * power.
+ *
+ * An edict with a payoff riding on the victim, so the whole card is the seam between the two steps:
+ * by the time the draw counts power, the creature is already in the graveyard. Both halves are
+ * existing primitives and the seam is already load-bearing elsewhere (Kylox, Visionary Inventor):
+ *
+ * - `Effects.Sacrifice(Creature, 1, <target player>)` is the Diabolic Edict half — the *player*
+ *   chooses which creature, which is what "of their choice" means (the sacrifice is not a target).
+ * - The sacrifice captures a last-known-information snapshot per sacrificed permanent (CR 608.2h)
+ *   and `CompositeEffect` merges it into the resolving context, so
+ *   `DynamicAmounts.totalPowerSacrificedThisWay()` reads the creature's power *as it last existed
+ *   on the battlefield* — the only reading of "that creature's power" that can be correct here.
+ *
+ * A target player with no creatures sacrifices nothing and the amount is 0, so you draw nothing;
+ * the spell still resolves. Negative power likewise draws nothing (the draw floors at 0).
+ */
+val TwistedJustice = card("Twisted Justice") {
+    manaCost = "{4}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Target player sacrifices a creature of their choice. You draw cards equal to " +
+        "that creature's power."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.Sacrifice(filter = GameObjectFilter.Creature, count = 1, target = player),
+            Effects.DrawCards(DynamicAmounts.totalPowerSacrificedThisWay()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Ralph Horsley"
+        flavorText = "In Otiev's mind, he ruled in favor of the accused. But in his courtroom he was only a spectator, watching his hand deliver the sign of death."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg?1783943608"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GateHoundScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GateHoundScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Gate Hound (Ravnica: City of Guilds).
+ *
+ * Oracle: "Creatures you control have vigilance as long as this creature is enchanted."
+ *
+ * The card is a lord behind a gate, and the gate is the only thing worth proving: a
+ * `ConditionalStaticAbility` whose condition is `SourceMatches(Any.enchanted())` has to be
+ * re-evaluated by the projector, not read once. So: no Aura → no vigilance anywhere; an Aura on the
+ * Hound → the whole team including the Hound; an Aura on a *different* creature → still nothing.
+ */
+class GateHoundScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gate Hound — vigilance while enchanted") {
+
+            test("grants nothing while the Hound is unenchanted") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gate Hound")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hound = game.findPermanent("Gate Hound")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("no Aura attached → the gate is shut") {
+                    game.state.projectedState.hasKeyword(hound, Keyword.VIGILANCE) shouldBe false
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+
+            test("an Aura on the Hound gives the whole team vigilance, the Hound included") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gate Hound")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Gate Hound")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hound = game.findPermanent("Gate Hound")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the grant is 'creatures you control', not 'other creatures'") {
+                    game.state.projectedState.hasKeyword(hound, Keyword.VIGILANCE) shouldBe true
+                }
+                game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+            }
+
+            test("an Aura on some other creature does not open the gate") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gate Hound")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hound = game.findPermanent("Gate Hound")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the condition reads the Hound, not any enchanted creature") {
+                    game.state.projectedState.hasKeyword(hound, Keyword.VIGILANCE) shouldBe false
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InstillFurorScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InstillFurorScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Instill Furor (Ravnica: City of Guilds).
+ *
+ * Oracle: "Enchant creature / Enchanted creature has \"At the beginning of your end step, sacrifice
+ * this creature unless it attacked this turn.\""
+ *
+ * Three claims the composition makes, each provable:
+ *
+ *  1. The granted ability's "this creature" is the *enchanted* creature, not the Aura — an idle host
+ *     is sacrificed at its controller's end step.
+ *  2. "Unless it attacked this turn" is read at resolution: a host that attacked survives.
+ *  3. The trigger belongs to the *host's* controller, per the 2005-10-01 ruling — the last two tests
+ *     put the Aura on an opponent's creature and run the same board on each player's end step: the
+ *     Aura controller's does nothing, the host controller's sacrifices it.
+ */
+class InstillFurorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Instill Furor — sacrifice unless it attacked") {
+
+            test("an idle enchanted creature is sacrificed at its controller's end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Instill Furor", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("it did not attack, so the granted ability sacrifices it") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("an enchanted creature that attacked this turn survives") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Instill Furor", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("the 'unless' clause spares an attacker") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("nothing happens on the Aura controller's end step when the host is an opponent's") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Instill Furor", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("player 1's end step is not the host controller's end step") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("the host is sacrificed on its own controller's end step, not the Aura controller's") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Instill Furor", "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("the granted ability is controlled by the host's controller (2005-10-01 ruling)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TwistedJusticeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TwistedJusticeScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Twisted Justice (Ravnica: City of Guilds).
+ *
+ * Oracle: "Target player sacrifices a creature of their choice. You draw cards equal to that
+ * creature's power."
+ *
+ * The seam under test is the one between the two sentences: the creature is in the graveyard by the
+ * time the draw counts its power, so the count can only come from the last-known-information
+ * snapshot the sacrifice captured (CR 608.2h). If that snapshot were missed the card would silently
+ * draw zero, which is why the interesting assertion is the *card count*, not the sacrifice.
+ */
+class TwistedJusticeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Twisted Justice — sacrifice, then draw that creature's power") {
+
+            test("draws cards equal to the sacrificed creature's power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twisted Justice")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Siege Wurm")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpellTargetingPlayer(1, "Twisted Justice", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("the target player sacrificed their only creature") {
+                    game.isOnBattlefield("Siege Wurm") shouldBe false
+                    game.isInGraveyard(2, "Siege Wurm") shouldBe true
+                }
+                withClue("Siege Wurm is a 5/5, so five cards — read from the LKI snapshot") {
+                    // handBefore counts Twisted Justice itself, which left the hand to be cast.
+                    game.handSize(1) shouldBe handBefore - 1 + 5
+                }
+            }
+
+            test("a target player with no creatures sacrifices nothing and draws nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twisted Justice")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpellTargetingPlayer(1, "Twisted Justice", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing sacrificed → the amount is 0, and the spell still resolved") {
+                    game.handSize(1) shouldBe handBefore - 1
+                    game.isInGraveyard(1, "Twisted Justice") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3188,6 +3188,50 @@
     ]
 }
 
+// Gate Hound
+{
+    "name": "Gate Hound",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Creatures you control have vigilance as long as this creature is enchanted.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEnchanted"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Ralph Horsley",
+        "flavorText": "\"Ditri, I leave this checkpoint in your capable teeth.\"\n—Kitov, nightguard patrol",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06732c6f-c3b5-4c68-82a0-655cffff79db.jpg?1783943700"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Gather Courage
 {
     "name": "Gather Courage",
@@ -3230,6 +3274,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Glare of Subdual
+{
+    "name": "Glare of Subdual",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Tap an untapped creature you control: Tap target artifact or creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact or creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|creature"
+                        },
+                        "id": "target artifact or creature"
+                    }
+                ],
+                "descriptionOverride": "Tap an untapped creature you control: Tap target artifact or creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "The righteous light of Selesnya is channeled through the devout, striking out to blind the nonbelievers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed6166c1-3c2e-47af-873e-d3b39f42bd27.jpg?1783943621"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -4514,6 +4608,78 @@
     ]
 }
 
+// Instill Furor
+{
+    "name": "Instill Furor",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"At the beginning of your end step, sacrifice this creature unless it attacked this turn.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "END"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "Not",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": "Self",
+                                    "filter": {
+                                        "statePredicates": [
+                                            "AttackedThisTurn"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "type": "SacrificeTarget",
+                            "target": "Self"
+                        }
+                    },
+                    "descriptionOverride": "At the beginning of your end step, sacrifice this creature unless it attacked this turn."
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Jim Nelson",
+        "flavorText": "\"The Rakdos know little of technology, but they definitely know how to push buttons.\"\n—Trivaz, Izzet mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6164762-c02d-4553-9064-2b99ff6352c9.jpg?1783943651",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "Instill Furor grants a triggered ability that triggers at the end of the creature's controller's turn."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Once the ability triggers, nothing that happens to Instill Furor can prevent the ability from resolving."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ivy Dancer
 {
     "name": "Ivy Dancer",
@@ -5765,6 +5931,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Phytohydra
+{
+    "name": "Phytohydra",
+    "manaCost": "{2}{G}{W}{W}",
+    "typeLine": "Creature — Plant Hydra",
+    "oracleText": "If damage would be dealt to this creature, put that many +1/+1 counters on it instead.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "ReplaceDamageWithCounters",
+                "counterType": "+1/+1",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "RARE",
+        "artist": "Jim Murray",
+        "flavorText": "\"Look at this creature, so like the Conclave it serves. Cut one head and it grows two. Damage it and it flourishes.\"\n—Veszka, Selesnya evangel",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86c336d2-cc14-4b74-a6f9-aab7a084d0de.jpg?1783943615",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "Phytohydra's ability doesn't prevent damage. Damage that can't be prevented will still be replaced by +1/+1 counters being put on Phytohydra."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If another effect would prevent damage from being dealt to Phytohydra or replace it with something else, Phytohydra's controller chooses which effect to apply first."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If Phytohydra blocks or is blocked by a creature with first strike or double strike, Phytohydra will get the counters during the first-strike combat damage step before it deals its own combat damage during the second combat damage step."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -8377,6 +8592,50 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Twisted Justice
+{
+    "name": "Twisted Justice",
+    "manaCost": "{4}{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player sacrifices a creature of their choice. You draw cards equal to that creature's power.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": "TotalPowerSacrificedThisWay"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Ralph Horsley",
+        "flavorText": "In Otiev's mind, he ruled in favor of the accused. But in his courtroom he was only a spectator, watching his hand deliver the sign of death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8efa02d-c301-47e1-8cdf-26ff9e97a243.jpg?1783943608"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Five RAV cards, each built entirely from existing SDK vocabulary — no new effect, executor, condition, or keyword, so nothing in `docs/card-sdk-language-reference.md` moved.

| Card | What it does | Composes |
|---|---|---|
| **Gate Hound** `{2}{W}` 1/1 | Creatures you control have vigilance as long as this creature is enchanted | `ConditionalStaticAbility` gating `GrantKeyword(VIGILANCE, GroupFilter.AllCreaturesYouControl)` on `Conditions.SourceMatches(GameObjectFilter.Any.enchanted())` |
| **Instill Furor** `{1}{R}` | Aura granting "At the beginning of your end step, sacrifice this creature unless it attacked this turn" | `GrantTriggeredAbility` over `GroupFilter.attachedCreature()`, with a `ConditionalEffect(Not(SourceAttackedThisTurn), SacrificeTarget(Self))` payload |
| **Phytohydra** `{2}{G}{W}{W}` 1/1 | Damage to it becomes that many +1/+1 counters instead | `ReplaceDamageWithCounters(+1/+1, appliesTo = DamageEvent(recipient = Self))` |
| **Twisted Justice** `{4}{U}{B}` | Target player sacrifices a creature of their choice; you draw cards equal to its power | `Effects.Sacrifice(Creature, 1, <target player>)` + `Effects.DrawCards(DynamicAmounts.totalPowerSacrificedThisWay())` |
| **Glare of Subdual** `{2}{G}{W}` | Tap an untapped creature you control: tap target artifact or creature | `Costs.TapPermanents(1, Creature)` → `TapUntapEffect(tap = true)` over `Artifact or Creature` |

### The two decisions worth reviewing

**Instill Furor's "unless" is not an intervening "if".** "Sacrifice this creature unless it attacked this turn" is a resolution-time test (CR 608.2), so it lives inside the effect as a `ConditionalEffect` rather than as `interveningIf` on the trigger. That is what makes the 2005-10-01 ruling true — "once the ability triggers, nothing that happens to Instill Furor can prevent the ability from resolving." Granting the ability rather than printing it on the Aura is likewise load-bearing: the granted ability's controller is the *creature's* controller, so `Triggers.YourEndStep` reads that player's end step, and `Conditions.SourceAttackedThisTurn` reads the enchanted creature — the printed "it".

**Twisted Justice's draw counts a creature that is already dead.** The sacrifice captures an LKI snapshot per permanent (CR 608.2h) and `CompositeEffect` merges it into the resolving context, so `totalPowerSacrificedThisWay()` reads power as it last existed on the battlefield. If that snapshot were missed the card would silently draw zero, which is why the scenario test asserts the *card count* rather than the sacrifice.

### Tests

Three scenario tests, one file per card, for the three cards whose composition makes a claim that could silently be wrong:

- `GateHoundScenarioTest` (3) — unenchanted grants nothing; an Aura on the Hound arms the whole team including the Hound; an Aura on a *different* creature leaves the gate shut (i.e. the condition reads the source, and the projector re-evaluates it).
- `InstillFurorScenarioTest` (4) — idle host sacrificed; attacker spared; the same board run on each player's end step, proving the clock belongs to the host's controller and not the Aura's.
- `TwistedJusticeScenarioTest` (2) — a 5/5 Siege Wurm draws five; a target with no creatures sacrifices nothing, draws nothing, and the spell still resolves.

Phytohydra reuses an already-tested clause (Anti-Venom) verbatim and Glare of Subdual is a plain cost-plus-tap, so both rely on the snapshot and lint nets.

### Verification

- `just build` — clean (the only failure was the expected `CardDefinitionSnapshotTest` diff).
- `just rebless-cards` — `RAV.json` is 259 lines of **pure insertion**; only these five cards appear, no existing card's tree changed.
- `just test-class` — 9/9 across the three scenario tests.
- `just assay-differential --set RAV` — **103 compared, 0 DIVERGENT**. Assay's independent reading of each oracle text agrees with every hand-written definition.
- `just check-card-printing` — ok for all five; RAV is each card's earliest real-expansion printing, so every canonical belongs here. (Phytohydra's RVR reprint and Glare of Subdual's EMA/GK1 reprints are in sets we have not scaffolded, so there are no `Printing` rows to add.)
- Field-by-field Scryfall re-verify (mana cost, type line, P/T, rarity, collector number, artist, image URI) clean for all five; every `image_uris.normal` returns HTTP 200.

RAV has no `backlog/sets/` entry, so there was nothing to tick.

### Two cards dropped from the batch

Both were triaged in and then out — each needs an engine change, which makes it `add-feature` work with its own PR, not a card:

- **Mausoleum Turnkey** — "return target creature card **of an opponent's choice**" needs `TargetChooser.Opponent` on a *triggered* ability. `TriggerProcessor.resolveTargetChooser` deliberately maps `Opponent` back to the controller (it needs the controller to first pick *which* opponent decides, which only the activated-ability path's `pauseForOpponentTargetChooser` does), and `CardLinter` refuses it there. Shipping it would have looked right and quietly let the controller pick.
- **Excruciator** — "damage dealt by this creature can't be prevented" would be `DamageCantBePrevented(appliesTo = DamageEvent(source = SourceFilter.Self))`, but `DamageUtils.isDamagePreventionDisabled` ignores `appliesTo` entirely and returns true for *any* such replacement on the battlefield. The self-scoping would be silently dropped and the card would disable damage prevention for the whole board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw