### PR TITLE
Add four Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ArbiterOfKnollridge.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ArbiterOfKnollridge.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Arbiter of Knollridge
+ * {6}{W}
+ * Creature — Giant Wizard
+ * 5/5
+ *
+ * Vigilance
+ * When this creature enters, each player's life total becomes the highest life total among
+ * all players.
+ *
+ * "The highest life total among all players" is a per-player maximum, not a sum, so it reads
+ * [DynamicAmount.GreatestAmongPlayers] — that combinator rebinds the measured player for each
+ * seat, letting the inner `LifeTotal(Player.You)` mean "that player's life". The amount is
+ * re-evaluated per player as the effect walks the seats, which is safe here precisely because
+ * setting everyone to the maximum can only ever raise a life total: the maximum is a fixed
+ * point of the operation, so every player lands on the same number regardless of order.
+ */
+val ArbiterOfKnollridge = card("Arbiter of Knollridge") {
+    manaCost = "{6}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant Wizard"
+    power = 5
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "When this creature enters, each player's life total becomes the highest life total " +
+        "among all players."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.SetLifeTotal(
+            amount = DynamicAmount.GreatestAmongPlayers(
+                players = Player.Each,
+                inner = DynamicAmount.LifeTotal(Player.You)
+            ),
+            target = EffectTarget.PlayerRef(Player.Each)
+        )
+        description = "each player's life total becomes the highest life total among all players."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Brandon Dorman"
+        flavorText = "Though giants are mortal, they live so long and on such a grand scale " +
+            "that many small folk don't believe they ever truly die."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg?1783942919"
+        ruling("2010-06-15", "In a Two-Headed Giant game, each team chooses one person on that team to gain the appropriate amount of life. This basically means that the triggered ability will set the life total of each team to that of the team with the highest life total.")
+        ruling("2007-10-01", "Abilities that trigger when a player gains life may trigger as a result of this ability.")
+        ruling("2007-10-01", "In other multiplayer formats, each player's life total is set to the highest life total within their range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice's life total will become 8 and Barry and Doug's life totals will each become 11.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HowltoothHollow.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/HowltoothHollow.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Howltooth Hollow
+ * Land
+ *
+ * Hideaway 4 (When this land enters, look at the top four cards of your library, exile
+ * one face down, then put the rest on the bottom in a random order.)
+ * This land enters tapped.
+ * {T}: Add {B}.
+ * {B}, {T}: You may play the exiled card without paying its mana cost if each player has
+ * no cards in hand.
+ *
+ * Same shape as [MosswortBridge] — see its comment for how hideaway is composed. The only
+ * difference is the gate on the free-cast ability: "each player has no cards in hand" is
+ * modelled as the *summed* hand size across every seat being zero, which is exactly the
+ * universal claim (a sum of non-negative counts is 0 iff every term is 0) and so stays
+ * correct in multiplayer, where a per-opponent comparison would not.
+ */
+val HowltoothHollow = card("Howltooth Hollow") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "Hideaway 4 (When this land enters, look at the top four cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "This land enters tapped.\n" +
+        "{T}: Add {B}.\n" +
+        "{B}, {T}: You may play the exiled card without paying its mana cost if each player " +
+        "has no cards in hand."
+
+    keywordAbility(KeywordAbility.hideaway(4))
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(4),
+                        player = Player.You
+                    ),
+                    storeAs = "hideawayTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hideawayTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "hideawayPicked",
+                    storeRemainder = "hideawayRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hideawayLinked"
+                ),
+                GrantMayPlayFromExileEffect("hideawayLinked"),
+                GrantPlayWithoutPayingCostEffect("hideawayLinked")
+            )
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    DynamicAmount.Count(Player.Each, Zone.HAND),
+                    ComparisonOperator.EQ,
+                    DynamicAmount.Fixed(0)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "269"
+        artist = "John Franklin Howe"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg?1783942847"
+        ruling("2022-04-29", "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\"")
+        ruling("2022-04-29", "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card.")
+        ruling("2022-04-29", "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4.")
+        ruling("2022-04-29", "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SpinerockKnoll.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SpinerockKnoll.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * Spinerock Knoll
+ * Land
+ *
+ * Hideaway 4 (When this land enters, look at the top four cards of your library, exile
+ * one face down, then put the rest on the bottom in a random order.)
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {R}, {T}: You may play the exiled card without paying its mana cost if an opponent was
+ * dealt 7 or more damage this turn.
+ *
+ * Same shape as [MosswortBridge] — see its comment for how hideaway is composed. The gate is
+ * "an opponent was dealt 7 or more damage this turn": an *existential* over opponents, so it
+ * reads [DynamicAmount.GreatestAmongPlayers] rather than a plain per-opponent tracker. Summing
+ * `DAMAGE_RECEIVED` across `Player.EachOpponent` would let three opponents on 3 damage each
+ * satisfy a 7-damage threshold no single one of them reached; taking the greatest measures each
+ * opponent separately, which is what the card asks. Damage of any kind counts, combat or not
+ * (2007-10-01 ruling), which is why this is `DAMAGE_RECEIVED` and not the combat-only tracker.
+ */
+val SpinerockKnoll = card("Spinerock Knoll") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "Hideaway 4 (When this land enters, look at the top four cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "This land enters tapped.\n" +
+        "{T}: Add {R}.\n" +
+        "{R}, {T}: You may play the exiled card without paying its mana cost if an opponent " +
+        "was dealt 7 or more damage this turn."
+
+    keywordAbility(KeywordAbility.hideaway(4))
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(4),
+                        player = Player.You
+                    ),
+                    storeAs = "hideawayTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hideawayTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "hideawayPicked",
+                    storeRemainder = "hideawayRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hideawayLinked"
+                ),
+                GrantMayPlayFromExileEffect("hideawayLinked"),
+                GrantPlayWithoutPayingCostEffect("hideawayLinked")
+            )
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    DynamicAmount.GreatestAmongPlayers(
+                        players = Player.EachOpponent,
+                        inner = DynamicAmount.TurnTracking(Player.You, TurnTracker.DAMAGE_RECEIVED)
+                    ),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(7)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "274"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg?1783942847"
+        ruling("2022-04-29", "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\"")
+        ruling("2022-04-29", "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card.")
+        ruling("2022-04-29", "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4.")
+        ruling("2022-04-29", "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order.")
+        ruling("2007-10-01", "It doesn't matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don't specify an opponent when you activate the ability.")
+        ruling("2007-10-01", "You'll get to play the card even if Spinerock Knoll wasn't on the battlefield at the time some or all of the 7 damage was dealt.")
+        ruling("2007-10-01", "At the time the last ability resolves, you'll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time they left the game, has been dealt 7 damage over the course of the turn.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WindbriskHeights.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/WindbriskHeights.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Windbrisk Heights
+ * Land
+ *
+ * Hideaway 4 (When this land enters, look at the top four cards of your library, exile
+ * one face down, then put the rest on the bottom in a random order.)
+ * This land enters tapped.
+ * {T}: Add {W}.
+ * {W}, {T}: You may play the exiled card without paying its mana cost if you attacked with
+ * three or more creatures this turn.
+ *
+ * Same shape as [MosswortBridge] — see its comment for how hideaway is composed. The gate is
+ * the attack tracker rather than a board scan: per the 2007-10-01 ruling it asks whether you
+ * *declared* three or more creatures as attackers at any point this turn, so it must survive
+ * those creatures dying, a second combat phase, and the attack being over. A creature declared
+ * in two combats counts once, and a creature that entered the battlefield already attacking was
+ * never declared and so never counts — both of which the tracker already gets right.
+ */
+val WindbriskHeights = card("Windbrisk Heights") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "Hideaway 4 (When this land enters, look at the top four cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "This land enters tapped.\n" +
+        "{T}: Add {W}.\n" +
+        "{W}, {T}: You may play the exiled card without paying its mana cost if you attacked " +
+        "with three or more creatures this turn."
+
+    keywordAbility(KeywordAbility.hideaway(4))
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(4),
+                        player = Player.You
+                    ),
+                    storeAs = "hideawayTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hideawayTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "hideawayPicked",
+                    storeRemainder = "hideawayRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hideawayLinked"
+                ),
+                GrantMayPlayFromExileEffect("hideawayLinked"),
+                GrantPlayWithoutPayingCostEffect("hideawayLinked")
+            )
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouAttackedWithCreaturesThisTurn(GameObjectFilter.Creature, atLeast = 3)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "281"
+        artist = "Omar Rayyan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg?1783942846"
+        ruling("2022-04-29", "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\"")
+        ruling("2022-04-29", "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card.")
+        ruling("2022-04-29", "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4.")
+        ruling("2022-04-29", "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order.")
+        ruling("2007-10-01", "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArbiterOfKnollridgeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArbiterOfKnollridgeScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Arbiter of Knollridge (LRW #2) — {6}{W} 5/5 Giant Wizard with vigilance.
+ *
+ * "When this creature enters, each player's life total becomes the highest life total among
+ *  all players."
+ *
+ * The interesting claim is that the amount is a per-player *maximum*, not a sum, and that it
+ * lands on every seat rather than just the controller — so the test runs it from behind on life
+ * (the controller gains) and from ahead (the opponent gains, the controller is untouched).
+ */
+class ArbiterOfKnollridgeScenarioTest : FunSpec({
+
+    test("the controller behind on life is raised to the opponent's total") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(player, 4)
+        driver.setLifeTotal(opponent, 17)
+
+        val arbiter = driver.putCardInHand(player, "Arbiter of Knollridge")
+        driver.giveMana(player, Color.WHITE, 7)
+        driver.castSpell(player, arbiter)
+        driver.bothPass() // resolve the spell → it enters → the trigger goes on the stack
+        driver.bothPass() // resolve the trigger
+
+        driver.getLifeTotal(player) shouldBe 17
+        driver.getLifeTotal(opponent) shouldBe 17
+    }
+
+    test("the opponent behind on life is raised; a sum would overshoot both") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(player, 23)
+        driver.setLifeTotal(opponent, 6)
+
+        val arbiter = driver.putCardInHand(player, "Arbiter of Knollridge")
+        driver.giveMana(player, Color.WHITE, 7)
+        driver.castSpell(player, arbiter)
+        driver.bothPass()
+        driver.bothPass()
+
+        // 23 is the maximum; the sum of the two totals (29) is what a summed reading would give.
+        driver.getLifeTotal(player) shouldBe 23
+        driver.getLifeTotal(opponent) shouldBe 23
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HowltoothHollowScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HowltoothHollowScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.HowltoothHollow
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Howltooth Hollow (LRW #269).
+ *
+ * "Hideaway 4 … This land enters tapped. {T}: Add {B}.
+ *  {B}, {T}: You may play the exiled card without paying its mana cost if each player has no
+ *  cards in hand."
+ *
+ * Covers the gate, which is the only part of the card that isn't shared with Mosswort Bridge.
+ * "Each player" is universal, so a card in *either* hand — the controller's or the opponent's —
+ * must keep the ability shut. Emptying only your own hand is the case a summed-over-opponents
+ * reading would get right and a controller-only reading would get wrong, so both halves are
+ * exercised separately.
+ */
+class HowltoothHollowScenarioTest : FunSpec({
+
+    /** Index 0 is the {T}: Add {B} mana ability; index 1 is the gated free-cast ability. */
+    val freeCastAbilityId = HowltoothHollow.activatedAbilities[1].id
+
+    fun freeCastOffered(driver: GameTestDriver, player: EntityId, land: EntityId): Boolean =
+        driver.legalActions(player).any {
+            val action = it.action
+            action is ActivateAbility && action.sourceId == land && action.abilityId == freeCastAbilityId
+        }
+
+    /** Play the land from hand so hideaway runs, exile a card, then untap it (it enters tapped). */
+    fun playHowltoothHollow(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Howltooth Hollow")
+        driver.playLand(player, card)
+        driver.bothPass() // resolve the hideaway trigger → pauses to exile one of the top four
+        val decision = driver.pendingDecision
+        require(decision is SelectCardsDecision) { "expected hideaway selection, got $decision" }
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+        val land = driver.findPermanent(player, "Howltooth Hollow")!!
+        driver.untapPermanent(land)
+        return land
+    }
+
+    fun emptyHand(driver: GameTestDriver, player: EntityId) {
+        driver.getHand(player).forEach(driver::moveToGraveyard)
+    }
+
+    test("a card in either hand keeps the free-cast ability shut") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playHowltoothHollow(driver, player)
+        driver.giveMana(player, Color.BLACK, 1)
+
+        // Both hands full.
+        freeCastOffered(driver, player, land) shouldBe false
+
+        // Only your own hand emptied — the opponent still holds cards, so the gate stays shut.
+        emptyHand(driver, player)
+        driver.giveMana(player, Color.BLACK, 1)
+        freeCastOffered(driver, player, land) shouldBe false
+
+        // Only the opponent's hand emptied.
+        driver.putCardInHand(player, "Swamp")
+        emptyHand(driver, opponent)
+        driver.giveMana(player, Color.BLACK, 1)
+        freeCastOffered(driver, player, land) shouldBe false
+    }
+
+    test("with every hand empty the free-cast ability is offered") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playHowltoothHollow(driver, player)
+        emptyHand(driver, player)
+        emptyHand(driver, driver.getOpponent(player))
+        driver.giveMana(player, Color.BLACK, 1)
+
+        freeCastOffered(driver, player, land) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinerockKnollScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinerockKnollScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SpinerockKnoll
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Spinerock Knoll (LRW #274).
+ *
+ * "Hideaway 4 … This land enters tapped. {T}: Add {R}.
+ *  {R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt
+ *  7 or more damage this turn."
+ *
+ * Covers the gate, which is the only part of the card that isn't shared with Mosswort Bridge:
+ * six damage is not enough and seven is, and the threshold is measured against the opponent's
+ * running total for the turn rather than against a single damage event.
+ */
+class SpinerockKnollScenarioTest : FunSpec({
+
+    /** Index 0 is the {T}: Add {R} mana ability; index 1 is the gated free-cast ability. */
+    val freeCastAbilityId = SpinerockKnoll.activatedAbilities[1].id
+
+    fun freeCastOffered(driver: GameTestDriver, player: EntityId, land: EntityId): Boolean =
+        driver.legalActions(player).any {
+            val action = it.action
+            action is ActivateAbility && action.sourceId == land && action.abilityId == freeCastAbilityId
+        }
+
+    /** Play the land from hand so hideaway runs, exile a card, then untap it (it enters tapped). */
+    fun playSpinerockKnoll(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Spinerock Knoll")
+        driver.playLand(player, card)
+        driver.bothPass() // resolve the hideaway trigger → pauses to exile one of the top four
+        val decision = driver.pendingDecision
+        require(decision is SelectCardsDecision) { "expected hideaway selection, got $decision" }
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+        val land = driver.findPermanent(player, "Spinerock Knoll")!!
+        driver.untapPermanent(land)
+        return land
+    }
+
+    /**
+     * Attack an empty board with [count] 3/3s, so the defending player takes 3 × [count] damage.
+     * Two of them is 6 — one short of the gate; three is 9.
+     */
+    fun attackWithBears(driver: GameTestDriver, player: EntityId, count: Int) {
+        val attackers = (1..count).map {
+            driver.putCreatureOnBattlefield(player, "Hill Giant").also(driver::removeSummoningSickness)
+        }
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, attackers, driver.getOpponent(player))
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+    }
+
+    test("six damage to the opponent is not enough to open the free-cast ability") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playSpinerockKnoll(driver, player)
+        attackWithBears(driver, player, count = 2)
+        driver.getLifeTotal(driver.getOpponent(player)) shouldBe 14
+        driver.giveMana(player, Color.RED, 1)
+
+        freeCastOffered(driver, player, land) shouldBe false
+    }
+
+    test("nine damage to the opponent opens the free-cast ability") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playSpinerockKnoll(driver, player)
+        attackWithBears(driver, player, count = 3)
+        driver.getLifeTotal(driver.getOpponent(player)) shouldBe 11
+        driver.giveMana(player, Color.RED, 1)
+
+        freeCastOffered(driver, player, land) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WindbriskHeightsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WindbriskHeightsScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.WindbriskHeights
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Windbrisk Heights (LRW #281).
+ *
+ * "Hideaway 4 … This land enters tapped. {T}: Add {W}.
+ *  {W}, {T}: You may play the exiled card without paying its mana cost if you attacked with
+ *  three or more creatures this turn."
+ *
+ * Covers the gate, which is the only part of the card that isn't shared with Mosswort Bridge:
+ * the free-cast ability must be unavailable before an attack and after a two-creature attack,
+ * and available once three creatures have been declared as attackers this turn.
+ */
+class WindbriskHeightsScenarioTest : FunSpec({
+
+    /** Index 0 is the {T}: Add {W} mana ability; index 1 is the gated free-cast ability. */
+    val freeCastAbilityId = WindbriskHeights.activatedAbilities[1].id
+
+    fun freeCastOffered(driver: GameTestDriver, player: EntityId, land: EntityId): Boolean =
+        driver.legalActions(player).any {
+            val action = it.action
+            action is ActivateAbility && action.sourceId == land && action.abilityId == freeCastAbilityId
+        }
+
+    /** Play the land from hand so hideaway runs, exile a card, then untap it (it enters tapped). */
+    fun playWindbriskHeights(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Windbrisk Heights")
+        driver.playLand(player, card)
+        driver.bothPass() // resolve the hideaway trigger → pauses to exile one of the top four
+        val decision = driver.pendingDecision
+        require(decision is SelectCardsDecision) { "expected hideaway selection, got $decision" }
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+        val land = driver.findPermanent(player, "Windbrisk Heights")!!
+        driver.untapPermanent(land)
+        return land
+    }
+
+    test("the free-cast ability is gated behind attacking with three or more creatures") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playWindbriskHeights(driver, player)
+        driver.giveMana(player, Color.WHITE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe false
+
+        // Two attackers is not enough.
+        val attackers = (1..3).map {
+            driver.putCreatureOnBattlefield(player, "Grizzly Bears").also(driver::removeSummoningSickness)
+        }
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, attackers.take(2), driver.getOpponent(player))
+        driver.giveMana(player, Color.WHITE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe false
+    }
+
+    test("attacking with three creatures opens the free-cast ability") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = playWindbriskHeights(driver, player)
+        val attackers = (1..3).map {
+            driver.putCreatureOnBattlefield(player, "Grizzly Bears").also(driver::removeSummoningSickness)
+        }
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, attackers, driver.getOpponent(player))
+        driver.giveMana(player, Color.WHITE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe true
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ArbiterOfKnollridgeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ArbiterOfKnollridgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arbiter of Knollridge reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val ArbiterOfKnollridgeReprint = Printing(
+    oracleId = "62705a41-7c4d-4e6c-85b0-36a9d27ab5ae",
+    name = "Arbiter of Knollridge",
+    setCode = "C15",
+    collectorNumber = "59",
+    scryfallId = "1ba767e7-b9c6-41ab-aa6b-7ec506a9f76f",
+    artist = "Brandon Dorman",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1ba767e7-b9c6-41ab-aa6b-7ec506a9f76f.jpg?1783938103",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SpinerockKnollReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SpinerockKnollReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spinerock Knoll reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val SpinerockKnollReprint = Printing(
+    oracleId = "690c7f8e-fea2-4920-afa7-02ff120701a1",
+    name = "Spinerock Knoll",
+    setCode = "C15",
+    collectorNumber = "309",
+    scryfallId = "48f09add-2ec3-4447-84d3-3a4b268b17ca",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48f09add-2ec3-4447-84d3-3a4b268b17ca.jpg?1783938035",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SpinerockKnollReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SpinerockKnollReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spinerock Knoll reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val SpinerockKnollReprint = Printing(
+    oracleId = "690c7f8e-fea2-4920-afa7-02ff120701a1",
+    name = "Spinerock Knoll",
+    setCode = "C16",
+    collectorNumber = "327",
+    scryfallId = "4c38757c-8707-4834-afd0-169afec1e235",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4c38757c-8707-4834-afd0-169afec1e235.jpg?1783937021",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/WindbriskHeightsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/WindbriskHeightsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windbrisk Heights reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val WindbriskHeightsReprint = Printing(
+    oracleId = "3589bcfc-42b0-414a-adce-bc690dc631c8",
+    name = "Windbrisk Heights",
+    setCode = "C16",
+    collectorNumber = "336",
+    scryfallId = "cc8e7dac-f537-4acf-9854-ca3b5faa67e3",
+    artist = "Omar Rayyan",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/cc8e7dac-f537-4acf-9854-ca3b5faa67e3.jpg?1783937020",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ArbiterOfKnollridgeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ArbiterOfKnollridgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arbiter of Knollridge reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val ArbiterOfKnollridgeReprint = Printing(
+    oracleId = "62705a41-7c4d-4e6c-85b0-36a9d27ab5ae",
+    name = "Arbiter of Knollridge",
+    setCode = "CMD",
+    collectorNumber = "6",
+    scryfallId = "a5714c90-59ca-4a39-ab38-6336fb8adb0a",
+    artist = "Brandon Dorman",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5714c90-59ca-4a39-ab38-6336fb8adb0a.jpg?1783941257",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SpinerockKnollReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SpinerockKnollReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spinerock Knoll reprint in CLB. Canonical CardDefinition lives in its earliest set.
+ */
+val SpinerockKnollReprint = Printing(
+    oracleId = "690c7f8e-fea2-4920-afa7-02ff120701a1",
+    name = "Spinerock Knoll",
+    setCode = "CLB",
+    collectorNumber = "916",
+    scryfallId = "1e5d990f-0eb4-4634-a446-7783915e8eec",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e5d990f-0eb4-4634-a446-7783915e8eec.jpg?1783922366",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/WindbriskHeightsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/WindbriskHeightsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windbrisk Heights reprint in CLB. Canonical CardDefinition lives in its earliest set.
+ */
+val WindbriskHeightsReprint = Printing(
+    oracleId = "3589bcfc-42b0-414a-adce-bc690dc631c8",
+    name = "Windbrisk Heights",
+    setCode = "CLB",
+    collectorNumber = "930",
+    scryfallId = "cc4aa7d1-e168-4fa0-baf0-1102086dc717",
+    artist = "Omar Rayyan",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/cc4aa7d1-e168-4fa0-baf0-1102086dc717.jpg?1783922359",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SpinerockKnollReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SpinerockKnollReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spinerock Knoll reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val SpinerockKnollReprint = Printing(
+    oracleId = "690c7f8e-fea2-4920-afa7-02ff120701a1",
+    name = "Spinerock Knoll",
+    setCode = "NCC",
+    collectorNumber = "429",
+    scryfallId = "acd4d8c9-fe97-4bed-87a4-d7f0f99c00e2",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/acd4d8c9-fe97-4bed-87a4-d7f0f99c00e2.jpg?1783923187",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WindbriskHeightsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WindbriskHeightsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windbrisk Heights reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val WindbriskHeightsReprint = Printing(
+    oracleId = "3589bcfc-42b0-414a-adce-bc690dc631c8",
+    name = "Windbrisk Heights",
+    setCode = "NCC",
+    collectorNumber = "447",
+    scryfallId = "43af2a0a-8809-49e7-926b-45b6f0c6390f",
+    artist = "Omar Rayyan",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/43af2a0a-8809-49e7-926b-45b6f0c6390f.jpg?1783923181",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -180,6 +180,71 @@
     ]
 }
 
+// Arbiter of Knollridge
+{
+    "name": "Arbiter of Knollridge",
+    "manaCost": "{6}{W}",
+    "typeLine": "Creature — Giant Wizard",
+    "oracleText": "Vigilance\nWhen this creature enters, each player's life total becomes the highest life total among all players.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "SetLifeTotal",
+                    "amount": {
+                        "type": "GreatestAmongPlayers",
+                        "inner": {
+                            "type": "LifeTotal",
+                            "player": "You"
+                        }
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                "descriptionOverride": "each player's life total becomes the highest life total among all players."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "RARE",
+        "artist": "Brandon Dorman",
+        "flavorText": "Though giants are mortal, they live so long and on such a grand scale that many small folk don't believe they ever truly die.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b598cf2-c327-422b-9527-1b28645ba70c.jpg?1783942919",
+        "rulings": [
+            {
+                "date": "2010-06-15",
+                "text": "In a Two-Headed Giant game, each team chooses one person on that team to gain the appropriate amount of life. This basically means that the triggered ability will set the life total of each team to that of the team with the highest life total."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Abilities that trigger when a player gains life may trigger as a result of this ability."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "In other multiplayer formats, each player's life total is set to the highest life total within their range of influence. These changes happen at the same time. For example, if each player has a range of influence of one, and the players in the game are Alice (4 life), Barry (8 life), Carrie (11 life), and Doug (7 life), in that order, then Alice's life total will become 8 and Barry and Doug's life totals will each become 11."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Auntie's Hovel
 {
     "name": "Auntie's Hovel",
@@ -4550,6 +4615,181 @@
     ]
 }
 
+// Howltooth Hollow
+{
+    "name": "Howltooth Hollow",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Hideaway 4 (When this land enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nThis land enters tapped.\n{T}: Add {B}.\n{B}, {T}: You may play the exiled card without paying its mana cost if each player has no cards in hand.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "hideawayTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hideawayTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hideawayPicked",
+                            "storeRemainder": "hideawayRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "hideawayLinked"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "Each",
+                                "zone": "Hand"
+                            },
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 0
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "269",
+        "rarity": "RARE",
+        "artist": "John Franklin Howe",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c678643-6640-49e1-a5b0-2954123bcabc.jpg?1783942847",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\""
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hunter of Eyeblights
 {
     "name": "Hunter of Eyeblights",
@@ -8355,6 +8595,197 @@
     ]
 }
 
+// Spinerock Knoll
+{
+    "name": "Spinerock Knoll",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Hideaway 4 (When this land enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nThis land enters tapped.\n{T}: Add {R}.\n{R}, {T}: You may play the exiled card without paying its mana cost if an opponent was dealt 7 or more damage this turn.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "hideawayTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hideawayTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hideawayPicked",
+                            "storeRemainder": "hideawayRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "hideawayLinked"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "GreatestAmongPlayers",
+                                "players": "EachOpponent",
+                                "inner": {
+                                    "type": "TurnTracking",
+                                    "player": "You",
+                                    "tracker": "DAMAGE_RECEIVED"
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/dec6abed-8fbb-4d3e-8f89-64ea1b3913db.jpg?1783942847",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\""
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "It doesn't matter how the opponent was dealt damage or by whom, as long as the total damage is 7 or more. You don't specify an opponent when you activate the ability."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "You'll get to play the card even if Spinerock Knoll wasn't on the battlefield at the time some or all of the 7 damage was dealt."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "At the time the last ability resolves, you'll get to play the card if a player who is currently your opponent, or a player who was your opponent at the time they left the game, has been dealt 7 damage over the course of the turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Springleaf Drum
 {
     "name": "Springleaf Drum",
@@ -10169,6 +10600,177 @@
         "artist": "Brandon Dorman",
         "flavorText": "\"You've discovered that boggarts bite, I see. And will the militia be chasing this lot? . . . Ah, you're staying in town to avoid Nath's hunt. Wise. Now this poultice . . .\"",
         "imageUri": "https://cards.scryfall.io/normal/front/1/2/129933ba-60a0-4764-a705-28fa7bb10bd3.jpg?1783942907"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Windbrisk Heights
+{
+    "name": "Windbrisk Heights",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Hideaway 4 (When this land enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nThis land enters tapped.\n{T}: Add {W}.\n{W}, {T}: You may play the exiled card without paying its mana cost if you attacked with three or more creatures this turn.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "hideawayTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hideawayTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hideawayPicked",
+                            "storeRemainder": "hideawayRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "hideawayLinked"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "PlayerAttackedWithCreaturesThisTurn",
+                            "filter": "creature",
+                            "atLeast": 3
+                        }
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "281",
+        "rarity": "RARE",
+        "artist": "Omar Rayyan",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9df6a31a-5c49-4506-b8f8-84c9ab4a2ece.jpg?1783942846",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\""
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "At the time the ability resolves, you'll get to play the card if you declared three different creatures as attackers at any point in the turn. A creature declared as an attacker in two different attack phases counts only once. A creature that entered attacking (such as a token created by Militia's Pride) doesn't count because you never attacked with it."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "WHITE"


### PR DESCRIPTION
Four Lorwyn cards, all composed from existing SDK primitives. Three of them are the rest of the hideaway-land cycle that `Mosswort Bridge` already established, so the only new work per land is its free-cast gate.

- **Howltooth Hollow** — Hideaway 4 land. Gate: "each player has no cards in hand", modelled as the summed hand size across every seat being zero. A sum of non-negative counts is 0 iff every term is 0, so the universal claim stays correct in multiplayer where a per-opponent comparison would not.
- **Spinerock Knoll** — Hideaway 4 land. Gate: "an opponent was dealt 7 or more damage this turn". This is an *existential* over opponents, so it reads `DynamicAmount.GreatestAmongPlayers` rather than a summed per-opponent tracker — summing would let three opponents on 3 damage each satisfy a 7-damage threshold no single one of them reached. Damage of any kind counts, combat or not (2007-10-01 ruling), hence `DAMAGE_RECEIVED` and not the combat-only tracker.
- **Windbrisk Heights** — Hideaway 4 land. Gate: `Conditions.YouAttackedWithCreaturesThisTurn`. Per the 2007-10-01 ruling this asks whether you *declared* three or more creatures as attackers at any point in the turn, so it has to survive those creatures dying and the combat ending — a board scan would be wrong. A creature declared in two combats counts once, and one that entered already attacking was never declared.
- **Arbiter of Knollridge** — {6}{W} 5/5 Giant Wizard, vigilance, ETB "each player's life total becomes the highest life total among all players". A per-player maximum, not a sum, so it also uses `GreatestAmongPlayers`, with `EffectTarget.PlayerRef(Player.Each)` so the set lands on every seat.

Reprint rows added alongside the canonicals: Spinerock Knoll (C15, C16, NCC, CLB), Windbrisk Heights (C16, NCC, CLB), Arbiter of Knollridge (CMD, C15). `just check-card-printing` is clean for all four.

## Tests

One scenario test file per card, four in total. Each land's test proves its gate in both directions — closed when the condition is unmet, open when it is met — because these gates are the first uses of those conditions in an `ActivationRestriction` slot, and a silently fail-closed gate would make the card unplayable while still looking right. Howltooth Hollow's test empties each hand separately, since a controller-only reading would pass a test that only empties your own.

## Dropped from the batch

Two candidate cards need new SDK vocabulary and so are not in this PR:

- **Shelldock Isle** — "a library has twenty or fewer cards in it" needs a *least*-among-players combinator; only `GreatestAmongPlayers` exists.
- The LRW **"reveal a &lt;tribe&gt; card from your hand or pay {3}"** cycle (Goldmeadow Stalwart, Silvergill Adept, Wren's Run Vanquisher, Squeaking Pie Sneak, Flamekin Bladewhirl) — `AdditionalCost.OrPay` recovers which leg the caster took from which `AdditionalCostPayment` field the client populated, and `CostAtom.RevealFromHand` has no such field. `Behold` is not a faithful substitute: it also lets you show a permanent you control, which these cards do not. Both want their own PR.

## Verification

`just build` green. `just assay-differential --set LRW` shows 10 DIVERGENT rows, all pre-existing and unrelated (the harbinger cycle, Epic Proportions, Kithkin Greatheart); Assay declines hideaway, so none of these four cards are covered by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw