### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BrigidHeroOfKinsbaile.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BrigidHeroOfKinsbaile.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brigid, Hero of Kinsbaile
+ * {2}{W}{W}
+ * Legendary Creature — Kithkin Archer
+ * 2/3
+ *
+ * First strike
+ * {T}: Brigid deals 2 damage to each attacking or blocking creature target player controls.
+ *
+ * The player is the only *target*; the creatures are a group gathered on resolution, so a
+ * creature that joins combat after the ability was activated is still hit and one that leaves
+ * simply drops out. `targetPlayerControls` binds the group's controller predicate to that
+ * target rather than to Brigid's controller — pointing the ability at yourself is legal and
+ * shoots your own attackers.
+ *
+ * `attackingOrBlocking()` is one filter carrying both state predicates as alternatives, so the
+ * group holds each matching permanent exactly once and nothing takes 2 damage twice.
+ *
+ * Brigid is the damage source but this is not combat damage — her first strike has nothing to
+ * do with it. Activated in the declare-blockers step it kills blockers before combat damage is
+ * dealt, which is the whole point of the card.
+ */
+val BrigidHeroOfKinsbaile = card("Brigid, Hero of Kinsbaile") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Kithkin Archer"
+    power = 2
+    toughness = 3
+    oracleText = "First strike\n" +
+        "{T}: Brigid deals 2 damage to each attacking or blocking creature target player controls."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val player = target("target player", Targets.Player)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.attackingOrBlocking().targetPlayerControls(player)),
+            Effects.DealDamage(2, EffectTarget.Self)
+        )
+        description = "Brigid deals 2 damage to each attacking or blocking creature target " +
+            "player controls."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "6"
+        artist = "Steve Prescott"
+        flavorText = "Thanks to one champion archer, the true borders of Kinsbaile extend an " +
+            "arrow's flight beyond the buildings."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg?1783942917"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DolmenGate.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/DolmenGate.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Dolmen Gate
+ * {2}
+ * Artifact
+ *
+ * Prevent all combat damage that would be dealt to attacking creatures you control.
+ *
+ * A static prevention shield in the Fog Bank / Daunting Defender family — a [PreventDamage]
+ * replacement effect with no amount (prevent *all* of it) whose recipient is a live filter
+ * rather than a fixed entity. The filter is re-read when each damage instance would be dealt,
+ * so a creature that stops attacking, or that comes under your control mid-combat, is judged
+ * as it is at that moment.
+ *
+ * [DamageType.Combat] is load-bearing: the shield covers only combat damage, so a burn spell
+ * aimed at an attacker of yours still connects. "You control" scopes to the Gate's controller,
+ * so it does nothing for an opponent's attackers — it only protects your own alpha strike.
+ */
+val DolmenGate = card("Dolmen Gate") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Prevent all combat damage that would be dealt to attacking creatures you control."
+
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Matching(
+                    GameObjectFilter.Creature.youControl().attacking()
+                ),
+                damageType = DamageType.Combat
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Richard Sardinha"
+        flavorText = "Lorwyn's stones resonate with the place from which they were hewed. " +
+            "Though taken far, still they call to their home when silence is upon the land."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg?1783942851"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GalepowderMage.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GalepowderMage.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Galepowder Mage
+ * {3}{W}
+ * Creature — Kithkin Wizard
+ * 3/3
+ *
+ * Flying
+ * Whenever this creature attacks, exile another target creature. Return that card to the
+ * battlefield under its owner's control at the beginning of the next end step.
+ *
+ * The exile-and-return-later blink, built as Kykar builds it: an [Effects.Exile] followed by a
+ * [CreateDelayedTriggerEffect] on [Step.END] that moves the exiled card back. The delayed
+ * trigger is what makes this a *blink* rather than removal — the card leaves and comes back as
+ * a new object, so Auras fall off, counters are gone, and enters-the-battlefield triggers fire
+ * again.
+ *
+ * Two details the text carries and the script honors: "another" excludes Galepowder Mage itself
+ * ([TargetFilter.OtherCreature]), and the target is any creature, not just yours — the classic
+ * use is exiling your own enters-trigger creature, but pointing it at an opposing blocker to
+ * remove it from combat is equally legal. "Under its owner's control" is [Zone.BATTLEFIELD]'s
+ * default for a returning card, so a creature you stole and then blinked goes home.
+ */
+val GalepowderMage = card("Galepowder Mage") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, exile another target creature. Return that card to " +
+        "the battlefield under its owner's control at the beginning of the next end step."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target(
+            "another target creature",
+            TargetCreature(filter = TargetFilter.OtherCreature)
+        )
+        effect = Effects.Composite(
+            Effects.Exile(creature),
+            CreateDelayedTriggerEffect(
+                step = Step.END,
+                effect = Effects.Move(creature, Zone.BATTLEFIELD)
+            )
+        )
+        description = "exile another target creature. Return that card to the battlefield " +
+            "under its owner's control at the beginning of the next end step."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Jeremy Jarvis"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg?1783942915"
+
+        ruling(
+            "2007-10-01",
+            "Galepowder Mage's ability can target a creature controlled by any player. " +
+                "It's not optional."
+        )
+        ruling(
+            "2007-10-01",
+            "The exiled card will be returned to the battlefield at the beginning of the end " +
+                "step even if Galepowder Mage is no longer on the battlefield at that time."
+        )
+        ruling(
+            "2007-10-01",
+            "If Galepowder Mage is the only creature on the battlefield when it attacks, its " +
+                "ability has no effect."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MirrorEntity.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MirrorEntity.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mirror Entity
+ * {2}{W}
+ * Creature — Shapeshifter
+ * 1/1
+ *
+ * Changeling (This card is every creature type.)
+ * {X}: Until end of turn, creatures you control have base power and toughness X/X and gain all
+ * creature types.
+ *
+ * The group is gathered when the ability resolves, so creatures that arrive later in the turn
+ * are unaffected — the ability doesn't keep applying to whatever you control at any moment.
+ * Mirror Entity is in that group and sets its own base P/T too.
+ *
+ * "Base power and toughness X/X" is layer 7b (setting), so it *overwrites* earlier setting
+ * effects but sits underneath +N/+N counters and pump spells, which apply in 7c/7d. Activating
+ * for X=1 after a big X therefore shrinks your team; activating twice, the later activation
+ * wins on timestamp. `SetBasePowerAndToughness` freezes [DynamicAmount.XValue] at resolution
+ * rather than re-reading it, which is what a one-shot activation needs.
+ *
+ * "Gain all creature types" is Changeling granted for the turn (CR 702.73) — the same expansion
+ * the printed keyword uses, so the pumped team is Elves and Goblins and Merfolk at once for
+ * every tribal lord you control.
+ */
+val MirrorEntity = card("Mirror Entity") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "{X}: Until end of turn, creatures you control have base power and toughness X/X and " +
+        "gain all creature types."
+
+    keywords(Keyword.CHANGELING)
+
+    activatedAbility {
+        cost = Costs.Mana("{X}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.Composite(
+                Effects.SetBasePowerAndToughness(
+                    power = DynamicAmount.XValue,
+                    toughness = DynamicAmount.XValue,
+                    target = EffectTarget.Self,
+                    duration = Duration.EndOfTurn
+                ),
+                Effects.GrantKeyword(Keyword.CHANGELING, EffectTarget.Self, Duration.EndOfTurn)
+            )
+        )
+        description = "Until end of turn, creatures you control have base power and toughness " +
+            "X/X and gain all creature types."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "31"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Unaware of Lorwyn's diversity, it sees only itself, reflected a thousand " +
+            "times over."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg?1783942911"
+
+        ruling("2021-03-19", "Changeling applies in all zones, not just the battlefield.")
+        ruling(
+            "2021-03-19",
+            "Mirror Entity's ability overwrites any effects that previously set a creature's " +
+                "base power and/or toughness. Any existing effects or counters that raise or " +
+                "lower a creature's power and/or toughness continue to apply to the creature's " +
+                "newly-set power and toughness."
+        )
+        ruling(
+            "2021-03-19",
+            "Activating the ability with X = 0 will cause all creatures you control to become " +
+                "0/0 and be put into the graveyard."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ShieldsOfVelisVel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ShieldsOfVelisVel.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shields of Velis Vel
+ * {W}
+ * Kindred Instant — Shapeshifter
+ *
+ * Changeling (This card is every creature type.)
+ * Creatures target player controls get +0/+1 and gain all creature types until end of turn.
+ *
+ * The toughness-side twin of Ego Erasure, and built the same way: the player is the only
+ * *target*, and the creatures are a group resolved on resolution, so `targetPlayerControls`
+ * binds the group's controller predicate to that target rather than to the spell's controller.
+ * Both riders land on each member with [EffectTarget.Self] inside the iteration, so a creature
+ * that leaves mid-resolution simply drops out.
+ *
+ * "Gains all creature types" is modelled by granting Changeling — the engine expands that
+ * keyword into every creature type (CR 702.73), the same shape Blades of Velis Vel uses.
+ *
+ * Note: "Tribal" was errata'd to "Kindred" in 2024.
+ */
+val ShieldsOfVelisVel = card("Shields of Velis Vel") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Kindred Instant — Shapeshifter"
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "Creatures target player controls get +0/+1 and gain all creature types until end of turn."
+
+    keywords(Keyword.CHANGELING)
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.targetPlayerControls(player)),
+            Effects.Composite(
+                Effects.ModifyStats(0, 1, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.CHANGELING, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Ralph Horsley"
+        flavorText = "Changelings can alter shape based on what the beings around them desire most."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg?1783942908"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrigidHeroOfKinsbaileScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrigidHeroOfKinsbaileScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.BrigidHeroOfKinsbaile
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Brigid, Hero of Kinsbaile (LRW #6) — "{T}: Brigid deals 2 damage to each attacking or blocking
+ * creature target player controls."
+ *
+ * The group carries three predicates and the card is wrong if any one of them is dropped:
+ * `IsCreature`, the attacking-or-blocking state pair, and "the *target player* controls it" —
+ * which is a bound player reference, not Brigid's controller. A filter that fell back to the
+ * implicit "you control" reading would shoot Brigid's own team and read identically on the card.
+ *
+ * The negative half is the point: a creature the target player controls that is *not* in combat
+ * must be untouched, and a creature in combat that someone else controls must be untouched too.
+ */
+class BrigidHeroOfKinsbaileScenarioTest : FunSpec({
+
+    val brigidAbility = BrigidHeroOfKinsbaile.activatedAbilities.single().id
+
+    fun GameTestDriver.graveyard(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
+
+    test("only the target player's attacking creatures are hit") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BrigidHeroOfKinsbaile)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opponent = d.getOpponent(d.player1)
+        val brigid = d.putCreatureOnBattlefield(d.player1, "Brigid, Hero of Kinsbaile")
+        d.removeSummoningSickness(brigid)
+
+        // The opponent brings one 2/2 to the fight and leaves another at home.
+        val attackingBears = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val homeBears = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        d.removeSummoningSickness(attackingBears)
+        // Our own 2/2, also attacking, must survive: it is not controlled by the target player.
+        val ourBears = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.removeSummoningSickness(ourBears)
+
+        // Hand the turn over so the opponent is the attacker.
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(opponent, listOf(attackingBears), d.player1)
+        d.passPriority(opponent)
+
+        d.submit(
+            ActivateAbility(
+                d.player1,
+                brigid,
+                brigidAbility,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("the attacking 2/2 took 2 and died") {
+            d.graveyard(opponent).contains(attackingBears) shouldBe true
+        }
+        withClue("the 2/2 that stayed home was never attacking or blocking") {
+            d.graveyard(opponent).contains(homeBears) shouldBe false
+        }
+        withClue("our own 2/2 is not controlled by the target player") {
+            d.graveyard(d.player1).contains(ourBears) shouldBe false
+        }
+    }
+
+    test("blockers count too, and Brigid taps to pay") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BrigidHeroOfKinsbaile)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opponent = d.getOpponent(d.player1)
+        val brigid = d.putCreatureOnBattlefield(d.player1, "Brigid, Hero of Kinsbaile")
+        d.removeSummoningSickness(brigid)
+        val ours = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        d.removeSummoningSickness(ours)
+        val blocker = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(ours), opponent)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opponent, mapOf(blocker to listOf(ours)))
+        // Blockers-declared leaves priority with the defending player; hand it back to us.
+        if (d.priorityPlayer != d.player1) d.passPriority(d.priorityPlayer!!)
+
+        d.submit(
+            ActivateAbility(
+                d.player1,
+                brigid,
+                brigidAbility,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("the blocking 2/2 took 2 and died before combat damage") {
+            d.graveyard(opponent).contains(blocker) shouldBe true
+        }
+
+        withClue("the ability is once per untap — Brigid is now tapped and can't pay again") {
+            d.submitExpectFailure(
+                ActivateAbility(
+                    d.player1,
+                    brigid,
+                    brigidAbility,
+                    targets = listOf(ChosenTarget.Player(opponent))
+                )
+            ).isSuccess shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DolmenGateScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DolmenGateScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.DolmenGate
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dolmen Gate (LRW #256) — "Prevent all combat damage that would be dealt to attacking creatures
+ * you control."
+ *
+ * The shield's recipient is a *live* filter, not a fixed entity, and every axis of it can fail
+ * open or fail closed without changing how the card reads:
+ *
+ *  - **attacking** — a shield that ignores the state predicate protects your blockers and your
+ *    creatures sitting at home too, which is a strictly better card.
+ *  - **you control** — a shield that ignores the controller predicate protects the opponent's
+ *    attackers as well, which is a strictly worse one.
+ *  - **direction** — a shield that also covered damage dealt *by* the attacker would be Fog Bank,
+ *    not Dolmen Gate.
+ *
+ * Nothing in the corpus had previously combined `RecipientFilter.Matching` with a *state*
+ * predicate, so each axis gets its own assertion rather than one "the attacker lived".
+ */
+class DolmenGateScenarioTest : FunSpec({
+
+    fun GameTestDriver.graveyard(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
+
+    /**
+     * Player 1 on the attack with the Gate out, stopped in the declare-blockers step with
+     * player 2 still to declare.
+     */
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + DolmenGate)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("your attacker survives a bigger blocker; the blocker still takes its damage") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Dolmen Gate")
+
+        // A 2/2 of ours into a 3/3 of theirs: without the Gate our attacker dies, with it the
+        // 3/3 still dies to our 2 damage because the shield is one-directional.
+        val ours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.removeSummoningSickness(ours)
+        val theirs = d.putCreatureOnBattlefield(opponent, "Hill Giant")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(ours), opponent)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opponent, mapOf(theirs to listOf(ours)))
+        d.passPriorityUntil(Step.END)
+
+        withClue("the Gate prevented the 3 combat damage dealt to our attacker") {
+            d.graveyard(d.player1).contains(ours) shouldBe false
+        }
+        withClue("our attacker's own 2 damage was not prevented, but a 3/3 survives it") {
+            d.graveyard(opponent).contains(theirs) shouldBe false
+        }
+    }
+
+    test("the shield does not cover a creature you control that is blocking") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Dolmen Gate")
+
+        // Hand the turn to the opponent so they are the attacker and we are the blocker.
+        val theirs = d.putCreatureOnBattlefield(opponent, "Hill Giant")
+        val ours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.removeSummoningSickness(theirs)
+
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(opponent, listOf(theirs), d.player1)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(d.player1, mapOf(ours to listOf(theirs)))
+        d.passPriorityUntil(Step.END)
+
+        withClue("our 2/2 was blocking, not attacking, so the Gate did nothing for it") {
+            d.graveyard(d.player1).contains(ours) shouldBe true
+        }
+    }
+
+    test("the shield does not cover an opponent's attacking creature") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Dolmen Gate")
+
+        val theirs = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val ours = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        d.removeSummoningSickness(theirs)
+
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(opponent, listOf(theirs), d.player1)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(d.player1, mapOf(ours to listOf(theirs)))
+        d.passPriorityUntil(Step.END)
+
+        withClue("their 2/2 was attacking, but we control the Gate — it takes our 3 and dies") {
+            d.graveyard(opponent).contains(theirs) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GalepowderMageScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GalepowderMageScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.GalepowderMage
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Galepowder Mage (LRW #15) — "Whenever this creature attacks, exile another target creature.
+ * Return that card to the battlefield under its owner's control at the beginning of the next
+ * end step."
+ *
+ * A blink built from an exile plus a delayed end-step trigger has one way to fail that a
+ * board-state assertion at end of turn would miss entirely: the delayed trigger holds a
+ * reference to a card that has *changed zones*, and a reference that doesn't survive the move
+ * leaves the creature exiled forever. So the exile and the return are asserted separately, with
+ * a checkpoint in between.
+ *
+ * The second test pins the "under its **owner's** control" clause. "Another target creature" is
+ * not restricted to creatures you control, so the natural aggressive line is to blink an
+ * opposing blocker — and that creature must come back to its owner, not to whoever exiled it.
+ */
+class GalepowderMageScenarioTest : FunSpec({
+
+    fun GameTestDriver.battlefield(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD))
+
+    fun GameTestDriver.exile(): List<EntityId> =
+        state.zones.filterKeys { it.zoneType == Zone.EXILE }.values.flatten()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + GalepowderMage)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("the target leaves on attack and comes back at the beginning of the end step") {
+        val d = driver()
+        val mage = d.putCreatureOnBattlefield(d.player1, "Galepowder Mage")
+        d.removeSummoningSickness(mage)
+        val ours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(mage), d.getOpponent(d.player1))
+        d.submitTargetSelection(d.player1, listOf(ours))
+        d.bothPass()
+
+        withClue("the attack trigger exiled the target immediately") {
+            d.exile().contains(ours) shouldBe true
+            d.battlefield(d.player1).contains(ours) shouldBe false
+        }
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+
+        withClue("the delayed trigger returned the card — a reference that died on the zone change would strand it") {
+            d.exile().any { it == ours } shouldBe false
+        }
+        withClue("a Grizzly Bears is back on our battlefield") {
+            d.battlefield(d.player1).any {
+                d.getCardName(it) == "Grizzly Bears"
+            } shouldBe true
+        }
+    }
+
+    test("an opposing creature returns under its owner's control, not ours") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        val mage = d.putCreatureOnBattlefield(d.player1, "Galepowder Mage")
+        d.removeSummoningSickness(mage)
+        val theirs = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(mage), opponent)
+        d.submitTargetSelection(d.player1, listOf(theirs))
+        d.bothPass()
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+
+        withClue("the opponent's creature came back to the opponent") {
+            d.battlefield(opponent).any {
+                d.getCardName(it) == "Grizzly Bears"
+            } shouldBe true
+        }
+        withClue("and not to us") {
+            d.battlefield(d.player1).any {
+                d.getCardName(it) == "Grizzly Bears"
+            } shouldBe false
+        }
+    }
+
+    // "The exiled card will be returned to the battlefield at the beginning of the end step even
+    // if Galepowder Mage is no longer on the battlefield at that time." (2007-10-01)
+    //
+    // The delayed trigger is a free-standing object, not a linked ability gated on its source, so
+    // killing the Mage must not strand the card in exile — the failure mode a source-gated
+    // implementation would produce.
+    test("the card comes back even after the Mage has left the battlefield") {
+        val d = driver()
+        val mage = d.putCreatureOnBattlefield(d.player1, "Galepowder Mage")
+        d.removeSummoningSickness(mage)
+        val ours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(mage), d.getOpponent(d.player1))
+        d.submitTargetSelection(d.player1, listOf(ours))
+        d.bothPass()
+        d.exile().contains(ours) shouldBe true
+
+        d.moveToGraveyard(mage)
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+
+        withClue("the delayed trigger fired without its source") {
+            d.exile().contains(ours) shouldBe false
+            d.battlefield(d.player1).any {
+                d.getCardName(it) == "Grizzly Bears"
+            } shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrorEntityScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrorEntityScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.MirrorEntity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mirror Entity (LRW #31) — "{X}: Until end of turn, creatures you control have base power and
+ * toughness X/X and gain all creature types."
+ *
+ * Three things are being proved, none of which is visible in the card's own text:
+ *
+ *  - **X reaches the group body.** The X paid for the activation has to survive into a
+ *    `ForEachInGroup` iteration. If it were lost, every creature would be set to 0/0 and the
+ *    board would evaporate — a failure that looks exactly like a legitimate X=0 activation, so
+ *    the X=0 case is asserted separately to keep the two distinguishable.
+ *  - **It sets a *base*, not a bonus.** A 3/3 taken to X=1 must *shrink*, which is what
+ *    separates layer 7b from a `ModifyStats` that would read the same on the card.
+ *  - **The changeling half is not decoration.** "Gain all creature types" is the reason this
+ *    card is a tribal payoff at all; a script that only set P/T would pass every stat assertion.
+ *
+ * The X=0 board wipe is the printed behaviour, not a bug: "Activating the ability with X = 0
+ * will cause all creatures you control to become 0/0 and be put into the graveyard."
+ * (2021-03-19)
+ */
+class MirrorEntityScenarioTest : FunSpec({
+
+    val entityAbility = MirrorEntity.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + MirrorEntity)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.activate(x: Int): Boolean {
+        giveMana(player1, Color.WHITE, maxOf(x, 1))
+        val entity = getCreatures(player1).first { getCardName(it) == "Mirror Entity" }
+        val result = submit(ActivateAbility(player1, entity, entityAbility, xValue = x))
+        bothPass()
+        return result.isSuccess
+    }
+
+    fun GameTestDriver.power(id: EntityId): Int? = state.projectedState.getPower(id)
+    fun GameTestDriver.toughness(id: EntityId): Int? = state.projectedState.getToughness(id)
+
+    test("X=4 sets every creature you control to a base 4/4 and makes them every creature type") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putCreatureOnBattlefield(d.player1, "Mirror Entity")
+        val giant = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        val bears = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val theirs = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.activate(4) shouldBe true
+
+        withClue("the 2/2 became a base 4/4 — X reached the iteration body") {
+            d.power(bears) shouldBe 4
+            d.toughness(bears) shouldBe 4
+        }
+        withClue("the 3/3 also became 4/4") {
+            d.power(giant) shouldBe 4
+            d.toughness(giant) shouldBe 4
+        }
+        withClue("a Bear that gained all creature types is now a Goblin too") {
+            d.state.projectedState.hasSubtype(bears, "Goblin") shouldBe true
+        }
+        withClue("the opponent's creature is not one you control") {
+            d.power(theirs) shouldBe 2
+            d.state.projectedState.hasSubtype(theirs, "Goblin") shouldBe false
+        }
+    }
+
+    test("X=1 shrinks a 3/3, proving this is a base-setting effect and not a pump") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Mirror Entity")
+        val giant = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+
+        d.activate(1) shouldBe true
+
+        withClue("a +1/+1 bonus would have made it 4/4; a base set makes it 1/1") {
+            d.power(giant) shouldBe 1
+            d.toughness(giant) shouldBe 1
+        }
+    }
+
+    test("X=0 wipes your own board, exactly as the ruling says") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putCreatureOnBattlefield(d.player1, "Mirror Entity")
+        d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.activate(0) shouldBe true
+
+        withClue("every creature you control became 0/0 and died to state-based actions") {
+            d.getCreatures(d.player1).size shouldBe 0
+        }
+        withClue("the opponent's board is untouched") {
+            d.getCreatures(opponent).size shouldBe 1
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShieldsOfVelisVelScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShieldsOfVelisVelScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ShieldsOfVelisVel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Shields of Velis Vel (LRW #39) — "Creatures target player controls get +0/+1 and gain all
+ * creature types until end of turn."
+ *
+ * The spell targets a *player*, not the creatures, and the controller predicate on the group has
+ * to resolve against that bound target rather than against the caster. A filter that fell back to
+ * the implicit "you control" reading would still buff a board and still read correctly on the
+ * card, so the test aims the spell at the **opponent** — a shape where the two readings give
+ * opposite answers.
+ *
+ * The changeling grant is asserted alongside the stats: "gain all creature types" is the half a
+ * pump-only script would silently drop, and it is the half the card is named for.
+ */
+class ShieldsOfVelisVelScenarioTest : FunSpec({
+
+    fun GameTestDriver.toughness(id: EntityId): Int? = state.projectedState.getToughness(id)
+
+    test("the target player's creatures get the buff and every creature type; yours do not") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ShieldsOfVelisVel)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opponent = d.getOpponent(d.player1)
+        val theirs = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val ours = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+
+        val shields = d.putCardInHand(d.player1, "Shields of Velis Vel")
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.castSpellWithTargets(d.player1, shields, listOf(ChosenTarget.Player(opponent)))
+            .error shouldBe null
+        d.bothPass()
+
+        withClue("the opponent's 2/2 became a 2/3") {
+            d.toughness(theirs) shouldBe 3
+        }
+        withClue("and gained all creature types, so their Bear is also a Goblin") {
+            d.state.projectedState.hasSubtype(theirs, "Goblin") shouldBe true
+        }
+        withClue("our own creature was never in the group — the target player is not us") {
+            d.toughness(ours) shouldBe 2
+            d.state.projectedState.hasSubtype(ours, "Goblin") shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/MirrorEntityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/MirrorEntityReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mirror Entity reprint in C13. The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes
+ * only per-printing presentation data.
+ */
+val MirrorEntityReprint = Printing(
+    oracleId = "17e905ca-c0bd-473d-95a7-e180ba5fea43",
+    name = "Mirror Entity",
+    setCode = "C13",
+    collectorNumber = "17",
+    scryfallId = "295c8a21-7a4e-42cb-9420-9e59a1b75954",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/295c8a21-7a4e-42cb-9420-9e59a1b75954.jpg?1783939690",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/MirrorEntityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/MirrorEntityReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mirror Entity reprint in C16. The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes
+ * only per-printing presentation data.
+ */
+val MirrorEntityReprint = Printing(
+    oracleId = "17e905ca-c0bd-473d-95a7-e180ba5fea43",
+    name = "Mirror Entity",
+    setCode = "C16",
+    collectorNumber = "70",
+    scryfallId = "ce459d29-af63-4714-a1df-f33ecbf33708",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce459d29-af63-4714-a1df-f33ecbf33708.jpg?1783937077",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/GalepowderMageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/GalepowderMageReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Galepowder Mage reprint in CLB. The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes
+ * only per-printing presentation data.
+ */
+val GalepowderMageReprint = Printing(
+    oracleId = "b2457982-6c28-47e9-9b32-9db359eb0ac5",
+    name = "Galepowder Mage",
+    setCode = "CLB",
+    collectorNumber = "694",
+    scryfallId = "222b4c5a-2cd0-4851-9f2f-8685a658ebb4",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg?1783922490",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MirrorEntityReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MirrorEntityReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mirror Entity reprint in CLB. The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes
+ * only per-printing presentation data.
+ */
+val MirrorEntityReprint = Printing(
+    oracleId = "17e905ca-c0bd-473d-95a7-e180ba5fea43",
+    name = "Mirror Entity",
+    setCode = "CLB",
+    collectorNumber = "701",
+    scryfallId = "3d9149ed-0e59-48b3-b48c-d5ea77b7239e",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d9149ed-0e59-48b3-b48c-d5ea77b7239e.jpg?1783922484",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/MirrorEntityReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/MirrorEntityReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mirror Entity reprint in VOC. The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes
+ * only per-printing presentation data.
+ */
+val MirrorEntityReprint = Printing(
+    oracleId = "17e905ca-c0bd-473d-95a7-e180ba5fea43",
+    name = "Mirror Entity",
+    setCode = "VOC",
+    collectorNumber = "94",
+    scryfallId = "6733ee04-a282-43ea-830f-1ba806331c7b",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/6733ee04-a282-43ea-830f-1ba806331c7b.jpg?1783924970",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1211,6 +1211,83 @@
     ]
 }
 
+// Brigid, Hero of Kinsbaile
+{
+    "name": "Brigid, Hero of Kinsbaile",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Creature — Kithkin Archer",
+    "oracleText": "First strike\n{T}: Brigid deals 2 damage to each attacking or blocking creature target player controls.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ],
+                                "controllerPredicate": {
+                                    "type": "ControlledByReferencedPlayer",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target player"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "Brigid deals 2 damage to each attacking or blocking creature target player controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "Thanks to one champion archer, the true borders of Kinsbaile extend an arrow's flight beyond the buildings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg?1783942917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Caterwauling Boggart
 {
     "name": "Caterwauling Boggart",
@@ -1873,6 +1950,37 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Dolmen Gate
+{
+    "name": "Dolmen Gate",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Prevent all combat damage that would be dealt to attacking creatures you control.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": "creature attacking ctrl:you"
+                    },
+                    "damageType": "DamageCombat"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "RARE",
+        "artist": "Richard Sardinha",
+        "flavorText": "Lorwyn's stones resonate with the place from which they were hewed. Though taken far, still they call to their home when silence is upon the land.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdcbf10e-32f2-41c5-a7a2-5f24662892d2.jpg?1783942851"
+    },
+    "colorIdentityOverride": []
 }
 
 // Doran, the Siege Tower
@@ -3472,6 +3580,86 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Galepowder Mage
+{
+    "name": "Galepowder Mage",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Kithkin Wizard",
+    "oracleText": "Flying\nWhenever this creature attacks, exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target creature"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target creature"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature"
+                },
+                "descriptionOverride": "exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Jeremy Jarvis",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/8152999d-5e65-4ea6-b1e7-94b41808faa0.jpg?1783942915",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Galepowder Mage's ability can target a creature controlled by any player. It's not optional."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The exiled card will be returned to the battlefield at the beginning of the end step even if Galepowder Mage is no longer on the battlefield at that time."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If Galepowder Mage is the only creature on the battlefield when it attacks, its ability has no effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -6700,6 +6888,86 @@
     ]
 }
 
+// Mirror Entity
+{
+    "name": "Mirror Entity",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\n{X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{X}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBaseStats",
+                                "target": "Self",
+                                "power": "XValue",
+                                "toughness": "XValue",
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "CHANGELING",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Until end of turn, creatures you control have base power and toughness X/X and gain all creature types."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Unaware of Lorwyn's diversity, it sees only itself, reflected a thousand times over.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/adfff880-cbf6-4085-bc05-c72658b75f25.jpg?1783942911",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "Changeling applies in all zones, not just the battlefield."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "Mirror Entity's ability overwrites any effects that previously set a creature's base power and/or toughness. Any existing effects or counters that raise or lower a creature's power and/or toughness continue to apply to the creature's newly-set power and toughness."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "Activating the ability with X = 0 will cause all creatures you control to become 0/0 and be put into the graveyard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Moonglove Extract
 {
     "name": "Moonglove Extract",
@@ -8221,6 +8489,76 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Shields of Velis Vel
+{
+    "name": "Shields of Velis Vel",
+    "manaCost": "{W}",
+    "typeLine": "Kindred Instant — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nCreatures target player controls get +0/+1 and gain all creature types until end of turn.",
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "controllerPredicate": {
+                            "type": "ControlledByReferencedPlayer",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        }
+                    }
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "CHANGELING",
+                        "target": "Self"
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Ralph Horsley",
+        "flavorText": "Changelings can alter shape based on what the beings around them desire most.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f550f44f-8b8f-4c1d-a583-9fd986d3061c.jpg?1783942908"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Five Lorwyn cards, all composed from existing `Effects.*` / `Patterns.*` — no new SDK vocabulary. LRW goes 192/286 → 197/286.

| Card | What it does | Composed from |
|---|---|---|
| **Shields of Velis Vel** `{W}` | Creatures target player controls get +0/+1 and gain all creature types | `ForEachInGroup` over `Creature.targetPlayerControls(p)` + `ModifyStats` + `GrantKeyword(CHANGELING)` — the toughness-side twin of Ego Erasure |
| **Dolmen Gate** `{2}` | Prevent all combat damage to attacking creatures you control | `PreventDamage` replacement, `RecipientFilter.Matching(Creature.youControl().attacking())`, `DamageType.Combat` |
| **Galepowder Mage** `{3}{W}` | Attack trigger: exile another target creature, return it at the next end step | `Effects.Exile` + `CreateDelayedTriggerEffect(Step.END)` + `Move(…, BATTLEFIELD)` — the Kykar shape |
| **Brigid, Hero of Kinsbaile** `{2}{W}{W}` | `{T}`: 2 damage to each attacking or blocking creature target player controls | `ForEachInGroup` over `Creature.attackingOrBlocking().targetPlayerControls(p)` + `DealDamage` — the Leonin Bladetrap shape |
| **Mirror Entity** `{2}{W}` | `{X}`: creatures you control have base P/T X/X and gain all creature types | `ForEachInGroup` + `SetBasePowerAndToughness(XValue, XValue)` + `GrantKeyword(CHANGELING)` — the Katara shape |

## Tests

Every card gets its own scenario test, aimed at the half that fails silently rather than at "the card did something":

- **Dolmen Gate** — nothing in the corpus had combined `RecipientFilter.Matching` with a *state* predicate before, and each axis can fail open or closed without changing how the card reads. Three tests: your attacker is shielded, your *blocker* is not, an opponent's attacker is not.
- **Brigid** and **Shields of Velis Vel** — both bind a group's controller predicate to a *player target*. A filter falling back to the implicit "you control" reading would still do something plausible, so both tests aim at the opponent, the shape where the two readings disagree.
- **Galepowder Mage** — the delayed trigger holds a reference to a card that changed zones. A reference that didn't survive the move would strand the creature in exile forever, so exile and return are asserted separately, and a third test kills the Mage mid-turn to prove the return isn't source-gated (2007-10-01 ruling).
- **Mirror Entity** — losing X inside the iteration looks exactly like a legitimate X=0 activation, so X=4, X=1 and X=0 are asserted separately. X=1 *shrinking* a 3/3 is what pins this as layer 7b rather than a `ModifyStats`.

## Also

- `Printing` rows for the reprints canonical placement requires: Galepowder Mage in CLB; Mirror Entity in C13, C16, VOC, CLB.
- Rulings added to Galepowder Mage and Mirror Entity where they carry mechanical weight.
- LRW card snapshot golden re-blessed — only these five cards moved.

## Dropped from the batch

**Turtleshell Changeling** — "{1}{U}: Switch this creature's power and toughness until end of turn." Switching P/T is CR layer 7e and has **no SDK vocabulary at all**: `grep` over `mtg-sdk/` and `rules-engine/` returns only *rulings text* mentioning the concept, never an effect. That is `add-feature` work and gets its own PR rather than a lookalike here.

## Verification

`just build` green. `just assay-differential --set LRW` — 101 confirmed, 10 divergent, all ten pre-existing (the Harbinger cycle, Epic Proportions, Boggart Sprite-Chaser, Kithkin Greatheart); none of these five. `just check-card-printing` clean for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6