### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CrushUnderfoot.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CrushUnderfoot.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Crush Underfoot
+ * {1}{R}
+ * Kindred Instant — Giant
+ * Choose a Giant creature you control. It deals damage equal to its power to target creature.
+ *
+ * Two decisions at two different times, and the card is only right if they stay apart:
+ *
+ *  - **"target creature"** is a printed target, declared when Crush Underfoot goes on the stack
+ *    (index 0), so shroud/hexproof/protection are checked at announcement and the spell fizzles
+ *    if the creature is gone on resolution.
+ *  - **"Choose a Giant creature you control"** is *not* a target. It is picked mid-resolution by
+ *    [SelectTargetEffect], after priority has passed — so an opponent can't respond to which
+ *    Giant you picked, and the choice is made against the board as it stands when the spell
+ *    resolves rather than as it stood when you cast it.
+ *
+ * The chosen Giant lands in the resolution pipeline's `crushGiant` collection, which the damage
+ * step then reads twice: [EntityReference.FromCostStorage] for "equal to its power" (the generic
+ * `storedCollections` reader — the linter pairs it with `SelectTarget.storeAs`) and
+ * [EffectTarget.PipelineTarget] as the `damageSource`, so the damage is dealt *by the Giant*.
+ * That distinction is load-bearing: it makes the damage red-creature damage rather than spell
+ * damage, so lifelink, deathtouch, and "prevent all damage a creature would deal" all read off
+ * the Giant.
+ *
+ * Both zero-Giant and zero-power cases fizzle gracefully. With no Giant to choose, the select
+ * step stores an empty collection and [DealDamageEffect] skips the whole instruction rather than
+ * falling back to Crush Underfoot itself as the source (CR 608.2b); a 0-power Giant deals no
+ * damage because the amount is not positive.
+ *
+ * Known deviation: the Giant is found through the engine's `TargetFinder`, which filters out
+ * permanents with shroud. Because the Giant is *chosen* and not targeted, the rules would let you
+ * pick a Giant you control that has shroud. Hexproof is unaffected (you control it), so this only
+ * bites the vanishingly rare "my own Giant has shroud" board.
+ *
+ * "Kindred Instant — Giant" is the 2024 errata of the printed "Tribal Instant — Giant": the card
+ * has the Giant creature type in every zone, so it is itself fetched by Lorwyn's Giant-matters
+ * cards (Ancient Amphitheater, Boldwyr Intimidator).
+ */
+val CrushUnderfoot = card("Crush Underfoot") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Kindred Instant — Giant"
+    oracleText = "Choose a Giant creature you control. It deals damage equal to its power to target creature."
+
+    spell {
+        val victim = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            SelectTargetEffect(
+                requirement = TargetCreature(
+                    filter = TargetFilter.Creature.youControl().withSubtype(Subtype.GIANT),
+                    id = "a Giant creature you control"
+                ),
+                storeAs = "crushGiant"
+            ),
+            DealDamageEffect(
+                amount = DynamicAmount.EntityProperty(
+                    EntityReference.FromCostStorage("crushGiant"),
+                    EntityNumericProperty.Power
+                ),
+                target = victim,
+                damageSource = EffectTarget.PipelineTarget("crushGiant")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Steven Belledin"
+        flavorText = "Five-toed grave\n—Kithkin phrase meaning \"a giant's footprint\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg?1783942877"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FootbottomFeast.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FootbottomFeast.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Footbottom Feast
+ * {2}{B}
+ * Instant
+ * Put any number of target creature cards from your graveyard on top of your library.
+ * Draw a card.
+ *
+ * Drafna's Restoration's shape, scoped to your own graveyard: one `unlimited = true` target slot
+ * ("any number of target …", so zero is a legal choice and the spell still resolves for the
+ * cantrip), gathered with [CardSource.ChosenTargets] and moved to the top of your library.
+ *
+ * The printed text has no "in any order", but CR 401.4 gives the order to the effect's controller
+ * whenever a spell puts two or more cards on top of a library without specifying one — hence
+ * [CardOrder.ControllerChooses]. The draw is sequenced *after* the move, so a single creature card
+ * put back on top is the card you then draw.
+ */
+val FootbottomFeast = card("Footbottom Feast") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Put any number of target creature cards from your graveyard on top of your library.\n" +
+        "Draw a card."
+
+    spell {
+        target(
+            "any number of target creature cards from your graveyard",
+            TargetObject(unlimited = true, filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "feast_cards"),
+            MoveCollectionEffect(
+                from = "feast_cards",
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY,
+                    player = Player.You,
+                    placement = ZonePlacement.Top
+                ),
+                order = CardOrder.ControllerChooses
+            ),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Jim Nelson"
+        flavorText = "The scent of rot and vinegar fills the marsh, inviting boggarts from every " +
+            "warren to reunite and feast."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg?1783942890"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Goatnapper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Goatnapper.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Goatnapper
+ * {2}{R}
+ * Creature — Goblin Rogue
+ * 2/2
+ * When this creature enters, untap target Goat and gain control of it until end of turn.
+ * It gains haste until end of turn.
+ *
+ * The Threaten pattern hung off an enters trigger: the same
+ * `Untap` + `GainControl(EndOfTurn)` + `GrantKeyword(HASTE)` composite Blind with Anger uses,
+ * with the target narrowed to a Goat.
+ *
+ * "Target Goat" is any Goat on the battlefield, not just an opponent's — stealing your own Goat
+ * back from nobody is legal (and pointless), and the untap/haste half still applies. Lorwyn's own
+ * Goats are Cloudgoat Ranger's tokens and Springjack Pasture's Goats, but the changeling cycle
+ * makes every changeling a legal target too, which is exactly why the filter is a subtype test on
+ * *projected* state rather than a printed-type read.
+ */
+val Goatnapper = card("Goatnapper") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, untap target Goat and gain control of it until end of turn. " +
+        "It gains haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val goat = target(
+            "target Goat",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.GOAT))
+        )
+        effect = Effects.Composite(
+            Effects.Untap(goat),
+            Effects.GainControl(goat, Duration.EndOfTurn),
+            Effects.GrantKeyword(Keyword.HASTE, goat)
+        )
+        description = "untap target Goat and gain control of it until end of turn. " +
+            "It gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "172"
+        artist = "Ron Spencer"
+        flavorText = "Kith goats are just for practice. The real prize, of course, is a giant's cloudgoat."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg?1783942876"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HeatShimmer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HeatShimmer.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heat Shimmer
+ * {2}{R}
+ * Sorcery
+ * Create a token that's a copy of target creature, except it has haste and
+ * "At the beginning of the end step, exile this token."
+ *
+ * The exile sibling of Electroduplicate: the same `addedKeywords = HASTE` copy exception, but the
+ * token is *exiled* rather than sacrificed, so it triggers no dies/leaves-the-battlefield
+ * abilities of its own. `exileAtStep = Step.END` fires on the next end step of **any** player's
+ * turn — the printed text says "the end step", not "your end step" — so a Heat Shimmer cast on an
+ * opponent's turn loses the token that same turn.
+ *
+ * Unlike Electroduplicate, the target is any creature on the battlefield, not just one you
+ * control: this is red's take on a Clone, and stealing the mould off an opponent's best creature
+ * for one attack is the point.
+ */
+val HeatShimmer = card("Heat Shimmer") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a token that's a copy of target creature, except it has haste and " +
+        "\"At the beginning of the end step, exile this token.\""
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.CreateTokenCopyOfTarget(
+            creature,
+            addedKeywords = setOf(Keyword.HASTE),
+            exileAtStep = Step.END
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "175"
+        artist = "Franz Vohwinkel"
+        flavorText = "\"Better to flare out than to gutter.\"\n—Flamekin expression"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg?1783942875"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SowerOfTemptation.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SowerOfTemptation.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Sower of Temptation
+ * {2}{U}{U}
+ * Creature — Faerie Wizard
+ * 2/2
+ * Flying
+ * When this creature enters, gain control of target creature for as long as this creature
+ * remains on the battlefield.
+ *
+ * The control change is a CR 611.2b "for as long as …" continuous effect, so it rides
+ * [Duration.WhileSourceOnBattlefield] keyed to Sower rather than being a static ability on Sower
+ * itself: the effect belongs to the resolving enters trigger, and `EndedDurationExpiryCheck`
+ * hands the creature back the instant Sower leaves the battlefield.
+ *
+ * The duration matters more than it looks. Because the grab is a one-shot trigger with a
+ * source-keyed duration and *not* a static ability, killing Sower in response to the trigger
+ * means the trigger resolves with its duration already ended — the creature is never stolen at
+ * all (its own ruling). Bouncing Sower after the fact likewise returns the creature immediately,
+ * and a second Sower entering later starts a fresh, independent grab.
+ */
+val SowerOfTemptation = card("Sower of Temptation") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, gain control of target creature for as long as this creature " +
+        "remains on the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GainControl(
+            creature,
+            Duration.WhileSourceOnBattlefield("Sower of Temptation")
+        )
+        description = "gain control of target creature for as long as this creature remains on the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "88"
+        artist = "Christopher Moeller"
+        flavorText = "One glamer leads him far from home. The next washes away his memory that home " +
+            "was ever anywhere but at her side."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg?1783942897"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrushUnderfootScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrushUnderfootScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Crush Underfoot (LRW #162) — "Choose a Giant creature you control. It deals damage equal to its
+ * power to target creature."
+ *
+ * The card's whole shape is two decisions at two different times: "target creature" is declared on
+ * announcement, while the Giant is chosen mid-resolution by `SelectTargetEffect`. These tests pin
+ * the consequences of that split — the damage scales to whichever Giant is picked, the spell is a
+ * clean no-op with no Giant to choose (rather than dealing damage as the *spell*), and it still
+ * needs a legal creature target to be cast at all.
+ */
+class CrushUnderfootScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Crush Underfoot") {
+
+            test("the sole Giant is auto-chosen and deals damage equal to its power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crush Underfoot")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    // Axegrinder Giant is a 6/4 — plenty to kill a 2/2.
+                    .withCardOnBattlefield(1, "Axegrinder Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Crush Underfoot", bears).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("6 damage from the Giant kills the 2/2") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("The Giant itself is untouched — it dealt the damage, it didn't fight") {
+                    game.findPermanent("Axegrinder Giant") shouldNotBe null
+                }
+            }
+
+            test("with two Giants the controller picks which one swings, mid-resolution") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crush Underfoot")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Axegrinder Giant")   // 6/4
+                    .withCardOnBattlefield(1, "Hill Giant")         // 3/3
+                    .withCardOnBattlefield(2, "Hunted Dragon")      // 6/6, survives 3 but not 6
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findPermanent("Hunted Dragon")!!
+                val smallGiant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Crush Underfoot", dragon).error shouldBe null
+                game.resolveStack()
+
+                val choice = game.state.pendingDecision
+                withClue("Two Giants means a mid-resolution choice, not an auto-select") {
+                    choice shouldNotBe null
+                }
+                // Deliberately pick the *smaller* Giant: 3 damage is not lethal to a 6/6.
+                game.submitDecision(TargetsResponse(choice!!.id, mapOf(0 to listOf(smallGiant))))
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("The chosen Giant's power decided the damage — 3 is not lethal to a 6/6") {
+                    game.findPermanent("Hunted Dragon") shouldNotBe null
+                }
+            }
+
+            test("with no Giant to choose the spell does nothing — it does not deal damage itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crush Underfoot")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Crush Underfoot", bears).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("No Giant means no damage source, and CR 608.2b skips the instruction") {
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+                withClue("Crush Underfoot still resolved and went to the graveyard") {
+                    game.isInGraveyard(1, "Crush Underfoot") shouldBe true
+                }
+            }
+
+            test("an opponent's Giant can't be chosen — the clause says \"you control\"") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crush Underfoot")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Axegrinder Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Crush Underfoot", bears).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("Their Giant is not yours to swing, so nothing happens") {
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FootbottomFeastScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FootbottomFeastScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Footbottom Feast (LRW #115) — "Put any number of target creature cards from your graveyard on
+ * top of your library. Draw a card."
+ *
+ * `unlimited = true` targeting scoped to your own graveyard. The cases that matter: a subset of
+ * the creature cards can be chosen (not all of them), noncreature cards and an opponent's
+ * graveyard are off limits, zero targets is legal because "any number" includes none, and the
+ * draw is sequenced *after* the move so a single returned creature is the card you draw.
+ */
+class FootbottomFeastScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Footbottom Feast") {
+
+            fun TestGame.graveyardCard(playerNumber: Int, name: String) =
+                state.getGraveyard(if (playerNumber == 1) player1Id else player2Id)
+                    .first { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+            fun TestGame.handCard(name: String) = state.getHand(player1Id)
+                .first { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+            test("returns the chosen subset to the library top, then draws the top card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Footbottom Feast")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Shock") // noncreature control — must not be targetable
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.graveyardCard(1, "Grizzly Bears")
+                val giant = game.graveyardCard(1, "Hill Giant")
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard("Footbottom Feast"),
+                        targets = listOf(
+                            ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD),
+                            ChosenTarget.Card(giant, game.player1Id, Zone.GRAVEYARD)
+                        )
+                    )
+                )
+                withClue("Two creature cards in your own graveyard are legal targets: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                game.resolveStack()
+                // Two cards on top means CR 401.4 hands you the order: Bears first, then Giant.
+                game.state.pendingDecision?.let {
+                    game.submitDecision(OrderedResponse(it.id, listOf(bears, giant)))
+                }
+                game.resolveStack()
+
+                withClue("The Bears was on top, so the draw picked it up") {
+                    game.state.getHand(game.player1Id).contains(bears) shouldBe true
+                }
+                withClue("The Giant is the new top card, above the pre-existing Swamp") {
+                    game.state.getLibrary(game.player1Id).first() shouldBe giant
+                }
+                withClue("Shock was never targeted and stays in the graveyard") {
+                    val shock = game.graveyardCard(1, "Shock")
+                    game.state.getGraveyard(game.player1Id).contains(shock) shouldBe true
+                }
+            }
+
+            test("a creature card in an opponent's graveyard is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Footbottom Feast")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val theirBears = game.graveyardCard(2, "Grizzly Bears")
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard("Footbottom Feast"),
+                        targets = listOf(ChosenTarget.Card(theirBears, game.player2Id, Zone.GRAVEYARD))
+                    )
+                )
+                withClue("\"from your graveyard\" excludes the opponent's") {
+                    (cast.error != null) shouldBe true
+                }
+            }
+
+            test("zero targets is legal — the spell is still a cantrip") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Footbottom Feast")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.state.getHand(game.player1Id).size
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard("Footbottom Feast"),
+                        targets = emptyList()
+                    )
+                )
+                withClue("\"Any number\" includes none, even with an empty graveyard: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Feast left hand and one card was drawn, so the hand is back to its old size") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore
+                }
+                withClue("The library card was the one drawn") {
+                    game.state.getHand(game.player1Id).map {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    } shouldContainExactly listOf("Swamp")
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoatnapperScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoatnapperScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Goatnapper (LRW #172) — "When this creature enters, untap target Goat and gain control of it
+ * until end of turn. It gains haste until end of turn."
+ *
+ * Three things are worth proving from the outside: the target filter really is a Goat filter (a
+ * non-Goat creature must be rejected, a changeling must be accepted), all three riders land
+ * together (untapped, controlled, hasty), and the control grab expires at end of turn while the
+ * untap does not.
+ */
+class GoatnapperScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Goatnapper") {
+
+            /** Resolve the enters trigger, aiming it at [goat] if the engine asks. */
+            fun TestGame.stealWith(goat: com.wingedsheep.sdk.model.EntityId?) {
+                resolveStack()
+                val decision = state.pendingDecision
+                if (decision != null && goat != null) {
+                    submitDecision(TargetsResponse(decision.id, mapOf(0 to listOf(goat))))
+                }
+                resolveStack()
+            }
+
+            test("steals a tapped Goat: untapped, under your control, and hasty") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Goatnapper")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Mountain Goat", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goat = game.findPermanent("Mountain Goat")!!
+
+                game.castSpell(1, "Goatnapper").error shouldBe null
+                game.stealWith(goat)
+
+                withClue("The Goat is untapped") {
+                    game.state.getEntity(goat)?.get<TappedComponent>() shouldBe null
+                }
+                withClue("Control changed to Goatnapper's controller") {
+                    game.state.projectedState.getController(goat) shouldBe game.player1Id
+                }
+                withClue("The stolen Goat has haste, so it can attack the turn it is stolen") {
+                    game.state.projectedState.hasKeyword(goat, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("a changeling is a legal target — changeling makes it a Goat") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Goatnapper")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    // Avian Changeling is "every creature type", so it is a Goat (CR 702.73a).
+                    .withCardOnBattlefield(2, "Avian Changeling")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val changeling = game.findPermanent("Avian Changeling")!!
+
+                game.castSpell(1, "Goatnapper").error shouldBe null
+                game.stealWith(changeling)
+
+                withClue("The changeling counted as a Goat and was stolen") {
+                    game.state.projectedState.getController(changeling) shouldBe game.player1Id
+                }
+            }
+
+            test("a non-Goat creature is not a legal target, so the trigger finds nothing to steal") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Goatnapper")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Goatnapper").error shouldBe null
+                game.stealWith(null)
+
+                withClue("Grizzly Bears is no Goat — it stays with its controller") {
+                    game.state.projectedState.getController(bears) shouldBe game.player2Id
+                }
+                withClue("Goatnapper itself still resolved onto the battlefield") {
+                    game.findPermanent("Goatnapper") shouldNotBe null
+                }
+            }
+
+            test("control reverts at end of turn but the Goat stays untapped") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Goatnapper")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Mountain Goat", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goat = game.findPermanent("Mountain Goat")!!
+
+                game.castSpell(1, "Goatnapper").error shouldBe null
+                game.stealWith(goat)
+
+                game.state.projectedState.getController(goat) shouldBe game.player1Id
+
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+
+                withClue("\"Until end of turn\" hands the Goat back in the cleanup step") {
+                    game.state.projectedState.getController(goat) shouldBe game.player2Id
+                }
+                withClue("The untap is a one-shot, not a duration — the Goat is still untapped") {
+                    game.state.getEntity(goat)?.get<TappedComponent>() shouldBe null
+                }
+                withClue("The Goat is still the Goat it always was") {
+                    game.state.getEntity(goat)?.get<CardComponent>()?.name shouldBe "Mountain Goat"
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HeatShimmerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HeatShimmerScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Heat Shimmer (LRW #175) — "Create a token that's a copy of target creature, except it has haste
+ * and 'At the beginning of the end step, exile this token.'"
+ *
+ * Electroduplicate's exile sibling. Two things separate it from that card and are worth proving:
+ * the token leaves via **exile**, not the graveyard (so it triggers nothing on the way out), and
+ * the copy may be made of a creature you don't control.
+ */
+class HeatShimmerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Heat Shimmer") {
+
+            test("copies an opponent's creature, and the copy has haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Heat Shimmer")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Heat Shimmer", bears).error shouldBe null
+                game.resolveStack()
+
+                val copies = game.findPermanents("Grizzly Bears")
+                withClue("The original plus one token copy") {
+                    copies.size shouldBe 2
+                }
+                val token = copies.first { it != bears }
+                withClue("The token is under Heat Shimmer's controller, not the copied creature's") {
+                    game.state.projectedState.getController(token) shouldBe game.player1Id
+                }
+                withClue("The \"except it has haste\" copy exception landed") {
+                    game.state.projectedState.hasKeyword(token, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("the token is exiled at the next end step, not sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Heat Shimmer")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Heat Shimmer", bears).error shouldBe null
+                game.resolveStack()
+                game.findPermanents("Grizzly Bears").size shouldBe 2
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Only the original Bears is left on the battlefield") {
+                    val remaining = game.findPermanents("Grizzly Bears")
+                    remaining.size shouldBe 1
+                    remaining.single() shouldBe bears
+                }
+                withClue("A token that is exiled never reaches a graveyard, so nothing died") {
+                    game.state.getGraveyard(game.player1Id).none {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                }
+                withClue("The original creature is untouched by its copy's expiry") {
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SowerOfTemptationScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SowerOfTemptationScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sower of Temptation (LRW #88) — "Flying. When this creature enters, gain control of target
+ * creature for as long as this creature remains on the battlefield."
+ *
+ * The interesting half is the duration, not the grab. `Duration.WhileSourceOnBattlefield` has to
+ * survive an ordinary turn boundary (an "until end of turn" steal would not) and has to hand the
+ * creature back the moment Sower leaves — which is the whole reason the card is answerable by
+ * killing the Faerie rather than by racing a clock.
+ */
+class SowerOfTemptationScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sower of Temptation") {
+
+            fun TestGame.resolveGrab(victim: com.wingedsheep.sdk.model.EntityId) {
+                resolveStack()
+                state.pendingDecision?.let {
+                    submitDecision(TargetsResponse(it.id, mapOf(0 to listOf(victim))))
+                }
+                resolveStack()
+            }
+
+            test("steals a creature on entry and keeps it across the turn boundary") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sower of Temptation")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Sower of Temptation").error shouldBe null
+                game.resolveGrab(bears)
+
+                withClue("The Bears changed hands as the Faerie entered") {
+                    game.state.projectedState.getController(bears) shouldBe game.player1Id
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+
+                withClue("The steal is not \"until end of turn\" — it survives cleanup") {
+                    game.state.projectedState.getController(bears) shouldBe game.player1Id
+                }
+            }
+
+            test("the creature goes home the moment Sower leaves the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sower of Temptation")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Sower of Temptation").error shouldBe null
+                game.resolveGrab(bears)
+                game.state.projectedState.getController(bears) shouldBe game.player1Id
+
+                // Shock the 2/2 Faerie down. Its own controller can do this — the duration is keyed
+                // to the permanent being on the battlefield, not to who owns it.
+                val sower = game.findPermanent("Sower of Temptation")!!
+                game.castSpell(1, "Shock", sower).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("Sower died, so the \"for as long as\" duration ended") {
+                    game.findPermanent("Sower of Temptation") shouldBe null
+                    game.state.projectedState.getController(bears) shouldBe game.player2Id
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FootbottomFeastReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FootbottomFeastReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Footbottom Feast reprint in CMD. Canonical CardDefinition lives in its earliest set (LRW).
+ */
+val FootbottomFeastReprint = Printing(
+    oracleId = "0a35df9d-80a0-4b6f-91d5-dad980af47e1",
+    name = "Footbottom Feast",
+    setCode = "CMD",
+    collectorNumber = "84",
+    scryfallId = "1584404b-c086-4734-89e5-8a10c3f29504",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/1584404b-c086-4734-89e5-8a10c3f29504.jpg?1783941223",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1565,6 +1565,70 @@
     ]
 }
 
+// Crush Underfoot
+{
+    "name": "Crush Underfoot",
+    "manaCost": "{1}{R}",
+    "typeLine": "Kindred Instant — Giant",
+    "oracleText": "Choose a Giant creature you control. It deals damage equal to its power to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "SelectTarget",
+                    "requirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Giant ctrl:you"
+                        },
+                        "id": "a Giant creature you control"
+                    },
+                    "storeAs": "crushGiant"
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": {
+                            "type": "FromCostStorage",
+                            "collectionName": "crushGiant"
+                        },
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "damageSource": {
+                        "type": "PipelineTarget",
+                        "collectionName": "crushGiant"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "Five-toed grave\n—Kithkin phrase meaning \"a giant's footprint\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0386925-53bc-4902-ac30-cbdcb099936d.jpg?1783942877"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Dauntless Dourbark
 {
     "name": "Dauntless Dourbark",
@@ -3247,6 +3311,63 @@
     ]
 }
 
+// Footbottom Feast
+{
+    "name": "Footbottom Feast",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Put any number of target creature cards from your graveyard on top of your library.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "feast_cards"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "feast_cards",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Top"
+                    },
+                    "order": "ControllerChooses"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "unlimited": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "any number of target creature cards from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Jim Nelson",
+        "flavorText": "The scent of rot and vinegar fills the marsh, inviting boggarts from every warren to reunite and feast.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc04f820-9505-4ccd-98e7-1bb861161af5.jpg?1783942890"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Forced Fruition
 {
     "name": "Forced Fruition",
@@ -3745,6 +3866,76 @@
     ]
 }
 
+// Goatnapper
+{
+    "name": "Goatnapper",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "When this creature enters, untap target Goat and gain control of it until end of turn. It gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Goat"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "GainControl",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Goat"
+                            },
+                            "duration": "EndOfTurn"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Goat"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Goat"
+                    },
+                    "id": "target Goat"
+                },
+                "descriptionOverride": "untap target Goat and gain control of it until end of turn. It gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spencer",
+        "flavorText": "Kith goats are just for practice. The real prize, of course, is a giant's cloudgoat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78f32852-2a18-453d-910a-829c3a2b5b1b.jpg?1783942876"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goldmeadow Dodger
 {
     "name": "Goldmeadow Dodger",
@@ -4181,6 +4372,46 @@
         "artist": "Zoltan Boros & Gabor Szikszai",
         "flavorText": "The flamekin are mere kindling for his warmth.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb0d4d3f-d3ad-4c70-b9af-9bfcdd9efd1f.jpg?1783942874"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Heat Shimmer
+{
+    "name": "Heat Shimmer",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target creature, except it has haste and \"At the beginning of the end step, exile this token.\"",
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            },
+            "addedKeywords": [
+                "HASTE"
+            ],
+            "exileAtStep": "END"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "\"Better to flare out than to gutter.\"\n—Flamekin expression",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a432470c-7f68-4429-970a-3da8eabcf0b8.jpg?1783942875"
     },
     "colorIdentityOverride": [
         "RED"
@@ -8018,6 +8249,61 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Sower of Temptation
+{
+    "name": "Sower of Temptation",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\nWhen this creature enters, gain control of target creature for as long as this creature remains on the battlefield.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": {
+                        "type": "WhileSourceOnBattlefield",
+                        "sourceDescription": "Sower of Temptation"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "gain control of target creature for as long as this creature remains on the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "RARE",
+        "artist": "Christopher Moeller",
+        "flavorText": "One glamer leads him far from home. The next washes away his memory that home was ever anywhere but at her side.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f5320da-7214-4348-84d8-74bf951c9f2f.jpg?1783942897"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, each composing existing SDK primitives — no new engine vocabulary.

- **Goatnapper** ({2}{R} Goblin Rogue 2/2) — the Threaten pattern on an enters trigger, target narrowed to a Goat: `Effects.Untap` + `Effects.GainControl(EndOfTurn)` + `Effects.GrantKeyword(HASTE)`, the same composite Blind with Anger uses.
- **Sower of Temptation** ({2}{U}{U} Faerie Wizard 2/2) — flying plus an enters trigger whose `GainControl` rides `Duration.WhileSourceOnBattlefield`, so the steal survives the turn boundary and reverts the instant the Faerie leaves.
- **Heat Shimmer** ({2}{R} Sorcery) — Electroduplicate's exile sibling: `Effects.CreateTokenCopyOfTarget` with `addedKeywords = HASTE` and `exileAtStep = Step.END`, targeting any creature rather than one you control.
- **Footbottom Feast** ({2}{B} Instant) — Drafna's Restoration's shape scoped to your own graveyard: one `unlimited = true` target slot, `GatherCardsEffect(ChosenTargets)` → `MoveCollectionEffect` to the library top with `CardOrder.ControllerChooses` (CR 401.4 gives the order to the controller), then the draw. Also adds the missing CMD `Printing` row.
- **Crush Underfoot** ({1}{R} Kindred Instant — Giant) — keeps the card's two decisions apart. "Target creature" is a cast-time target; "Choose a Giant creature you control" is a mid-resolution `SelectTargetEffect`, so an opponent can't respond to which Giant you picked. The damage step reads that pipeline slot twice — `EntityReference.FromCostStorage` for "equal to its power" and `EffectTarget.PipelineTarget` as the `damageSource` — so the damage is dealt *by the Giant*, not by the spell. With no Giant to choose the whole instruction is skipped (CR 608.2b) rather than falling back to the spell as the source.

**Dropped from the batch:** Turtleshell Changeling. `Modification.SwitchPowerToughness` exists engine-side but nothing produces it — there is no SDK effect for "switch this creature's power and toughness", so it needs new vocabulary and belongs in its own PR.

**Known deviation** (documented in `CrushUnderfoot.kt`): the chosen Giant is found through `TargetFinder`, which filters out permanents with shroud. Because the Giant is *chosen* and not targeted, the rules would allow picking a Giant you control that has shroud. Hexproof is unaffected (you control it).

## Verification

- `just build` — green.
- 15 new scenario tests across five files, one per card, all passing: subtype filtering (a changeling counts as a Goat, Grizzly Bears does not), the end-of-turn control revert vs. the one-shot untap, the "for as long as" duration surviving cleanup and ending on death, the token copy leaving via exile rather than the graveyard, unlimited-target subset selection and the zero-target cantrip case, and all four Crush Underfoot branches (auto-select, two-Giant choice, no Giant, opponent's Giant).
- All five field-verified against Scryfall — mana cost, type line, oracle text, flavor, P/T, rarity, collector number, artist, and image URI all match.
- `just check-card-printing` clean for all five; LRW is the canonical printing for each.
- `just rebless-cards` — only the five new cards move in `snapshots/cards/LRW.json`.
- `just assay-differential --set LRW` — 10 divergences, all pre-existing (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). None of the five new cards diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6