### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CopyEnchantment.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CopyEnchantment.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Copy Enchantment
+ * {2}{U}
+ * Enchantment
+ *
+ * You may have this enchantment enter as a copy of any enchantment on the battlefield.
+ *
+ * The enchantment counterpart of [com.wingedsheep.mtg.sets.definitions.lea.cards.Clone] —
+ * same [EntersAsCopy] replacement, with the copy filter widened from creature to enchantment.
+ */
+val CopyEnchantment = card("Copy Enchantment") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "You may have this enchantment enter as a copy of any enchantment on the battlefield."
+
+    replacementEffect(EntersAsCopy(optional = true, copyFilter = GameObjectFilter.Enchantment))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Joel Thomas"
+        flavorText = "Simic mages create redundant backups of their experiments to reduce the " +
+            "consequences of catastrophe."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Mindmoil.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Mindmoil.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mindmoil
+ * {4}{R}
+ * Enchantment
+ * Whenever you cast a spell, put the cards in your hand on the bottom of your library in any
+ * order, then draw that many cards.
+ *
+ * A Gather → Move → Draw pipeline: the whole hand is gathered into one collection, moved to the
+ * bottom of the library with [CardOrder.ControllerChooses] for the printed "in any order", and
+ * the draw counts that same collection. Counting the collection rather than the hand is what
+ * makes "that many" the hand size *before* the shuffle-back — the count is read by entity id, so
+ * it survives the cards having already left the hand.
+ *
+ * The spell that triggered this is on the stack, not in hand, so it is never bottomed — and the
+ * trigger resolves before the spell does.
+ */
+val Mindmoil = card("Mindmoil") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a spell, put the cards in your hand on the bottom of your " +
+        "library in any order, then draw that many cards."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "hand"
+                ),
+                MoveCollectionEffect(
+                    from = "hand",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.ControllerChooses
+                ),
+                Effects.DrawCards(DynamicAmount.DistinctEntitiesInCollections(listOf("hand")))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"My criticism of the Izzet is that their impulse for learning seems too " +
+            "much like impulse and too little like learning.\"\n—Trigori, Azorius senator"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PollenbrightWings.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PollenbrightWings.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Pollenbright Wings
+ * {4}{G}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature has flying.
+ * Whenever enchanted creature deals combat damage to a player, create that many 1/1 green
+ * Saproling creature tokens.
+ *
+ * "That many" is the damage the *enchanted* creature dealt, so the trigger is the ordinary
+ * combat-damage-to-a-player event read one object out — [TriggerBinding.ATTACHED] — and the
+ * token count is [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT], the same payload
+ * [com.wingedsheep.mtg.sets.definitions.ons.cards.BroodhatchNantuko] counts its Insects with.
+ * The tokens are created under the Aura's controller, not the enchanted creature's — that is
+ * `CreateTokenEffect`'s default, and it is what makes stealing a creature with this Aura work.
+ */
+val PollenbrightWings = card("Pollenbright Wings") {
+    manaCost = "{4}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has flying.\n" +
+        "Whenever enchanted creature deals combat damage to a player, create that many 1/1 green " +
+        "Saproling creature tokens."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = CreateTokenEffect(
+            count = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Terese Nielsen"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SavraQueenOfTheGolgari.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SavraQueenOfTheGolgari.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Savra, Queen of the Golgari
+ * {2}{B}{G}
+ * Legendary Creature — Elf Shaman
+ * 2/2
+ * Whenever you sacrifice a black creature, you may pay 2 life. If you do, each other player
+ * sacrifices a creature of their choice.
+ * Whenever you sacrifice a green creature, you may gain 2 life.
+ *
+ * Both triggers use the bare-article [Triggers.YouSacrificeA] template, which fires once per
+ * matching creature sacrificed and counts Savra sacrificing *herself* — she is both black and
+ * green, so sacrificing Savra triggers both abilities (her own ruling), and a black-green
+ * creature likewise triggers both.
+ *
+ * "You may pay 2 life. If you do, …" is the [Gate.MayPay] pay-then-payoff over [PayLifeEffect],
+ * the shape [com.wingedsheep.mtg.sets.definitions.fin.cards.SeymourFlux] uses; the plain "you may
+ * gain 2 life" is the builder's `optional = true`. "Each other player" renders as
+ * [Player.EachOpponent], this corpus's standing spelling for it (Syphon Soul), and the sacrificing
+ * player picks their own creature — `ForceSacrificeEffect` names who sacrifices, not what.
+ */
+val SavraQueenOfTheGolgari = card("Savra, Queen of the Golgari") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Elf Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you sacrifice a black creature, you may pay 2 life. If you do, each " +
+        "other player sacrifices a creature of their choice.\n" +
+        "Whenever you sacrifice a green creature, you may gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Creature.withColor(Color.BLACK))
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayLifeEffect(2)),
+            then = Effects.Sacrifice(
+                GameObjectFilter.Creature,
+                target = EffectTarget.PlayerRef(Player.EachOpponent)
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Creature.withColor(Color.GREEN))
+        optional = true
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Scott M. Fischer"
+        flavorText = "\"Nature's most raw beauty is the circle: perfect in its continuance, with " +
+            "no break between death and life.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Terraformer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Terraformer.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.OptionType
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Terraformer
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/2
+ * {1}: Choose a basic land type. Each land you control becomes that type until end of turn.
+ *
+ * The untargeted, whole-board sibling of
+ * [com.wingedsheep.mtg.sets.definitions.inv.cards.DreamThrush]: the same
+ * `ChooseOption(BASIC_LAND_TYPE) → SetLandType(fromChosenValueKey = …)` pair, with the single
+ * target swapped for a [Effects.ForEachInGroup] over the lands you control — inside that loop
+ * `EffectTarget.Self` is the land being iterated.
+ *
+ * "Becomes" replaces the land's existing land subtypes (CR 305.7), so each land loses the mana
+ * abilities of its old types and gains the chosen type's — [Effects.SetLandType], not the
+ * additive `AddSubtype`. The group is snapshotted before the first iteration, and the chosen
+ * type is picked once, up front, for every land.
+ */
+val Terraformer = card("Terraformer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{1}: Choose a basic land type. Each land you control becomes that type until end of turn."
+
+    val chosenKey = "chosenLandType"
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.Composite(
+            Effects.ChooseOption(
+                optionType = OptionType.BASIC_LAND_TYPE,
+                storeAs = chosenKey
+            ),
+            Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Land.youControl()),
+                effect = Effects.SetLandType(
+                    target = EffectTarget.Self,
+                    duration = Duration.EndOfTurn,
+                    fromChosenValueKey = chosenKey
+                )
+            )
+        )
+        description = "{1}: Choose a basic land type. Each land you control becomes that type until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Luca Zontini"
+        flavorText = "\"This feels a little more like home.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/PollenbrightWingsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/PollenbrightWingsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pollenbright Wings reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val PollenbrightWingsReprint = Printing(
+    oracleId = "582c8030-1d41-4c63-8ed6-06aad398a96c",
+    name = "Pollenbright Wings",
+    setCode = "PC2",
+    collectorNumber = "103",
+    scryfallId = "1058765f-cf3f-4fd9-945c-f41f49ef1926",
+    artist = "Terese Nielsen",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/1058765f-cf3f-4fd9-945c-f41f49ef1926.jpg?1783940594",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1740,6 +1740,36 @@
     ]
 }
 
+// Copy Enchantment
+{
+    "name": "Copy Enchantment",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "You may have this enchantment enter as a copy of any enchantment on the battlefield.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "copyFilter": {
+                    "cardPredicates": [
+                        "IsEnchantment"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "Joel Thomas",
+        "flavorText": "Simic mages create redundant backups of their experiments to reduce the consequences of catastrophe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac22117d-bd58-439f-b199-da72bc7160b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Courier Hawk
 {
     "name": "Courier Hawk",
@@ -5816,6 +5846,65 @@
     ]
 }
 
+// Mindmoil
+{
+    "name": "Mindmoil",
+    "manaCost": "{4}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a spell, put the cards in your hand on the bottom of your library in any order, then draw that many cards.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "DistinctEntitiesInCollections",
+                                "collections": [
+                                    "hand"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "RARE",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"My criticism of the Izzet is that their impulse for learning seems too much like impulse and too little like learning.\"\n—Trigori, Azorius senator",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mnemonic Nexus
 {
     "name": "Mnemonic Nexus",
@@ -6654,6 +6743,64 @@
     "colorIdentityOverride": []
 }
 
+// Pollenbright Wings
+{
+    "name": "Pollenbright Wings",
+    "manaCost": "{4}{G}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has flying.\nWhenever enchanted creature deals combat damage to a player, create that many 1/1 green Saproling creature tokens.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3ca4f3b9-c952-4fd3-a586-3e063b62b23d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Primordial Sage
 {
     "name": "Primordial Sage",
@@ -7395,6 +7542,80 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Savra, Queen of the Golgari
+{
+    "name": "Savra, Queen of the Golgari",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Legendary Creature — Elf Shaman",
+    "oracleText": "Whenever you sacrifice a black creature, you may pay 2 life. If you do, each other player sacrifices a creature of their choice.\nWhenever you sacrifice a green creature, you may gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "creature black",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 2
+                        }
+                    },
+                    "then": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "creature green",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "flavorText": "\"Nature's most raw beauty is the circle: perfect in its continuance, with no break between death and life.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15accf35-a174-4ba5-a633-cc46da848dbe.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -8833,6 +9054,66 @@
     "colorIdentityOverride": [
         "GREEN",
         "WHITE"
+    ]
+}
+
+// Terraformer
+{
+    "name": "Terraformer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}: Choose a basic land type. Each land you control becomes that type until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ChooseOption",
+                            "optionType": "BASIC_LAND_TYPE",
+                            "storeAs": "chosenLandType"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "land ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "SetLandType",
+                                "target": "Self",
+                                "fromChosenValueKey": "chosenLandType"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}: Choose a basic land type. Each land you control becomes that type until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Luca Zontini",
+        "flavorText": "\"This feels a little more like home.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0b9d4f3-4570-4fe0-857f-97f5bd6ead44.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five RAV cards, each composed entirely from existing `Effects.*` / `Triggers.*` primitives — no new SDK vocabulary.

- **Copy Enchantment** `{2}{U}` — `EntersAsCopy(optional = true, copyFilter = GameObjectFilter.Enchantment)`. Clone's replacement effect with the copy filter widened from creature to enchantment.
- **Mindmoil** `{4}{R}` — `Triggers.YouCastSpell` over a Gather → Move → Draw pipeline: `GatherCards(FromZone(HAND, You))` → `MoveCollection(→ LIBRARY, placement = Bottom, order = ControllerChooses)` → `DrawCards(DistinctEntitiesInCollections(["hand"]))`. Counting the collection rather than the hand is what makes "that many" the hand size *before* the bottoming — the count reads by entity id, so it survives the cards having left the hand. `CardOrder.ControllerChooses` is the printed "in any order".
- **Pollenbright Wings** `{4}{G}{W}` — Aura: `GrantKeyword(FLYING)` plus `dealsDamage(Combat, AnyPlayer, binding = ATTACHED)` creating `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT` Saprolings (Broodhatch Nantuko's payload, read one object out). Tokens go to the Aura's controller, which is what makes stealing a creature with it work.
- **Savra, Queen of the Golgari** `{2}{B}{G}` — two `Triggers.YouSacrificeA` colour-filtered triggers. The bare-article template fires once per matching creature and counts Savra sacrificing *herself*; she is both colours, so sacrificing her triggers both abilities (her own ruling). "You may pay 2 life. If you do, …" is `Gate.MayPay(PayLifeEffect(2))`; "each other player" renders as `Player.EachOpponent`, this corpus's standing spelling (Syphon Soul).
- **Terraformer** `{2}{U}` — the untargeted, whole-board sibling of Dream Thrush: `ChooseOption(BASIC_LAND_TYPE) → ForEachInGroup(Land.youControl(), SetLandType(Self, fromChosenValueKey))`. "Becomes" replaces existing land subtypes (CR 305.7), so `SetLandType`, not the additive `AddSubtype`.

Also adds the **PC2 `Printing` row** for Pollenbright Wings, which `check-card-printing` requires now that the canonical exists.

RAV goes 196 → 201 / 291.

### Considered and dropped

RAV's tail is mostly dredge / transmute / radiance / forecast, all still absent. Beyond those, a capability probe of ten more candidates found each of these needs new vocabulary, so none joined the batch:

| Card | Missing piece |
|---|---|
| Remand | `CounterDestination` has only `Graveyard` and `Exile`; needs a `Hand` case + `counterSpellToHand`. `ReturnSpellToOwnersHand` is explicitly *not* a counter. |
| Quickchange | `ChooseColorThenEffect` stores one `chosenColor`; "the colour **or colours** of your choice" needs a multi-colour decision. |
| Suppression Field | `IncreaseActivatedAbilityCost` has no mana-ability exemption, so a global tax would tax every land. |
| Wizened Snitches | `RevealTopOfLibrary` is controller-scoped; "**players** play with the top card of their libraries revealed" needs an all-players scope. |
| Leashling | No cost atom puts a card from hand on top of the library. |
| Dream Leash | `auraTarget`'s filter is re-checked continuously by `UnattachedAurasCheck`, so a `tapped` filter would drop the Aura the moment the host untaps; the restriction is cast-time-only. |
| Mausoleum Turnkey | `TargetChooser.Opponent` is honoured only for activated abilities; `CardLinter` rejects it on a trigger. |
| Belltower Sphinx | `takesDamage(SourceFilter.Any)` binds the damaged permanent, not the damage source; and `Patterns.Library.mill` cannot address the source's controller. |
| Grifter's Blade | Composable in principle (`EntersWithChoice` + `OnEnterRunEffect` + `AttachEquipment`), but no card pairs those two primitives yet — held back rather than shipped untested. |

### Pre-existing bug found in passing (not fixed here)

`MesmericOrb.kt:24` (MRD) passes `EffectTarget.ControllerOfTriggeringEntity` into `Patterns.Library.mill`, which maps any unrecognised `EffectTarget` to `Player.You` (`LibraryPatterns.kt:800-807`) and serialises with no `player` field (see `snapshots/cards/MRD.json`). It currently mills the Orb's controller instead of the untapped permanent's controller. Out of scope for this PR — flagging it rather than widening the change set.

### Verification

- `just build` — green (`:mtg-sets:test`, all era scenario suites).
- `just rebless-cards` — only `snapshots/cards/RAV.json` moved, and only for these five cards.
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent.
- `just check-card-printing` — clean for all five.

No scenario tests: every card composes existing primitives only, so the snapshot and lint nets cover them (skill Step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw