### PR TITLE
Add 65 Assay-ready cards to Kaldheim

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredForestReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredForestReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Forest reprint in CSP. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredForestReprint = Printing(
+    oracleId = "5f0d3be8-e63e-4ade-ae58-6b0c14f2ce6d",
+    name = "Snow-Covered Forest",
+    setCode = "CSP",
+    collectorNumber = "155",
+    scryfallId = "838c915d-8153-43c2-b513-dfbe4e9388a5",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/838c915d-8153-43c2-b513-dfbe4e9388a5.jpg",
+    releaseDate = "2006-07-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredIslandReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredIslandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Island reprint in CSP. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredIslandReprint = Printing(
+    oracleId = "5b2460a5-6ae5-4cad-ba94-1a9e98e6e4c0",
+    name = "Snow-Covered Island",
+    setCode = "CSP",
+    collectorNumber = "152",
+    scryfallId = "6abf0692-07d1-4b72-af06-93d0e338589d",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6abf0692-07d1-4b72-af06-93d0e338589d.jpg",
+    releaseDate = "2006-07-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredMountainReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredMountainReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Mountain reprint in CSP. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredMountainReprint = Printing(
+    oracleId = "ca9f660b-e07d-4f42-a46e-abd0ca72510c",
+    name = "Snow-Covered Mountain",
+    setCode = "CSP",
+    collectorNumber = "154",
+    scryfallId = "0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79",
+    artist = "John Zeleznik",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0dc9a6d1-a1ca-4b8f-894d-71c2a9933f79.jpg",
+    releaseDate = "2006-07-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredPlainsReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredPlainsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Plains reprint in CSP. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredPlainsReprint = Printing(
+    oracleId = "ac8cc74d-e43b-4118-bba0-dfa8b9c04d45",
+    name = "Snow-Covered Plains",
+    setCode = "CSP",
+    collectorNumber = "151",
+    scryfallId = "b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a",
+    artist = "Mark Romanoski",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b1e3a010-dae3-41b6-8dd8-e31d14c3ac4a.jpg",
+    releaseDate = "2006-07-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredSwampReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SnowCoveredSwampReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Swamp reprint in CSP. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredSwampReprint = Printing(
+    oracleId = "d8239a86-7184-4005-ba1e-2dddcd756c47",
+    name = "Snow-Covered Swamp",
+    setCode = "CSP",
+    collectorNumber = "153",
+    scryfallId = "c4dacaf1-09b8-42bb-8064-990190fdaf81",
+    artist = "Rob Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4dacaf1-09b8-42bb-8064-990190fdaf81.jpg",
+    releaseDate = "2006-07-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElderleafMentorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElderleafMentorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elderleaf Mentor reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val ElderleafMentorReprint = Printing(
+    oracleId = "3795fc31-2369-47d0-b9c9-120f44b8f114",
+    name = "Elderleaf Mentor",
+    setCode = "J22",
+    collectorNumber = "652",
+    scryfallId = "a175c5cf-b33d-481d-b093-57072f6f671e",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a175c5cf-b33d-481d-b093-57072f6f671e.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElvishWarmasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElvishWarmasterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elvish Warmaster reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val ElvishWarmasterReprint = Printing(
+    oracleId = "bda83ef4-e345-495d-878c-4da171f997ba",
+    name = "Elvish Warmaster",
+    setCode = "J22",
+    collectorNumber = "654",
+    scryfallId = "3bc94b52-1cb1-4c1e-8b17-5632abc2490d",
+    artist = "Alexander Mokhov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3bc94b52-1cb1-4c1e-8b17-5632abc2490d.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KarfellKennelMasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KarfellKennelMasterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Karfell Kennel-Master reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val KarfellKennelMasterReprint = Printing(
+    oracleId = "2cde1ca7-d126-4d3a-82a6-0acfd7c85cdb",
+    name = "Karfell Kennel-Master",
+    setCode = "J22",
+    collectorNumber = "430",
+    scryfallId = "1f2e14c7-1bee-4bc6-ad26-03dc55e149d5",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1f2e14c7-1bee-4bc6-ad26-03dc55e149d5.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/KaldheimSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/KaldheimSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.khm
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -22,11 +21,14 @@ object KaldheimSet : MtgSet {
     override val displayName = "Kaldheim"
     override val releaseDate = "2021-02-05"
     override val block = "Kaldheim"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/AlpineMeadow.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/AlpineMeadow.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Alpine Meadow
+ *
+ * Snow Land — Mountain Plains
+ * ({T}: Add {R} or {W}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val AlpineMeadow = card("Alpine Meadow") {
+    manaCost = ""
+    colorIdentity = "RW"
+    typeLine = "Snow Land — Mountain Plains"
+    oracleText = "({T}: Add {R} or {W}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "248"
+        artist = "Piotr Dura"
+        flavorText = "\"Here perished Rognar the Reckless after his hundred-day battle with the Ironmaw Dragon. We raised these stones to mark his resting place.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ArcticTreeline.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ArcticTreeline.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Arctic Treeline
+ *
+ * Snow Land — Forest Plains
+ * ({T}: Add {G} or {W}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val ArcticTreeline = card("Arctic Treeline") {
+    manaCost = ""
+    colorIdentity = "GW"
+    typeLine = "Snow Land — Forest Plains"
+    oracleText = "({T}: Add {G} or {W}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Alayna Danner"
+        flavorText = "\"When the Light of Starnheim shines here, every frost-edged needle glitters with the reflected glory of the Cosmos.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/AuguryRaven.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/AuguryRaven.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Augury Raven
+ * {3}{U}
+ * Creature — Bird
+ * 3/3
+ * Flying
+ * Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Foretell is the card's only structural part — the printed `Keyword.FORETELL` is display-only,
+ * so it is lowered into [KeywordAbility.foretell], which the engine's ForetellEnumerator reads to
+ * offer the pay-{2}-and-exile special action and the later cast from exile for the foretell cost.
+ * The card builder derives the printed keyword back out of that ability.
+ */
+val AuguryRaven = card("Augury Raven") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying\n" +
+        "Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.foretell("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Jesper Ejsing"
+        flavorText = "Some ravens collect shiny baubles; others hoard omens and secrets."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BattlefieldRaptor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BattlefieldRaptor.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battlefield Raptor
+ * {W}
+ * Creature — Bird
+ * 1/2
+ * Flying, first strike
+ * */
+val BattlefieldRaptor = card("Battlefield Raptor") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying, first strike"
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Mike Bierek"
+        flavorText = "It wheeled upward, away from the shrieks and thunder. It reached the point where sky met smoke, and, with but a glance at the horizon, aimed itself and dove."
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BeholdTheMultiverse.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BeholdTheMultiverse.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Behold the Multiverse
+ * {3}{U}
+ * Instant
+ * Scry 2, then draw two cards.
+ * Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Two library primitives in sequence — the scry resolves before the draw, so the cards it
+ * arranges are the ones drawn. Foretell is lowered into [KeywordAbility.foretell]; the printed
+ * `Keyword.FORETELL` is display-only and the card builder derives it back from the ability.
+ */
+val BeholdTheMultiverse = card("Behold the Multiverse") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Scry 2, then draw two cards.\n" +
+        "Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Scry(2),
+            Effects.DrawCards(2)
+        )
+    }
+
+    keywordAbility(KeywordAbility.foretell("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Magali Villeneuve"
+        flavorText = "Countless worlds unfolded before Niko, every one in need of heroes."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BeskirShieldmate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BeskirShieldmate.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beskir Shieldmate
+ * {1}{W}
+ * Creature — Human Warrior
+ * 2/1
+ * When this creature dies, create a 1/1 white Human Warrior creature token.
+ *
+ * A plain dies trigger. [Triggers.Dies] already fires from the graveyard, so the token is created
+ * after the Shieldmate has left the battlefield.
+ */
+val BeskirShieldmate = card("Beskir Shieldmate") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    oracleText = "When this creature dies, create a 1/1 white Human Warrior creature token."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human", "Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Manuel Castañón"
+        flavorText = "\"If we fall today, let us fall with honor, defending our realm from the horrors that would defile it. Forward, shieldmates! To Starnheim!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BreakneckBerserker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BreakneckBerserker.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Breakneck Berserker
+ * {2}{R}
+ * Creature — Dwarf Berserker
+ * 3/2
+ * Haste
+ * */
+val BreakneckBerserker = card("Breakneck Berserker") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Berserker"
+    oracleText = "Haste"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Scott Murphy"
+        flavorText = "\"Go for the knees! The last giant who tried to get past us got rolled back down the mountain in a dozen pieces.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BrinebarrowIntruder.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BrinebarrowIntruder.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brinebarrow Intruder
+ * {U}
+ * Creature — Human Rogue
+ * 1/2
+ * Flash
+ * When this creature enters, target creature an opponent controls gets -2/-0 until end of turn.
+ *
+ * Flash plus a targeted enters trigger: cast during combat, the -2/-0 shrinks an attacker or
+ * blocker before damage. The -0 toughness half is written out so the modifier reads as printed.
+ */
+val BrinebarrowIntruder = card("Brinebarrow Intruder") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "Flash\n" +
+        "When this creature enters, target creature an opponent controls gets -2/-0 until end of turn."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-2, 0, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Scott Murphy"
+        flavorText = "Locked in the ice of Karfell, the treasures of ancient nobles await in ruins guarded by the dead."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/CanopyTactician.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/CanopyTactician.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Canopy Tactician
+ * {3}{G}
+ * Creature — Elf Warrior
+ * 3/3
+ * Other Elves you control get +1/+1.
+ * {T}: Add {G}{G}{G}.
+ *
+ * An Elf lord that is also a three-mana rock. The lord filter is [GameObjectFilter.Permanent]
+ * rather than `.Creature` because the printed line says "Other Elves", which reaches a noncreature
+ * Elf permanent too; `excludeSelf = true` carries the printed "Other".
+ */
+val CanopyTactician = card("Canopy Tactician") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "Other Elves you control get +1/+1.\n" +
+        "{T}: Add {G}{G}{G}."
+    power = 3
+    toughness = 3
+
+    // Other Elves you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.ELF).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    // {T}: Add {G}{G}{G}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 3)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "378"
+        artist = "Ekaterina Burmak"
+        flavorText = "\"Death and life are two ends of the same spear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ClarionSpirit.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ClarionSpirit.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Clarion Spirit
+ * {1}{W}
+ * Creature — Spirit
+ * 2/2
+ * Whenever you cast your second spell each turn, create a 1/1 white Spirit creature token with flying.
+ *
+ * "Whenever you cast your second spell each turn" is [Triggers.NthSpellCast] with n = 2 scoped to
+ * [Player.You] — the engine already tracks each player's per-turn cast count, so the ordinal needs
+ * no bookkeeping on the card.
+ */
+val ClarionSpirit = card("Clarion Spirit") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast your second spell each turn, create a 1/1 white Spirit creature token with flying."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "To the living, the horn sounds faint and mournful, but to the spirits of Istfell, it is a thunderous call that must be obeyed."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DepartTheRealm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DepartTheRealm.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Depart the Realm
+ * {1}{U}
+ * Instant
+ * Return target nonland permanent to its owner's hand.
+ * Foretell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A one-effect bounce spell whose foretell cost is a single {U} — the cheapest way to pay for it
+ * is to foretell on an earlier turn, which is exactly what [KeywordAbility.foretell] models.
+ */
+val DepartTheRealm = card("Depart the Realm") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent to its owner's hand.\n" +
+        "Foretell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        val victim = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(victim)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Denman Rooke"
+        flavorText = "\"My home calls to me, I must go.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoggedPursuit.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoggedPursuit.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dogged Pursuit
+ * {3}{B}
+ * Enchantment
+ * At the beginning of your end step, each opponent loses 1 life and you gain 1 life.
+ *
+ * A drain-on-a-stick enchantment. The two halves are separate effects rather than a single drain
+ * so that the life loss reaches every opponent ([Player.EachOpponent]) while the gain stays fixed
+ * at 1 for the controller — a multiplayer game drains each opponent but still gains only 1.
+ */
+val DoggedPursuit = card("Dogged Pursuit") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your end step, each opponent loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Jason Rainville"
+        flavorText = "Kaya had stalked countless horrific foes, but never one that killed with such callous precision and twisted creativity."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Doomskar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Doomskar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Doomskar
+ * {3}{W}{W}
+ * Sorcery
+ * Destroy all creatures.
+ * Foretell {1}{W}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A wrath whose whole point is the foretell line: exiling it face down on turn three hides the
+ * board wipe, and [KeywordAbility.foretell] is what lets the engine offer the later {1}{W}{W} cast
+ * from exile.
+ */
+val Doomskar = card("Doomskar") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all creatures.\n" +
+        "Foretell {1}{W}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{1}{W}{W}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Piotr Dura"
+        flavorText = "The realms crashed together, with Bretagard at the center of the calamity."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoomskarOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoomskarOracle.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Doomskar Oracle
+ * {2}{W}
+ * Creature — Human Cleric
+ * 3/2
+ * Whenever you cast your second spell each turn, you gain 2 life.
+ * Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * The second-spell ordinal is [Triggers.NthSpellCast] with n = 2 scoped to [Player.You]; the
+ * engine tracks each player's per-turn cast count, so no bookkeeping lives on the card. Foretell
+ * is lowered into [KeywordAbility.foretell] — it is a real cast, so it advances that count.
+ */
+val DoomskarOracle = card("Doomskar Oracle") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Whenever you cast your second spell each turn, you gain 2 life.\n" +
+        "Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Effects.GainLife(2)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Taylor Ingvarsson"
+        flavorText = "\"Giants and monsters loom on the horizon, and the elves plan to murder our gods!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoomskarTitan.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DoomskarTitan.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Doomskar Titan
+ * {4}{R}{R}
+ * Creature — Giant Berserker
+ * 4/4
+ * When this creature enters, creatures you control get +1/+0 and gain haste until end of turn.
+ * Foretell {4}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * The pump and the haste grant are one [Patterns.Group.pumpAndGrantToAll] pass, not a composite of
+ * two group walks: the printed sentence names its group once, and gathering it twice would let a
+ * P/T-sensitive filter match a different set on the second pass.
+ */
+val DoomskarTitan = card("Doomskar Titan") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Berserker"
+    oracleText = "When this creature enters, creatures you control get +1/+0 and gain haste until end of turn.\n" +
+        "Foretell {4}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 1,
+            toughness = 0,
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    keywordAbility(KeywordAbility.foretell("{4}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DwarvenReinforcements.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DwarvenReinforcements.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Dwarven Reinforcements
+ * {3}{R}
+ * Sorcery
+ * Create two 2/1 red Dwarf Berserker creature tokens.
+ * Foretell {1}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A two-token sorcery whose foretell cost undercuts its printed one by two generic — the standard
+ * Kaldheim tempo trade that [KeywordAbility.foretell] models.
+ */
+val DwarvenReinforcements = card("Dwarven Reinforcements") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create two 2/1 red Dwarf Berserker creature tokens.\n" +
+        "Foretell {1}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dwarf", "Berserker"),
+            count = 2
+        )
+    }
+
+    keywordAbility(KeywordAbility.foretell("{1}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Orders? We don't wait for orders!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElderfangDisciple.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElderfangDisciple.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elderfang Disciple
+ * {1}{B}
+ * Creature — Elf Cleric
+ * 1/1
+ * When this creature enters, each opponent discards a card.
+ *
+ * [Effects.EachOpponentDiscards] is the shared gather -> choose -> discard pipeline, one iteration
+ * per opponent, so each opponent picks their own card rather than the Disciple's controller picking
+ * for them.
+ */
+val ElderfangDisciple = card("Elderfang Disciple") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elf Cleric"
+    oracleText = "When this creature enters, each opponent discards a card."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.EachOpponentDiscards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Miranda Meeks"
+        flavorText = "\"One day, the great serpent will rejoin us on Skemfar, and those who've wronged us will taste of our venom.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElderleafMentor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElderleafMentor.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elderleaf Mentor
+ * {3}{G}
+ * Creature — Elf Warrior
+ * 3/2
+ * When this creature enters, create a 1/1 green Elf Warrior creature token.
+ *
+ * Four mana for two Elf Warrior bodies — the common that feeds Kaldheim's Elf count.
+ */
+val ElderleafMentor = card("Elderleaf Mentor") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "When this creature enters, create a 1/1 green Elf Warrior creature token."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf", "Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Zoltan Boros"
+        flavorText = "\"Our ancestors grew complacent in their divinity, allowing their lessers to topple them. Never again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElvenAmbush.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElvenAmbush.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Elven Ambush
+ * {3}{G}
+ * Instant
+ * Create a 1/1 green Elf Warrior creature token for each Elf you control.
+ *
+ * The token count is read at resolution from the battlefield, so the Elves counted are the ones
+ * present when the spell resolves — and because the count is over Elf *permanents*, a noncreature
+ * Elf would count too, exactly as the printed "each Elf you control" says.
+ */
+val ElvenAmbush = card("Elven Ambush") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Create a 1/1 green Elf Warrior creature token for each Elf you control."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Permanent.withSubtype(Subtype.ELF)
+            ).count(),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf", "Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "391"
+        artist = "Chris Seaman"
+        flavorText = "\"No elf can match a Tuskeri in combat. Why not charge?\"\n" +
+            "—Knorjolvin, Tuskeri raider"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElvishWarmaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ElvishWarmaster.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Elvish Warmaster
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 2/2
+ * Whenever one or more other Elves you control enter, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.
+ * {5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.
+ *
+ * Two details carry the printed text:
+ *
+ *  - **"one or more other Elves"** is the batching [Triggers.OneOrMorePermanentsEnter] with
+ *    `excludeSource = true`, so a single mass-entry makes one token, not one per Elf, and the
+ *    Warmaster's own arrival never counts.
+ *  - **"This ability triggers only once each turn"** is the builder's `oncePerTurn` flag, which the
+ *    engine's TriggerDetector enforces per `(sourceId, abilityId)` and resets each turn.
+ *
+ * The activated pump is one [Patterns.Group.pumpAndGrantToAll] pass for the same reason as every
+ * other "get +N/+N and gain <keyword>" line: the sentence names its group once.
+ */
+val ElvishWarmaster = card("Elvish Warmaster") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "Whenever one or more other Elves you control enter, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n" +
+        "{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn."
+    power = 2
+    toughness = 2
+
+    // Whenever one or more other Elves you control enter, create a 1/1 green Elf Warrior token.
+    triggeredAbility {
+        trigger = Triggers.OneOrMorePermanentsEnter(
+            GameObjectFilter.Permanent.withSubtype(Subtype.ELF).youControl(),
+            excludeSource = true
+        )
+        oncePerTurn = true
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf", "Warrior")
+        )
+    }
+
+    // {5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}{G}")
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 2,
+            toughness = 2,
+            keyword = Keyword.DEATHTOUCH,
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ELF).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FeedTheSerpent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FeedTheSerpent.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feed the Serpent
+ * {2}{B}{B}
+ * Instant
+ * Exile target creature or planeswalker.
+ *
+ * Unconditional exile at instant speed — no "destroy", so indestructible and regeneration are both
+ * irrelevant, and the permanent leaves without a dies trigger.
+ */
+val FeedTheSerpent = card("Feed the Serpent") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target creature or planeswalker."
+
+    spell {
+        val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Exile(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Nicholas Gregory"
+        flavorText = "He spent the final moments of his existence tumbling down the length of the serpent's jaws, driven mad by the magnitude of the Cosmos."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FirjaJudgeOfValor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FirjaJudgeOfValor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Firja, Judge of Valor
+ * {2}{W}{B}{B}
+ * Legendary Creature — Angel Cleric
+ * 2/4
+ * Flying, lifelink
+ * Whenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+ *
+ * The payoff is [Patterns.Library.lookAtTopAndKeep] at its defaults — gather three, choose exactly
+ * one for hand, remainder to the graveyard. The "second spell" ordinal is [Triggers.NthSpellCast]
+ * with n = 2 scoped to [Player.You]; the engine already tracks each player's per-turn cast count.
+ */
+val FirjaJudgeOfValor = card("Firja, Judge of Valor") {
+    manaCost = "{2}{W}{B}{B}"
+    colorIdentity = "BW"
+    typeLine = "Legendary Creature — Angel Cleric"
+    oracleText = "Flying, lifelink\n" +
+        "Whenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(2, Player.You)
+        effect = Patterns.Library.lookAtTopAndKeep(count = 3, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Livia Prima"
+        flavorText = "She is both shepherd and reaper, and her judgment is final."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FuneralLongboat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FuneralLongboat.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Funeral Longboat
+ * {2}
+ * Artifact — Vehicle
+ * 3/3
+ * Vigilance
+ * Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)
+ *
+ * A Vehicle: not a creature until crewed. Crew is a real ability the engine reads, so it is lowered
+ * into [KeywordAbility.crew] rather than left as the display-only `Keyword.CREW` — the card builder
+ * derives the printed keyword back out of the ability.
+ */
+val FuneralLongboat = card("Funeral Longboat") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Vigilance\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.VIGILANCE)
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Donato Giancola"
+        flavorText = "\"Cast onto the windless water, he drifted until the sea turned to sky.\"\n" +
+            "—*Saga of the Lost King*"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GatesOfIstfell.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GatesOfIstfell.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Gates of Istfell
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W}.
+ * {2}{W}{U}{U}, {T}, Sacrifice this land: You gain 2 life and draw two cards.
+ *
+ * One of Kaldheim's five "realm" lands: a tapped mono-colour source with an expensive sacrifice
+ * ability in two colours. The sacrifice is part of the cost, so the land is already gone when the
+ * draw resolves and countering the ability does not give it back.
+ */
+val GatesOfIstfell = card("Gates of Istfell") {
+    manaCost = ""
+    colorIdentity = "UW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W}.\n" +
+        "{2}{W}{U}{U}, {T}, Sacrifice this land: You gain 2 life and draw two cards."
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {W}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE, 1)
+        manaAbility = true
+    }
+
+    // {2}{W}{U}{U}, {T}, Sacrifice this land: You gain 2 life and draw two cards.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{W}{U}{U}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Composite(
+            Effects.GainLife(2),
+            Effects.DrawCards(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Anastasia Ovchinnikova"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GlacialFloodplain.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GlacialFloodplain.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Glacial Floodplain
+ *
+ * Snow Land — Plains Island
+ * ({T}: Add {W} or {U}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val GlacialFloodplain = card("Glacial Floodplain") {
+    manaCost = ""
+    colorIdentity = "UW"
+    typeLine = "Snow Land — Plains Island"
+    oracleText = "({T}: Add {W} or {U}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Sarah Finnigan"
+        flavorText = "\"A cliff once rose from the surf here—until Bjora Dawn-Greeter declared that it was blocking her view and pulled it down bare-handed.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GnottvoldRecluse.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GnottvoldRecluse.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnottvold Recluse
+ * {2}{G}
+ * Creature — Spider
+ * 4/2
+ * Reach
+ * */
+val GnottvoldRecluse = card("Gnottvold Recluse") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Reach"
+    power = 4
+    toughness = 2
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Nicholas Gregory"
+        flavorText = "Fed up with webs impeding travelers in other realms, Kolvori banished the giant spiders to Gnottvold, where their webs snare only the occasional rampaging troll."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GnottvoldSlumbermound.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GnottvoldSlumbermound.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Gnottvold Slumbermound
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {3}{R}{G}{G}, {T}, Sacrifice this land: Destroy target land. Create a 4/4 green Troll Warrior creature token with trample.
+ *
+ * The Gruul realm land: a Stone Rain stapled to a 4/4 trampler. The land sacrifices itself as part
+ * of the cost, so the target land is destroyed by an ability whose source has already left the
+ * battlefield.
+ */
+val GnottvoldSlumbermound = card("Gnottvold Slumbermound") {
+    manaCost = ""
+    colorIdentity = "GR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R}.\n" +
+        "{3}{R}{G}{G}, {T}, Sacrifice this land: Destroy target land. Create a 4/4 green Troll Warrior creature token with trample."
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {R}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED, 1)
+        manaAbility = true
+    }
+
+    // {3}{R}{G}{G}, {T}, Sacrifice this land: Destroy target land. Create a 4/4 green Troll
+    // Warrior creature token with trample.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{R}{G}{G}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        val victim = target("target land", Targets.Land)
+        effect = Effects.Composite(
+            Effects.Destroy(victim),
+            Effects.CreateToken(
+                power = 4,
+                toughness = 4,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Troll", "Warrior"),
+                keywords = setOf(Keyword.TRAMPLE)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GodsHallGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GodsHallGuardian.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Gods' Hall Guardian
+ * {5}{W}
+ * Creature — Cat
+ * 3/6
+ * Vigilance
+ * Foretell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Foretell is the card's only structural part — the printed `Keyword.FORETELL` is display-only,
+ * so it is lowered into [KeywordAbility.foretell], which the engine's ForetellEnumerator reads to
+ * offer the pay-{2}-and-exile special action and the later cast from exile for the foretell cost.
+ * The card builder derives the printed keyword back out of that ability.
+ */
+val GodsHallGuardian = card("Gods' Hall Guardian") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    oracleText = "Vigilance\n" +
+        "Foretell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 3
+    toughness = 6
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.foretell("{3}{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "Not a single rat has been seen in Istfell since the gods moved in."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GuardianGladewalker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GuardianGladewalker.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guardian Gladewalker
+ * {1}{G}
+ * Creature — Shapeshifter
+ * 1/1
+ * Changeling (This card is every creature type.)
+ * When this creature enters, put a +1/+1 counter on target creature.
+ *
+ * Changeling is a characteristic-defining ability the engine's StateProjector reads straight off
+ * `Keyword.CHANGELING`, so the Gladewalker is every creature type in every zone — which is what makes
+ * a 1/1 for two an Elf, a Dwarf and a Shapeshifter at once.
+ */
+val GuardianGladewalker = card("Guardian Gladewalker") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "When this creature enters, put a +1/+1 counter on target creature."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.CHANGELING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val recipient = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, recipient)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Mila Pesic"
+        flavorText = "The raiders' only warning was a whisper floating through the mist: \"Trespassers.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/IceTunnel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/IceTunnel.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Ice Tunnel
+ *
+ * Snow Land — Island Swamp
+ * ({T}: Add {U} or {B}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val IceTunnel = card("Ice Tunnel") {
+    manaCost = ""
+    colorIdentity = "BU"
+    typeLine = "Snow Land — Island Swamp"
+    oracleText = "({T}: Add {U} or {B}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Johannes Voss"
+        flavorText = "\"The ice cracked underfoot; strange shapes swam beneath the surface. Who else has walked this blighted path?\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/IronVerdict.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/IronVerdict.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Iron Verdict
+ * {2}{W}
+ * Instant
+ * Iron Verdict deals 5 damage to target tapped creature.
+ * Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A punisher for attackers: the tapped restriction lives in the target requirement, so an untapped
+ * creature is not a legal target at all rather than being targeted and then spared.
+ */
+val IronVerdict = card("Iron Verdict") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Iron Verdict deals 5 damage to target tapped creature.\n" +
+        "Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        val victim = target("target tapped creature", Targets.TappedCreature)
+        effect = Effects.DealDamage(5, victim)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Bryan Sola"
+        flavorText = "\"You'll raid nothing but mist in Istfell.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/JasperaSentinel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/JasperaSentinel.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Jaspera Sentinel
+ * {G}
+ * Creature — Elf Rogue
+ * 1/2
+ * Reach
+ * {T}, Tap an untapped creature you control: Add one mana of any color.
+ *
+ * A two-body mana dork: the cost taps the Sentinel *and* another untapped creature you control, so
+ * it needs a partner to produce anything. [Costs.TapAnotherPermanent] carries the "another" — the
+ * Sentinel cannot pay its own second half.
+ */
+val JasperaSentinel = card("Jaspera Sentinel") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Rogue"
+    oracleText = "Reach\n" +
+        "{T}, Tap an untapped creature you control: Add one mana of any color."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.TapAnotherPermanent(GameObjectFilter.Creature.youControl())
+        )
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Raoul Vitale"
+        flavorText = "The arrows of the elvish elite strike as true and deadly as the fangs of the Cosmos Serpent they revere."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KaldheimBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KaldheimBasicLands.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Kaldheim Basic Lands
+ *
+ * Kaldheim's five nonsnow basics, cards 394-398. The set's *snow* basics are a different card
+ * (they carry the Snow supertype and a different name), so they are reprint rows against Ice Age's
+ * canonicals rather than [basicLand] vals — see `SnowCovered*Reprint.kt` in this package.
+ */
+
+val KaldheimPlains394 = basicLand("Plains") {
+    collectorNumber = "394"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cbfbafa-f58f-40b2-a374-68ac35b77d89.jpg"
+}
+
+val KaldheimIsland395 = basicLand("Island") {
+    collectorNumber = "395"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a25a714-c7f3-4697-8b69-8f966b4d370a.jpg"
+}
+
+val KaldheimSwamp396 = basicLand("Swamp") {
+    collectorNumber = "396"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f9e61c0-b185-4704-913f-9284ed0ce250.jpg"
+}
+
+val KaldheimMountain397 = basicLand("Mountain") {
+    collectorNumber = "397"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/69419307-53d5-40d7-82da-cab2e7bfbda4.jpg"
+}
+
+val KaldheimForest398 = basicLand("Forest") {
+    collectorNumber = "398"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/771e307c-b2e3-47ac-aac2-59f0c3542fa6.jpg"
+}
+
+/**
+ * All Kaldheim basic land variants.
+ */
+val KaldheimBasicLands = listOf(
+    KaldheimPlains394,
+    KaldheimIsland395,
+    KaldheimSwamp396,
+    KaldheimMountain397,
+    KaldheimForest398
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KarfellKennelMaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KarfellKennelMaster.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Karfell Kennel-Master
+ * {4}{B}
+ * Creature — Zombie Berserker
+ * 4/4
+ * When this creature enters, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say "destroy" don't destroy them.)
+ *
+ * "Up to two target creatures **each** get …" is a multi-slot target: the effect runs once per
+ * chosen creature. [ForEachTargetEffect] with [EffectTarget.ContextTarget] `0` is the shape that
+ * binds — a single effect naming the multi-slot handle directly resolves against nothing.
+ */
+val KarfellKennelMaster = card("Karfell Kennel-Master") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Berserker"
+    oracleText = "When this creature enters, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetPermanent(count = 2, optional = true, filter = TargetFilter.Creature)
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Izzy"
+        flavorText = "Trapped in a realm of dead flesh and scarce hunting, the ravenous wolves of Karfell follow the Dread Marn to warm game."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KayasOnslaught.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/KayasOnslaught.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Kaya's Onslaught
+ * {2}{W}
+ * Instant
+ * Target creature gets +1/+1 and gains double strike until end of turn.
+ * Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A combat trick whose real cost is {W} if it was foretold a turn earlier — double strike on an
+ * unblocked attacker is the payoff [KeywordAbility.foretell] is hiding.
+ */
+val KayasOnslaught = card("Kaya's Onslaught") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+1 and gains double strike until end of turn.\n" +
+        "Foretell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        val recipient = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, recipient),
+            Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, recipient)
+        )
+    }
+
+    keywordAbility(KeywordAbility.foretell("{W}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Daarken"
+        flavorText = "\"Your trail ends here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/LittjaraGladeWarden.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/LittjaraGladeWarden.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Littjara Glade-Warden
+ * {3}{G}
+ * Creature — Shapeshifter
+ * 3/3
+ * Changeling (This card is every creature type.)
+ * {2}{G}, {T}, Exile a creature card from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.
+ *
+ * A repeatable counter engine gated on graveyard fuel. The exile is part of the cost, so it happens
+ * on activation and the ability cannot be activated at all with an empty graveyard; "Activate only as
+ * a sorcery" is [TimingRule.SorcerySpeed]. Changeling makes the Warden itself a legal Elf for every
+ * tribal payoff in the set.
+ */
+val LittjaraGladeWarden = card("Littjara Glade-Warden") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "{2}{G}, {T}, Exile a creature card from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.CHANGELING)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{G}"),
+            Costs.Tap,
+            Costs.ExileFromGraveyard(1, GameObjectFilter.Creature)
+        )
+        val recipient = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, recipient)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "Deruchenko Alexander"
+        flavorText = "In every tree, a restless spirit."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/MajaBretagardProtector.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/MajaBretagardProtector.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Maja, Bretagard Protector
+ * {2}{G}{W}{W}
+ * Legendary Creature — Human Warrior
+ * 2/3
+ * Other creatures you control get +1/+1.
+ * Landfall — Whenever a land you control enters, create a 1/1 white Human Warrior creature token.
+ *
+ * An anthem plus a landfall token-maker, which compound: every land drop adds a Human Warrior that
+ * the anthem immediately pumps. `excludeSelf = true` on the anthem carries the printed "Other".
+ *
+ * The landfall trigger binds [TriggerBinding.ANY], not the default `SELF`: the permanent that enters
+ * is the land, not Maja, so a source-bound trigger would never fire.
+ */
+val MajaBretagardProtector = card("Maja, Bretagard Protector") {
+    manaCost = "{2}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "Other creatures you control get +1/+1.\n" +
+        "Landfall — Whenever a land you control enters, create a 1/1 white Human Warrior creature token."
+    power = 2
+    toughness = 3
+
+    // Other creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl(), excludeSelf = true)
+        )
+    }
+
+    // Landfall — Whenever a land you control enters, create a 1/1 white Human Warrior token.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Land.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human", "Warrior")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Lie Setiawan"
+        flavorText = "\"Our enemies have breached our realm. To survive, the clans must fight as one!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/MammothGrowth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/MammothGrowth.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Mammoth Growth
+ * {2}{G}
+ * Instant
+ * Target creature gets +4/+4 until end of turn.
+ * Foretell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A Giant Growth variant whose foretold cost is a single {G}, which is what makes it a real combat
+ * trick rather than a three-mana one.
+ */
+val MammothGrowth = card("Mammoth Growth") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +4/+4 until end of turn.\n" +
+        "Foretell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        val recipient = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(4, 4, recipient)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Ilse Gort"
+        flavorText = "Thus the longhall became a flathall."
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/RavenousLindwurm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/RavenousLindwurm.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Lindwurm
+ * {4}{G}{G}
+ * Creature — Wurm
+ * 6/6
+ * When this creature enters, you gain 4 life.
+ *
+ * A six-mana 6/6 with a four-point lifegain rider — the green common that stabilises a limited board.
+ */
+val RavenousLindwurm = card("Ravenous Lindwurm") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    oracleText = "When this creature enters, you gain 4 life."
+    power = 6
+    toughness = 6
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Filip Burburan"
+        flavorText = "\"I'm no coward, but I'd sooner tangle with a rampaging Torga troll than a hungry lindwurm!\"\n" +
+            "—Yegar, Beskir warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/RimewoodFalls.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/RimewoodFalls.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Rimewood Falls
+ *
+ * Snow Land — Forest Island
+ * ({T}: Add {G} or {U}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val RimewoodFalls = card("Rimewood Falls") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Snow Land — Forest Island"
+    oracleText = "({T}: Add {G} or {U}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "266"
+        artist = "Piotr Dura"
+        flavorText = "\"For a fortnight, our warband lay still beneath the icy waters, breathing through reeds as we waited for the great bear to appear.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SarulfsPackmate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SarulfsPackmate.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Sarulf's Packmate
+ * {3}{G}
+ * Creature — Wolf
+ * 3/3
+ * When this creature enters, draw a card.
+ * Foretell {1}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A cantrip body. Foretelling it splits the four mana across two turns, which is the whole design.
+ */
+val SarulfsPackmate = card("Sarulf's Packmate") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "When this creature enters, draw a card.\n" +
+        "Foretell {1}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{1}{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Ilse Gort"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SawItComing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SawItComing.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Saw It Coming
+ * {1}{U}{U}
+ * Instant
+ * Counter target spell.
+ * Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Kaldheim's Cancel: foretold on an earlier turn it holds up only {1}{U}, and the face-down exile
+ * hides which answer is coming.
+ */
+val SawItComing = card("Saw It Coming") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\n" +
+        "Foretell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    keywordAbility(KeywordAbility.foretell("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Randy Vargas"
+        flavorText = "\"How predictable.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ScornEffigy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ScornEffigy.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Scorn Effigy
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 2/3
+ * Foretell {0} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Foretell is the card's only structural part — the printed `Keyword.FORETELL` is display-only,
+ * so it is lowered into [KeywordAbility.foretell], which the engine's ForetellEnumerator reads to
+ * offer the pay-{2}-and-exile special action and the later cast from exile for the foretell cost.
+ * The card builder derives the printed keyword back out of that ability.
+ */
+val ScornEffigy = card("Scorn Effigy") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    oracleText = "Foretell {0} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 2
+    toughness = 3
+
+    keywordAbility(KeywordAbility.foretell("{0}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Wayne Reynolds"
+        flavorText = "It remembers every wound it has seen or suffered—and nothing else."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ShepherdOfTheCosmos.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ShepherdOfTheCosmos.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shepherd of the Cosmos
+ * {4}{W}{W}
+ * Creature — Angel Warrior
+ * 3/3
+ * Flying
+ * When this creature enters, return target permanent card with mana value 2 or less from your graveyard to the battlefield.
+ * Foretell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A six-mana flier that reanimates a cheap permanent. The target lives in the graveyard, so the
+ * requirement is a graveyard-scoped [TargetObject] rather than a battlefield one; the mana-value cap
+ * reads the card in the graveyard, where no continuous effect can change it.
+ *
+ * `fromZone = Zone.GRAVEYARD` on the move is load-bearing: without it the move looks up the target on
+ * the battlefield, finds nothing, and the trigger resolves as a no-op.
+ */
+val ShepherdOfTheCosmos = card("Shepherd of the Cosmos") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Warrior"
+    oracleText = "Flying\n" +
+        "When this creature enters, return target permanent card with mana value 2 or less from your graveyard to the battlefield.\n" +
+        "Foretell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.manaValueAtMost(2).ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Move(card, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{3}{W}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SkemfarElderhall.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SkemfarElderhall.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Skemfar Elderhall
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G}.
+ * {2}{B}{B}{G}, {T}, Sacrifice this land: Up to one target creature you don't control gets -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens. Activate only as a sorcery.
+ *
+ * The Golgari realm land. The target is "up to one", so the ability can be activated purely for the
+ * two Elf Warriors when there is nothing worth shrinking — `optional = true` on the requirement is
+ * what makes an empty board a legal activation.
+ *
+ * "you don't control" is spelled as `Not(ControlledByYou)` rather than `ControlledByOpponent`. The two
+ * coincide in a duel and diverge in Two-Headed Giant, where a teammate's creature is one you don't
+ * control but is not an opponent's.
+ */
+val SkemfarElderhall = card("Skemfar Elderhall") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G}.\n" +
+        "{2}{B}{B}{G}, {T}, Sacrifice this land: Up to one target creature you don't control gets -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {G}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 1)
+        manaAbility = true
+    }
+
+    // {2}{B}{B}{G}, {T}, Sacrifice this land: Up to one target creature you don't control gets
+    // -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}{B}{G}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        val victim = target(
+            "target",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.copy(
+                        controllerPredicate = ControllerPredicate.Not(ControllerPredicate.ControlledByYou)
+                    )
+                )
+            )
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(-2, -2, victim),
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Elf", "Warrior"),
+                count = 2
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "268"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredForestReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredForestReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Forest reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredForestReprint = Printing(
+    oracleId = "5f0d3be8-e63e-4ade-ae58-6b0c14f2ce6d",
+    name = "Snow-Covered Forest",
+    setCode = "KHM",
+    collectorNumber = "284",
+    scryfallId = "ca17acea-f079-4e53-8176-a2f5c5c408a1",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/ca17acea-f079-4e53-8176-a2f5c5c408a1.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredIslandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredIslandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Island reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredIslandReprint = Printing(
+    oracleId = "5b2460a5-6ae5-4cad-ba94-1a9e98e6e4c0",
+    name = "Snow-Covered Island",
+    setCode = "KHM",
+    collectorNumber = "278",
+    scryfallId = "3bfa5ebc-5623-4eec-89ea-dc187489ee4a",
+    artist = "Piotr Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3bfa5ebc-5623-4eec-89ea-dc187489ee4a.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredMountainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredMountainReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Mountain reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredMountainReprint = Printing(
+    oracleId = "ca9f660b-e07d-4f42-a46e-abd0ca72510c",
+    name = "Snow-Covered Mountain",
+    setCode = "KHM",
+    collectorNumber = "282",
+    scryfallId = "5474e67c-628f-41b0-aa31-3d85a267265a",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/5474e67c-628f-41b0-aa31-3d85a267265a.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredPlainsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredPlainsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Plains reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredPlainsReprint = Printing(
+    oracleId = "ac8cc74d-e43b-4118-bba0-dfa8b9c04d45",
+    name = "Snow-Covered Plains",
+    setCode = "KHM",
+    collectorNumber = "276",
+    scryfallId = "afd2730f-878e-47ee-ad2a-73f8fa4e0794",
+    artist = "Sarah Finnigan",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/afd2730f-878e-47ee-ad2a-73f8fa4e0794.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredSwampReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowCoveredSwampReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Swamp reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val SnowCoveredSwampReprint = Printing(
+    oracleId = "d8239a86-7184-4005-ba1e-2dddcd756c47",
+    name = "Snow-Covered Swamp",
+    setCode = "KHM",
+    collectorNumber = "280",
+    scryfallId = "6aa85af8-15f5-4620-8aea-0b45c28372ed",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6aa85af8-15f5-4620-8aea-0b45c28372ed.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Squash.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Squash.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Squash
+ * {4}{R}
+ * Instant
+ * This spell costs {3} less to cast if you control a Giant.
+ * Squash deals 6 damage to target creature or planeswalker.
+ *
+ * The cost reduction is a [ModifySpellCost] static on the spell itself ([SpellCostTarget.SelfCast]),
+ * gated on controlling a Giant. It rides the existing spell-cost rail rather than a second one, so
+ * the discount is visible in the cost preview the client shows before the spell is cast.
+ */
+val Squash = card("Squash") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell costs {3} less to cast if you control a Giant.\n" +
+        "Squash deals 6 damage to target creature or planeswalker."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(3),
+            gating = CostGating.OnlyIf(
+                Conditions.YouControl(GameObjectFilter.Permanent.withSubtype(Subtype.GIANT))
+            )
+        )
+    }
+
+    spell {
+        val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(6, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Caio Monteiro"
+        flavorText = "The troll had recently crushed a human in much the same way. Sadly, he expired too quickly to appreciate the irony."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/StorySeeker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/StorySeeker.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Story Seeker
+ * {1}{W}
+ * Creature — Dwarf Cleric
+ * 2/2
+ * Lifelink
+ * */
+val StorySeeker = card("Story Seeker") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Cleric"
+    oracleText = "Lifelink"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Svetlin Velinov"
+        flavorText = "Dwarven skalds are the most renowned storytellers in all of Kaldheim. They travel across the realms, seeking out heroic deeds and chronicling them in epic sagas."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SulfurousMire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SulfurousMire.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Sulfurous Mire
+ *
+ * Snow Land — Swamp Mountain
+ * ({T}: Add {B} or {R}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val SulfurousMire = card("Sulfurous Mire") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Snow Land — Swamp Mountain"
+    oracleText = "({T}: Add {B} or {R}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Titus Lunter"
+        flavorText = "\"In my youth, we used to best each other at hopping rabbit-fast between the lava spouts, the burning tar spattering our legs.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SurtlandFrostpyre.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SurtlandFrostpyre.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Surtland Frostpyre
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {2}{U}{U}{R}, {T}, Sacrifice this land: Scry 2. This land deals 2 damage to each creature. Activate only as a sorcery.
+ *
+ * The Izzet realm land: a scry stapled to a symmetric two-point sweeper. The damage hits *each*
+ * creature including your own, and the land is already sacrificed when it resolves — the damage
+ * source is a permanent that has left the battlefield, which is why the printed text says "This land
+ * deals" rather than naming a creature.
+ */
+val SurtlandFrostpyre = card("Surtland Frostpyre") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R}.\n" +
+        "{2}{U}{U}{R}, {T}, Sacrifice this land: Scry 2. This land deals 2 damage to each creature. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {R}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED, 1)
+        manaAbility = true
+    }
+
+    // {2}{U}{U}{R}, {T}, Sacrifice this land: Scry 2. This land deals 2 damage to each creature.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{U}{U}{R}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Composite(
+            Effects.Scry(2),
+            Patterns.Group.dealDamageToAll(2, GroupFilter(GameObjectFilter.Creature))
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "271"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VengefulReaper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VengefulReaper.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Vengeful Reaper
+ * {3}{B}
+ * Creature — Angel Cleric
+ * 2/3
+ * Flying, deathtouch, haste
+ * Foretell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * Foretell is the card's only structural part — the printed `Keyword.FORETELL` is display-only,
+ * so it is lowered into [KeywordAbility.foretell], which the engine's ForetellEnumerator reads to
+ * offer the pay-{2}-and-exile special action and the later cast from exile for the foretell cost.
+ * The card builder derives the printed keyword back out of that ability.
+ */
+val VengefulReaper = card("Vengeful Reaper") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Angel Cleric"
+    oracleText = "Flying, deathtouch, haste\n" +
+        "Foretell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH, Keyword.HASTE)
+    keywordAbility(KeywordAbility.foretell("{1}{B}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "116"
+        artist = "Billy Christian"
+        flavorText = "\"Starnheim is closed to you, coward.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VillageRitesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VillageRitesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Village Rites reprint in KHM. Canonical CardDefinition lives in its earliest set.
+ */
+val VillageRitesReprint = Printing(
+    oracleId = "365548fb-5acc-4a8a-b20b-26d28b7d029f",
+    name = "Village Rites",
+    setCode = "KHM",
+    collectorNumber = "117",
+    scryfallId = "0fab9ee8-776a-48e5-b309-bcd381e67bf7",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fab9ee8-776a-48e5-b309-bcd381e67bf7.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VolatileFjord.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VolatileFjord.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Volatile Fjord
+ *
+ * Snow Land — Island Mountain
+ * ({T}: Add {U} or {R}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val VolatileFjord = card("Volatile Fjord") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Snow Land — Island Mountain"
+    oracleText = "({T}: Add {U} or {R}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "273"
+        artist = "Randy Vargas"
+        flavorText = "\"I watched with my own eyes as Jari Eagle-Caller fell from these cliffs, only to be snatched from the air by a giant bird!\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WarhornBlast.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WarhornBlast.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Warhorn Blast
+ * {4}{W}
+ * Instant
+ * Creatures you control get +2/+1 until end of turn.
+ * Foretell {2}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A team pump at instant speed. One [Patterns.Group.modifyStatsForAll] pass, not a per-creature
+ * composite: the printed sentence names its group once, so the group is gathered once.
+ */
+val WarhornBlast = card("Warhorn Blast") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+1 until end of turn.\n" +
+        "Foretell {2}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            power = 2,
+            toughness = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    keywordAbility(KeywordAbility.foretell("{2}{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Bryan Sola"
+        flavorText = "\"Mead down! Swords up!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WeighDown.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WeighDown.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Weigh Down
+ * {B}
+ * Sorcery
+ * As an additional cost to cast this spell, exile a creature card from your graveyard.
+ * Target creature gets -3/-3 until end of turn.
+ *
+ * The graveyard exile is an *additional cost*, not part of the effect: it is paid on casting, so an
+ * empty graveyard makes the spell uncastable rather than making it resolve for free.
+ */
+val WeighDown = card("Weigh Down") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, exile a creature card from your graveyard.\n" +
+        "Target creature gets -3/-3 until end of turn."
+
+    additionalCost(
+        Costs.additional.ExileCards(count = 1, filter = GameObjectFilter.Creature)
+    )
+
+    spell {
+        val victim = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, -3, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "John Di Giovanni"
+        flavorText = "The draugr often drown intruders. Years later, their corpses rise from the depths to join the ranks of the Dread Marn."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WingsOfTheCosmos.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WingsOfTheCosmos.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wings of the Cosmos
+ * {W}
+ * Instant
+ * Target creature gets +1/+3 and gains flying until end of turn. Untap it.
+ *
+ * A one-mana trick that does three things to one creature. The untap is a separate sentence on the
+ * card and a separate effect here — it lets a tapped attacker block, which the +1/+3 and flying then
+ * make survivable.
+ */
+val WingsOfTheCosmos = card("Wings of the Cosmos") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+3 and gains flying until end of turn. Untap it."
+
+    spell {
+        val recipient = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 3, recipient),
+            Effects.GrantKeyword(Keyword.FLYING, recipient),
+            Effects.Untap(recipient)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Ilse Gort"
+        flavorText = "The wolf's startled yelp changed quickly to a howl of elation as she soared over her envious packmates."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WoodlandChasm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/WoodlandChasm.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Woodland Chasm
+ *
+ * Snow Land — Swamp Forest
+ * ({T}: Add {B} or {G}.)
+ * This land enters tapped.
+ *
+ * One of Kaldheim's ten snow dual lands. The whole card is a single [EntersTapped] replacement
+ * effect: the parenthesised mana line is reminder text for the intrinsic abilities the two basic
+ * land subtypes already grant, so writing a mana ability here would let the land tap twice. The
+ * Snow supertype rides along in the type line.
+ */
+val WoodlandChasm = card("Woodland Chasm") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Snow Land — Swamp Forest"
+    oracleText = "({T}: Add {B} or {G}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land subtypes in the type line.
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "274"
+        artist = "Titus Lunter"
+        flavorText = "\"Is this the grave of a god? A tunnel carved by the Cosmos Serpent? It matters not. It is no place for us.\"\n" +
+            "—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElvishWarmasterScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElvishWarmasterScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Elvish Warmaster (KHM #167) — {1}{G} Creature — Elf Warrior, 2/2.
+ *
+ *   Whenever one or more other Elves you control enter, create a 1/1 green Elf Warrior
+ *   creature token. This ability triggers only once each turn.
+ *   {5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.
+ *
+ * Two things about the trigger are easy to get wrong and are what these tests pin:
+ *
+ *  - **"one or more … enter" is a batch, not a per-permanent trigger.** A single spell that puts
+ *    two Elves onto the battlefield makes *one* token, not two. That is the batching
+ *    `PermanentsEnteredEvent`, not a per-entry `ZoneChangeEvent`.
+ *  - **"triggers only once each turn" is the ability's own cap**, enforced by the engine per
+ *    `(sourceId, abilityId)` and reset at end of turn — a second, separate Elf entering later in
+ *    the same turn makes no token.
+ */
+class ElvishWarmasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the batch trigger") {
+
+            test("one Elf entering makes exactly one token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Elvish Warmaster")
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val before = game.findAllPermanents("Elf Warrior Token").size
+
+                val cast = game.castSpell(1, "Llanowar Elves")
+                withClue("Casting Llanowar Elves should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The Warmaster's trigger made one 1/1 Elf Warrior token") {
+                    game.findAllPermanents("Elf Warrior Token").size shouldBe before + 1
+                }
+            }
+
+            test("the Warmaster's own entry does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Elvish Warmaster")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Elvish Warmaster")
+                withClue("Casting Elvish Warmaster should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("\"other Elves\" excludes the Warmaster itself, so no token was made") {
+                    game.isOnBattlefield("Elvish Warmaster") shouldBe true
+                    game.findAllPermanents("Elf Warrior Token").size shouldBe 0
+                }
+            }
+
+            test("a second Elf later the same turn makes no further token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Elvish Warmaster")
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withCardsInHand(1, "Elvish Mystic", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Llanowar Elves")
+                game.resolveStack()
+
+                val afterFirst = game.findAllPermanents("Elf Warrior Token").size
+                withClue("The first Elf triggered the Warmaster") { afterFirst shouldBe 1 }
+
+                game.castSpell(1, "Elvish Mystic")
+                game.resolveStack()
+
+                withClue("\"only once each turn\" caps the ability, so the second Elf makes nothing") {
+                    game.findAllPermanents("Elf Warrior Token").size shouldBe afterFirst
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JasperaSentinelScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JasperaSentinelScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Jaspera Sentinel (KHM #178) — {G} Creature — Elf Rogue, 1/2.
+ *
+ *   Reach
+ *   {T}, Tap an untapped creature you control: Add one mana of any color.
+ *
+ * The cost has two tap halves paid together, and the Sentinel cannot fill both: the {T} symbol
+ * already taps it, so it is not available as the "untapped creature you control" (CR 601.2h — the
+ * costs are paid simultaneously, and one permanent cannot be tapped twice for the same payment).
+ * The cost atom carries that as `excludeSelf`, which is what makes a lone Sentinel unable to
+ * activate at all. The "you control" scope is the other half these tests pin: an opponent's
+ * untapped creature is not a legal partner.
+ */
+class JasperaSentinelScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the mana ability's second tap cost") {
+
+            test("a lone Sentinel cannot pay — it cannot tap itself twice") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jaspera Sentinel")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentinel = game.findPermanent("Jaspera Sentinel")!!
+                val abilityId = cardRegistry.getCard("Jaspera Sentinel")!!
+                    .activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = sentinel, abilityId = abilityId)
+                )
+                withClue("With no other creature to tap, the cost is unpayable") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("another creature you control pays the second half and both end up tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jaspera Sentinel")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentinel = game.findPermanent("Jaspera Sentinel")!!
+                val abilityId = cardRegistry.getCard("Jaspera Sentinel")!!
+                    .activatedAbilities.first().id
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = sentinel,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(bears))
+                    )
+                )
+                withClue("The Bears can pay the second tap: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Both the Sentinel and its partner are tapped by the cost") {
+                    game.state.getEntity(sentinel)?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("an opponent's untapped creature cannot pay the second half") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Jaspera Sentinel")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentinel = game.findPermanent("Jaspera Sentinel")!!
+                val abilityId = cardRegistry.getCard("Jaspera Sentinel")!!
+                    .activatedAbilities.first().id
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = sentinel,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(tappedPermanents = listOf(bears))
+                    )
+                )
+                withClue("\"a creature you control\" excludes the opponent's Bears") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShepherdOfTheCosmosScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShepherdOfTheCosmosScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Shepherd of the Cosmos (KHM #28) — {4}{W}{W} Creature — Angel Warrior, 3/3.
+ *
+ *   Flying
+ *   When this creature enters, return target permanent card with mana value 2 or less from your
+ *   graveyard to the battlefield.
+ *   Foretell {3}{W}
+ *
+ * The trigger's target lives in the *graveyard*, so both halves have to name that zone: the target
+ * requirement is graveyard-scoped, and so is the move's `fromZone`. Getting the second one wrong is
+ * silent — the move looks the target up on the battlefield, finds nothing, and the trigger resolves
+ * as a no-op with no error anywhere. These tests pin the card actually returning the permanent, and
+ * the mana-value cap being enforced as a targeting restriction rather than on resolution.
+ */
+class ShepherdOfTheCosmosScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the enters trigger") {
+
+            test("returns a mana value 2 permanent card from your graveyard to the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shepherd of the Cosmos")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Shepherd of the Cosmos")
+                withClue("Casting the Shepherd should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // the Shepherd enters; its trigger pauses for a target
+
+                withClue("The enters trigger should pause for target selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val select = game.selectTargets(listOf(bears))
+                withClue("Grizzly Bears ({1}{G}) is within the mana value cap: ${select.error}") {
+                    select.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears left the graveyard for the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a mana value 3 permanent card is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shepherd of the Cosmos")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Shepherd of the Cosmos")
+                game.resolveStack()
+
+                val giant = game.findCardsInGraveyard(1, "Hill Giant").single()
+                if (game.hasPendingDecision()) {
+                    withClue("Hill Giant ({3}{R}) is above the cap, so it is not a legal target") {
+                        game.selectTargets(listOf(giant)).error shouldNotBe null
+                    }
+                    game.skipTargets()
+                }
+                game.resolveStack()
+
+                withClue("Hill Giant costs {3}{R} — above the cap, so it stays in the graveyard") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("The Shepherd itself still resolved") {
+                    game.isOnBattlefield("Shepherd of the Cosmos") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -1,3 +1,80 @@
+// Alpine Meadow
+{
+    "name": "Alpine Meadow",
+    "manaCost": "",
+    "typeLine": "Snow Land — Mountain Plains",
+    "oracleText": "({T}: Add {R} or {W}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "artist": "Piotr Dura",
+        "flavorText": "\"Here perished Rognar the Reckless after his hundred-day battle with the Ironmaw Dragon. We raised these stones to mark his resting place.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8702d6b9-bb01-4841-a76d-4a576066c772.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Arctic Treeline
+{
+    "name": "Arctic Treeline",
+    "manaCost": "",
+    "typeLine": "Snow Land — Forest Plains",
+    "oracleText": "({T}: Add {G} or {W}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Alayna Danner",
+        "flavorText": "\"When the Light of Starnheim shines here, every frost-edged needle glitters with the reflected glory of the Cosmos.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b20e3117-f1e4-4449-ae9d-0b66abfc717d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Augury Raven
+{
+    "name": "Augury Raven",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{U}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Some ravens collect shiny baubles; others hoard omens and secrets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9947cfd-91d6-479e-a7f6-2a2050f020f3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Axgard Cavalry
 {
     "name": "Axgard Cavalry",
@@ -105,6 +182,120 @@
     "layout": "MODAL_DFC"
 }
 
+// Battlefield Raptor
+{
+    "name": "Battlefield Raptor",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, first strike",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Mike Bierek",
+        "flavorText": "It wheeled upward, away from the shrieks and thunder. It reached the point where sky met smoke, and, with but a glance at the horizon, aimed itself and dove.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/389f0045-218d-41cd-bdca-8a9a0ab1b31b.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Behold the Multiverse
+{
+    "name": "Behold the Multiverse",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Scry 2, then draw two cards.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Magali Villeneuve",
+        "flavorText": "Countless worlds unfolded before Niko, every one in need of heroes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27855a38-a682-4f97-ad22-ac625e86faec.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Beskir Shieldmate
+{
+    "name": "Beskir Shieldmate",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "When this creature dies, create a 1/1 white Human Warrior creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human",
+                        "Warrior"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Manuel Castañón",
+        "flavorText": "\"If we fall today, let us fall with honor, defending our realm from the horrors that would defile it. Forward, shieldmates! To Starnheim!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfc1df84-9c47-444b-9d58-d9c7bed51c66.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Blightstep Pathway
 {
     "name": "Blightstep Pathway",
@@ -164,6 +355,187 @@
         "BLACK"
     ],
     "layout": "MODAL_DFC"
+}
+
+// Breakneck Berserker
+{
+    "name": "Breakneck Berserker",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dwarf Berserker",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Go for the knees! The last giant who tried to get past us got rolled back down the mountain in a dozen pieces.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6eb23c9-6061-4ad1-a8f3-2c791c49f352.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Brinebarrow Intruder
+{
+    "name": "Brinebarrow Intruder",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Flash\nWhen this creature enters, target creature an opponent controls gets -2/-0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Scott Murphy",
+        "flavorText": "Locked in the ice of Karfell, the treasures of ancient nobles await in ruins guarded by the dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89960a74-9e17-4e30-874a-4286dd4c917d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Canopy Tactician
+{
+    "name": "Canopy Tactician",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Other Elves you control get +1/+1.\n{T}: Add {G}{G}{G}.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Elf ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "378",
+        "rarity": "RARE",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "\"Death and life are two ends of the same spear.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Clarion Spirit
+{
+    "name": "Clarion Spirit",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast your second spell each turn, create a 1/1 white Spirit creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "To the living, the horn sounds faint and mournful, but to the spirits of Istfell, it is a thunderous call that must be obeyed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86a4c348-1012-4339-960a-c7bc7fd84fbb.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Darkbore Pathway
@@ -272,6 +644,564 @@
     ]
 }
 
+// Depart the Realm
+{
+    "name": "Depart the Realm",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent to its owner's hand.\nForetell {U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Denman Rooke",
+        "flavorText": "\"My home calls to me, I must go.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ce0403d-76ed-4eb0-abdd-74ed28f96137.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dogged Pursuit
+{
+    "name": "Dogged Pursuit",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your end step, each opponent loses 1 life and you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Jason Rainville",
+        "flavorText": "Kaya had stalked countless horrific foes, but never one that killed with such callous precision and twisted creativity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60f6a159-b969-4767-802e-409f8bf286fe.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Doomskar
+{
+    "name": "Doomskar",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all creatures.\nForetell {1}{W}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "flavorText": "The realms crashed together, with Bretagard at the center of the calamity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Doomskar Oracle
+{
+    "name": "Doomskar Oracle",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Whenever you cast your second spell each turn, you gain 2 life.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Taylor Ingvarsson",
+        "flavorText": "\"Giants and monsters loom on the horizon, and the elves plan to murder our gods!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6dae01c8-15bb-44ad-a2c6-9bcf7a9e8c17.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Doomskar Titan
+{
+    "name": "Doomskar Titan",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Giant Berserker",
+    "oracleText": "When this creature enters, creatures you control get +1/+0 and gain haste until end of turn.\nForetell {4}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{4}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4e125e4-103f-4a68-b85f-1382646da71e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Dwarven Reinforcements
+{
+    "name": "Dwarven Reinforcements",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 2/1 red Dwarf Berserker creature tokens.\nForetell {1}{R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 2,
+            "toughness": 1,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Dwarf",
+                "Berserker"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Orders? We don't wait for orders!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40bcc7cb-65dd-4bc6-8606-a162fa6c65f7.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Elderfang Disciple
+{
+    "name": "Elderfang Disciple",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Elf Cleric",
+    "oracleText": "When this creature enters, each opponent discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Miranda Meeks",
+        "flavorText": "\"One day, the great serpent will rejoin us on Skemfar, and those who've wronged us will taste of our venom.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f3a6148-d005-49c1-a7fc-867c4e8251cd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Elderleaf Mentor
+{
+    "name": "Elderleaf Mentor",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "When this creature enters, create a 1/1 green Elf Warrior creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elf",
+                        "Warrior"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Our ancestors grew complacent in their divinity, allowing their lessers to topple them. Never again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e8bded3-46c3-474f-9d09-978df8705ad1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Elven Ambush
+{
+    "name": "Elven Ambush",
+    "manaCost": "{3}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Create a 1/1 green Elf Warrior creature token for each Elf you control.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent Elf"
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Elf",
+                "Warrior"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "391",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Seaman",
+        "flavorText": "\"No elf can match a Tuskeri in combat. Why not charge?\"\n—Knorjolvin, Tuskeri raider",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70479c44-da7c-48c7-8c6a-47210dc03277.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Elvish Warmaster
+{
+    "name": "Elvish Warmaster",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Whenever one or more other Elves you control enter, create a 1/1 green Elf Warrior creature token. This ability triggers only once each turn.\n{5}{G}{G}: Elves you control get +2/+2 and gain deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsEnteredEvent",
+                    "filter": "permanent Elf ctrl:you",
+                    "excludeSource": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elf",
+                        "Warrior"
+                    ]
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Elf ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "DEATHTOUCH",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "RARE",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Esika's Chariot
 {
     "name": "Esika's Chariot",
@@ -348,6 +1278,156 @@
     ]
 }
 
+// Feed the Serpent
+{
+    "name": "Feed the Serpent",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature or planeswalker"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Nicholas Gregory",
+        "flavorText": "He spent the final moments of his existence tumbling down the length of the serpent's jaws, driven mad by the magnitude of the Cosmos.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99a1a75b-20cf-4db9-a244-cc54411446c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Firja, Judge of Valor
+{
+    "name": "Firja, Judge of Valor",
+    "manaCost": "{2}{W}{B}{B}",
+    "typeLine": "Legendary Creature — Angel Cleric",
+    "oracleText": "Flying, lifelink\nWhenever you cast your second spell each turn, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 2,
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Livia Prima",
+        "flavorText": "She is both shepherd and reaper, and her judgment is final.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df87077c-85d8-499e-bce0-27697caada5a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Funeral Longboat
+{
+    "name": "Funeral Longboat",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Vigilance\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Donato Giancola",
+        "flavorText": "\"Cast onto the windless water, he drifted until the sea turned to sky.\"\n—*Saga of the Lost King*",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45c48042-178f-432e-9eee-10bfa1e0795f.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Fynn, the Fangbearer
 {
     "name": "Fynn, the Fangbearer",
@@ -399,6 +1479,245 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Gates of Istfell
+{
+    "name": "Gates of Istfell",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W}.\n{2}{W}{U}{U}, {T}, Sacrifice this land: You gain 2 life and draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}{U}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/2627acb7-57d9-4429-9bc5-e7dd444d8d48.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Glacial Floodplain
+{
+    "name": "Glacial Floodplain",
+    "manaCost": "",
+    "typeLine": "Snow Land — Plains Island",
+    "oracleText": "({T}: Add {W} or {U}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Sarah Finnigan",
+        "flavorText": "\"A cliff once rose from the surf here—until Bjora Dawn-Greeter declared that it was blocking her view and pulled it down bare-handed.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9de5fadd-4559-479f-b45d-abe792f0f6e5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Gnottvold Recluse
+{
+    "name": "Gnottvold Recluse",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Fed up with webs impeding travelers in other realms, Kolvori banished the giant spiders to Gnottvold, where their webs snare only the occasional rampaging troll.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af46c8c8-5dfa-4ebb-b0b9-cd25d01dd432.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Gnottvold Slumbermound
+{
+    "name": "Gnottvold Slumbermound",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}.\n{3}{R}{G}{G}, {T}, Sacrifice this land: Destroy target land. Create a 4/4 green Troll Warrior creature token with trample.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}{G}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "CreateToken",
+                            "power": 4,
+                            "toughness": 4,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Troll",
+                                "Warrior"
+                            ],
+                            "keywords": [
+                                "TRAMPLE"
+                            ]
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target land"
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/735470df-65d8-43e9-837e-4869c8e4f052.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Gods' Hall Guardian
+{
+    "name": "Gods' Hall Guardian",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Vigilance\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{3}{W}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "Not a single rat has been seen in Istfell since the gods moved in.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8e645c8-90ac-4865-b441-e64251d6c9a8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -491,6 +1810,57 @@
     ]
 }
 
+// Guardian Gladewalker
+{
+    "name": "Guardian Gladewalker",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nWhen this creature enters, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Mila Pesic",
+        "flavorText": "The raiders' only warning was a whisper floating through the mist: \"Trespassers.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/587eed42-5111-4161-9af5-bf76556c542a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hengegate Pathway
 {
     "name": "Hengegate Pathway",
@@ -572,6 +1942,29 @@
     "colorIdentityOverride": [
         "GREEN",
         "RED"
+    ]
+}
+
+// Ice Tunnel
+{
+    "name": "Ice Tunnel",
+    "manaCost": "",
+    "typeLine": "Snow Land — Island Swamp",
+    "oracleText": "({T}: Add {U} or {B}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Johannes Voss",
+        "flavorText": "\"The ice cracked underfoot; strange shapes swam beneath the surface. Who else has walked this blighted path?\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cff3ef0-4dfb-472e-aa1e-77613dd0f6d8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
     ]
 }
 
@@ -663,6 +2056,423 @@
     ]
 }
 
+// Iron Verdict
+{
+    "name": "Iron Verdict",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Iron Verdict deals 5 damage to target tapped creature.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target tapped creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature tapped"
+                },
+                "id": "target tapped creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Bryan Sola",
+        "flavorText": "\"You'll raid nothing but mist in Istfell.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2fb38f5b-a2c2-4b06-8c9c-9615475a43e7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Jaspera Sentinel
+{
+    "name": "Jaspera Sentinel",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Rogue",
+    "oracleText": "Reach\n{T}, Tap an untapped creature you control: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature ctrl:you",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Raoul Vitale",
+        "flavorText": "The arrows of the elvish elite strike as true and deadly as the fangs of the Cosmos Serpent they revere.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a68615d-9808-479d-aa80-50651246954e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Karfell Kennel-Master
+{
+    "name": "Karfell Kennel-Master",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Berserker",
+    "oracleText": "When this creature enters, up to two target creatures each get +1/+0 and gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Izzy",
+        "flavorText": "Trapped in a realm of dead flesh and scarce hunting, the ravenous wolves of Karfell follow the Dread Marn to warm game.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f670c380-6faa-42ec-ab41-6be8137169b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kaya's Onslaught
+{
+    "name": "Kaya's Onslaught",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+1 and gains double strike until end of turn.\nForetell {W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"Your trail ends here.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f28e151f-b61b-486f-b7f8-7abde207c442.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Littjara Glade-Warden
+{
+    "name": "Littjara Glade-Warden",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\n{2}{G}, {T}, Exile a creature card from your graveyard: Put two +1/+1 counters on target creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "In every tree, a restless spirit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a92dde51-310e-4f28-bd3b-d43b639785ec.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Maja, Bretagard Protector
+{
+    "name": "Maja, Bretagard Protector",
+    "manaCost": "{2}{G}{W}{W}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Other creatures you control get +1/+1.\nLandfall — Whenever a land you control enters, create a 1/1 white Human Warrior creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human",
+                        "Warrior"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"Our enemies have breached our realm. To survive, the clans must fight as one!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc3707f1-ed9d-412e-a7be-b6d8b554bd6c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Mammoth Growth
+{
+    "name": "Mammoth Growth",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +4/+4 until end of turn.\nForetell {G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Ilse Gort",
+        "flavorText": "Thus the longhall became a flathall.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e55041f-69a5-4bcf-899f-a4b44c208b4d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mistwalker
 {
     "name": "Mistwalker",
@@ -732,6 +2542,182 @@
     ]
 }
 
+// Ravenous Lindwurm
+{
+    "name": "Ravenous Lindwurm",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "When this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Filip Burburan",
+        "flavorText": "\"I'm no coward, but I'd sooner tangle with a rampaging Torga troll than a hungry lindwurm!\"\n—Yegar, Beskir warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9961e3fc-167e-4043-8510-cc5cf08d473e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Rimewood Falls
+{
+    "name": "Rimewood Falls",
+    "manaCost": "",
+    "typeLine": "Snow Land — Forest Island",
+    "oracleText": "({T}: Add {G} or {U}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "artist": "Piotr Dura",
+        "flavorText": "\"For a fortnight, our warband lay still beneath the icy waters, breathing through reeds as we waited for the great bear to appear.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da1db084-f235-4e26-8867-5f0835a0d283.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Sarulf's Packmate
+{
+    "name": "Sarulf's Packmate",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "When this creature enters, draw a card.\nForetell {1}{G} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Ilse Gort",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/6061113e-7dd8-4739-b4dd-55bb7f9e39a2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Saw It Coming
+{
+    "name": "Saw It Coming",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell.\nForetell {1}{U} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "flavorText": "\"How predictable.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/877a1bb9-5eae-453a-bec0-a9de20ea6815.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Scorn Effigy
+{
+    "name": "Scorn Effigy",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "Foretell {0} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{0}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Wayne Reynolds",
+        "flavorText": "It remembers every wound it has seen or suffered—and nothing else.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fa13084-3e68-49f4-8cc9-6d02286fd150.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Seize the Spoils
 {
     "name": "Seize the Spoils",
@@ -770,6 +2756,172 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Shepherd of the Cosmos
+{
+    "name": "Shepherd of the Cosmos",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Angel Warrior",
+    "oracleText": "Flying\nWhen this creature enters, return target permanent card with mana value 2 or less from your graveyard to the battlefield.\nForetell {3}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{3}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent mv<=2 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce33c84e-008c-48d8-a8e8-77cd19cc4f1f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Skemfar Elderhall
+{
+    "name": "Skemfar Elderhall",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G}.\n{2}{B}{B}{G}, {T}, Sacrifice this land: Up to one target creature you don't control gets -2/-2 until end of turn. Create two 1/1 green Elf Warrior creature tokens. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{B}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Elf",
+                                "Warrior"
+                            ]
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControllerNot",
+                                    "predicate": "ControlledByYou"
+                                }
+                            }
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82c2a0f7-0f53-4627-8be8-227fde331a69.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -846,6 +2998,61 @@
     ]
 }
 
+// Squash
+{
+    "name": "Squash",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {3} less to cast if you control a Giant.\nSquash deals 6 damage to target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 6
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature or planeswalker"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 3
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Exists",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "permanent Giant"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Caio Monteiro",
+        "flavorText": "The troll had recently crushed a human in much the same way. Sadly, he expired too quickly to appreciate the irony.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0b99299-bf84-4654-a331-e4406768b33c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Starnheim Aspirant
 {
     "name": "Starnheim Aspirant",
@@ -894,6 +3101,132 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Story Seeker
+{
+    "name": "Story Seeker",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Dwarf Cleric",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Dwarven skalds are the most renowned storytellers in all of Kaldheim. They travel across the realms, seeking out heroic deeds and chronicling them in epic sagas.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3dae817-3db1-4edf-86ba-c2c2b238fcf5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sulfurous Mire
+{
+    "name": "Sulfurous Mire",
+    "manaCost": "",
+    "typeLine": "Snow Land — Swamp Mountain",
+    "oracleText": "({T}: Add {B} or {R}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Titus Lunter",
+        "flavorText": "\"In my youth, we used to best each other at hopping rabbit-fast between the lava spouts, the burning tar spattering our legs.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35ebe245-ebb5-493c-b9c1-56fbfda9bd66.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Surtland Frostpyre
+{
+    "name": "Surtland Frostpyre",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}.\n{2}{U}{U}{R}, {T}, Sacrifice this land: Scry 2. This land deals 2 damage to each creature. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Scry",
+                            "count": 2
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "UNCOMMON",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b02149a-4a8f-4be9-9944-3d216248b549.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
     ]
 }
 
@@ -982,6 +3315,252 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Vengeful Reaper
+{
+    "name": "Vengeful Reaper",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Angel Cleric",
+    "oracleText": "Flying, deathtouch, haste\nForetell {1}{B} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH",
+        "HASTE",
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{1}{B}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "UNCOMMON",
+        "artist": "Billy Christian",
+        "flavorText": "\"Starnheim is closed to you, coward.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/854c99fd-71ba-40b7-98cf-b783f01a77b4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Volatile Fjord
+{
+    "name": "Volatile Fjord",
+    "manaCost": "",
+    "typeLine": "Snow Land — Island Mountain",
+    "oracleText": "({T}: Add {U} or {R}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "273",
+        "artist": "Randy Vargas",
+        "flavorText": "\"I watched with my own eyes as Jari Eagle-Caller fell from these cliffs, only to be snatched from the air by a giant bird!\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2392fbb-d9c4-4688-b99c-4e7614c60c12.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Warhorn Blast
+{
+    "name": "Warhorn Blast",
+    "manaCost": "{4}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+1 until end of turn.\nForetell {2}{W} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{2}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Bryan Sola",
+        "flavorText": "\"Mead down! Swords up!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3fc98aff-edc0-4f78-ae4f-e08735c9e512.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Weigh Down
+{
+    "name": "Weigh Down",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nTarget creature gets -3/-3 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "John Di Giovanni",
+        "flavorText": "The draugr often drown intruders. Years later, their corpses rise from the depths to join the ranks of the Dread Marn.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6ffa795d-2211-49b0-a6df-812599758f7b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wings of the Cosmos
+{
+    "name": "Wings of the Cosmos",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+3 and gains flying until end of turn. Untap it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Ilse Gort",
+        "flavorText": "The wolf's startled yelp changed quickly to a howl of elation as she soared over her envious packmates.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6b26c95-f90d-43fb-8c99-2a3aa13ac2c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Woodland Chasm
+{
+    "name": "Woodland Chasm",
+    "manaCost": "",
+    "typeLine": "Snow Land — Swamp Forest",
+    "oracleText": "({T}: Add {B} or {G}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "artist": "Titus Lunter",
+        "flavorText": "\"Is this the grave of a god? A tunnel carved by the Cosmos Serpent? It matters not. It is no place for us.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2dd0b71-5a60-418c-82fc-f13d1b5075d0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Kaldheim had not authored yet. `just assay-ready KHM` read **65** on `main` and reads **0** on this branch (re-run on the branch, not inferred).

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 54 | full `card(...)` in KHM — this set is the earliest real printing for all of them |
| `basic` | 5 | `KaldheimBasicLands.kt` + the `basicLands` override |
| `basic` (snow) | 5 | `Printing(...)` rows against Ice Age's canonicals, following the MH1 precedent |
| `row-only` | 1 | Village Rites → `Printing(...)` row (canonical in M21) |
| `elsewhere` / `unscaffolded` | 0 | — |

**Reprint tail:** 3 rows in J22 (Elderleaf Mentor, Elvish Warmaster, Karfell Kennel-Master) — invisible to `check-card-printing` until their canonicals existed, so they land here.

`KaldheimSet` gained a `basicLands` override and dropped `basicLandsFallback = PortalSet`, which is now dead: the set has basics of its own.

## Capability pre-flight

Every mechanic on the list is engine-live, so nothing needed lowering out of a display-only keyword:

| Mechanic | SDK | `rules-engine` consumer | Copied from |
|---|---|---|---|
| Foretell (18 cards) | `KeywordAbility.foretell` | `ForetellEnumerator`, `ForetellCardHandler` | khm/`DemonBolt.kt` |
| Changeling (2) | `Keyword.CHANGELING` | `StateProjector`, `AffectsFilterResolver` | khm/`Mistwalker.kt` |
| Crew 1 | `KeywordAbility.crew` | `TapHelpers`, `AttackAvailability` | kld/`SkySkiff.kt` |
| "your second spell each turn" (3) | `Triggers.NthSpellCast(2, Player.You)` | `TriggerMatcher`, `TriggerDetector` | ltr/`SarumanOfManyColors.kt` |
| "triggers only once each turn" | `oncePerTurn` | `TriggerDetector`, `TriggerProcessor` | vow/`WhisperingWizard.kt` |
| Snow dual lands (8) | `EntersTapped()` | replacement | khm/`HighlandForest.kt` |

## Differential

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| before (`main`, freshly-built binary) | 6230 | 6178 | 52 |
| after | 6284 | 6230 | 54 |

+54 compared, +2 divergent. Five appeared on the first pass; three were card bugs and are fixed:

- **Maja, Bretagard Protector** — the landfall trigger defaulted to `TriggerBinding.SELF`. The permanent that enters is the land, not Maja, so it would never have fired. Now `TriggerBinding.ANY`.
- **Shepherd of the Cosmos** — the reanimation move was missing `fromZone = Zone.GRAVEYARD`, so it looked the target up on the battlefield, found nothing, and resolved as a silent no-op.
- **Skemfar Elderhall** — "creature you don't control" was spelled `ControlledByOpponent`. The two coincide in a duel and diverge in Two-Headed Giant, where a teammate's creature is one you don't control but is not an opponent's. Now `Not(ControlledByYou)`, matching Assay's reading.

## Findings not fixed here — two Assay parser gaps

The remaining +2 are both Assay dropping a **"you control"** scope that the printed text carries. In each case the card is right and the parser is not:

- **Elvish Warmaster** — "Whenever one or more other Elves **you control** enter": Assay builds the batch trigger's filter with no `controllerPredicate`, so its reading also fires off an opponent's Elves.
- **Jaspera Sentinel** — "Tap an untapped creature **you control**": Assay's cost atom has neither the controller predicate nor `excludeSelf`. The `excludeSelf` half matters too — the `{T}` symbol already taps the Sentinel, so per CR 601.2h it cannot also be the untapped creature (Gatherer says the same).

Both look like the same gap: a controller scope on a *filter inside a cost or a batch trigger* rather than on a target.

## Also fixed

Coldsnap owed `Printing` rows for all five snow basics — a pre-existing gap that `just check-card-printing "Snow-Covered Plains"` fails on, surfaced because this sweep touches the same card family. Five generated rows, same run, same script.

## Verification

- `just build` — green (full compile + test).
- `just rebless-cards` — the KHM golden moved by exactly the 54 new cards; nothing removed (diffed by name).
- `just assay-differential` — classified above.
- `just check-card-printing` on every authored canonical — all `ok`.
- `just assay-ready KHM` on the branch — **0**.
- `just test-scenarios 2017-2022` — green.

## Scenario tests

Three, for the cards whose failure modes are silent rather than loud:

- `ElvishWarmasterScenarioTest` — the batch trigger fires once per batch, excludes the Warmaster's own entry, and the `oncePerTurn` cap holds against a second Elf later the same turn.
- `ShepherdOfTheCosmosScenarioTest` — the reanimation actually moves the card (the `fromZone` bug above would pass every other gate), and the mana-value cap is enforced as a targeting restriction.
- `JasperaSentinelScenarioTest` — a lone Sentinel cannot pay, a creature you control can, an opponent's cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9L9dP5Cbgnqaq7cLpTuWM