### PR TITLE
Add 51 Assay-ready cards to Champions of Kamigawa

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/AkkiAvalanchers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/AkkiAvalanchers.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Akki Avalanchers
+ * {R}
+ * Creature — Goblin Warrior
+ * 1 / 1
+ *
+ * Sacrifice a land: This creature gets +2/+0 until end of turn. Activate only once each turn.
+ *
+ * The whole card is one activated ability: a bare [Costs.Sacrifice] over `GameObjectFilter.Land`
+ * (no mana half at all) pumping [EffectTarget.Self], with the printed "Activate only once each
+ * turn" carried by [ActivationRestriction.OncePerTurn] rather than by any condition on the effect.
+ */
+val AkkiAvalanchers = card("Akki Avalanchers") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice a land: This creature gets +2/+0 until end of turn. Activate only once each turn."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Land)
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Matt Thompson"
+        flavorText = "Among Godo's hordes, \"beware of falling rocks\" came to mean \"akki live nearby.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg?1783944307"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/ChampionsOfKamigawaBasicLands.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/ChampionsOfKamigawaBasicLands.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Champions of Kamigawa Basic Lands
+ *
+ * Champions of Kamigawa contains 4 art variants of each basic land type.
+ * Cards 287-306 (Plains 287-290, Island 291-294, Swamp 295-298, Mountain 299-302,
+ * Forest 303-306).
+ */
+
+// =============================================================================
+// Plains (Cards 287-290)
+// =============================================================================
+
+val Plains287 = basicLand("Plains") {
+    collectorNumber = "287"
+    artist = "Greg Staples"
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/deff6a75-2ecd-49d6-b58b-a9d24615f9b7.jpg?1783944270"
+}
+
+val Plains288 = basicLand("Plains") {
+    collectorNumber = "288"
+    artist = "Greg Staples"
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4add62bc-d24c-4a1f-81bc-e3a6befe3f0d.jpg?1783944271"
+}
+
+val Plains289 = basicLand("Plains") {
+    collectorNumber = "289"
+    artist = "Greg Staples"
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/28fae600-d829-412a-8f77-3f25a106f574.jpg?1783944271"
+}
+
+val Plains290 = basicLand("Plains") {
+    collectorNumber = "290"
+    artist = "Greg Staples"
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e590059d-57e5-4696-9bb1-30d8d35c4329.jpg?1783944271"
+}
+
+// =============================================================================
+// Island (Cards 291-294)
+// =============================================================================
+
+val Island291 = basicLand("Island") {
+    collectorNumber = "291"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5170ce9-2463-4fec-945b-6c2f23eb7e22.jpg?1783944270"
+}
+
+val Island292 = basicLand("Island") {
+    collectorNumber = "292"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f12c5ae3-8c55-4bd9-a64f-3960d45c0563.jpg?1783944269"
+}
+
+val Island293 = basicLand("Island") {
+    collectorNumber = "293"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5d141922-570d-4652-9620-2b53eb68294a.jpg?1783944269"
+}
+
+val Island294 = basicLand("Island") {
+    collectorNumber = "294"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35c20f8b-6ad1-4aa2-94d3-7bd42562a1ac.jpg?1783944268"
+}
+
+// =============================================================================
+// Swamp (Cards 295-298)
+// =============================================================================
+
+val Swamp295 = basicLand("Swamp") {
+    collectorNumber = "295"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d376282-adf0-4d37-b9a4-1329cd496516.jpg?1783944269"
+}
+
+val Swamp296 = basicLand("Swamp") {
+    collectorNumber = "296"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f88a6fa7-58e7-459c-8e2e-be5a4692450b.jpg?1783944269"
+}
+
+val Swamp297 = basicLand("Swamp") {
+    collectorNumber = "297"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d0878ac9-6a80-4412-999d-4c6549b9afd4.jpg?1783944268"
+}
+
+val Swamp298 = basicLand("Swamp") {
+    collectorNumber = "298"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb3d03a6-35bf-415e-9faa-972edff92777.jpg?1783944268"
+}
+
+// =============================================================================
+// Mountain (Cards 299-302)
+// =============================================================================
+
+val Mountain299 = basicLand("Mountain") {
+    collectorNumber = "299"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22262a3a-c2e0-4639-9002-361b39ea9b3a.jpg?1783944268"
+}
+
+val Mountain300 = basicLand("Mountain") {
+    collectorNumber = "300"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/266a514a-076a-40c0-a756-c6fdd261c3cb.jpg?1783944268"
+}
+
+val Mountain301 = basicLand("Mountain") {
+    collectorNumber = "301"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e1a59c7-53d9-4e2c-9596-c64394838575.jpg?1783944268"
+}
+
+val Mountain302 = basicLand("Mountain") {
+    collectorNumber = "302"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c15e5767-64e1-4f4e-a02e-1143db0f648e.jpg?1783944267"
+}
+
+// =============================================================================
+// Forest (Cards 303-306)
+// =============================================================================
+
+val Forest303 = basicLand("Forest") {
+    collectorNumber = "303"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3209b22-56af-45ac-9224-67574c035638.jpg?1783944267"
+}
+
+val Forest304 = basicLand("Forest") {
+    collectorNumber = "304"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9cf9a4b-be51-4f5d-ac0e-e4f79bbfaecd.jpg?1783944266"
+}
+
+val Forest305 = basicLand("Forest") {
+    collectorNumber = "305"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1629dba-02af-4586-ba59-58faac7cf59b.jpg?1783944266"
+}
+
+val Forest306 = basicLand("Forest") {
+    collectorNumber = "306"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88f06e37-f113-4865-9ad9-13483dd15084.jpg?1783944266"
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/ConsumingVortex.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/ConsumingVortex.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Consuming Vortex
+ * {1}{U}
+ * Instant — Arcane
+ * Return target creature to its owner's hand.
+ * Splice onto Arcane {3}{U}
+ *
+ * The splice cost is not the mana cost: {3}{U} to graft the bounce onto another Arcane spell.
+ * The declared `spell { }` effect *is* the spliced text (CR 702.47a), so `splice(...)` needs no
+ * further wiring.
+ */
+val ConsumingVortex = card("Consuming Vortex") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant — Arcane"
+    oracleText = "Return target creature to its owner's hand.\n" +
+        "Splice onto Arcane {3}{U} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{3}{U}")
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg?1783944329"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/CursedRonin.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/CursedRonin.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cursed Ronin
+ * {3}{B}
+ * Creature — Human Samurai
+ * 1/1
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ * {B}: This creature gets +1/+1 until end of turn.
+ *
+ * The firebreathing-shaped pump is a plain activated ability: a mana-only cost and
+ * `ModifyStats(+1/+1)` on [EffectTarget.Self], matching Assay's compiled model exactly. It is
+ * repeatable, so no once-per-turn restriction is declared.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val CursedRonin = card("Cursed Ronin") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Samurai"
+    power = 1
+    toughness = 1
+    oracleText = "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\n" +
+        "{B}: This creature gets +1/+1 until end of turn."
+
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "{B}: This creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Carl Critchlow"
+        flavorText = "\"You are fortunate, my enemy. You have paid the price but once. I never stop paying.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg?1783944316"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DampenThought.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DampenThought.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dampen Thought
+ * {1}{U}
+ * Instant — Arcane
+ * Target player mills four cards.
+ * Splice onto Arcane {1}{U}
+ *
+ * `Patterns.Library.mill` is the Gather-then-Move pipeline the mill sentence compiles to: the
+ * four cards are gathered off the top of the *target* player's library (`isMill = true`) and then
+ * moved to that same player's graveyard as one batch, so a single zone-change batch trigger sees
+ * all four.
+ */
+val DampenThought = card("Dampen Thought") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant — Arcane"
+    oracleText = "Target player mills four cards.\n" +
+        "Splice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{1}{U}")
+
+    spell {
+        val player = target("target", Targets.Player)
+        effect = Patterns.Library.mill(4, player)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg?1783944329"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DesperateRitual.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DesperateRitual.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Desperate Ritual
+ * {1}{R}
+ * Instant — Arcane
+ * Add {R}{R}{R}.
+ * Splice onto Arcane {1}{R}
+ *
+ * A Pyretic Ritual with a type line: the whole spell effect is [Effects.AddMana], no restriction
+ * and no rider, so the mana is plain red mana that empties like any other. The splice half is what
+ * makes it more than a ritual — grafting "add {R}{R}{R}" onto an Arcane spell refunds most of the
+ * splice cost as you cast it.
+ */
+val DesperateRitual = card("Desperate Ritual") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant — Arcane"
+    oracleText = "Add {R}{R}{R}.\n" +
+        "Splice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{1}{R}")
+
+    spell {
+        effect = Effects.AddMana(Color.RED, 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg?1783944301"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DevotedRetainer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/DevotedRetainer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Devoted Retainer
+ * {W}
+ * Creature — Human Samurai
+ * 1/1
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability, "Whenever this creature blocks or becomes blocked, it gets +N/+N until end of
+ * turn"; the SDK has no single event covering both directions from the source's point of view, so it
+ * is written as two triggers over the two distinct events. They are mutually exclusive in any one
+ * combat — the Retainer either declares a block or is blocked, never both — so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val DevotedRetainer = card("Devoted Retainer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Samurai"
+    power = 1
+    toughness = 1
+    oracleText = "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)"
+
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Greg Hildebrandt"
+        flavorText = "Deep within Eiganjo Castle lay the Palace of Infinite Halls, a seemingly endless network of corridors once guarded by a seemingly endless legion of samurai."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg?1783944342"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/Earthshaker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/Earthshaker.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Earthshaker
+ * {4}{R}{R}
+ * Creature — Spirit
+ * 4/5
+ * Whenever you cast a Spirit or Arcane spell, this creature deals 2 damage to each creature without flying.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes. `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, in one call — the `or` infix collapses to the same
+ * predicate here, but only because both branches are homogeneous, so the direct spelling is the
+ * one all thirteen CHK cards in this family share. `Triggers.youCastSpell` supplies `Player.You`
+ * and `TriggerBinding.ANY`, so Earthshaker also triggers off its own cast.
+ *
+ * The payoff is a group sweep, not a targeted burn: `ForEachInGroup` over every creature lacking
+ * flying, with `EffectTarget.Self` inside the body resolving to the current iteration entity.
+ * Earthshaker has no flying itself, so it is in its own blast radius (and survives it at 4/5).
+ */
+val Earthshaker = card("Earthshaker") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, this creature deals 2 damage to each creature without flying."
+    power = 4
+    toughness = 5
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures.withoutKeyword(Keyword.FLYING),
+            Effects.DealDamage(2, EffectTarget.Self)
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Ron Spencer"
+        flavorText = "It scaled the Sokenzan Mountains in search of Kumano's secret. The mountain shook for two days, and the kami never returned."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg?1783944301"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/EerieProcession.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/EerieProcession.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Eerie Procession
+ * {2}{U}
+ * Sorcery — Arcane
+ *
+ * Search your library for an Arcane card, reveal that card, put it into your hand, then shuffle.
+ *
+ * `assay compile` declines this line — its grammar has no rule for the noun phrase "an Arcane
+ * card" — so it is authored straight from the printed text. The tutor is the stock
+ * [Patterns.Library.searchLibrary] facade with `destination = HAND` and `reveal = true`
+ * (`shuffleAfter` already defaults to true, which is the printed "then shuffle").
+ *
+ * The filter is [Subtype.ARCANE] alone, with no card-type predicate beside it. Every Arcane card
+ * ever printed happens to be an instant or a sorcery, so narrowing to `InstantOrSorcery` would
+ * select the same cards today — but the printed text restricts by subtype and nothing else, and
+ * the extra `Or(IsInstant, IsSorcery)` is a divergence the Assay differential flags against the
+ * model it builds from that same text. Say what the card says.
+ */
+val EerieProcession = card("Eerie Procession") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery — Arcane"
+    oracleText = "Search your library for an Arcane card, reveal that card, put it into your hand, then shuffle."
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.ARCANE),
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Jim Murray"
+        flavorText = "\"Though in years past speculation was not encouraged about the strange ways " +
+            "of kami, now we must understand their motivations, if such is even possible to the " +
+            "mortal mind.\"\n—Lady Azami"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg?1783944329"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/EtherealHaze.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/EtherealHaze.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.effects.PreventionDirection
+import com.wingedsheep.sdk.scripting.effects.PreventionSourceFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ethereal Haze
+ * {W}
+ * Instant — Arcane
+ *
+ * Prevent all damage that would be dealt by creatures this turn.
+ *
+ * Not a Fog: Fog prevents all *combat* damage, while this prevents *all* damage from a class of
+ * sources, so the shield keeps `PreventionScope.AllDamage` (the default) and narrows the
+ * *source* side instead — [PreventionDirection.FromTarget] with a
+ * [PreventionSourceFilter.FromGroup] over every creature. A creature's activated ability that
+ * pings is stopped too, which is what the printed line says. The group is re-evaluated when each
+ * damage instance would be dealt, so a creature that enters later this turn is covered.
+ *
+ * The closest facade, `Effects.PreventCombatDamageFrom`, hard-codes `PreventionScope.CombatOnly`
+ * and would silently narrow the card, so the shield is spelled out here — the same shape
+ * `leg/cards/AlabarasCarpet.kt` uses.
+ */
+val EtherealHaze = card("Ethereal Haze") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant — Arcane"
+    oracleText = "Prevent all damage that would be dealt by creatures this turn."
+
+    spell {
+        effect = PreventDamageEffect(
+            direction = PreventionDirection.FromTarget,
+            sourceFilter = PreventionSourceFilter.FromGroup(GroupFilter(GameObjectFilter.Creature))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Chris Appelhans"
+        flavorText = "\"Imagine a dove flying through smoke. Does the dove injure the smoke? Does the smoke impede the dove?\"\n—Teachings of Eight-and-a-Half-Tails"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg?1783944341"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/FieldOfReality.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/FieldOfReality.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Field of Reality
+ * {2}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature can't be blocked by Spirits.
+ * {1}{U}: Return this Aura to its owner's hand.
+ *
+ * "Enchant creature" is the `auraTarget` declaration — without it the Aura has nothing to attach
+ * to. The evasion clause is a [CantBeBlockedBy] static scoped to [GroupFilter.attachedCreature],
+ * so it follows the enchanted creature rather than the Aura itself. "Spirits" is a bare tribal
+ * noun with no "creature" after it, so the blocker filter is `Permanent.withSubtype("Spirit")`
+ * (blockers are creatures anyway; the printed word decides the filter). The self-bounce is the
+ * ordinary [Effects.Move] of [EffectTarget.Self] to hand.
+ */
+val FieldOfReality = card("Field of Reality") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature can't be blocked by Spirits.\n" +
+        "{1}{U}: Return this Aura to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = CantBeBlockedBy(
+            blockerFilter = GameObjectFilter.Permanent.withSubtype("Spirit"),
+            filter = GroupFilter.attachedCreature()
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Christopher Rush"
+        flavorText = "\"The scholars of the Minamo School understood the veil between their world and that of the kami. Moreover, they knew how to exploit it.\"\n—*Observations of the Kami War*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg?1783944328"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GhostlyPrison.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GhostlyPrison.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ghostly Prison
+ * {2}{W}
+ * Enchantment
+ *
+ * Creatures can't attack you unless their controller pays {2} for each creature they control that's
+ * attacking you.
+ *
+ * The whole card is one [AttackTax] static — the engine's combat-tax rules already charge the
+ * per-attacker amount to each attacking creature's controller, so a flat [DynamicAmount.Fixed] of
+ * 2 is the entire card. Same shape as Propaganda, which prints the identical line in blue.
+ */
+val GhostlyPrison = card("Ghostly Prison") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you."
+
+    staticAbility {
+        ability = AttackTax(amountPerAttacker = DynamicAmount.Fixed(2))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Lars Grant-West"
+        flavorText = "Destroyed in one of the first battles of the Kami War, the town of Reito still grieved."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg?1783944341"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GlacialRay.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GlacialRay.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Ray
+ * {1}{R}
+ * Instant — Arcane
+ * Glacial Ray deals 2 damage to any target.
+ * Splice onto Arcane {1}{R}
+ *
+ * "Any target" is [Targets.Any] — creature, player, or planeswalker. The splice cost equals the
+ * mana cost, which is what made this the archetypal splice card: every Arcane spell in the deck
+ * becomes a second Glacial Ray.
+ */
+val GlacialRay = card("Glacial Ray") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant — Arcane"
+    oracleText = "Glacial Ray deals 2 damage to any target.\n" +
+        "Splice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{1}{R}")
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Jim Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg?1783944301"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GuardianOfSolitude.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/GuardianOfSolitude.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Guardian of Solitude
+ * {1}{U}
+ * Creature — Spirit
+ * 1/2
+ * Whenever you cast a Spirit or Arcane spell, target creature gains flying until end of turn.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Guardian of Solitude also triggers off its own cast.
+ */
+val GuardianOfSolitude = card("Guardian of Solitude") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, target creature gains flying until end of turn."
+    power = 1
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Stephen Tappin"
+        flavorText = "\"It seemed an easy thing, to step into the nothingness, to fall, to die. But then, for an instant, I saw it, eyes filled with endless sorrow, and I turned back to face my pain.\"\n—Snow-Fur, kitsune poet"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg?1783944327"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HairStrungKoto.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HairStrungKoto.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hair-Strung Koto
+ * {6}
+ * Artifact
+ *
+ * Tap an untapped creature you control: Target player mills a card.
+ *
+ * The cost is [Costs.TapPermanents], not [Costs.Tap] — the Koto itself is never tapped; tapping a
+ * creature *as a cost* rather than paying the `{T}` symbol means summoning sickness never applies
+ * (CR 302.6) and only untapped permanents may be chosen (CR 701.26a). "You control" and "untapped"
+ * are carried by the atom, so the filter only has to say *creature*; the artifact is not itself a
+ * legal choice because it isn't one. Same shape as `chk/cards/AzamiLadyOfScrolls.kt` and
+ * `lrw/cards/DrownerOfSecrets.kt`.
+ */
+val HairStrungKoto = card("Hair-Strung Koto") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Tap an untapped creature you control: Target player mills a card."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature)
+        val player = target("target", Targets.Player)
+        effect = Patterns.Library.mill(1, player)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Rebecca Guay"
+        flavorText = "\"The Kami War drove many members of Konda's court insane. As their spiritual world turned against them, so too did their minds turn from reality.\"\n—*The History of Kamigawa*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg?1783944281"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HanaKami.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HanaKami.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Hana Kami
+ * {G}
+ * Creature — Spirit
+ * 1/1
+ *
+ * {1}{G}, Sacrifice this creature: Return target Arcane card from your graveyard to your hand.
+ *
+ * Argentum Assay declines this one — its grammar has no rule for the noun phrase "an Arcane card" —
+ * so it is authored straight from the printed text. The graveyard target is the bare-noun-subtype
+ * spelling [TargetFilter.CardInGraveyard]`.withSubtype(Subtype.ARCANE).ownedByYou()`, the same shape
+ * Lord of the Undead and Misery Charm use for their tribal graveyard retrieval; the cost is the
+ * ordinary mana + sacrifice-self composite.
+ */
+val HanaKami = card("Hana Kami") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{G}, Sacrifice this creature: Return target Arcane card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.SacrificeSelf)
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter.CardInGraveyard.withSubtype(Subtype.ARCANE).ownedByYou())
+        )
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Rebecca Guay"
+        flavorText = "It grew in lands lit by pride and watered by tears."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg?1783944290"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HearthKami.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HearthKami.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Hearth Kami
+ * {1}{R}
+ * Creature — Spirit
+ * 2/1
+ *
+ * {X}, Sacrifice this creature: Destroy target artifact with mana value X.
+ *
+ * The X paid for the ability threads into the *target filter* rather than into the effect:
+ * `manaValueEqualsX()` lowers to `CardPredicate.ManaValueEqualsX`, which the target enumerator reads
+ * off the X chosen for this activation, so activating for X=3 can only ever target a mana-value-3
+ * artifact. That is the whole card — the destroy itself is the plain [Effects.Destroy].
+ */
+val HearthKami = card("Hearth Kami") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "{X}, Sacrifice this creature: Destroy target artifact with mana value X."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.SacrificeSelf)
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.manaValueEqualsX()))
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Luca Zontini"
+        flavorText = "\"Every treachery, great or small, begets a spirit that rages at the " +
+            "injustice. Given the opportunity, each will return that treachery to its owner " +
+            "tenfold.\"\n—Sensei Hisoka"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg?1783944300"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HideousLaughter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HideousLaughter.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Hideous Laughter
+ * {2}{B}{B}
+ * Instant — Arcane
+ * All creatures get -2/-2 until end of turn.
+ * Splice onto Arcane {3}{B}{B}
+ *
+ * "All creatures" — not "creatures you control", not "creatures your opponents control" — so the
+ * group is [GroupFilter.AllCreatures] and the sweep hits your own board too.
+ * `Patterns.Group.modifyStatsForAll` names the group once and applies the modifier per member,
+ * which is the single-pass shape the grammar builds.
+ */
+val HideousLaughter = card("Hideous Laughter") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant — Arcane"
+    oracleText = "All creatures get -2/-2 until end of turn.\n" +
+        "Splice onto Arcane {3}{B}{B} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{3}{B}{B}")
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(-2, -2, GroupFilter.AllCreatures)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg?1783944315"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HorizonSeed.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/HorizonSeed.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Horizon Seed
+ * {4}{W}
+ * Creature — Spirit
+ * 2/1
+ * Whenever you cast a Spirit or Arcane spell, regenerate target creature.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Horizon Seed also triggers off its own cast.
+ *
+ * Regeneration has no `Effects.` facade — `RegenerateEffect` is the corpus spelling (Reknit,
+ * Asceticism), and it lays down the one-shot destruction shield rather than acting immediately.
+ */
+val HorizonSeed = card("Horizon Seed") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, regenerate target creature."
+    power = 2
+    toughness = 1
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = RegenerateEffect(t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Matt Cavotta"
+        flavorText = "In peaceful times, these beings escorted the honored kami to their new shrines. In the Kami War, they became the medics of an unstoppable army."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg?1783944339"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/InnocenceKami.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/InnocenceKami.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Innocence Kami
+ * {3}{W}{W}
+ * Creature — Spirit
+ * 2/3
+ * {W}, {T}: Tap target creature.
+ * Whenever you cast a Spirit or Arcane spell, untap this creature.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Innocence Kami also triggers off its own cast.
+ *
+ * Both halves lower to the same `TapUntapEffect` atom: the activated ability taps the chosen
+ * target, the trigger untaps the source (`EffectTarget.Self`), which is what lets the tapper fire
+ * repeatedly in a Spirit-heavy turn.
+ */
+val InnocenceKami = card("Innocence Kami") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "{W}, {T}: Tap target creature.\n" +
+        "Whenever you cast a Spirit or Arcane spell, untap this creature."
+    power = 2
+    toughness = 3
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Tap(t)
+    }
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Mark Zug"
+        flavorText = "Her voice was light, her substance music."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg?1783944338"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/JadeIdol.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/JadeIdol.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Jade Idol
+ * {4}
+ * Artifact
+ * Whenever you cast a Spirit or Arcane spell, this artifact becomes a 4/4 Spirit artifact creature until end of turn.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Jade Idol also animates off its own cast — though it is not itself a
+ * Spirit or Arcane spell, so in practice that only matters for a copy or a text-changing effect.
+ *
+ * The animation is additive: `BecomeCreature` with no `removeTypes` leaves the Artifact type in
+ * place and `addTypes = setOf("ARTIFACT")` restates it, matching the printed "artifact creature".
+ * The default `target` is `EffectTarget.Self` (the Idol) and the default duration is end of turn.
+ */
+val JadeIdol = card("Jade Idol") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, this artifact becomes a 4/4 Spirit artifact creature until end of turn."
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.BecomeCreature(
+            power = 4,
+            toughness = 4,
+            creatureTypes = setOf(Subtype.SPIRIT.value),
+            addTypes = setOf("ARTIFACT")
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Ben Thompson"
+        flavorText = "Before the Kami War, the shishi were symbolic guardians, protecting the shrines where they stood. But after the kami turned on the material world, shishi began pouncing from their perches to attack would-be supplicants."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg?1783944278"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfFiresRoar.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfFiresRoar.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kami of Fire's Roar
+ * {3}{R}
+ * Creature — Spirit
+ * 2/3
+ * Whenever you cast a Spirit or Arcane spell, target creature can't block this turn.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Kami of Fire's Roar also triggers off its own cast.
+ *
+ * "Can't block this turn" is `Effects.CantBlock`, whose default `Duration.EndOfTurn` already says
+ * "this turn"; it is a combat-legality rider on the target, not a projection change.
+ */
+val KamiOfFiresRoar = card("Kami of Fire's Roar") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, target creature can't block this turn."
+    power = 2
+    toughness = 3
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.CantBlock(t)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Dave Dorman"
+        flavorText = "\"I can hear the shamans chanting in the hills. They say their magic will protect us from the kami, that our gold has bought our safety. But no one sleeps soundly tonight.\"\n—Scroll fragment from the ruins of Reito"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg?1783944299"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfTheHunt.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfTheHunt.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kami of the Hunt
+ * {2}{G}
+ * Creature — Spirit
+ * 2/2
+ * Whenever you cast a Spirit or Arcane spell, this creature gets +1/+1 until end of turn.
+ *
+ * The Kamigawa "Whenever you cast a Spirit or Arcane spell" trigger is a `SpellCastEvent` watching
+ * *your* casts with an OR over the two subtypes — `withAnySubtype` builds the single
+ * `CardPredicate.Or` the grammar expects, rather than the `anyOf` branch list that the `or` infix
+ * on `GameObjectFilter` would produce. `Triggers.youCastSpell` supplies `Player.You` and
+ * `TriggerBinding.ANY`, so Kami of the Hunt also triggers off its own cast.
+ *
+ * The pump names `EffectTarget.Self` rather than the triggering entity: the boost belongs to the
+ * Kami, not to the spell that set it off.
+ */
+val KamiOfTheHunt = card("Kami of the Hunt") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, this creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "219"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"Don't worry, Jiro. The kami would never attack us this close to home . . . . Jiro?\"\n—Hoto, temple guardian, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg?1783944287"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfTheWaningMoon.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KamiOfTheWaningMoon.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Kami of the Waning Moon
+ * {2}{B}
+ * Creature — Spirit
+ * 1/1
+ * Flying
+ * Whenever you cast a Spirit or Arcane spell, target creature gains fear until end of turn.
+ *
+ * The Kamigawa block's signature payoff trigger. "Whenever you cast a Spirit or Arcane spell" is a
+ * [Triggers.youCastSpell] over a homogeneous OR of two subtype filters, which the SDK collapses to
+ * a single `CardPredicate.Or` — the flat shape the whole engine already resolves subtypes against.
+ * The binding is `ANY` (the factory's default), not `OTHER`: the card watches every Spirit or
+ * Arcane spell *you* cast, including the one that is this card itself when a later copy is cast
+ * while this one is already on the battlefield.
+ *
+ * "Target creature" is chosen when the trigger goes on the stack, and fear is a plain
+ * end-of-turn [Effects.GrantKeyword] — the same channel Gravelgill Duo and Breach use.
+ */
+val KamiOfTheWaningMoon = card("Kami of the Waning Moon") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "Whenever you cast a Spirit or Arcane spell, target creature gains fear until end of " +
+        "turn. (It can't be blocked except by artifact creatures and/or black creatures.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FEAR, creature)
+        description = "Whenever you cast a Spirit or Arcane spell, target creature gains fear " +
+            "until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Matt Thompson"
+        flavorText = "\"For a moment, Reito's defenders regrouped. Then wailing kami reappeared " +
+            "to send them scattering like flocks of frightened birds.\"\n" +
+            "—*Great Battles of Kamigawa*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg?1783944313"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KitsuneBlademaster.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KitsuneBlademaster.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kitsune Blademaster
+ * {2}{W}
+ * Creature — Fox Samurai
+ * 2/2
+ * First strike
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ *
+ * First strike is an engine-live keyword, so it stays a plain `keywords(…)` declaration.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val KitsuneBlademaster = card("Kitsune Blademaster") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Fox Samurai"
+    power = 2
+    toughness = 2
+    oracleText = "First strike\n" +
+        "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.FIRST_STRIKE)
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Keith Garletts"
+        flavorText = "Those kitsune trained in the blade preferred to fight with a blade-catching jitte in the off hand, buying them just enough time to deliver the first deadly cut."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg?1783944336"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KodamasMight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KodamasMight.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kodama's Might
+ * {G}
+ * Instant — Arcane
+ * Target creature gets +2/+2 until end of turn.
+ * Splice onto Arcane {G}
+ *
+ * A one-mana pump whose splice cost is also {G}: the cheapest graft in the cluster, and the reason
+ * a splice deck can stack several combat tricks onto one Arcane spell.
+ */
+val KodamasMight = card("Kodama's Might") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant — Arcane"
+    oracleText = "Target creature gets +2/+2 until end of turn.\n" +
+        "Splice onto Arcane {G} (As you cast an Arcane spell, you may reveal this card from your " +
+        "hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{G}")
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Terese Nielsen"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg?1783944286"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KondaLordOfEiganjo.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/KondaLordOfEiganjo.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Konda, Lord of Eiganjo
+ * {5}{W}{W}
+ * Legendary Creature — Human Samurai
+ * 3/3
+ * Vigilance, indestructible
+ * Bushido 5 (Whenever this creature blocks or becomes blocked, it gets +5/+5 until end of turn.)
+ *
+ * Vigilance and indestructible are engine-live keywords, so they stay a plain `keywords(…)`
+ * declaration. Legendary is carried by the type line — `TypeLine.parse` reads the supertype.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat — Konda either declares a block or is blocked, never both —
+ * so the +5/+5 never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val KondaLordOfEiganjo = card("Konda, Lord of Eiganjo") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Samurai"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance, indestructible\n" +
+        "Bushido 5 (Whenever this creature blocks or becomes blocked, it gets +5/+5 until end of turn.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.INDESTRUCTIBLE)
+    keywordAbility(KeywordAbility.bushido(5))
+
+    // Bushido 5, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(5, 5, EffectTarget.Self)
+        description = "Bushido 5"
+    }
+
+    // Bushido 5, half two: "… or becomes blocked, it gets +5/+5 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(5, 5, EffectTarget.Self)
+        description = "Bushido 5"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "30"
+        artist = "John Bolton"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg?1783944335"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/LiftedByClouds.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/LiftedByClouds.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Lifted by Clouds
+ * {2}{U}
+ * Instant — Arcane
+ * Target creature gains flying until end of turn.
+ * Splice onto Arcane {1}{U}
+ *
+ * `Effects.GrantKeyword` defaults to `Duration.EndOfTurn`, which is exactly the printed duration.
+ * The splice cost ({1}{U}) is a mana cheaper than casting the card outright.
+ */
+val LiftedByClouds = card("Lifted by Clouds") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant — Arcane"
+    oracleText = "Target creature gains flying until end of turn.\n" +
+        "Splice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{1}{U}")
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg?1783944325"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MelokuTheCloudedMirror.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MelokuTheCloudedMirror.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Meloku the Clouded Mirror
+ * {4}{U}
+ * Legendary Creature — Moonfolk Wizard
+ * 2 / 4
+ *
+ * Flying
+ * {1}, Return a land you control to its owner's hand: Create a 1/1 blue Illusion creature token
+ * with flying.
+ *
+ * The Moonfolk land-bounce cost is [Costs.ReturnToHand] over `GameObjectFilter.Land` composed with
+ * the mana half — the atom's enumerator is already you-control-only, so "you control" needs no
+ * extra predicate. The ability has no activation limit, so the whole card is one activated ability
+ * whose payoff is the plain [Effects.CreateToken] facade.
+ */
+val MelokuTheCloudedMirror = card("Meloku the Clouded Mirror") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Moonfolk Wizard"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "{1}, Return a land you control to its owner's hand: Create a 1/1 blue Illusion creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.ReturnToHand(GameObjectFilter.Land))
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Illusion"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "74"
+        artist = "Scott M. Fischer"
+        flavorText = "He loved his cities in the clouds. When he traveled to the lands below, he brought many reminders of his home."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg?1783944325"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MidnightCovenant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MidnightCovenant.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Midnight Covenant
+ * {1}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has "{B}: This creature gets +1/+1 until end of turn."
+ *
+ * "Enchant creature" is the builder's `auraTarget`. The granted ability rides
+ * [GrantActivatedAbility], whose `filter` defaults to `GroupFilter.attachedCreature()` — exactly the
+ * "enchanted creature" scope this card wants, so no filter is written. Inside the granted ability
+ * [EffectTarget.Self] is the creature that activated it, which is what the quoted "this creature"
+ * means once the ability has moved onto the enchanted permanent.
+ */
+val MidnightCovenant = card("Midnight Covenant") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has \"{B}: This creature gets +1/+1 until end of turn.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{B}"),
+                effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Pete Venters"
+        flavorText = "\"Not all mortals fought the kami. The ogres revered the oni, while some " +
+            "humans made pacts based upon empty promises.\"\n—*The History of Kamigawa*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg?1783944312"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MothriderSamurai.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MothriderSamurai.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mothrider Samurai
+ * {3}{W}
+ * Creature — Human Samurai
+ * 2/2
+ * Flying
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ *
+ * Flying is an engine-live keyword, so it stays a plain `keywords(…)` declaration.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val MothriderSamurai = card("Mothrider Samurai") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Samurai"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Mark Zug"
+        flavorText = "When the night blossoms open, the wings of Eiganjo take flight."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg?1783944334"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NagaoBoundByHonor.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NagaoBoundByHonor.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nagao, Bound by Honor
+ * {3}{W}
+ * Legendary Creature — Human Samurai
+ * 3/3
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ * Whenever Nagao attacks, Samurai creatures you control get +1/+1 until end of turn.
+ *
+ * The attack trigger is [Triggers.Attacks] (a SELF binding — it fires only when Nagao himself is
+ * declared as an attacker) over a group pump. The printed wording says "Samurai *creatures* you
+ * control", so the group filter is `Creature.withSubtype(SAMURAI).youControl()` rather than a bare
+ * permanent filter — the same spelling `chk/cards/CallToGlory.kt` uses for the identical phrase, and
+ * the same shape Assay compiles (`ForEach` over an `IterationSpace.Group` whose body is
+ * `ModifyStats` on the iterated entity). Nagao is a Samurai creature himself, so he pumps too.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The bushido pump targets [EffectTarget.Self] rather than `TriggeringEntity` because
+ * [Triggers.Blocks] fires off a block event that does not bind the source as the triggering entity.
+ */
+val NagaoBoundByHonor = card("Nagao, Bound by Honor") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Samurai"
+    power = 3
+    toughness = 3
+    oracleText = "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\n" +
+        "Whenever Nagao attacks, Samurai creatures you control get +1/+1 until end of turn."
+
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SAMURAI).youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+        description = "Whenever Nagao attacks, Samurai creatures you control get +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg?1783944334"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NezumiRonin.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NezumiRonin.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nezumi Ronin
+ * {2}{B}
+ * Creature — Rat Samurai
+ * 3/1
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val NezumiRonin = card("Nezumi Ronin") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat Samurai"
+    power = 3
+    toughness = 1
+    oracleText = "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)"
+
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Scott M. Fischer"
+        flavorText = "\"Some nezumi became as skilled in the samurai arts as the humans and kitsune. Yet no lord would have them, so they sold their swords to the highest bidder.\"\n—*The History of Kamigawa*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg?1783944311"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NumaiOutcast.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/NumaiOutcast.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Numai Outcast
+ * {3}{B}
+ * Creature — Human Samurai
+ * 1/1
+ * Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)
+ * {B}, Pay 5 life: Regenerate this creature.
+ *
+ * The regeneration cost is a two-atom composite — mana plus a life payment — matching Assay's
+ * `CostComposite(AtomMana, AtomPayLife)`. "Regenerate this creature" is [RegenerateEffect] on
+ * [EffectTarget.Self]; there is no `Effects.Regenerate` facade, the effect class is the shipped
+ * spelling (`m10/cards/CudgelTroll.kt`).
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val NumaiOutcast = card("Numai Outcast") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Samurai"
+    power = 1
+    toughness = 1
+    oracleText = "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)\n" +
+        "{B}, Pay 5 life: Regenerate this creature."
+
+    keywordAbility(KeywordAbility.bushido(2))
+
+    // Bushido 2, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    // Bushido 2, half two: "… or becomes blocked, it gets +2/+2 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.PayLife(5))
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{B}, Pay 5 life: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Adam Rex"
+        flavorText = "\"Beware the blade of dishonor. It kills more silently than war, more quickly than age.\"\n—Sensei Golden-Tail"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg?1783944310"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/OrbweaverKumo.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/OrbweaverKumo.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Orbweaver Kumo
+ * {4}{G}{G}
+ * Creature — Spirit
+ * 3/4
+ * Reach
+ * Whenever you cast a Spirit or Arcane spell, this creature gains forestwalk until end of turn.
+ *
+ * The same "Whenever you cast a Spirit or Arcane spell" trigger the rest of the CHK Spirit cycle
+ * carries — [Triggers.youCastSpell] over a homogeneous OR of the two subtype filters, binding
+ * `ANY` — with the payoff pointed at the source rather than at a target.
+ *
+ * [EffectTarget.Self] is the right handle here, not `TriggeringEntity`: the entity bound by a
+ * spell-cast trigger is the *spell*, and "this creature gains forestwalk" names the permanent
+ * whose ability it is.
+ */
+val OrbweaverKumo = card("Orbweaver Kumo") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spirit"
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "Whenever you cast a Spirit or Arcane spell, this creature gains forestwalk until end of " +
+        "turn. (It can't be blocked as long as defending player controls a Forest.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.GrantKeyword(Keyword.FORESTWALK, EffectTarget.Self)
+        description = "Whenever you cast a Spirit or Arcane spell, this creature gains " +
+            "forestwalk until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg?1783944285"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/OreGorger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/OreGorger.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ore Gorger
+ * {3}{R}{R}
+ * Creature — Spirit
+ * 3/1
+ * Whenever you cast a Spirit or Arcane spell, you may destroy target nonbasic land.
+ *
+ * The red half of the CHK "Whenever you cast a Spirit or Arcane spell" cycle: the shared
+ * [Triggers.youCastSpell] over a homogeneous OR of the two subtype filters, binding `ANY`.
+ *
+ * The printed "you may" is the builder's `optional = true`, which lowers to a `Gate.MayDecide`
+ * around the destroy — the model has no separate optional flag. The target is still chosen when
+ * the trigger goes on the stack (a "you may" gates the *action*, not the targeting, CR 603.3d),
+ * so an ability with no legal nonbasic land in play never goes on the stack at all.
+ *
+ * [TargetFilter.NonbasicLand] is `IsLand` plus `Not(IsBasicLand)` — a supertype test, so a
+ * nonbasic land printed with a basic land type (a Kamigawa legendary land, a shockland) is a
+ * legal target while a real basic never is.
+ */
+val OreGorger = card("Ore Gorger") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, you may destroy target nonbasic land."
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val land = target("target", TargetPermanent(filter = TargetFilter.NonbasicLand))
+        effect = Effects.Destroy(land)
+        optional = true
+        description = "Whenever you cast a Spirit or Arcane spell, you may destroy target " +
+            "nonbasic land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "rk post"
+        flavorText = "\"We've stumbled upon a network of caves not on our maps. We can only hope " +
+            "it is safe to spend the night.\"\n" +
+            "—Lost Battalion, message to General Takeno"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg?1783944296"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/PsychicPuppetry.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/PsychicPuppetry.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Psychic Puppetry
+ * {1}{U}
+ * Instant — Arcane
+ * You may tap or untap target permanent.
+ * Splice onto Arcane {U}
+ *
+ * The Pestermite idiom: a [MayEffect] (the printed "you may") wrapped around a two-[Mode]
+ * [ModalEffect] over the one declared target, with `countsAsModalSpell = false` so the tap/untap
+ * choice isn't read as a modal *spell* — it's a choice made on resolution, after the target is
+ * locked in. That ordering matters: if an opponent taps the permanent in response, you simply pick
+ * the untap half instead.
+ */
+val PsychicPuppetry = card("Psychic Puppetry") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant — Arcane"
+    oracleText = "You may tap or untap target permanent.\n" +
+        "Splice onto Arcane {U} (As you cast an Arcane spell, you may reveal this card from your " +
+        "hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{U}")
+
+    spell {
+        val permanent = target("target", Targets.Permanent)
+        effect = MayEffect(
+            ModalEffect(
+                modes = listOf(
+                    Mode.noTarget(Effects.Tap(permanent)),
+                    Mode.noTarget(Effects.Untap(permanent))
+                ),
+                countsAsModalSpell = false
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Joel Thomas"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg?1783944323"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/RoninHoundmaster.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/RoninHoundmaster.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ronin Houndmaster
+ * {2}{R}
+ * Creature — Human Samurai
+ * 2/2
+ * Haste
+ * Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)
+ *
+ * Haste is an engine-live keyword, so it stays a plain `keywords(…)` declaration.
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val RoninHoundmaster = card("Ronin Houndmaster") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Samurai"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.bushido(1))
+
+    // Bushido 1, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    // Bushido 1, half two: "… or becomes blocked, it gets +1/+1 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Bushido 1"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "Some samurai fell so far out of grace that only dogs would keep them company."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg?1783944297"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SamuraiEnforcers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SamuraiEnforcers.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Samurai Enforcers
+ * {4}{W}{W}
+ * Creature — Human Samurai
+ * 4/4
+ * Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates is
+ * wired explicitly, following `mh2/cards/JadeAvenger.kt`. CR 702.45a defines bushido N as one
+ * triggered ability; the SDK has no single event covering "blocks or becomes blocked" from the
+ * source's point of view, so it is written as two triggers over the two distinct events. They are
+ * mutually exclusive in any one combat, so the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks] fires
+ * off a block event that does not bind the source as the triggering entity.
+ */
+val SamuraiEnforcers = card("Samurai Enforcers") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Samurai"
+    power = 4
+    toughness = 4
+    oracleText = "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)"
+
+    keywordAbility(KeywordAbility.bushido(2))
+
+    // Bushido 2, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    // Bushido 2, half two: "… or becomes blocked, it gets +2/+2 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "42"
+        artist = "Mitch Cotie"
+        flavorText = "From the moment they swore their oaths, they belonged to their lord, sword and soul."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg?1783944332"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SeshiroTheAnointed.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SeshiroTheAnointed.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Seshiro the Anointed
+ * {4}{G}{G}
+ * Legendary Creature — Snake Monk
+ * 3/4
+ *
+ * Other Snake creatures you control get +2/+2.
+ * Whenever a Snake you control deals combat damage to a player, you may draw a card.
+ *
+ * Two different Snake filters, because the two lines print two different nouns. The lord says
+ * "Snake **creatures**", so it is [GameObjectFilter.Creature]`.withSubtype(SNAKE).youControl()` with
+ * `excludeSelf` for the printed "Other"; the trigger says a bare "a Snake you control", which is any
+ * *permanent* with the subtype, so that one is [GameObjectFilter.Permanent].
+ *
+ * The trigger is a [GrantTriggeredAbility]: each of your Snakes carries its own copy of "whenever
+ * *this* deals combat damage to a player", so the granted ability keeps the default SELF binding and
+ * the source of the damage is the Snake that bears it. The printed "you may" is an explicit
+ * [Gate.MayDecide] around the draw.
+ */
+val SeshiroTheAnointed = card("Seshiro the Anointed") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Snake Monk"
+    power = 3
+    toughness = 4
+    oracleText = "Other Snake creatures you control get +2/+2.\n" +
+        "Whenever a Snake you control deals combat damage to a player, you may draw a card."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.SNAKE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = GatedEffect(
+                    gate = Gate.MayDecide(),
+                    then = Effects.DrawCards(1)
+                )
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SNAKE).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "241"
+        artist = "Daren Bader"
+        flavorText = "His family was the first to reach out to the human monks. He soon knew as " +
+            "many koans as he did blade strikes."
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg?1783944282"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SireOfTheStorm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SireOfTheStorm.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sire of the Storm
+ * {4}{U}{U}
+ * Creature — Spirit
+ * 3/3
+ * Flying
+ * Whenever you cast a Spirit or Arcane spell, you may draw a card.
+ *
+ * The blue half of the CHK "Whenever you cast a Spirit or Arcane spell" cycle: the shared
+ * [Triggers.youCastSpell] over a homogeneous OR of the two subtype filters, binding `ANY`.
+ *
+ * The printed "you may" is the builder's `optional = true`, which lowers to a `Gate.MayDecide`
+ * around the draw. The "may" matters here rather than being flavour: the trigger goes on the
+ * stack even with an empty library, and declining is what keeps a Sire from decking its own
+ * controller.
+ */
+val SireOfTheStorm = card("Sire of the Storm") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "Whenever you cast a Spirit or Arcane spell, you may draw a card."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        effect = Effects.DrawCards(1)
+        optional = true
+        description = "Whenever you cast a Spirit or Arcane spell, you may draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "85"
+        artist = "Arnie Swekel"
+        flavorText = "This storm blows gales through the dreams of men."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg?1783944322"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiCloudskater.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiCloudskater.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Soratami Cloudskater
+ * {1}{U}
+ * Creature — Moonfolk Rogue
+ * 1 / 1
+ *
+ * Flying
+ * {2}, Return a land you control to its owner's hand: Draw a card, then discard a card.
+ *
+ * The Moonfolk land-bounce cost is [Costs.ReturnToHand] over `GameObjectFilter.Land` composed with
+ * the mana half; "you control" is carried by the atom's enumerator, not by the filter. The loot is
+ * the ordinary draw-then-discard composition — [Effects.DrawCards] followed by
+ * [Patterns.Hand.discardCards], whose Gather → Select → Move pipeline is what makes the discard a
+ * real choice rather than a random one.
+ */
+val SoratamiCloudskater = card("Soratami Cloudskater") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Moonfolk Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{2}, Return a land you control to its owner's hand: Draw a card, then discard a card."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.ReturnToHand(GameObjectFilter.Land))
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Michael Sutfin"
+        flavorText = "\"You hide your actions from eyes on the ground, but nothing escapes the clouds.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg?1783944321"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiMirrorGuard.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiMirrorGuard.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Soratami Mirror-Guard
+ * {3}{U}
+ * Creature — Moonfolk Wizard
+ * 3 / 1
+ *
+ * Flying
+ * {2}, Return a land you control to its owner's hand: Target creature with power 2 or less can't be
+ * blocked this turn.
+ *
+ * The Moonfolk land-bounce cost is [Costs.ReturnToHand] over `GameObjectFilter.Land` composed with
+ * the mana half; "you control" lives in the atom's enumerator. "Can't be blocked" is an
+ * [AbilityFlag], not a [Keyword], so the grant goes through the `AbilityFlag` overload of
+ * [Effects.GrantKeyword] at its default `Duration.EndOfTurn` — the printed "this turn". The power
+ * clamp belongs to the *target restriction*, so it rides on the target filter rather than on the
+ * effect.
+ */
+val SoratamiMirrorGuard = card("Soratami Mirror-Guard") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Moonfolk Wizard"
+    power = 3
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{2}, Return a land you control to its owner's hand: Target creature with power 2 or less can't be blocked this turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.ReturnToHand(GameObjectFilter.Land))
+        val t = target("target", Targets.CreatureWithPowerAtMost(2))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg?1783944321"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiRainshaper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoratamiRainshaper.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Soratami Rainshaper
+ * {2}{U}
+ * Creature — Moonfolk Wizard
+ * 2 / 1
+ *
+ * Flying
+ * {3}, Return a land you control to its owner's hand: Target creature you control gains shroud until
+ * end of turn. (It can't be the target of spells or abilities.)
+ *
+ * The Moonfolk land-bounce cost is [Costs.ReturnToHand] over `GameObjectFilter.Land` composed with
+ * the mana half; "you control" on the *cost* is the atom's own enumerator, while "you control" on
+ * the *target* is a controller predicate on the target filter — two different you-control clauses
+ * that must not be conflated. Shroud is a real [Keyword], so the grant is the keyword overload of
+ * [Effects.GrantKeyword] at its default `Duration.EndOfTurn`.
+ */
+val SoratamiRainshaper = card("Soratami Rainshaper") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Moonfolk Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{3}, Return a land you control to its owner's hand: Target creature you control gains " +
+        "shroud until end of turn. (It can't be the target of spells or abilities.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.ReturnToHand(GameObjectFilter.Land))
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.GrantKeyword(Keyword.SHROUD, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Ittoku"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg?1783944320"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SosukeSonOfSeshiro.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SosukeSonOfSeshiro.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sosuke, Son of Seshiro
+ * {2}{G}{G}
+ * Legendary Creature — Snake Warrior
+ * 3/4
+ *
+ * Other Snake creatures you control get +1/+0.
+ * Whenever a Warrior you control deals combat damage to a creature, destroy that creature at end of
+ * combat.
+ *
+ * The lord line prints "Snake **creatures**", so it filters on [GameObjectFilter.Creature] with
+ * `excludeSelf` for the printed "Other"; the trigger's bare "a Warrior you control" is any permanent
+ * with the subtype, hence [GameObjectFilter.Permanent] there.
+ *
+ * The granted ability is the Serpentine Basilisk shape: the deathtouch-at-a-delay is a
+ * [CreateDelayedTriggerEffect] at [Step.END_COMBAT] destroying [EffectTarget.TriggeringEntity] — the
+ * creature that was dealt the damage — rather than an immediate destroy, so a creature that leaves
+ * combat or gains indestructible in the meantime behaves correctly.
+ */
+val SosukeSonOfSeshiro = card("Sosuke, Son of Seshiro") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Snake Warrior"
+    power = 3
+    toughness = 4
+    oracleText = "Other Snake creatures you control get +1/+0.\n" +
+        "Whenever a Warrior you control deals combat damage to a creature, destroy that creature " +
+        "at end of combat."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.SNAKE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToCreature.event,
+                binding = Triggers.DealsCombatDamageToCreature.binding,
+                effect = CreateDelayedTriggerEffect(
+                    step = Step.END_COMBAT,
+                    effect = Effects.Destroy(EffectTarget.TriggeringEntity)
+                )
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.WARRIOR).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg?1783944282"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoulOfMagma.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoulOfMagma.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Soul of Magma
+ * {3}{R}{R}
+ * Creature — Spirit
+ * 2/2
+ * Whenever you cast a Spirit or Arcane spell, this creature deals 1 damage to target creature.
+ *
+ * The shared CHK "Whenever you cast a Spirit or Arcane spell" trigger — [Triggers.youCastSpell]
+ * over a homogeneous OR of the two subtype filters, binding `ANY` — with a mandatory ping as its
+ * payoff.
+ *
+ * The damage source is left implicit rather than passed as an explicit `damageSource`: with no
+ * override, [Effects.DealDamage] attributes the damage to the ability's own source, which is
+ * exactly what "this creature deals 1 damage" means (and what makes the damage red and lifelink-
+ * or deathtouch-aware should Soul of Magma ever gain either).
+ */
+val SoulOfMagma = card("Soul of Magma") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a Spirit or Arcane spell, this creature deals 1 damage to " +
+        "target creature."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(1, creature)
+        description = "Whenever you cast a Spirit or Arcane spell, this creature deals 1 damage " +
+            "to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Darrell Riche"
+        flavorText = "\"In every other mind, the battle was lost. General Takeno alone was not " +
+            "touched by despair. Drawing his blade, he was attack and rallying cry in one.\"\n" +
+            "—*Battle of Akagi River: A Survivor's Tale*"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg?1783944295"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoullessRevival.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/SoullessRevival.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Soulless Revival
+ * {1}{B}
+ * Instant — Arcane
+ * Return target creature card from your graveyard to your hand.
+ * Splice onto Arcane {1}{B}
+ *
+ * [TargetFilter.CreatureInYourGraveyard] carries both halves of the restriction the sentence
+ * names: the card must be a creature card, and it must be in *your* graveyard (an ownership
+ * predicate, not a controller one — graveyard cards have no controller).
+ */
+val SoullessRevival = card("Soulless Revival") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant — Arcane"
+    oracleText = "Return target creature card from your graveyard to your hand.\n" +
+        "Splice onto Arcane {1}{B} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{1}{B}")
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg?1783944306"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TellerOfTales.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TellerOfTales.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Teller of Tales
+ * {3}{U}{U}
+ * Creature — Spirit
+ * 3/3
+ * Flying
+ * Whenever you cast a Spirit or Arcane spell, you may tap or untap target creature.
+ *
+ * The shared CHK "Whenever you cast a Spirit or Arcane spell" trigger — [Triggers.youCastSpell]
+ * over a homogeneous OR of the two subtype filters, binding `ANY`.
+ *
+ * "You may tap or untap target creature" is the corpus' Granite Witness idiom: the printed
+ * "you may" is the builder's `optional = true` (lowering to a `Gate.MayDecide`), and the
+ * tap-or-untap half is a two-[Mode] [ModalEffect] over the single declared target with
+ * `countsAsModalSpell = false` — CR 700.2 modality is a property of a *spell*, and this choice is
+ * made on resolution. The SDK deliberately has no "tap or untap" effect: [TapUntapEffect] carries
+ * the direction as a boolean, so the choice between two fixed directions is what a modal already
+ * spells.
+ *
+ * The target is locked in when the trigger goes on the stack while the direction is not, so an
+ * opponent who taps the creature in response doesn't strand you on the useless half.
+ */
+val TellerOfTales = card("Teller of Tales") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "Whenever you cast a Spirit or Arcane spell, you may tap or untap target creature."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")
+        )
+        val creature = target("target", Targets.Creature)
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(TapUntapEffect(creature, tap = true)),
+                Mode.noTarget(TapUntapEffect(creature, tap = false))
+            ),
+            chooseCount = 1,
+            countsAsModalSpell = false
+        )
+        optional = true
+        description = "Whenever you cast a Spirit or Arcane spell, you may tap or untap target " +
+            "creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Jim Murray"
+        flavorText = "Words never uttered by mortals flowed incessantly from its many mouths."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg?1783944319"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TheUnspeakable.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TheUnspeakable.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * The Unspeakable
+ * {6}{U}{U}{U}
+ * Legendary Creature — Spirit
+ * 6/7
+ *
+ * Flying, trample
+ * Whenever The Unspeakable deals combat damage to a player, you may return target Arcane card from
+ * your graveyard to your hand.
+ *
+ * Argentum Assay declines this one — its grammar has no rule for the noun phrase "an Arcane card" —
+ * so it is authored straight from the printed text. The printed "you may" is the builder's
+ * `optional = true` (which lowers to a `Gate.MayDecide` around the return), and the target is the
+ * bare-noun-subtype graveyard spelling `CardInGraveyard.withSubtype(ARCANE).ownedByYou()`. A target
+ * is still chosen when the trigger goes on the stack — the yes/no comes at resolution.
+ */
+val TheUnspeakable = card("The Unspeakable") {
+    manaCost = "{6}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Spirit"
+    power = 6
+    toughness = 7
+    oracleText = "Flying, trample\n" +
+        "Whenever The Unspeakable deals combat damage to a player, you may return target Arcane " +
+        "card from your graveyard to your hand."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        optional = true
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter.CardInGraveyard.withSubtype(Subtype.ARCANE).ownedByYou())
+        )
+        effect = Effects.Move(t, Zone.HAND)
+        description = "Whenever The Unspeakable deals combat damage to a player, you may return " +
+            "target Arcane card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "Khang Le"
+        flavorText = "It is madness that drives men to seek forbidden knowledge, and madness has given it form."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg?1783944319"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/UnearthlyBlizzard.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/UnearthlyBlizzard.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Unearthly Blizzard
+ * {2}{R}
+ * Sorcery — Arcane
+ *
+ * Up to three target creatures can't block this turn.
+ *
+ * "Up to three target creatures" is one requirement with `count = 3, optional = true`, and the body
+ * runs once per chosen target through [IterationSpace.Targets] — so zero, one, two or three targets
+ * all resolve, and a target that became illegal is simply skipped.
+ */
+val UnearthlyBlizzard = card("Unearthly Blizzard") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery — Arcane"
+    oracleText = "Up to three target creatures can't block this turn."
+
+    spell {
+        target = TargetCreature(count = 3, optional = true)
+        effect = ForEachEffect(
+            space = IterationSpace.Targets,
+            body = Effects.CantBlock()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Joel Thomas"
+        flavorText = "\"We are trapped. The mountains and blinding kami storms have made us " +
+            "hopelessly lost. We are starving. In the name of all things sacred, please, send " +
+            "help . . . .\"\n—Lost Battalion, final message to General Takeno"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg?1783944294"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/UntaidakeTheCloudKeeper.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/UntaidakeTheCloudKeeper.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Untaidake, the Cloud Keeper
+ * Legendary Land
+ *
+ * Untaidake enters tapped.
+ * {T}, Pay 2 life: Add {C}{C}. Spend this mana only to cast legendary spells.
+ *
+ * The entry clause is the [EntersTapped] replacement effect rather than a trigger — it is a
+ * replacement on the zone change, so the land never touches the battlefield untapped. The mana
+ * ability carries [ManaRestriction.LegendarySpellsOnly], which `ManaPool` enforces at spend time,
+ * and is marked `manaAbility` with [TimingRule.ManaAbility] so it never uses the stack.
+ */
+val UntaidakeTheCloudKeeper = card("Untaidake, the Cloud Keeper") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Legendary Land"
+    oracleText = "Untaidake enters tapped.\n" +
+        "{T}, Pay 2 life: Add {C}{C}. Spend this mana only to cast legendary spells."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(2))
+        effect = Effects.AddColorlessMana(2, restriction = ManaRestriction.LegendarySpellsOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "285"
+        artist = "John Avon"
+        flavorText = "Untaidake is the needle that weaves the fabric of creation."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg?1783944272"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/WearAway.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/WearAway.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.splice
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Wear Away
+ * {G}{G}
+ * Instant — Arcane
+ * Destroy target artifact or enchantment.
+ * Splice onto Arcane {3}{G}
+ *
+ * Destruction is `Effects.Move(..., Zone.GRAVEYARD, byDestruction = true)` — the flag is what makes
+ * regeneration and indestructible able to see it. The one-predicate `Or` in
+ * [TargetFilter.ArtifactOrEnchantment] is the "artifact or enchantment" noun phrase.
+ */
+val WearAway = card("Wear Away") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant — Arcane"
+    oracleText = "Destroy target artifact or enchantment.\n" +
+        "Splice onto Arcane {3}{G} (As you cast an Arcane spell, you may reveal this card from " +
+        "your hand and pay its splice cost. If you do, add this card's effects to that spell.)"
+
+    splice("{3}{G}")
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment))
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "250"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg?1783944280"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthshakerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthshakerScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Earthshaker (CHK #165) — {4}{R}{R} Creature — Spirit 4/5.
+ *
+ *   Whenever you cast a Spirit or Arcane spell, this creature deals 2 damage to each creature
+ *   without flying.
+ *
+ * **This pins the "Whenever you cast a Spirit or Arcane spell" trigger, which thirteen Champions of
+ * Kamigawa cards share and which no card in the corpus had before this sweep.** The trigger is a
+ * `SpellCastEvent` over `withAnySubtype("Spirit", "Arcane")` with `TriggerBinding.ANY`, so three
+ * things need proving and each fails silently on its own:
+ *
+ *  1. a **Spirit** spell fires it — the `HasSubtype(Spirit)` half of the `CardPredicate.Or`;
+ *  2. an **Arcane** spell fires it — the other half, which a predicate list flattened as a
+ *     *conjunction* rather than a disjunction would quietly never satisfy (a Spirit-and-Arcane
+ *     card is vanishingly rare, so an AND would look almost exactly like a working card);
+ *  3. a spell that is **neither** does not fire it, which is what catches a filter that matched
+ *     everything.
+ *
+ * The sweep itself is the payoff rather than the point, but it doubles as the assertion: Earthshaker
+ * has no flying, so it takes its own 2 damage, and a flyer on the board must be untouched.
+ */
+class EarthshakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Earthshaker") {
+
+            test("casting a Spirit spell sweeps every creature without flying") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Earthshaker")
+                    .withCardOnBattlefield(1, "Kabuto Moth")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lantern Kami")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val earthshaker = game.findPermanent("Earthshaker").shouldNotBeNull()
+
+                // Lantern Kami is {W} Creature — Spirit: the Spirit half of the OR.
+                game.castSpell(1, "Lantern Kami").error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is a 2/2 without flying — 2 damage kills it") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Kabuto Moth has flying, so the sweep skips it entirely") {
+                    game.findPermanent("Kabuto Moth").shouldNotBeNull()
+                }
+                withClue("Earthshaker has no flying either — 'each creature' includes itself") {
+                    game.state.getEntity(earthshaker)?.get<DamageComponent>()?.amount shouldBe 2
+                }
+            }
+
+            test("casting an Arcane spell fires the same trigger") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Earthshaker")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lava Spike")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Lava Spike is {R} Sorcery — Arcane: no Spirit anywhere on it.
+                game.castSpellTargetingPlayer(1, "Lava Spike", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Arcane half of the OR must fire the trigger on its own") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+            }
+
+            test("a spell that is neither Spirit nor Arcane does not fire it") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Earthshaker")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Kitsune Blademaster")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Kitsune Blademaster is Creature — Fox Samurai: a CHK creature carrying neither subtype.
+                game.castSpell(1, "Kitsune Blademaster").error shouldBe null
+                game.resolveStack()
+
+                withClue("a filter that matched every spell would have killed the Bears here") {
+                    game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HanaKamiScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HanaKamiScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.chk.cards.HanaKami
+import com.wingedsheep.mtg.sets.definitions.chk.cards.KodamasMight
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hana Kami (CHK #211) — {G} Creature — Spirit 1/1.
+ *
+ *   {1}{G}, Sacrifice this creature: Return target Arcane card from your graveyard to your hand.
+ *
+ * **The first card in the corpus to filter on `Subtype.ARCANE`.** `Subtype.ARCANE` has existed in
+ * `mtg-sdk` for a long time, but until this sweep nothing read it, so a filter that silently matched
+ * every card in the graveyard — or matched nothing at all — would have looked identical from the
+ * outside. Both directions are asserted here: an Arcane card must be a legal target, and a
+ * non-Arcane card in the same graveyard must not be.
+ *
+ * Note also that Argentum Assay *declines* this card's line — its grammar has no rule for the noun
+ * phrase "an Arcane card" — so it was authored from the printed text rather than from `assay
+ * compile`. That makes this test the only mechanical check on the wiring.
+ */
+class HanaKamiScenarioTest : FunSpec({
+
+    val returnAbility = HanaKami.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + HanaKami + KodamasMight)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("returns an Arcane card from your graveyard to your hand") {
+        val d = driver()
+        val kami = d.putCreatureOnBattlefield(d.player1, "Hana Kami")
+        // Kodama's Might is {G} Instant — Arcane.
+        val might = d.putCardInGraveyard(d.player1, "Kodama's Might")
+        d.giveMana(d.player1, Color.GREEN, 1)
+        d.giveColorlessMana(d.player1, 1)
+
+        d.submit(
+            ActivateAbility(
+                d.player1,
+                kami,
+                returnAbility,
+                targets = listOf(ChosenTarget.Card(might, d.player1, Zone.GRAVEYARD)),
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("the Arcane card moves to hand") {
+            d.getGraveyardCardNames(d.player1) shouldNotContain "Kodama's Might"
+        }
+        withClue("Hana Kami sacrificed itself as part of the cost") {
+            d.state.getBattlefield().contains(kami) shouldBe false
+            d.getGraveyardCardNames(d.player1) shouldContain "Hana Kami"
+        }
+    }
+
+    test("a non-Arcane card in the same graveyard is not a legal target") {
+        val d = driver()
+        val kami = d.putCreatureOnBattlefield(d.player1, "Hana Kami")
+        // Grizzly Bears is a Creature — Bear: in the graveyard, owned by you, but not Arcane.
+        val bears = d.putCardInGraveyard(d.player1, "Grizzly Bears")
+        d.giveMana(d.player1, Color.GREEN, 1)
+        d.giveColorlessMana(d.player1, 1)
+
+        val result = d.submit(
+            ActivateAbility(
+                d.player1,
+                kami,
+                returnAbility,
+                targets = listOf(ChosenTarget.Card(bears, d.player1, Zone.GRAVEYARD)),
+            )
+        )
+
+        withClue("a filter that ignored the Arcane subtype would accept this and return the Bears") {
+            result.isSuccess shouldBe false
+            d.getGraveyardCardNames(d.player1) shouldContain "Grizzly Bears"
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/GhostlyPrisonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/GhostlyPrisonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Prison reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostlyPrisonReprint = Printing(
+    oracleId = "e828b189-0e8f-43b8-b909-4c23e742e028",
+    name = "Ghostly Prison",
+    setCode = "C16",
+    collectorNumber = "66",
+    scryfallId = "33d9f600-095e-4f3c-bec0-177e8aeb2422",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/33d9f600-095e-4f3c-bec0-177e8aeb2422.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GhostlyPrisonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GhostlyPrisonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Prison reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostlyPrisonReprint = Printing(
+    oracleId = "e828b189-0e8f-43b8-b909-4c23e742e028",
+    name = "Ghostly Prison",
+    setCode = "CMD",
+    collectorNumber = "14",
+    scryfallId = "b5ba872c-46e6-4524-8b5a-3a3e647f9785",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5ba872c-46e6-4524-8b5a-3a3e647f9785.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GhostlyPrisonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GhostlyPrisonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Prison reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostlyPrisonReprint = Printing(
+    oracleId = "e828b189-0e8f-43b8-b909-4c23e742e028",
+    name = "Ghostly Prison",
+    setCode = "PC2",
+    collectorNumber = "7",
+    scryfallId = "f1a0e932-f93b-4799-9075-9257192d7cf5",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f1a0e932-f93b-4799-9075-9257192d7cf5.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/MelokuTheCloudedMirrorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/MelokuTheCloudedMirrorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meloku the Clouded Mirror reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val MelokuTheCloudedMirrorReprint = Printing(
+    oracleId = "3b96b8c3-b9c8-4712-a3b1-243a67cc013a",
+    name = "Meloku the Clouded Mirror",
+    setCode = "CMR",
+    collectorNumber = "399",
+    scryfallId = "60b9db96-a6ab-454b-99a7-910ef77560d7",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/GhostlyPrisonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/GhostlyPrisonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Prison reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostlyPrisonReprint = Printing(
+    oracleId = "e828b189-0e8f-43b8-b909-4c23e742e028",
+    name = "Ghostly Prison",
+    setCode = "KHC",
+    collectorNumber = "26",
+    scryfallId = "1132a103-3dd7-4a17-afdc-27200b8cfbfc",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/1132a103-3dd7-4a17-afdc-27200b8cfbfc.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/GhostlyPrisonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/GhostlyPrisonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Prison reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostlyPrisonReprint = Printing(
+    oracleId = "e828b189-0e8f-43b8-b909-4c23e742e028",
+    name = "Ghostly Prison",
+    setCode = "VOC",
+    collectorNumber = "87",
+    scryfallId = "8169d44d-b15a-47e0-b417-24f2f4945d0f",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/8169d44d-b15a-47e0-b417-24f2f4945d0f.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SireOfTheStormReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SireOfTheStormReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sire of the Storm reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val SireOfTheStormReprint = Printing(
+    oracleId = "68f1db12-82fb-4bf1-908d-db38fd67efe5",
+    name = "Sire of the Storm",
+    setCode = "VOC",
+    collectorNumber = "113",
+    scryfallId = "bea64c04-6cd0-49e9-b4ba-1b50aab0a490",
+    artist = "Arnie Swekel",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/bea64c04-6cd0-49e9-b4ba-1b50aab0a490.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -1,3 +1,53 @@
+// Akki Avalanchers
+{
+    "name": "Akki Avalanchers",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Sacrifice a land: This creature gets +2/+0 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Matt Thompson",
+        "flavorText": "Among Godo's hordes, \"beware of falling rocks\" came to mean \"akki live nearby.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfef6acb-a11c-4a3f-9cfb-9394dece2675.jpg?1783944307"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Akki Coalflinger
 {
     "name": "Akki Coalflinger",
@@ -483,6 +533,50 @@
     ]
 }
 
+// Consuming Vortex
+{
+    "name": "Consuming Vortex",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Return target creature to its owner's hand.\nSplice onto Arcane {3}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/493ee99c-74ca-4d78-ade2-c6a93b0bd4fd.jpg?1783944329"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Counsel of the Soratami
 {
     "name": "Counsel of the Soratami",
@@ -555,6 +649,167 @@
     ]
 }
 
+// Cursed Ronin
+{
+    "name": "Cursed Ronin",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\n{B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{B}: This creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"You are fortunate, my enemy. You have paid the price but once. I never stop paying.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8f24fe9-22c4-4e53-9d7a-3cbf5533ac9b.jpg?1783944316"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dampen Thought
+{
+    "name": "Dampen Thought",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Target player mills four cards.\nSplice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        },
+                        "isMill": true
+                    },
+                    "storeAs": "milled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "milled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4806218-ff27-4df3-922d-5a085ffa44a6.jpg?1783944329"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dance of Shadows
 {
     "name": "Dance of Shadows",
@@ -603,6 +858,242 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Desperate Ritual
+{
+    "name": "Desperate Ritual",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Add {R}{R}{R}.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "AddMana",
+            "color": "RED",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8bdb92a-7bdb-434b-8cc0-873969faf566.jpg?1783944301"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Devoted Retainer
+{
+    "name": "Devoted Retainer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "Deep within Eiganjo Castle lay the Palace of Infinite Halls, a seemingly endless network of corridors once guarded by a seemingly endless legion of samurai.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc41d6d6-d7e5-4874-b6e2-fa4c72454f15.jpg?1783944342"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Earthshaker
+{
+    "name": "Earthshaker",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, this creature deals 2 damage to each creature without flying.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spencer",
+        "flavorText": "It scaled the Sokenzan Mountains in search of Kumano's secret. The mountain shook for two days, and the kami never returned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/283b47a9-c21e-4c0a-9c70-38b8ebbffab3.jpg?1783944301"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Eerie Procession
+{
+    "name": "Eerie Procession",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery — Arcane",
+    "oracleText": "Search your library for an Arcane card, reveal that card, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "Arcane"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Jim Murray",
+        "flavorText": "\"Though in years past speculation was not encouraged about the strange ways of kami, now we must understand their motivations, if such is even possible to the mortal mind.\"\n—Lady Azami",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3af326c1-fcc8-45c3-b75e-ae4dbbd59ced.jpg?1783944329"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -679,6 +1170,35 @@
     ]
 }
 
+// Ethereal Haze
+{
+    "name": "Ethereal Haze",
+    "manaCost": "{W}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Prevent all damage that would be dealt by creatures this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "direction": "FromTarget",
+            "sourceFilter": {
+                "type": "FromGroup",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Chris Appelhans",
+        "flavorText": "\"Imagine a dove flying through smoke. Does the dove injure the smoke? Does the smoke impede the dove?\"\n—Teachings of Eight-and-a-Half-Tails",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f1996af-5f15-447f-9b1d-98a7e97df53a.jpg?1783944341"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Eye of Nowhere
 {
     "name": "Eye of Nowhere",
@@ -709,6 +1229,66 @@
         "artist": "Alan Pollack",
         "flavorText": "\"Once we prayed to the kaijin for safe voyage. Now we only pray that we can escape their gaze.\"\n—Hayato, master sailor",
         "imageUri": "https://cards.scryfall.io/normal/front/b/3/b307af89-1890-4fac-a12e-f8a678f1101f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Field of Reality
+{
+    "name": "Field of Reality",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature can't be blocked by Spirits.\n{1}{U}: Return this Aura to its owner's hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsPermanent",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Spirit"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Christopher Rush",
+        "flavorText": "\"The scholars of the Minamo School understood the veil between their world and that of the kami. Moreover, they knew how to exploit it.\"\n—*Observations of the Kami War*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2ff7c6fc-324b-4cff-9109-6d817767865f.jpg?1783944328"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -752,6 +1332,386 @@
     ]
 }
 
+// Ghostly Prison
+{
+    "name": "Ghostly Prison",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "AttackTax",
+                "amountPerAttacker": {
+                    "type": "Fixed",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "Destroyed in one of the first battles of the Kami War, the town of Reito still grieved.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82d7de2b-c909-48dc-9ab7-c4a8328e37bb.jpg?1783944341"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Glacial Ray
+{
+    "name": "Glacial Ray",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Glacial Ray deals 2 damage to any target.\nSplice onto Arcane {1}{R} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Jim Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/5637a3b0-6204-4893-878e-c34babeab2e6.jpg?1783944301"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Guardian of Solitude
+{
+    "name": "Guardian of Solitude",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Tappin",
+        "flavorText": "\"It seemed an easy thing, to step into the nothingness, to fall, to die. But then, for an instant, I saw it, eyes filled with endless sorrow, and I turned back to face my pain.\"\n—Snow-Fur, kitsune poet",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85d16011-956b-40ac-afb6-6c7ad774802f.jpg?1783944327"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Hair-Strung Koto
+{
+    "name": "Hair-Strung Koto",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "Tap an untapped creature you control: Target player mills a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "RARE",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"The Kami War drove many members of Konda's court insane. As their spiritual world turned against them, so too did their minds turn from reality.\"\n—*The History of Kamigawa*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5354475-6a0b-4b1f-b94c-7c103d99e88b.jpg?1783944281"
+    },
+    "colorIdentityOverride": []
+}
+
+// Hana Kami
+{
+    "name": "Hana Kami",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{1}{G}, Sacrifice this creature: Return target Arcane card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "Arcane own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "flavorText": "It grew in lands lit by pride and watered by tears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8304b24-4db8-4082-bdb7-7010bf35e416.jpg?1783944290"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hearth Kami
+{
+    "name": "Hearth Kami",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{X}, Sacrifice this creature: Destroy target artifact with mana value X.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsArtifact",
+                                    "ManaValueEqualsX"
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Luca Zontini",
+        "flavorText": "\"Every treachery, great or small, begets a spirit that rages at the injustice. Given the opportunity, each will return that treachery to its owner tenfold.\"\n—Sensei Hisoka",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7361289-5111-49c2-a786-b7181384596b.jpg?1783944300"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Hideous Laughter
+{
+    "name": "Hideous Laughter",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "All creatures get -2/-2 until end of turn.\nSplice onto Arcane {3}{B}{B} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{3}{B}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/941fd135-1c5a-4650-8faf-dfa2c93ec8c9.jpg?1783944315"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hold the Line
 {
     "name": "Hold the Line",
@@ -787,6 +1747,70 @@
         "artist": "Ron Spears",
         "flavorText": "\"Forgive me, Master Kami, but in the interest of my people I must halt your advance.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/d/e/de34d107-8a28-4e88-919e-c7ccf984bcda.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Horizon Seed
+{
+    "name": "Horizon Seed",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, regenerate target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "In peaceful times, these beings escorted the honored kami to their new shrines. In the Kami War, they became the medics of an unstoppable army.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e6317b9-a426-453b-a82a-e63905a77019.jpg?1783944339"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -852,6 +1876,95 @@
     ]
 }
 
+// Innocence Kami
+{
+    "name": "Innocence Kami",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{W}, {T}: Tap target creature.\nWhenever you cast a Spirit or Arcane spell, untap this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Zug",
+        "flavorText": "Her voice was light, her substance music.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df62efbb-2313-4667-82e6-3b474d998ef5.jpg?1783944338"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Isamaru, Hound of Konda
 {
     "name": "Isamaru, Hound of Konda",
@@ -871,6 +1984,67 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Jade Idol
+{
+    "name": "Jade Idol",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, this artifact becomes a 4/4 Spirit artifact creature until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "addTypes": [
+                        "ARTIFACT"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Thompson",
+        "flavorText": "Before the Kami War, the shishi were symbolic guardians, protecting the shrines where they stood. But after the kami turned on the material world, shishi began pouncing from their perches to attack would-be supplicants.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a58f63c5-cdc5-4079-a727-cff45668d546.jpg?1783944278"
+    },
+    "colorIdentityOverride": []
 }
 
 // Journeyer's Kite
@@ -1100,6 +2274,69 @@
     ]
 }
 
+// Kami of Fire's Roar
+{
+    "name": "Kami of Fire's Roar",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, target creature can't block this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Dave Dorman",
+        "flavorText": "\"I can hear the shamans chanting in the hills. They say their magic will protect us from the kami, that our gold has bought our safety. But no one sleeps soundly tonight.\"\n—Scroll fragment from the ruins of Reito",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4380118d-f209-446d-829b-3564796e0219.jpg?1783944299"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Kami of Old Stone
 {
     "name": "Kami of Old Stone",
@@ -1164,6 +2401,205 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Kami of the Hunt
+{
+    "name": "Kami of the Hunt",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"Don't worry, Jiro. The kami would never attack us this close to home . . . . Jiro?\"\n—Hoto, temple guardian, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5ace3c4e-3287-4975-b4d0-91f009c0cf5b.jpg?1783944287"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kami of the Waning Moon
+{
+    "name": "Kami of the Waning Moon",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever you cast a Spirit or Arcane spell, target creature gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FEAR",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, target creature gains fear until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Matt Thompson",
+        "flavorText": "\"For a moment, Reito's defenders regrouped. Then wailing kami reappeared to send them scattering like flocks of frightened birds.\"\n—*Great Battles of Kamigawa*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23a395a6-b1f5-4b7f-87cc-c77b4d497e9a.jpg?1783944313"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kitsune Blademaster
+{
+    "name": "Kitsune Blademaster",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Fox Samurai",
+    "oracleText": "First strike\nBushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Keith Garletts",
+        "flavorText": "Those kitsune trained in the blade preferred to fight with a blade-catching jitte in the off hand, buying them just enough time to deliver the first deadly cut.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb9d108d-ee19-4b1d-9d4b-b4c4d9b8ad0d.jpg?1783944336"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1238,6 +2674,57 @@
     ]
 }
 
+// Kodama's Might
+{
+    "name": "Kodama's Might",
+    "manaCost": "{G}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Target creature gets +2/+2 until end of turn.\nSplice onto Arcane {G} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Terese Nielsen",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0ef91bb-ec25-463f-9fc9-f0f9c0652cf5.jpg?1783944286"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kodama's Reach
 {
     "name": "Kodama's Reach",
@@ -1291,6 +2778,77 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Konda, Lord of Eiganjo
+{
+    "name": "Konda, Lord of Eiganjo",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Legendary Creature — Human Samurai",
+    "oracleText": "Vigilance, indestructible\nBushido 5 (Whenever this creature blocks or becomes blocked, it gets +5/+5 until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "INDESTRUCTIBLE",
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 5
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 5"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 5"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "RARE",
+        "artist": "John Bolton",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg?1783944335"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1434,6 +2992,50 @@
     ]
 }
 
+// Lifted by Clouds
+{
+    "name": "Lifted by Clouds",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Target creature gains flying until end of turn.\nSplice onto Arcane {1}{U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "FLYING",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5f08f3d-82ef-4c3f-af2d-a3c834e22b99.jpg?1783944325"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Marrow-Gnawer
 {
     "name": "Marrow-Gnawer",
@@ -1495,6 +3097,123 @@
         "artist": "Wayne Reynolds",
         "flavorText": "Marrow-Gnawer united three nezumi gangs when he slew their leaders in a single night. Now they call him their first lord.",
         "imageUri": "https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Meloku the Clouded Mirror
+{
+    "name": "Meloku the Clouded Mirror",
+    "manaCost": "{4}{U}",
+    "typeLine": "Legendary Creature — Moonfolk Wizard",
+    "oracleText": "Flying\n{1}, Return a land you control to its owner's hand: Create a 1/1 blue Illusion creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomReturnToHand",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Illusion"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "flavorText": "He loved his cities in the clouds. When he traveled to the lands below, he brought many reminders of his home.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1caaa733-6d4c-4e18-a64e-f95851c7063b.jpg?1783944325"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Midnight Covenant
+{
+    "name": "Midnight Covenant",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has \"{B}: This creature gets +1/+1 until end of turn.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{B}"
+                        }
+                    },
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Pete Venters",
+        "flavorText": "\"Not all mortals fought the kami. The ogres revered the oni, while some humans made pacts based upon empty promises.\"\n—*The History of Kamigawa*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d797e91-3fc7-4f62-8cd8-dbd5f445e69c.jpg?1783944312"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -1592,6 +3311,76 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Mothrider Samurai
+{
+    "name": "Mothrider Samurai",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Flying\nBushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Mark Zug",
+        "flavorText": "When the night blossoms open, the wings of Eiganjo take flight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35a236f7-f008-4eb8-91d9-31ea8589cf0c.jpg?1783944334"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1715,6 +3504,101 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Nagao, Bound by Honor
+{
+    "name": "Nagao, Bound by Honor",
+    "manaCost": "{3}{W}",
+    "typeLine": "Legendary Creature — Human Samurai",
+    "oracleText": "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)\nWhenever Nagao attacks, Samurai creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_3",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Samurai ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever Nagao attacks, Samurai creatures you control get +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Dorman",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a45258f4-c36d-46cc-80e8-cc458351e003.jpg?1783944334"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1846,6 +3730,75 @@
     ]
 }
 
+// Nezumi Ronin
+{
+    "name": "Nezumi Ronin",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Rat Samurai",
+    "oracleText": "Bushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Scott M. Fischer",
+        "flavorText": "\"Some nezumi became as skilled in the samurai arts as the humans and kitsune. Yet no lord would have them, so they sold their swords to the highest bidder.\"\n—*The History of Kamigawa*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c3b8d6f-c60a-4107-b931-31b10f497237.jpg?1783944311"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Night of Souls' Betrayal
 {
     "name": "Night of Souls' Betrayal",
@@ -1936,6 +3889,105 @@
     "colorIdentityOverride": []
 }
 
+// Numai Outcast
+{
+    "name": "Numai Outcast",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)\n{B}, Pay 5 life: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 5
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{B}, Pay 5 life: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "flavorText": "\"Beware the blade of dishonor. It kills more silently than war, more quickly than age.\"\n—Sensei Golden-Tail",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b878d1c2-34ce-4cb4-9ea3-8d7cd2028484.jpg?1783944310"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Okina, Temple to the Grandfathers
 {
     "name": "Okina, Temple to the Grandfathers",
@@ -2013,6 +4065,64 @@
     ]
 }
 
+// Orbweaver Kumo
+{
+    "name": "Orbweaver Kumo",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nWhenever you cast a Spirit or Arcane spell, this creature gains forestwalk until end of turn. (It can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FORESTWALK",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, this creature gains forestwalk until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d8f0459-a839-4820-8f99-58da5851ff36.jpg?1783944285"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Order of the Sacred Bell
 {
     "name": "Order of the Sacred Bell",
@@ -2030,6 +4140,86 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Ore Gorger
+{
+    "name": "Ore Gorger",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, you may destroy target nonbasic land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may destroy target nonbasic land."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsLand",
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsBasicLand"
+                                }
+                            ]
+                        }
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may destroy target nonbasic land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "rk post",
+        "flavorText": "\"We've stumbled upon a network of caves not on our maps. We can only hope it is safe to spend the night.\"\n—Lost Battalion, message to General Takeno",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ecc8bbb9-d6a1-474b-8f34-594b5a9d4178.jpg?1783944296"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2103,6 +4293,71 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Psychic Puppetry
+{
+    "name": "Psychic Puppetry",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "You may tap or untap target permanent.\nSplice onto Arcane {U} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": "Gate.MayDecide",
+            "then": {
+                "type": "Modal",
+                "modes": [
+                    {
+                        "effect": {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    },
+                    {
+                        "effect": {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "tap": false
+                        }
+                    }
+                ],
+                "countsAsModalSpell": false
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Joel Thomas",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e341d6b-f4b0-4347-8055-f5fab756334c.jpg?1783944323"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -2314,6 +4569,76 @@
     ]
 }
 
+// Ronin Houndmaster
+{
+    "name": "Ronin Houndmaster",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Haste\nBushido 1 (Whenever this creature blocks or becomes blocked, it gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE",
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "Some samurai fell so far out of grace that only dogs would keep them company.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/614ead7b-1975-4a99-bdc2-f8afc6cf92d7.jpg?1783944297"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ryusei, the Falling Star
 {
     "name": "Ryusei, the Falling Star",
@@ -2497,6 +4822,76 @@
     ]
 }
 
+// Samurai Enforcers
+{
+    "name": "Samurai Enforcers",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Human Samurai",
+    "oracleText": "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "UNCOMMON",
+        "artist": "Mitch Cotie",
+        "flavorText": "From the moment they swore their oaths, they belonged to their lord, sword and soul.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b2be3fe-87a2-47b2-8af1-b99a48622c7b.jpg?1783944332"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sensei's Divining Top
 {
     "name": "Sensei's Divining Top",
@@ -2572,6 +4967,66 @@
         "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a08ca06-58db-4ce6-b490-be4bea8956a1.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Seshiro the Anointed
+{
+    "name": "Seshiro the Anointed",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Legendary Creature — Snake Monk",
+    "oracleText": "Other Snake creatures you control get +2/+2.\nWhenever a Snake you control deals combat damage to a player, you may draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature Snake ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "permanent Snake ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "RARE",
+        "artist": "Daren Bader",
+        "flavorText": "His family was the first to reach out to the human monks. He soon knew as many koans as he did blade strikes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg?1783944282"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Shinka, the Bloodsoaked Keep
@@ -2714,6 +5169,72 @@
     ]
 }
 
+// Sire of the Storm
+{
+    "name": "Sire of the Storm",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever you cast a Spirit or Arcane spell, you may draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may draw a card."
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "UNCOMMON",
+        "artist": "Arnie Swekel",
+        "flavorText": "This storm blows gales through the dreams of men.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e76d003-2d15-43d7-9cbb-e00564d0cabf.jpg?1783944322"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sokenzan Bruiser
 {
     "name": "Sokenzan Bruiser",
@@ -2735,6 +5256,406 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Soratami Cloudskater
+{
+    "name": "Soratami Cloudskater",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Moonfolk Rogue",
+    "oracleText": "Flying\n{2}, Return a land you control to its owner's hand: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomReturnToHand",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Michael Sutfin",
+        "flavorText": "\"You hide your actions from eyes on the ground, but nothing escapes the clouds.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e3d3024-bef2-4b50-ab84-8ae2a23cdf27.jpg?1783944321"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Soratami Mirror-Guard
+{
+    "name": "Soratami Mirror-Guard",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Moonfolk Wizard",
+    "oracleText": "Flying\n{2}, Return a land you control to its owner's hand: Target creature with power 2 or less can't be blocked this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomReturnToHand",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=2"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3ff8968b-cd96-4f44-85f8-2af20d61d7cb.jpg?1783944321"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Soratami Rainshaper
+{
+    "name": "Soratami Rainshaper",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Moonfolk Wizard",
+    "oracleText": "Flying\n{3}, Return a land you control to its owner's hand: Target creature you control gains shroud until end of turn. (It can't be the target of spells or abilities.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomReturnToHand",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "SHROUD",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Ittoku",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b942ee46-c78b-414a-9de7-4376370532fa.jpg?1783944320"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sosuke, Son of Seshiro
+{
+    "name": "Sosuke, Son of Seshiro",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Snake Warrior",
+    "oracleText": "Other Snake creatures you control get +1/+0.\nWhenever a Warrior you control deals combat damage to a creature, destroy that creature at end of combat.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Snake ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyCreature"
+                    },
+                    "effect": {
+                        "type": "CreateDelayedTrigger",
+                        "step": "END_COMBAT",
+                        "effect": {
+                            "type": "MoveToZone",
+                            "target": "TriggeringEntity",
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "permanent Warrior ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1aa2451-e4f0-423b-826e-ae1f93b99e07.jpg?1783944282"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Soul of Magma
+{
+    "name": "Soul of Magma",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a Spirit or Arcane spell, this creature deals 1 damage to target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, this creature deals 1 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Darrell Riche",
+        "flavorText": "\"In every other mind, the battle was lost. General Takeno alone was not touched by despair. Drawing his blade, he was attack and rallying cry in one.\"\n—*Battle of Akagi River: A Survivor's Tale*",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40b20126-da96-4d79-8d3f-8d7da8e94f4a.jpg?1783944295"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Soulless Revival
+{
+    "name": "Soulless Revival",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Return target creature card from your graveyard to your hand.\nSplice onto Arcane {1}{B} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{1}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Ron Spencer",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b36712c-1ccb-4efe-8db8-823b9b80a99f.jpg?1783944306"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2830,6 +5751,96 @@
     ]
 }
 
+// Teller of Tales
+{
+    "name": "Teller of Tales",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever you cast a Spirit or Arcane spell, you may tap or untap target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Spirit"
+                                    },
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Arcane"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target"
+                                    }
+                                }
+                            },
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target"
+                                    },
+                                    "tap": false
+                                }
+                            }
+                        ],
+                        "countsAsModalSpell": false
+                    },
+                    "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may tap or untap target creature."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever you cast a Spirit or Arcane spell, you may tap or untap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Jim Murray",
+        "flavorText": "Words never uttered by mortals flowed incessantly from its many mouths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c914db7d-c907-4d25-a180-f68b274a5cb7.jpg?1783944319"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Terashi's Cry
 {
     "name": "Terashi's Cry",
@@ -2868,6 +5879,66 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// The Unspeakable
+{
+    "name": "The Unspeakable",
+    "manaCost": "{6}{U}{U}{U}",
+    "typeLine": "Legendary Creature — Spirit",
+    "oracleText": "Flying, trample\nWhenever The Unspeakable deals combat damage to a player, you may return target Arcane card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "descriptionOverride": "Whenever The Unspeakable deals combat damage to a player, you may return target Arcane card from your graveyard to your hand."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "Arcane own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever The Unspeakable deals combat damage to a player, you may return target Arcane card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "Khang Le",
+        "flavorText": "It is madness that drives men to seek forbidden knowledge, and madness has given it form.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5212bd3e-e8d8-483e-871b-29fd378f817e.jpg?1783944319"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3110,6 +6181,46 @@
     ]
 }
 
+// Unearthly Blizzard
+{
+    "name": "Unearthly Blizzard",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery — Arcane",
+    "oracleText": "Up to three target creatures can't block this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "CantBlockTargetCreatures",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Joel Thomas",
+        "flavorText": "\"We are trapped. The mountains and blinding kami storms have made us hopelessly lost. We are starving. In the name of all things sacred, please, send help . . . .\"\n—Lost Battalion, final message to General Takeno",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d034ad87-fd28-4c23-b897-1d6343ce8282.jpg?1783944294"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Unnatural Speed
 {
     "name": "Unnatural Speed",
@@ -3144,6 +6255,55 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Untaidake, the Cloud Keeper
+{
+    "name": "Untaidake, the Cloud Keeper",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "Untaidake enters tapped.\n{T}, Pay 2 life: Add {C}{C}. Spend this mana only to cast legendary spells.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": "LegendarySpellsOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "285",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "Untaidake is the needle that weaves the fabric of creation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c571f66-7a00-4cb0-9da9-8271083f49d3.jpg?1783944272"
+    },
+    "colorIdentityOverride": []
 }
 
 // Vigilance
@@ -3263,5 +6423,50 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wear Away
+{
+    "name": "Wear Away",
+    "manaCost": "{G}{G}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Destroy target artifact or enchantment.\nSplice onto Arcane {3}{G} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)",
+    "keywords": [
+        "SPLICE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Splice",
+            "cost": "{3}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e809799-ce47-4eaf-b2c2-2c8807182532.jpg?1783944280"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }


### PR DESCRIPTION
Sweeps Champions of Kamigawa's Assay-ready backlog to zero.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 51 | full `card(...)` authored here — CHK is the earliest printing for every one |
| `basic` | 5 | `basicLand(...)` vals in `ChampionsOfKamigawaBasicLands.kt` (4 art variants each, #287–306) |
| `elsewhere` | 0 | — |
| `row-only` | 0 | — |
| `unscaffolded` | 0 | — |
| **reprint tail** | **7** | `Printing(...)` rows the new canonicals owe in 6 other sets |

The tail: Ghostly Prison → VOC, C16, CMD, KHC, PC2; Sire of the Storm → VOC; Meloku the Clouded Mirror → CMR. Generated with `scripts/generate-reprints.py --since main` after refreshing the printing caches; the scoped run resolved exactly 51 canonicals and 0 stale-cache skips.

An unusually clean shape for a sweep — these are the set's own designs, so nothing had to be authored into another set.

## What the cards needed

**"Whenever you cast a Spirit or Arcane spell" (13 cards) — first in the corpus.** `Triggers.youCastSpell` over `GameObjectFilter.Any.withAnySubtype("Spirit", "Arcane")` with `TriggerBinding.ANY`. All thirteen share one spelling.

**Splice onto Arcane (10 cards).** One `splice("{cost}")` line each; the declared `spell { }` effect *is* the text that gets spliced (CR 702.47a), so there is no other wiring. Splice is genuinely engine-live — `SpliceCasts`, `CastSpellEnumerator.enumerateSplice`, `StackResolver.buildSpliceEntries`. Six of the ten have a splice cost that differs from the mana cost.

**Bushido (10 cards) — lowered, not declared.** `Keyword.BUSHIDO` is display-only vocabulary: nothing in `rules-engine` reads it, so a card that declared the keyword alone would render a correct-looking line and do nothing. Each card keeps `keywordAbility(KeywordAbility.bushido(N))` **and** wires the two triggers CR 702.45a abbreviates, following `mh2/cards/JadeAvenger.kt`. Assay's `compile` JSON emits only the keyword, so this is the one place the batch deliberately goes beyond the model it authored to.

**Moonfolk land-bounce (4 cards).** `Costs.ReturnToHand(GameObjectFilter.Land)` composed with mana; the cost atom's enumerator is already you-control-only, which is what these four want.

**`Subtype.ARCANE` filtering (3 cards) — also first in the corpus.** Eerie Procession, Hana Kami, The Unspeakable. `Subtype.ARCANE` has existed in `mtg-sdk` for a long time with nothing reading it.

## Tests

Two scenario tests, for the two shapes that are new to the corpus:

- `EarthshakerScenarioTest` — the Spirit/Arcane trigger fires on a Spirit spell, fires on an Arcane spell, and does **not** fire on a spell carrying neither. The middle case is the one that matters: a predicate list flattened as a conjunction rather than a disjunction would look almost exactly like a working card, since a Spirit-and-Arcane spell essentially does not exist.
- `HanaKamiScenarioTest` — an Arcane card in the graveyard is a legal target; a non-Arcane card in the same graveyard is not. Hana Kami is one of the three cards Assay declines, so this test is the only mechanical check on its wiring.

Bushido already has `JadeAvengerScenarioTest`; splice already has `ThroughTheBreachScenarioTest` and `SpliceKeywordTest`.

## Verification

| Gate | Result |
|---|---|
| `just build` | green |
| `just test-scenarios 2003-2007` (force-rerun) | green |
| card golden | re-blessed; parsed and diffed per card — 69 → 120 cards, exactly +51, **0 removed, 0 pre-existing cards changed** (the line-level deletions are alphabetical-interleave noise) |
| `just check-card-printing` | clean on all 51 |
| `just assay-differential` | **54 → 54 divergent — zero new** |
| `just assay-ready CHK` | **56 → 0**, re-run on the branch |

Differential accounting against the baseline: +41 compared, +41 confirmed, +10 into `script slot not modelled` (the ten bushido cards, which the gate excludes by design — `Differential.kt` names bushido explicitly as a keyword whose authoring-time lowering it will not claim to have checked). 41 + 10 = 51.

One card diverged on the first pass and was fixed: **Eerie Procession** filtered with `InstantOrSorcery.withSubtype(ARCANE)` where Assay's model is the subtype alone. Every Arcane card ever printed is an instant or a sorcery, so it selected the same cards — but the printed text restricts by subtype and nothing else, and the extra `Or(IsInstant, IsSorcery)` is exactly the kind of over-specification the differential exists to catch. Now `Any.withSubtype(Subtype.ARCANE)`.

## Findings this sweep surfaced but did not fix

- **`Effects.PreventCombatDamageFrom` has no `scope` parameter.** Ethereal Haze is "prevent all damage that would be dealt by creatures this turn" — not a Fog. The facade hard-codes `PreventionScope.CombatOnly`, so using it would have silently dropped noncombat creature damage. The card constructs `PreventDamageEffect` directly (existing precedent: `leg/cards/AlabarasCarpet.kt`); a `scope` parameter or an `Effects.PreventAllDamageFrom(group)` sibling would give the shape a facade.
- **`assay compile` declines three lines the baked ledger counts as Assay-ready** — Eerie Procession, Hana Kami, The Unspeakable, all on the noun phrase "an Arcane card". The differential *does* model Eerie Procession, so `compile` and the differential disagree about the same line; the ledger and the live grammar have drifted apart on this phrase. All three were authored from the printed text.
- **No Illusion token art anywhere in the corpus.** Meloku the Clouded Mirror creates the first one. CHK predates token cards, so its token art is self-hosted (`web-client/public/images/tokens/`, currently just `chk-rat.jpeg`) and the Illusion has nothing to resolve to.

CHK now stands at 127/291. The remaining 164 are grammar work, not authoring work: 154 `LINE_DECLINED` and 10 multi-face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9L9dP5Cbgnqaq7cLpTuWM