### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AmoeboidChangeling.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AmoeboidChangeling.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Amoeboid Changeling
+ * {1}{U}
+ * Creature — Shapeshifter
+ * 1/1
+ *
+ * Changeling (This card is every creature type.)
+ * {T}: Target creature gains all creature types until end of turn.
+ * {T}: Target creature loses all creature types until end of turn.
+ *
+ * Both halves are Layer 4 type-changing effects; the engine's timestamp ordering decides which
+ * wins when both are pointed at the same creature in one turn, which is exactly what the card
+ * wants (the 2007-10-01 ruling: the later ability overwrites the earlier one).
+ *
+ * "Gains all creature types" is a grant of Changeling — the engine expands that keyword into every
+ * creature type (CR 702.73). The losing half is the dedicated [Effects.LoseAllCreatureTypes], not
+ * a keyword removal, because it must also strip printed subtypes.
+ */
+val AmoeboidChangeling = card("Amoeboid Changeling") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "{T}: Target creature gains all creature types until end of turn.\n" +
+        "{T}: Target creature loses all creature types until end of turn."
+
+    keywords(Keyword.CHANGELING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.CHANGELING, creature)
+        description = "{T}: Target creature gains all creature types until end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.LoseAllCreatureTypes(creature)
+        description = "{T}: Target creature loses all creature types until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg?1783942906"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ElvishBranchbender.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ElvishBranchbender.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Elvish Branchbender
+ * {2}{G}
+ * Creature — Elf Druid
+ * 2/2
+ *
+ * {T}: Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other
+ * types, where X is the number of Elves you control.
+ *
+ * X is locked in when the ability resolves (CR 613.4c) — the 2007-10-01 ruling says the animated
+ * Forest keeps that size even if Elves die afterwards — so the count goes in `power`/`toughness`
+ * rather than the continuously-re-evaluated `dynamicPower`/`dynamicToughness` pair.
+ *
+ * The bare noun "Elves" counts every Elf *permanent* you control, not only the creatures, and the
+ * Branchbender is itself an Elf, so it counts itself.
+ *
+ * "In addition to its other types" is [Effects.BecomeCreature]'s default: it adds CREATURE and the
+ * Treefolk subtype without removing LAND or the Forest subtype, so the animated land still taps
+ * for {G}. Any Forest is a legal target, including an opponent's.
+ */
+val ElvishBranchbender = card("Elvish Branchbender") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in " +
+        "addition to its other types, where X is the number of Elves you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val forest = target(
+            "target Forest",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.withSubtype(Subtype.FOREST)))
+        )
+        val elves = DynamicAmounts.battlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withSubtype(Subtype.ELF)
+        ).count()
+        effect = Effects.BecomeCreature(
+            target = forest,
+            power = elves,
+            toughness = elves,
+            creatureTypes = setOf("Treefolk"),
+            duration = Duration.EndOfTurn,
+        )
+        description = "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in " +
+            "addition to its other types, where X is the number of Elves you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "204"
+        artist = "Ralph Horsley"
+        flavorText = "\"How do the vinebred feel? Fah! We do not ask the puppet how it feels when " +
+            "the puppeteer bids it dance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg?1783942866"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MilitiasPride.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MilitiasPride.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Militia's Pride
+ * {1}{W}
+ * Kindred Enchantment — Kithkin
+ *
+ * Whenever a nontoken creature you control attacks, you may pay {W}. If you do, create a 1/1 white
+ * Kithkin Soldier creature token that's tapped and attacking.
+ *
+ * The trigger is per-attacker and `ANY`-bound — one instance for each nontoken attacker, not one
+ * for the attack as a whole — so a three-creature alpha strike offers the payment three times.
+ * The `nontoken()` half is what stops the tokens it makes from triggering it again.
+ *
+ * "You may pay {W}. If you do, …" is an optional cost rider on the triggered ability itself
+ * ([MayPayManaEffect] → `Gate.MayPay`), resolved as the ability resolves — Customs Depot's shape.
+ *
+ * The token enters tapped and attacking, so it was never declared as an attacker: it doesn't
+ * re-trigger this enchantment, and "whenever a creature attacks" triggers elsewhere don't see it
+ * either (CR 508.4).
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val MilitiasPride = card("Militia's Pride") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Kindred Enchantment — Kithkin"
+    oracleText = "Whenever a nontoken creature you control attacks, you may pay {W}. If you do, " +
+        "create a 1/1 white Kithkin Soldier creature token that's tapped and attacking."
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{W}"),
+            effect = CreateTokenEffect(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Kithkin", "Soldier"),
+                tapped = true,
+                attacking = true,
+                imageUri = "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "30"
+        artist = "Larry MacDougall"
+        flavorText = "If you pick a fight with one kithkin, be ready to fight them all."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg?1783942912"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThievingSprite.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThievingSprite.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Thieving Sprite
+ * {2}{B}
+ * Creature — Faerie Rogue
+ * 1/1
+ *
+ * Flying
+ * When this creature enters, target player reveals X cards from their hand, where X is the number
+ * of Faeries you control. You choose one of those cards. That player discards that card.
+ *
+ * Two choosers, in order, which is the whole shape of the card: the *targeted player* picks which
+ * X cards to reveal, then the Sprite's *controller* picks one of those revealed cards to be
+ * discarded. `ChooseExactly` clamps to the hand when the player holds fewer than X cards, which is
+ * the right reading of "reveals X cards" against a small hand — they reveal their whole hand.
+ *
+ * The bare noun "Faeries" counts every Faerie *permanent* you control, and the Sprite itself is a
+ * Faerie that has already entered when the trigger resolves, so X is at least 1 in the normal
+ * case. X is counted on resolution, not on the trigger going on the stack.
+ */
+val ThievingSprite = card("Thieving Sprite") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, target player reveals X cards from their hand, where X is " +
+        "the number of Faeries you control. You choose one of those cards. That player discards " +
+        "that card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target player", Targets.Player)
+        effect = Effects.Pipeline {
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.TargetPlayer))
+            val revealed = chooseExactly(
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Permanent.withSubtype(Subtype.FAERIE)
+                ).count(),
+                from = hand,
+                chooser = Chooser.TargetPlayer,
+                prompt = "Choose cards to reveal",
+                selectedLabel = "Reveal"
+            )
+            reveal(revealed)
+            val chosen = chooseExactly(
+                1,
+                from = revealed,
+                chooser = Chooser.Controller,
+                prompt = "Choose a revealed card for that player to discard",
+                selectedLabel = "Discard"
+            )
+            move(
+                chosen,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.TargetPlayer),
+                moveType = MoveType.Discard
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg?1783942881"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WingsOfVelisVel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WingsOfVelisVel.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wings of Velis Vel
+ * {1}{U}
+ * Kindred Instant — Shapeshifter
+ *
+ * Changeling (This card is every creature type.)
+ * Until end of turn, target creature has base power and toughness 4/4, gains all creature types,
+ * and gains flying.
+ *
+ * "Base power and toughness 4/4" is a Layer 7b *set* — it overwrites the printed values but still
+ * sits under any counters and pump the creature picks up afterwards, so `SetBasePowerAndToughness`
+ * is the right primitive rather than a `ModifyStats` delta.
+ *
+ * "Gains all creature types" is modelled by granting Changeling — the engine expands that keyword
+ * into every creature type (CR 702.73), the same way [BladesOfVelisVel] does.
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val WingsOfVelisVel = card("Wings of Velis Vel") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Kindred Instant — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Until end of turn, target creature has base power and toughness 4/4, gains all " +
+        "creature types, and gains flying."
+
+    keywords(Keyword.CHANGELING)
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.SetBasePowerAndToughness(4, 4, creature),
+            Effects.GrantKeyword(Keyword.CHANGELING, creature),
+            Effects.GrantKeyword(Keyword.FLYING, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Jim Pavelec"
+        flavorText = "Changeling magic grants unusual wishes."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg?1783942894"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AmoeboidChangelingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AmoeboidChangelingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Amoeboid Changeling reprint in J22. Canonical CardDefinition lives in Lorwyn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.lrw.cards.AmoeboidChangeling`.
+ */
+val AmoeboidChangelingReprint = Printing(
+    oracleId = "68865793-daeb-4c55-80cb-12853f9f96c4",
+    name = "Amoeboid Changeling",
+    setCode = "J22",
+    collectorNumber = "269",
+    scryfallId = "559a14ce-de7a-4ce4-8c46-99818372187f",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/559a14ce-de7a-4ce4-8c46-99818372187f.jpg?1783919075",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -54,6 +54,76 @@
     ]
 }
 
+// Amoeboid Changeling
+{
+    "name": "Amoeboid Changeling",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\n{T}: Target creature gains all creature types until end of turn.\n{T}: Target creature loses all creature types until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CHANGELING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target creature gains all creature types until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "LoseAllCreatureTypes",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{T}: Target creature loses all creature types until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/068518d2-f061-4061-b208-158e991156b6.jpg?1783942906"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ancient Amphitheater
 {
     "name": "Ancient Amphitheater",
@@ -1915,6 +1985,65 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Elvish Branchbender
+{
+    "name": "Elvish Branchbender",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other types, where X is the number of Elves you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Forest"
+                    },
+                    "power": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Elf"
+                    },
+                    "toughness": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Elf"
+                    },
+                    "creatureTypes": [
+                        "Treefolk"
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land Forest"
+                        },
+                        "id": "target Forest"
+                    }
+                ],
+                "descriptionOverride": "{T}: Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other types, where X is the number of Elves you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "artist": "Ralph Horsley",
+        "flavorText": "\"How do the vinebred feel? Fah! We do not ask the puppet how it feels when the puppeteer bids it dance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/5154fc12-a8f2-4a16-8b1f-f7415c87566d.jpg?1783942866"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -6045,6 +6174,61 @@
     ]
 }
 
+// Militia's Pride
+{
+    "name": "Militia's Pride",
+    "manaCost": "{1}{W}",
+    "typeLine": "Kindred Enchantment — Kithkin",
+    "oracleText": "Whenever a nontoken creature you control attacks, you may pay {W}. If you do, create a 1/1 white Kithkin Soldier creature token that's tapped and attacking.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature nontoken ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{W}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Kithkin",
+                            "Soldier"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad29eb21-7ee3-4a67-9601-a62ea0cbe4c0.jpg?1783942839",
+                        "tapped": true,
+                        "attacking": true
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "RARE",
+        "artist": "Larry MacDougall",
+        "flavorText": "If you pick a fight with one kithkin, be ready to fight them all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg?1783942912"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Moonglove Extract
 {
     "name": "Moonglove Extract",
@@ -8462,6 +8646,102 @@
     ]
 }
 
+// Thieving Sprite
+{
+    "name": "Thieving Sprite",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nWhen this creature enters, target player reveals X cards from their hand, where X is the number of Faeries you control. You choose one of those cards. That player discards that card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": "TargetPlayer"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": "permanent Faerie"
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "selected1",
+                            "prompt": "Choose cards to reveal",
+                            "selectedLabel": "Reveal"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "selected1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "selected1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected3",
+                            "prompt": "Choose a revealed card for that player to discard",
+                            "selectedLabel": "Discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected3",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "TargetPlayer"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b5b51c3-60a8-45b2-9de0-605388091e8a.jpg?1783942881"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Thorn of Amethyst
 {
     "name": "Thorn of Amethyst",
@@ -9606,6 +9886,74 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Wings of Velis Vel
+{
+    "name": "Wings of Velis Vel",
+    "manaCost": "{1}{U}",
+    "typeLine": "Kindred Instant — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nUntil end of turn, target creature has base power and toughness 4/4, gains all creature types, and gains flying.",
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "SetBaseStats",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "CHANGELING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Jim Pavelec",
+        "flavorText": "Changeling magic grants unusual wishes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb3c1f39-b6ac-4663-9623-bd573a1117b0.jpg?1783942894"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, each composed entirely from existing `Effects.*` / `Patterns.*` primitives — no new SDK vocabulary. Lorwyn goes 178 → 183 of 286.

- **Wings of Velis Vel** — `SetBasePowerAndToughness(4, 4)` (Layer 7b set, so counters and pump still stack on top) plus a Changeling grant for "all creature types" and a Flying grant. Same modelling as the already-shipped Blades of Velis Vel.
- **Amoeboid Changeling** — two `{T}` abilities: `GrantKeyword(CHANGELING)` for the gaining half, `LoseAllCreatureTypes` for the losing half (which also strips printed subtypes). Both Layer 4, so timestamp order settles it when both hit the same creature. J22 reprinted the card, so that set gets a `Printing` row.
- **Militia's Pride** — `Triggers.attacks(filter = Creature.youControl().nontoken(), binding = ANY)` — per-attacker, and the `nontoken()` half is what stops the tokens it makes from feeding it — with `MayPayManaEffect` (`Gate.MayPay`) as an optional cost rider on the ability itself, over a tapped-and-attacking `CreateTokenEffect`.
- **Elvish Branchbender** — `BecomeCreature` over `TargetPermanent(Land.withSubtype(FOREST))`, adding CREATURE + Treefolk without removing LAND, so the animated Forest still taps for {G}. Any Forest is legal, including an opponent's. X is `DynamicAmounts.battlefield(You, Permanent.withSubtype(ELF)).count()` in the fixed-at-resolution `power`/`toughness` slot, not the continuously re-evaluated pair — CR 613.4c and the 2007-10-01 ruling both lock X once.
- **Thieving Sprite** — an ETB `Effects.Pipeline` with two choosers in order: `Chooser.TargetPlayer` picks which X cards to reveal, `reveal`, then `Chooser.Controller` picks one of those, then a `Discard` move. `ChooseExactly` clamps to the hand, which is the right reading of "reveals X cards" when the hand is smaller than X.

## Verification

- `just build` — green (compile + full test suite).
- `just rebless-cards` — only the five new definitions move in `snapshots/cards/LRW.json`; the diff is 348 lines of pure additions.
- `just check-card-printing` — ok for all five; all are canonical to LRW, and the one scaffolded reprint (Amoeboid Changeling in J22) got its row.
- `just assay-differential --set LRW` — 101 confirmed / 10 divergent, and none of the ten is one of these cards (all are pre-existing: the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart).

Two `just build` runs failed first with `Gradle Test Executor finished with non-zero exit value 13` on `:mtg-sets:2024:tests:test` and one other era module — a JVM test-worker crash from machine saturation, not a test failure. Both passed on retry with no code change.

No scenario tests: per the `add-card` skill, a card built purely from existing primitives is covered by the snapshot and lint nets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw