### PR TITLE
Add four Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BorosFuryShield.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BorosFuryShield.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Boros Fury-Shield — Ravnica: City of Guilds #5
+ * {2}{W} · Instant
+ *
+ * Prevent all combat damage that would be dealt by target attacking or blocking creature this turn.
+ * If {R} was spent to cast this spell, Boros Fury-Shield deals damage to that creature's controller
+ * equal to the creature's power.
+ *
+ * The shield is directional — damage the creature *deals*, not damage dealt to it — so it is
+ * `PreventAllDamageDealtBy` narrowed to [PreventionScope.CombatOnly], the same shape as Warning.
+ *
+ * The red rider is one of Ravnica's "if {X} was spent" clauses: the card is mono-white and the red
+ * mana is a *payment* question, not a colour requirement, so a Boros land or an any-colour source
+ * turns it on. `Conditions.ManaSpentToCastIncludes` reads the payment recorded on the spell, which
+ * means a copy of Boros Fury-Shield — never cast, so nothing was spent for it — correctly misses
+ * the rider.
+ *
+ * Power is read at resolution, after the shield goes up but with the creature still on the
+ * battlefield, and `EffectTarget.TargetController` falls back to last-known control if it has since
+ * left (CR 608.2h).
+ */
+val BorosFuryShield = card("Boros Fury-Shield") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt by target attacking or blocking " +
+        "creature this turn. If {R} was spent to cast this spell, Boros Fury-Shield deals damage " +
+        "to that creature's controller equal to the creature's power."
+
+    spell {
+        val creature = target("target attacking or blocking creature", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.PreventAllDamageDealtBy(creature, scope = PreventionScope.CombatOnly)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredRed = 1),
+                    effect = Effects.DealDamage(
+                        DynamicAmounts.targetPower(0),
+                        EffectTarget.TargetController
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg?1783943705"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BrambleElemental.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BrambleElemental.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Bramble Elemental
+ * {3}{G}{G}
+ * Creature — Elemental
+ * 4/4
+ * Whenever an Aura becomes attached to this creature, create two 1/1 green Saproling creature tokens.
+ *
+ * The trigger watches the *host* side of the attach, which is the ANY binding rather than the
+ * default SELF one: SELF would mean "whenever **this** Aura becomes attached", and Bramble
+ * Elemental is the creature being enchanted, not the Aura. `sourceItself()` on the attached-to
+ * filter is what pins the host to this permanent.
+ *
+ * Any Aura counts, including an opponent's — the oracle text sets no controller restriction — and
+ * it fires on every attach path, not just an Aura spell resolving: moving an Aura onto this
+ * creature (Nomad Mythmaker, Aura Graft) attaches it too.
+ */
+val BrambleElemental = card("Bramble Elemental") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "Whenever an Aura becomes attached to this creature, create two 1/1 green Saproling creature tokens."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.becomesAttached(
+            attachmentFilter = GameObjectFilter.Enchantment.withSubtype("Aura"),
+            attachedToFilter = GameObjectFilter.Any.sourceItself(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Tomas Giorello"
+        flavorText = "Ravnica is a seamless urban tapestry, each city bleeding into the next. In abandoned corners, however, nature has begun to reclaim what it once owned."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg?1783943642"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HalcyonGlaze.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HalcyonGlaze.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Halcyon Glaze
+ * {1}{U}{U}
+ * Enchantment
+ * Whenever you cast a creature spell, this enchantment becomes a 4/4 Illusion creature with flying
+ * in addition to its other types until end of turn.
+ *
+ * "In addition to its other types" is [Effects.BecomeCreature]'s default: it adds CREATURE and
+ * leaves the printed types alone, so the animated Halcyon Glaze is an Enchantment Creature — an
+ * enchantment-removal spell still answers it, and it still counts as an enchantment for constellation
+ * and the like.
+ *
+ * The trigger resolves *before* the creature spell that caused it (both are on the stack, the
+ * trigger on top), so the animation is already live when the creature enters. It fires on the cast,
+ * not the resolution — countering the creature spell doesn't undo it.
+ */
+val HalcyonGlaze = card("Halcyon Glaze") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a creature spell, this enchantment becomes a 4/4 Illusion " +
+        "creature with flying in addition to its other types until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 4,
+            toughness = 4,
+            keywords = setOf(Keyword.FLYING),
+            creatureTypes = setOf("Illusion"),
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "54"
+        artist = "John Avon"
+        flavorText = "\"Earth to æther, window to wonder, stillness to the sky.\"\n—Glazing incantation"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg?1783943684"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InduceParanoia.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InduceParanoia.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Induce Paranoia — Ravnica: City of Guilds #56
+ * {2}{U}{U} · Instant
+ *
+ * Counter target spell. If {B} was spent to cast this spell, that spell's controller mills X cards,
+ * where X is the spell's mana value.
+ *
+ * Another of Ravnica's "if {X} was spent" riders: the card is mono-blue and the black mana is a
+ * *payment* question, so a Dimir land or an any-colour source switches the mill on.
+ *
+ * Both halves of the rider read the countered spell *after* it has already been put into its
+ * owner's graveyard, which is why they use the last-known-information references rather than a live
+ * battlefield lookup: `Player.ControllerOf` resolves the spell's controller as of the counter, and
+ * `targetManaValue` reads the mana value off the card it became. "The spell's mana value" is the
+ * countered spell's, not Induce Paranoia's — X for an X spell on the stack counts as the value
+ * chosen for it (CR 202.3b).
+ */
+val InduceParanoia = card("Induce Paranoia") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. If {B} was spent to cast this spell, that spell's " +
+        "controller mills X cards, where X is the spell's mana value."
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.CounterSpell()
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredBlack = 1),
+                    effect = Patterns.Library.mill(
+                        DynamicAmounts.targetManaValue(0),
+                        EffectTarget.PlayerRef(Player.ControllerOf("target spell"))
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Jim Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg?1783943682"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BorosFuryShieldScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BorosFuryShieldScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Boros Fury-Shield — {2}{W} instant.
+ *
+ *   Prevent all combat damage that would be dealt by target attacking or blocking creature this
+ *   turn. If {R} was spent to cast this spell, Boros Fury-Shield deals damage to that creature's
+ *   controller equal to the creature's power.
+ *
+ * Two independent things can fail silently here: a shield wired in the wrong direction (preventing
+ * damage dealt *to* the creature rather than *by* it), and a rider that reads the wrong power or
+ * points the damage at the wrong player. The tests separate the payment gate from the shield so a
+ * regression in either is attributable.
+ */
+class BorosFuryShieldScenarioTest : FunSpec({
+
+    /** Sets up an opposing 2/2 attacking the shield's caster, stopped in the declare-attackers step. */
+    fun attackingBears(driver: GameTestDriver): Triple<EntityId, EntityId, EntityId> {
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val defender = driver.activePlayer!!
+        val attacker = driver.getOpponent(defender)
+        val bears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(bears)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        if (driver.activePlayer != attacker) {
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        }
+        driver.declareAttackers(attacker, listOf(bears), defender)
+        // The attacking player holds priority after attackers are declared; hand it to the
+        // defender so the shield can be cast in the declare-attackers step.
+        driver.passPriority(attacker)
+        return Triple(defender, attacker, bears)
+    }
+
+    test("the shield stops the attacker's combat damage") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        val (defender, attacker, bears) = attackingBears(driver)
+
+        val shield = driver.putCardInHand(defender, "Boros Fury-Shield")
+        driver.giveMana(defender, Color.WHITE, 3)
+        driver.castSpellWithTargets(defender, shield, listOf(ChosenTarget.Permanent(bears)))
+            .error shouldBe null
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.END)
+
+        withClue("The 2/2's combat damage was prevented") {
+            driver.getLifeTotal(defender) shouldBe 20
+        }
+        withClue("No red mana was spent, so the rider did nothing") {
+            driver.getLifeTotal(attacker) shouldBe 20
+        }
+    }
+
+    test("red mana spent: the attacker's controller takes damage equal to its power") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        val (defender, attacker, bears) = attackingBears(driver)
+
+        val shield = driver.putCardInHand(defender, "Boros Fury-Shield")
+        // {2}{W} paid as one white plus two red: red covers the generic, so red was spent.
+        driver.giveMana(defender, Color.WHITE, 1)
+        driver.giveMana(defender, Color.RED, 2)
+        driver.castSpellWithTargets(defender, shield, listOf(ChosenTarget.Permanent(bears)))
+            .error shouldBe null
+        driver.bothPass()
+
+        withClue("Grizzly Bears is a 2/2, and the damage goes to its controller") {
+            driver.getLifeTotal(attacker) shouldBe 18
+        }
+
+        driver.passPriorityUntil(Step.END)
+        withClue("The shield still stopped the combat damage") {
+            driver.getLifeTotal(defender) shouldBe 20
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleElementalScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleElementalScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bramble Elemental (RAV #154) — {3}{G}{G} Creature — Elemental 4/4.
+ *
+ *   Whenever an Aura becomes attached to this creature, create two 1/1 green Saproling creature
+ *   tokens.
+ *
+ * The trigger watches the *host* side of a `BecomesAttachedEvent`, which is the ANY binding plus
+ * `attachedToFilter = Any.sourceItself()` — the first card to pin an attach trigger to its own
+ * permanent that way. The failure this guards against is silent in both directions: a binding that
+ * stayed SELF would never fire at all, and an `attachedToFilter` the matcher ignored would fire on
+ * an Aura landing anywhere on the battlefield. Both are covered below.
+ */
+class BrambleElementalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bramble Elemental") {
+
+            test("an Aura resolving onto it makes two Saprolings") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Bramble Elemental")
+                    .withCardInHand(1, "Holy Strength")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elemental = game.findPermanent("Bramble Elemental").shouldNotBeNull()
+
+                game.castSpell(1, "Holy Strength", elemental).error shouldBe null
+                game.resolveStack()
+
+                withClue("Two 1/1 green Saprolings enter") {
+                    val saprolings = game.findPermanents("Saproling Token")
+                    saprolings shouldHaveSize 2
+                    saprolings.forEach {
+                        game.state.projectedState.getPower(it) shouldBe 1
+                        game.state.projectedState.getToughness(it) shouldBe 1
+                    }
+                }
+            }
+
+            test("an Aura attaching to a different creature does not trigger it") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Bramble Elemental")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Holy Strength")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castSpell(1, "Holy Strength", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("The attached-to filter must pin the host to Bramble Elemental itself") {
+                    game.findPermanents("Saproling Token") shouldHaveSize 0
+                }
+            }
+
+            test("an opponent's Aura triggers it too — the text names no controller") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Bramble Elemental")
+                    .withCardInHand(2, "Pacifism")
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elemental = game.findPermanent("Bramble Elemental").shouldNotBeNull()
+
+                game.castSpell(2, "Pacifism", elemental).error shouldBe null
+                game.resolveStack()
+
+                withClue("Saprolings still appear, under Bramble Elemental's controller") {
+                    val saprolings = game.findPermanents("Saproling Token")
+                    saprolings shouldHaveSize 2
+                    saprolings.forEach {
+                        game.state.projectedState.getController(it) shouldBe game.player1Id
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HalcyonGlazeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HalcyonGlazeScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Halcyon Glaze (RAV #54) — {1}{U}{U} Enchantment.
+ *
+ *   Whenever you cast a creature spell, this enchantment becomes a 4/4 Illusion creature with
+ *   flying in addition to its other types until end of turn.
+ *
+ * "In addition to its other types" is the clause worth pinning: the animated Glaze must still be an
+ * Enchantment, so enchantment removal keeps answering it. The other half is the trigger's scope —
+ * it watches *creature* spells only, and only ones you cast.
+ */
+class HalcyonGlazeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Halcyon Glaze") {
+
+            test("casting a creature spell animates it into a 4/4 flying Illusion that stays an enchantment") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Halcyon Glaze")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glaze = game.findPermanent("Halcyon Glaze").shouldNotBeNull()
+
+                withClue("Before the trigger it is a plain enchantment with no P/T") {
+                    game.state.projectedState.isCreature(glaze) shouldBe false
+                }
+
+                game.castSpell(1, "Grizzly Bears").isSuccess shouldBe true
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("It is now a 4/4 Illusion with flying") {
+                    projected.isCreature(glaze) shouldBe true
+                    projected.getPower(glaze) shouldBe 4
+                    projected.getToughness(glaze) shouldBe 4
+                    projected.hasKeyword(glaze, Keyword.FLYING) shouldBe true
+                    projected.hasSubtype(glaze, "Illusion") shouldBe true
+                }
+                withClue("\"In addition to its other types\" — it is still an Enchantment") {
+                    projected.hasType(glaze, "ENCHANTMENT") shouldBe true
+                }
+            }
+
+            test("a noncreature spell does not animate it") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Halcyon Glaze")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glaze = game.findPermanent("Halcyon Glaze").shouldNotBeNull()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                game.castSpell(1, "Lightning Bolt", bears).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("The trigger reads \"creature spell\"") {
+                    game.state.projectedState.isCreature(glaze) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InduceParanoiaScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InduceParanoiaScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Induce Paranoia — {2}{U}{U} instant.
+ *
+ *   Counter target spell. If {B} was spent to cast this spell, that spell's controller mills X
+ *   cards, where X is the spell's mana value.
+ *
+ * The rider is the interesting half. Both of its references — "that spell's controller" and "the
+ * spell's mana value" — are read *after* the counter has already put the spell in its owner's
+ * graveyard, so a naive implementation either mills the wrong player (falling back to "you") or
+ * mills zero (failing to find the mana value). The two tests pin the count and the victim
+ * separately from the payment gate.
+ */
+class InduceParanoiaScenarioTest : FunSpec({
+
+    test("black mana spent: the countered spell's controller mills its mana value") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val counterer = driver.getOpponent(active)
+
+        // Grizzly Bears is MV 2, so the rider should mill exactly two.
+        val bears = driver.putCardInHand(active, "Grizzly Bears")
+        driver.giveMana(active, Color.GREEN, 2)
+        driver.castSpell(active, bears, emptyList())
+        val spellOnStack = driver.getTopOfStack()!!
+        // The caster keeps priority after putting a spell on the stack; hand it to the counterer.
+        driver.passPriority(active)
+
+        val induce = driver.putCardInHand(counterer, "Induce Paranoia")
+        // {2}{U}{U} paid as two blue plus two black: black covers the generic, so black was spent.
+        driver.giveMana(counterer, Color.BLUE, 2)
+        driver.giveMana(counterer, Color.BLACK, 2)
+
+        val graveyardBefore = driver.getGraveyard(active).size
+        driver.castSpellWithTargets(counterer, induce, listOf(ChosenTarget.Spell(spellOnStack)))
+            .error shouldBe null
+        driver.bothPass()
+
+        withClue("Grizzly Bears was countered") {
+            driver.getGraveyardCardNames(active).contains("Grizzly Bears") shouldBe true
+        }
+        withClue("Two milled cards land on top of the countered spell itself") {
+            driver.getGraveyard(active).size shouldBe graveyardBefore + 3
+        }
+        withClue("The mill hits the countered spell's controller, not Induce Paranoia's") {
+            driver.getGraveyard(counterer).size shouldBe 1 // Induce Paranoia itself
+        }
+    }
+
+    test("no black mana spent: the spell is countered and nobody mills") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val counterer = driver.getOpponent(active)
+
+        val bears = driver.putCardInHand(active, "Grizzly Bears")
+        driver.giveMana(active, Color.GREEN, 2)
+        driver.castSpell(active, bears, emptyList())
+        val spellOnStack = driver.getTopOfStack()!!
+        // The caster keeps priority after putting a spell on the stack; hand it to the counterer.
+        driver.passPriority(active)
+
+        val induce = driver.putCardInHand(counterer, "Induce Paranoia")
+        driver.giveMana(counterer, Color.BLUE, 4)
+
+        val graveyardBefore = driver.getGraveyard(active).size
+        driver.castSpellWithTargets(counterer, induce, listOf(ChosenTarget.Spell(spellOnStack)))
+            .error shouldBe null
+        driver.bothPass()
+
+        withClue("Only the countered spell reaches the graveyard") {
+            driver.getGraveyard(active).size shouldBe graveyardBefore + 1
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BrambleElementalReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BrambleElementalReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bramble Elemental reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val BrambleElementalReprint = Printing(
+    oracleId = "ac5c0078-e2f1-4ac1-8748-575d69e09cf8",
+    name = "Bramble Elemental",
+    setCode = "PC2",
+    collectorNumber = "59",
+    scryfallId = "35c9463e-0d9d-4366-a33b-2e1c1ea6dfc5",
+    artist = "Tomas Giorello",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35c9463e-0d9d-4366-a33b-2e1c1ea6dfc5.jpg?1783940613",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -329,6 +329,79 @@
     ]
 }
 
+// Boros Fury-Shield
+{
+    "name": "Boros Fury-Shield",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt by target attacking or blocking creature this turn. If {R} was spent to cast this spell, Boros Fury-Shield deals damage to that creature's controller equal to the creature's power.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    },
+                    "scope": "CombatOnly",
+                    "direction": "FromTarget"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredRed": 1
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": "TargetController"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target attacking or blocking creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c46b2f5c-3c7a-4421-9d6f-81197e93d8d0.jpg?1783943705"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Boros Garrison
 {
     "name": "Boros Garrison",
@@ -583,6 +656,67 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Bramble Elemental
+{
+    "name": "Bramble Elemental",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Whenever an Aura becomes attached to this creature, create two 1/1 green Saproling creature tokens.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesAttachedEvent",
+                    "attachmentFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment",
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Aura"
+                            }
+                        ]
+                    },
+                    "attachedToFilter": {
+                        "statePredicates": [
+                            "IsSource"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Tomas Giorello",
+        "flavorText": "Ravnica is a seamless urban tapestry, each city bleeding into the next. In abandoned corners, however, nature has begun to reclaim what it once owned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/470665e5-fa48-4772-ba71-5d4008d042f3.jpg?1783943642"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -3918,6 +4052,57 @@
     ]
 }
 
+// Halcyon Glaze
+{
+    "name": "Halcyon Glaze",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a creature spell, this enchantment becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "creatureTypes": [
+                        "Illusion"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "flavorText": "\"Earth to æther, window to wonder, stillness to the sky.\"\n—Glazing incantation",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fafd3018-1cfe-4c41-a08c-5c2ba3528c7e.jpg?1783943684"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Hammerfist Giant
 {
     "name": "Hammerfist Giant",
@@ -4557,6 +4742,84 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Induce Paranoia
+{
+    "name": "Induce Paranoia",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. If {B} was spent to cast this spell, that spell's controller mills X cards, where X is the spell's mana value.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredBlack": 1
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "EntityProperty",
+                                        "entity": "Target",
+                                        "numericProperty": "ManaValue"
+                                    },
+                                    "player": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "target spell"
+                                    },
+                                    "isMill": true
+                                },
+                                "storeAs": "milled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "target spell"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Jim Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc462b75-8b08-47a3-be22-d7b5c062ec5b.jpg?1783943682"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Four RAV cards, each built entirely from existing `Effects.*` / `Conditions.*` / `Triggers.*` primitives — no new SDK vocabulary.

| Card | Text | Composes |
|---|---|---|
| **Bramble Elemental** {3}{G}{G} 4/4 | Whenever an Aura becomes attached to this creature, create two 1/1 green Saproling creature tokens. | `Triggers.becomesAttached` (ANY binding, `attachedToFilter = Any.sourceItself()`) + `Effects.CreateToken` |
| **Halcyon Glaze** {1}{U}{U} | Whenever you cast a creature spell, this enchantment becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn. | `Triggers.YouCastCreature` + `Effects.BecomeCreature` |
| **Boros Fury-Shield** {2}{W} | Prevent all combat damage that would be dealt by target attacking or blocking creature this turn. If {R} was spent, deal damage to that creature's controller equal to its power. | `Effects.PreventAllDamageDealtBy(scope = CombatOnly)` + `Conditions.ManaSpentToCastIncludes` + `DynamicAmounts.targetPower` |
| **Induce Paranoia** {2}{U}{U} | Counter target spell. If {B} was spent, that spell's controller mills X, where X is the spell's mana value. | `Effects.CounterSpell` + `Conditions.ManaSpentToCastIncludes` + `Patterns.Library.mill(targetManaValue, Player.ControllerOf)` |

Bramble Elemental also gets its PC2 reprint row, which `just check-card-printing` requires.

### Notes on the two non-obvious wirings

**Bramble Elemental** is the first card to watch the *host* side of a `BecomesAttachedEvent`. The default SELF binding means "whenever **this** Aura becomes attached"; pinning the host to this permanent needs `TriggerBinding.ANY` plus `attachedToFilter = GameObjectFilter.Any.sourceItself()`. Both failure directions are covered by tests: a SELF binding never fires, and an ignored `attachedToFilter` fires on an Aura landing anywhere.

**Induce Paranoia**'s rider reads the countered spell *after* the counter has already put it in its owner's graveyard, so "that spell's controller" and "the spell's mana value" both go through the LKI-aware references. A naive wiring mills the wrong player or mills zero; the test pins the count and the victim separately from the payment gate.

### Dropped from the batch

**Excruciator** ({6}{R}{R} 7/7, "Damage that would be dealt by this creature can't be prevented") was investigated and dropped: `DamageCantBePrevented` carries an `appliesTo` `EventPattern`, but `DamageUtils.isDamagePreventionDisabled` ignores it entirely and treats *any* such replacement on the battlefield as a global prevention lock. Authoring Excruciator with `source = SourceFilter.Self` would have looked right and silently disabled all prevention for both players.

That is a live bug for an already-shipped card — **Frenzied Baloth** (EOE) declares `damageType = Combat` and that scoping is inert today, as is Spider Punk's. Fixing the read site changes behaviour for existing cards, so it belongs in its own PR with engine tests rather than riding along here.

### Verification

- `just build` — green (full build + tests)
- `just rebless-cards` — only the four new cards moved in `RAV.json`
- `just assay-differential --set RAV` — 103 compared, 103 confirmed, **0 DIVERGENT**
- `just check-card-printing` — clean for all four
- Scenario tests: `BrambleElementalScenarioTest` (3), `HalcyonGlazeScenarioTest` (2), `BorosFuryShieldScenarioTest` (2), `InduceParanoiaScenarioTest` (2) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6