### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ConclavesBlessing.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ConclavesBlessing.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Conclave's Blessing
+ * {3}{W}
+ * Enchantment — Aura
+ *
+ * Convoke
+ * Enchant creature
+ * Enchanted creature gets +0/+2 for each other creature you control.
+ *
+ * "Other" is measured against the *enchanted* creature, not against the Aura — and that is what
+ * `excludeSelf` means here: [DynamicAmount.AggregateBattlefield] takes "self" to be the affected
+ * entity when the aggregate is evaluated for a granted effect, which for an Aura's stat grant is
+ * the creature it enchants. "You" stays the Aura's controller, so enchanting an opponent's
+ * creature counts *your* creatures and excludes nothing (the host isn't among them).
+ */
+val ConclavesBlessing = card("Conclave's Blessing") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +0/+2 for each other creature you control."
+
+    keywords(Keyword.CONVOKE)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = Filters.EnchantedCreature,
+            powerBonus = DynamicAmount.Fixed(0),
+            // +2 per creature, not +1 — the printed bonus is +0/+2 *for each*, so the count has
+            // to be doubled before it becomes the toughness bonus.
+            toughnessBonus = DynamicAmount.Multiply(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature,
+                    excludeSelf = true
+                ),
+                multiplier = 2
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Shishizaru"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg?1783943702"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+        ruling(
+            "2024-01-12",
+            "Tapping a multicolored creature using convoke will pay for {1} or one mana of your " +
+                "choice of any of that creature's colors."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FollowedFootsteps.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FollowedFootsteps.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Followed Footsteps
+ * {3}{U}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * At the beginning of your upkeep, create a token that's a copy of enchanted creature.
+ *
+ * The copy is read at *resolution*, not when the trigger went on the stack — hence
+ * [EffectTarget.EnchantedCreature] rather than a captured entity: if the Aura has moved to a
+ * different creature in between, you get a copy of the newly-enchanted one (ruling of
+ * 2007-02-01).
+ */
+val FollowedFootsteps = card("Followed Footsteps") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "At the beginning of your upkeep, create a token that's a copy of enchanted creature."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.CreateTokenCopyOfTarget(EffectTarget.EnchantedCreature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Glen Angus"
+        flavorText = "Æther can turn a footprint into a blueprint."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg?1783943685"
+        ruling(
+            "2005-10-01",
+            "Any \"enters\" abilities of the copied creature trigger when the creature tokens " +
+                "enter the battlefield. The creature tokens also have any \"this enters with\" " +
+                "or \"as this enters\" abilities that the copied creature has."
+        )
+        ruling(
+            "2007-02-01",
+            "If Followed Footsteps moves after it has triggered, you get a copy of the " +
+                "newly-enchanted creature."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MarkOfEviction.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MarkOfEviction.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mark of Eviction
+ * {U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * At the beginning of your upkeep, return enchanted creature and all Auras attached to that
+ * creature to their owners' hands.
+ *
+ * Mark of Eviction is itself an Aura attached to that creature, so it bounces *itself* along
+ * with the host — that recursion is the card, not an accident of the script.
+ *
+ * Hence the gather-first shape. The Auras are collected into a pipeline collection while
+ * everything is still attached; only then does the host move, and the collection (entity ids,
+ * not a live attachment read) moves after it. Returning the Auras first instead would leave the
+ * later steps reading "enchanted creature" off an Aura that is already in its owner's hand.
+ * Nothing dies in between: an Aura attached to nothing is put into a graveyard by a state-based
+ * action (CR 704.5m), and state-based actions are not checked in the middle of a resolution.
+ *
+ * Equipment attached to the host is deliberately left alone — the printed text names Auras, and
+ * an unattached Equipment simply stays on the battlefield.
+ */
+val MarkOfEviction = card("Mark of Eviction") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "At the beginning of your upkeep, return enchanted creature and all Auras attached to " +
+        "that creature to their owners' hands."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.AttachedTo(
+                    host = EffectTarget.EnchantedCreature,
+                    filter = GameObjectFilter.Permanent.withSubtype(Subtype.AURA)
+                ),
+                storeAs = "evictedAuras"
+            ),
+            Effects.ReturnToHand(EffectTarget.EnchantedCreature),
+            MoveCollectionEffect(
+                from = "evictedAuras",
+                destination = CardDestination.ToZone(Zone.HAND)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Tsutomu Kawade"
+        flavorText = "Tharashk the Bold suddenly wasn't himself. Or anyone else, for that matter."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg?1783943682"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TolsimirWolfblood.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/TolsimirWolfblood.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tolsimir Wolfblood
+ * {4}{G}{W}
+ * Legendary Creature — Elf Warrior
+ * 3/4
+ *
+ * Other green creatures you control get +1/+1.
+ * Other white creatures you control get +1/+1.
+ * {T}: Create Voja, a legendary 2/2 green and white Wolf creature token.
+ *
+ * Two separate lord lines rather than one "green or white" filter: a creature that is *both*
+ * green and white — Voja itself, or another Selesnya gold creature — matches both and so gets
+ * +2/+2, which is exactly the printed ruling of 2005-10-01. Collapsing them into a single
+ * colour-set filter would apply the bonus once and quietly halve it.
+ *
+ * The token is one of the few whose name is not its creature type: it is named "Voja" and its
+ * type is Wolf, so [Effects.CreateToken] gets both `name` and `creatureTypes` explicitly, plus
+ * `legendary = true` so a second copy meets the legend rule.
+ */
+val TolsimirWolfblood = card("Tolsimir Wolfblood") {
+    manaCost = "{4}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Legendary Creature — Elf Warrior"
+    oracleText = "Other green creatures you control get +1/+1.\n" +
+        "Other white creatures you control get +1/+1.\n" +
+        "{T}: Create Voja, a legendary 2/2 green and white Wolf creature token."
+    power = 3
+    toughness = 4
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.GREEN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.WHITE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Wolf"),
+            name = "Voja",
+            legendary = true,
+            imageUri = "https://cards.scryfall.io/normal/front/a/f/af8ba142-4f39-45e4-8872-b6e348fd760c.jpg?1783913148"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "236"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg?1783943608"
+        ruling(
+            "2005-10-01",
+            "Other creatures you control that are both green and white, including Voja, get +2/+2."
+        )
+        ruling(
+            "2005-10-01",
+            "The token is named \"Voja\" and has creature type \"Wolf.\" This is different from " +
+                "most creature tokens, where the name and creature type are the same."
+        )
+        ruling(
+            "2013-07-01",
+            "The \"legend rule\" means that creating a second Voja while one is already under " +
+                "your control will result in one of them being put into its owner's graveyard " +
+                "(where it promptly ceases to exist). You choose which of the two remains on the " +
+                "battlefield and which is put into the graveyard."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoebringerDemon.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoebringerDemon.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Woebringer Demon
+ * {3}{B}{B}
+ * Creature — Demon
+ * 4/4
+ *
+ * Flying
+ * At the beginning of each player's upkeep, that player sacrifices a creature of their choice.
+ * If the player can't, sacrifice this creature.
+ *
+ * "If the player can't" is read off the sacrifice that just happened, not off a board scan:
+ * [DynamicAmount.PermanentsSacrificedThisWay] counts what the edict earlier in this same
+ * composite actually took, so the fallback fires exactly when nothing was sacrificed. A board
+ * count would have to re-derive the same answer a step later, after the creature is already
+ * gone.
+ *
+ * On its own controller's upkeep the Demon is itself a legal sacrifice, so the edict always has
+ * something to take and the self-sacrifice clause only bites on an opponent's empty board.
+ */
+val WoebringerDemon = card("Woebringer Demon") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    oracleText = "Flying\n" +
+        "At the beginning of each player's upkeep, that player sacrifices a creature of their " +
+        "choice. If the player can't, sacrifice this creature."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        effect = Effects.Composite(
+            Effects.Sacrifice(
+                filter = GameObjectFilter.Creature,
+                count = 1,
+                target = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+            ),
+            GatedEffect(
+                gate = Gate.WhenCondition(
+                    Conditions.CompareAmounts(
+                        DynamicAmount.PermanentsSacrificedThisWay,
+                        ComparisonOperator.EQ,
+                        DynamicAmount.Fixed(0)
+                    )
+                ),
+                then = Effects.SacrificeTarget(EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Daren Bader"
+        flavorText = "Each soul he devours adds its hunger to his own."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg?1783943660"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConclavesBlessingScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConclavesBlessingScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Conclave's Blessing (RAV #11) — {3}{W} Enchantment — Aura, convoke.
+ *
+ * "Enchant creature. Enchanted creature gets +0/+2 for each other creature you control."
+ *
+ * "Other" is measured against the enchanted creature, which is what `excludeSelf` means on an
+ * aggregate evaluated for a *granted* effect — self there is the affected entity, not the Aura.
+ * The off-by-one that reading is guarding against is exactly one point of toughness, so the two
+ * counting tests below pin the number rather than the direction. "You" stays the Aura's
+ * controller, hence the stolen-host case.
+ */
+class ConclavesBlessingScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Conclave's Blessing") {
+
+            test("alone on the battlefield the host gets nothing — it is not its own \"other\"") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Conclave's Blessing", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("zero other creatures means +0/+0") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("+0/+2 for each other creature its controller controls") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardAttachedTo(1, "Conclave's Blessing", "Grizzly Bears")
+                    // Bob's creature must not be counted.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanents("Grizzly Bears")
+                    .first { game.state.projectedState.getController(it) == game.player1Id }
+
+                withClue("two other creatures Alice controls, so +0/+4") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getToughness(bears) shouldBe 6
+                }
+            }
+
+            test("on an opponent's creature it counts the Aura controller's creatures") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    // Bob's creature carries Alice's Aura.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Conclave's Blessing", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("\"you\" is Alice: her two creatures count, and the host is not among them") {
+                    game.state.projectedState.getToughness(bears) shouldBe 6
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FollowedFootstepsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FollowedFootstepsScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Followed Footsteps (RAV #51) — {3}{U}{U} Enchantment — Aura.
+ *
+ * "Enchant creature. At the beginning of your upkeep, create a token that's a copy of enchanted
+ * creature."
+ *
+ * The copy is taken from `EffectTarget.EnchantedCreature` at resolution, so the token is a copy
+ * of whatever the Aura is on *then* — and it is created under the Aura's controller, which is the
+ * case worth pinning: enchanting an opponent's creature hands *you* the copy, not them.
+ */
+class FollowedFootstepsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Followed Footsteps") {
+
+            test("copies the enchanted creature on its controller's upkeep") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Followed Footsteps", "Grizzly Bears")
+                    // Start on Bob's turn so the next upkeep reached is Alice's.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.findPermanents("Grizzly Bears").size shouldBe 1
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                val bears = game.findPermanents("Grizzly Bears")
+                withClue("a token copy joins the original") {
+                    bears.size shouldBe 2
+                    bears.forEach {
+                        game.state.projectedState.getPower(it) shouldBe 2
+                        game.state.projectedState.getToughness(it) shouldBe 2
+                    }
+                }
+            }
+
+            test("the token is created under the Aura's controller, even on a stolen host") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    // Bob's creature, Alice's Aura on it.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Followed Footsteps", "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                val bears = game.findPermanents("Grizzly Bears")
+                bears.size shouldBe 2
+                withClue("exactly one of the two is Alice's — the token she created") {
+                    bears.count { game.state.projectedState.getController(it) == game.player1Id } shouldBe 1
+                }
+            }
+
+            test("it does not fire on the opponent's upkeep") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Followed Footsteps", "Grizzly Bears")
+                    // Alice is active, so the next upkeep reached is Bob's.
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("\"your upkeep\" is Alice's, and this one is Bob's") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkOfEvictionScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkOfEvictionScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mark of Eviction (RAV #58) — {U} Enchantment — Aura.
+ *
+ * "Enchant creature. At the beginning of your upkeep, return enchanted creature and all Auras
+ * attached to that creature to their owners' hands."
+ *
+ * Mark of Eviction is itself one of those Auras, so a correct script bounces the card that wrote
+ * it. That recursion is what these tests pin, along with the ordering hazard behind it: the Auras
+ * are gathered into a collection *before* the host moves, so the later steps never have to read
+ * "enchanted creature" off an Aura that is already in hand. Each Aura goes to its own owner's
+ * hand, not to the ability controller's.
+ */
+class MarkOfEvictionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mark of Eviction") {
+
+            test("returns the host, the other Auras, and itself to their owners' hands") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Mark of Eviction", "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Grizzly Bears")
+                    // Start on Bob's turn so the next upkeep reached is Alice's.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("the enchanted creature goes back to its owner's hand") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 0
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("the other Aura on it rides along rather than dying unattached") {
+                    game.findPermanents("Holy Strength").size shouldBe 0
+                    game.isInHand(1, "Holy Strength") shouldBe true
+                }
+                withClue("Mark of Eviction is attached to that creature too, so it bounces itself") {
+                    game.findPermanents("Mark of Eviction").size shouldBe 0
+                    game.isInHand(1, "Mark of Eviction") shouldBe true
+                }
+            }
+
+            test("an opponent's Aura on the same creature goes to that opponent's hand") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Mark of Eviction", "Grizzly Bears")
+                    .withCardAttachedTo(2, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("\"their owners' hands\" — Bob owns Pacifism, so Bob gets it back") {
+                    game.findPermanents("Pacifism").size shouldBe 0
+                    game.isInHand(2, "Pacifism") shouldBe true
+                    game.isInHand(1, "Pacifism") shouldBe false
+                }
+            }
+
+            test("it does not fire on the opponent's upkeep") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Mark of Eviction", "Grizzly Bears")
+                    // Alice is active, so the next upkeep reached is Bob's.
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("\"your upkeep\" is the Aura controller's, and this one is Bob's") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                    game.findPermanents("Mark of Eviction").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebringerDemonScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebringerDemonScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Woebringer Demon (RAV #113) — {3}{B}{B} Creature — Demon 4/4, flying.
+ *
+ * "At the beginning of each player's upkeep, that player sacrifices a creature of their choice.
+ * If the player can't, sacrifice this creature."
+ *
+ * The whole card is the "can't" clause, and it is the half a board scan gets wrong: by the time
+ * a later step could count creatures, the edict has already taken one. The script instead reads
+ * `DynamicAmount.PermanentsSacrificedThisWay` — what this resolution actually took — so the
+ * fallback fires exactly when the edict came up empty. Both directions are pinned below: an
+ * opponent with an empty board kills the Demon, and an opponent with one creature does not.
+ */
+class WoebringerDemonScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        return d
+    }
+
+    fun GameTestDriver.advanceToUpkeepOf(player: EntityId) {
+        passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        if (activePlayer != player) {
+            passPriorityUntil(Step.DRAW, maxPasses = 200)
+            passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        }
+        currentStep shouldBe Step.UPKEEP
+        activePlayer shouldBe player
+    }
+
+    test("an opponent who controls no creature can't sacrifice, so the Demon is sacrificed") {
+        val d = driver()
+        val controller = d.player1
+        val opponent = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val demon = d.putCreatureOnBattlefield(controller, "Woebringer Demon")
+
+        d.advanceToUpkeepOf(opponent)
+        d.stackSize shouldBe 1
+        d.bothPass()
+
+        withClue("nothing was sacrificed this way, so the fallback takes the Demon") {
+            d.state.getBattlefield().contains(demon) shouldBe false
+            d.getGraveyard(controller).contains(demon) shouldBe true
+        }
+    }
+
+    test("an opponent who controls a creature sacrifices it and the Demon survives") {
+        val d = driver()
+        val controller = d.player1
+        val opponent = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val demon = d.putCreatureOnBattlefield(controller, "Woebringer Demon")
+        val bear = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.advanceToUpkeepOf(opponent)
+        d.stackSize shouldBe 1
+        d.bothPass()
+
+        withClue("one legal sacrifice needs no prompt — the bear goes, the Demon stays") {
+            d.state.getBattlefield().contains(bear) shouldBe false
+            d.state.getBattlefield().contains(demon) shouldBe true
+        }
+    }
+
+    test("on its controller's upkeep the choice is theirs, and it need not be the Demon") {
+        val d = driver()
+        val controller = d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val demon = d.putCreatureOnBattlefield(controller, "Woebringer Demon")
+        val bear = d.putCreatureOnBattlefield(controller, "Grizzly Bears")
+        // The opponent's upkeep comes first and must not eat the Demon on the way past, so give
+        // them a creature of their own to feed the edict.
+        d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+
+        d.advanceToUpkeepOf(controller)
+        d.stackSize shouldBe 1
+        d.bothPass()
+
+        val decision = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe controller
+        d.submitCardSelection(controller, listOf(bear))
+
+        withClue("the Demon is itself a legal sacrifice, so its controller is never forced to lose it") {
+            d.state.getBattlefield().contains(bear) shouldBe false
+            d.state.getBattlefield().contains(demon) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1487,6 +1487,66 @@
     ]
 }
 
+// Conclave's Blessing
+{
+    "name": "Conclave's Blessing",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEnchant creature\nEnchanted creature gets +0/+2 for each other creature you control.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "toughnessBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    },
+                    "multiplier": 2
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Shishizaru",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86235d9f-ba69-417d-9203-812ab428b374.jpg?1783943702",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Congregation at Dawn
 {
     "name": "Congregation at Dawn",
@@ -3301,6 +3361,56 @@
         "artist": "Dan Murayama Scott",
         "flavorText": "\"A system to direct the flow of Ravnica's entire water supply? Thinking a bit small, aren't we?\"\n—Trivaz, Izzet mage",
         "imageUri": "https://cards.scryfall.io/normal/front/2/7/27203b79-b383-4698-8b81-b6198c51c2f6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Followed Footsteps
+{
+    "name": "Followed Footsteps",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nAt the beginning of your upkeep, create a token that's a copy of enchanted creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": "EnchantedCreature"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Glen Angus",
+        "flavorText": "Æther can turn a footprint into a blueprint.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d00e2fcc-0fa2-451e-8c69-7a24ba533e0b.jpg?1783943685",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "Any \"enters\" abilities of the copied creature trigger when the creature tokens enter the battlefield. The creature tokens also have any \"this enters with\" or \"as this enters\" abilities that the copied creature has."
+            },
+            {
+                "date": "2007-02-01",
+                "text": "If Followed Footsteps moves after it has triggered, you get a copy of the newly-enchanted creature."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -5640,6 +5750,69 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Mark of Eviction
+{
+    "name": "Mark of Eviction",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nAt the beginning of your upkeep, return enchanted creature and all Auras attached to that creature to their owners' hands.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "AttachedToTarget",
+                                "host": "EnchantedCreature",
+                                "filter": "permanent Aura"
+                            },
+                            "storeAs": "evictedAuras"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": "EnchantedCreature",
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "evictedAuras",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Tsutomu Kawade",
+        "flavorText": "Tharashk the Bold suddenly wasn't himself. Or anyone else, for that matter.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae826236-e591-4afb-817b-0017a11010ad.jpg?1783943682"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -8984,6 +9157,85 @@
     ]
 }
 
+// Tolsimir Wolfblood
+{
+    "name": "Tolsimir Wolfblood",
+    "manaCost": "{4}{G}{W}",
+    "typeLine": "Legendary Creature — Elf Warrior",
+    "oracleText": "Other green creatures you control get +1/+1.\nOther white creatures you control get +1/+1.\n{T}: Create Voja, a legendary 2/2 green and white Wolf creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "name": "Voja",
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/f/af8ba142-4f39-45e4-8872-b6e348fd760c.jpg?1783913148",
+                    "legendary": true
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature green ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature white ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "RARE",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/069ac859-e0ef-4685-bad3-5c741102b5b9.jpg?1783943608",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "Other creatures you control that are both green and white, including Voja, get +2/+2."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "The token is named \"Voja\" and has creature type \"Wolf.\" This is different from most creature tokens, where the name and creature type are the same."
+            },
+            {
+                "date": "2013-07-01",
+                "text": "The \"legend rule\" means that creating a second Voja while one is already under your control will result in one of them being put into its owner's graveyard (where it promptly ceases to exist). You choose which of the two remains on the battlefield and which is put into the graveyard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Torpid Moloch
 {
     "name": "Torpid Moloch",
@@ -10112,6 +10364,76 @@
     },
     "colorIdentityOverride": [
         "BLUE",
+        "BLACK"
+    ]
+}
+
+// Woebringer Demon
+{
+    "name": "Woebringer Demon",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\nAt the beginning of each player's upkeep, that player sacrifices a creature of their choice. If the player can't, sacrifice this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForceSacrifice",
+                            "filter": "creature",
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "TriggeringPlayer"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": "PermanentsSacrificedThisWay",
+                                    "operator": "EQ",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "SacrificeTarget",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "RARE",
+        "artist": "Daren Bader",
+        "flavorText": "Each soul he devours adds its hunger to his own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg?1783943660"
+    },
+    "colorIdentityOverride": [
         "BLACK"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -198,7 +198,14 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 // Intersect the host's live attachments with the projected filter matches so
                 // type/control-changing effects are respected (e.g. "Equipment attached to that
                 // creature"). Empty when the host left play or has no matching attachments.
-                val hostId = context.resolveTarget(source.host)
+                //
+                // State-aware resolution: the host is often a *relational* reference — "enchanted
+                // creature" (Mark of Eviction's "all Auras attached to that creature") is read off
+                // the source's own attachment link, which only the `state` overload knows how to
+                // follow. The stateless overload returns null for those and the gather silently
+                // yields nothing; it is a strict subset of this one, so every other host shape
+                // resolves exactly as before.
+                val hostId = context.resolveTarget(source.host, state)
                 val attachedIds = hostId
                     ?.let { state.getEntity(it)?.get<AttachmentsComponent>()?.attachedIds }
                     ?: emptyList()


### PR DESCRIPTION
Five RAV cards, all built from existing primitives, plus the one engine fix the batch surfaced.

## Cards

- **Conclave's Blessing** ({3}{W} Aura, convoke) — `GrantDynamicStatsEffect` over a doubled `AggregateBattlefield` count. "Other" is the *enchanted* creature: `excludeSelf` on an aggregate evaluated for a granted effect means the affected entity, not the Aura.
- **Followed Footsteps** ({3}{U}{U} Aura) — `Triggers.YourUpkeep` + `Effects.CreateTokenCopyOfTarget(EnchantedCreature)`. The copy is read at resolution, so the Aura moving between trigger and resolution copies the new host (ruling of 2007-02-01).
- **Mark of Eviction** ({U} Aura) — `GatherCards(AttachedTo)` → `ReturnToHand(EnchantedCreature)` → `MoveCollection(→ hand)`. It is itself an Aura on that creature, so it bounces itself; gathering before the host moves is what keeps the later steps off a stale attachment read.
- **Tolsimir Wolfblood** ({4}{G}{W} 3/4 legend) — two separate `ModifyStats` lord lines so a green *and* white creature gets +2/+2, per the printed ruling; `Effects.CreateToken` with an explicit `name` for Voja, whose name is not its creature type.
- **Woebringer Demon** ({3}{B}{B} 4/4) — `ForceSacrifice` on `Player.TriggeringPlayer`, then a `Gate.WhenCondition` on `DynamicAmount.PermanentsSacrificedThisWay == 0` for "if the player can't". Reads what the edict took rather than re-scanning a board the edict has already changed.

## Engine fix

`CardSource.AttachedTo` resolved its host through the stateless `resolveTarget` overload, which returns null for every relational reference (`EnchantedCreature`, `EquippedCreature`, `EnchantedPermanent`, `ChosenCreature`) — so such a gather silently yielded nothing and the pipeline moved an empty collection. Switched to the state-aware overload, which is a strict superset. Found by Mark of Eviction; no other card in the corpus used a relational host here, which is why it had gone unnoticed.

## Verification

- `just build` — green (`:mtg-sets:test` included, RAV golden re-blessed; only the five new cards move).
- `just test-rules` — green (engine tests + the whole scenario suite, for the executor change).
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent.
- `just check-card-printing` — clean for all five; RAV is the earliest real printing of each.
- Four scenario tests (`ConclavesBlessing`, `FollowedFootsteps`, `MarkOfEviction`, `WoebringerDemon`), one file per card. Tolsimir is plain lords plus a token and is covered by the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6