### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FiremaneAngel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FiremaneAngel.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Firemane Angel
+ * {3}{R}{W}{W}
+ * Creature — Angel
+ * 4/3
+ *
+ * Flying, first strike
+ * At the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield,
+ * you may gain 1 life.
+ * {6}{R}{R}{W}{W}: Return this card from your graveyard to the battlefield.
+ * Activate only during your upkeep.
+ *
+ * The life trigger is the Edgar Markov shape, and for the same two rules. CR 113.6b — "an ability
+ * that states which zones it functions in functions only from those zones" — is
+ * `triggerZones = {GRAVEYARD, BATTLEFIELD}`, which is what makes the upkeep trigger fire off a dead
+ * Angel at all. The identical printed clause is *also* an intervening-"if" (CR 603.4), checked a
+ * second time as the ability resolves, and that second check is [Conditions.SourceInZone]. The two
+ * halves are what the 2017-11-17 ruling turns on: an Angel that dies or is reanimated during your
+ * upkeep after the trigger goes on the stack is a new object in a new zone, and you gain no life.
+ *
+ * The recursion is the ordinary graveyard-activation shape (Grim Reminder's template):
+ * `activateFromZone = Zone.GRAVEYARD` plus the your-turn/upkeep restriction pair, with the return
+ * an explicit `fromZone = GRAVEYARD` move so a card that has already left cannot be moved twice.
+ * Nothing links the two abilities — reanimating the Angel does not "use up" the life trigger, it
+ * just moves the card out from under it.
+ */
+val FiremaneAngel = card("Firemane Angel") {
+    manaCost = "{3}{R}{W}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Angel"
+    power = 4
+    toughness = 3
+    oracleText = "Flying, first strike\n" +
+        "At the beginning of your upkeep, if Firemane Angel is in your graveyard or on the " +
+        "battlefield, you may gain 1 life.\n" +
+        "{6}{R}{R}{W}{W}: Return this card from your graveyard to the battlefield. Activate only " +
+        "during your upkeep."
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerZones = setOf(Zone.BATTLEFIELD, Zone.GRAVEYARD)
+        interveningIf = Conditions.SourceInZone(Zone.BATTLEFIELD, Zone.GRAVEYARD)
+        effect = MayEffect(Effects.GainLife(1))
+        description = "At the beginning of your upkeep, if Firemane Angel is in your graveyard or " +
+            "on the battlefield, you may gain 1 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{6}{R}{R}{W}{W}")
+        activateFromZone = Zone.GRAVEYARD
+        effect = Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+        restrictions = listOf(
+            ActivationRestriction.All(
+                ActivationRestriction.OnlyDuringYourTurn,
+                ActivationRestriction.DuringStep(Step.UPKEEP)
+            )
+        )
+        description = "Return this card from your graveyard to the battlefield. " +
+            "Activate only during your upkeep."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "205"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg?1783943621"
+        ruling(
+            "2017-11-17",
+            "If Firemane Angel is put into your graveyard from the battlefield or returned from " +
+                "your graveyard to the battlefield during your upkeep before its triggered " +
+                "ability resolves, you won't gain 1 life."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RaziasPurification.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RaziasPurification.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Razia's Purification
+ * {4}{R}{W}
+ * Sorcery
+ * Each player chooses three permanents they control, then sacrifices the rest.
+ *
+ * Global Ruin's shape: inside a [ForEachPlayerEffect] each player gathers the permanents they
+ * control, keeps a selection, and sacrifices the remainder. Two details the oracle text pins down:
+ *
+ * - The keep is [SelectionMode.ChooseExactly] three, not "up to three". A player who wants to keep
+ *   fewer doesn't get to — and [SelectionMode.ChooseExactly]'s clamp is exactly right for the
+ *   2005-10-01 ruling "if a player doesn't control three permanents, that player chooses all the
+ *   permanents they do control and doesn't sacrifice anything": with two permanents the executor
+ *   selects both and the remainder is empty.
+ * - `Player.Each` walks the table in turn order, and the sacrifice for each player runs as that
+ *   player's own step. The second 2005-10-01 ruling wants the choices in turn order and then a
+ *   single simultaneous sacrifice; the engine's per-player fold makes the sacrifices sequential
+ *   instead. The distinction is only observable through leaves-the-battlefield triggers that count
+ *   other permanents mid-resolution, and no other card in this shape (Global Ruin included) models
+ *   it differently.
+ *
+ * "Permanents they control" is every permanent, lands and tokens included — [GameObjectFilter]'s
+ * bare `Permanent`, with `Player.You` inside the loop meaning the player being processed.
+ */
+val RaziasPurification = card("Razia's Purification") {
+    manaCost = "{4}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Each player chooses three permanents they control, then sacrifices the rest."
+
+    spell {
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Permanent
+                    ),
+                    storeAs = "permanents"
+                ),
+                SelectFromCollectionEffect(
+                    from = "permanents",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(3)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "kept",
+                    storeRemainder = "sacrificed",
+                    selectedLabel = "Keep",
+                    remainderLabel = "Sacrifice",
+                    prompt = "Choose three permanents you control to keep; the rest are sacrificed.",
+                    useTargetingUI = true,
+                    alwaysPrompt = true
+                ),
+                MoveCollectionEffect(
+                    from = "sacrificed",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    moveType = MoveType.Sacrifice
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "224"
+        artist = "Shishizaru"
+        flavorText = "Only the chosen ones are spared."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg?1783943615"
+        ruling(
+            "2005-10-01",
+            "If a player doesn't control three permanents, that player chooses all the permanents " +
+                "they do control and doesn't sacrifice anything."
+        )
+        ruling(
+            "2005-10-01",
+            "Players choose permanents in turn order around the table, then simultaneously " +
+                "sacrifice all permanents not chosen."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StasisCell.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/StasisCell.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stasis Cell
+ * {4}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * {3}{U}: Attach this Aura to target creature.
+ *
+ * The lock is the shared [AbilityFlag.DOESNT_UNTAP] grant onto the enchanted creature (Shackles'
+ * shape) — `BeginningPhaseManager.performUntapStep` skips any permanent whose projected keywords
+ * carry the flag, so the restriction follows the Aura when it moves rather than staying on the old
+ * host.
+ *
+ * Moving the Aura is `Effects.AttachEquipment` aimed at the ability's own target: that effect is
+ * attachment-generic (it rewrites `AttachedToComponent` / `AttachmentsComponent` and detaches from
+ * the previous host first), not Equipment-specific — the same call Bound by Moonsilver makes. The
+ * Aura stays under its controller's control while enchanting an opponent's creature, so only that
+ * controller ever sees the activation. Unlike an Aura moved by "attach" during the enchant-target
+ * check, the new host must merely be a creature; the printed ability names no further restriction.
+ */
+val StasisCell = card("Stasis Cell") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "{3}{U}: Attach this Aura to target creature."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        target = Targets.Creature
+        effect = Effects.AttachEquipment(EffectTarget.ContextTarget(0))
+        description = "{3}{U}: Attach this Aura to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Mark A. Nelson"
+        flavorText = "The Simic created the cells to preserve their experiments. " +
+            "The Azorius put the cells to use on the guilty."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg?1783943680"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SvogthosTheRestlessTomb.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SvogthosTheRestlessTomb.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Svogthos, the Restless Tomb
+ * Land
+ *
+ * {T}: Add {C}.
+ * {3}{B}{G}: Until end of turn, this land becomes a black and green Plant Zombie creature with
+ * "This creature's power and toughness are each equal to the number of creature cards in your
+ * graveyard." It's still a land.
+ *
+ * The granted clause is a **characteristic-defining ability**, not a size frozen at resolution, so
+ * the count goes in `dynamicPower`/`dynamicToughness` (re-evaluated at Layer 7b on every
+ * projection) rather than in `power`/`toughness`, which serve only as the star-P/T rules-text
+ * display. That is what the 2005-10-01 ruling requires: "Svogthos's power and toughness changes
+ * each time a creature card enters or leaves its controller's graveyard."
+ *
+ * Svogthos animates *itself*, so `you` in the CDA is its own controller — the same player the
+ * animating ability's controller is — and the two never disagree.
+ *
+ * "It's still a land" is [Effects.BecomeCreature]'s default: CREATURE and the two subtypes are
+ * added without removing LAND, so the animated Svogthos still taps for {C}. Note that it counts
+ * *creature cards*, so Svogthos itself in the graveyard (a land card) never adds to the total.
+ */
+val SvogthosTheRestlessTomb = card("Svogthos, the Restless Tomb") {
+    typeLine = "Land"
+    colorIdentity = "BG"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}{B}{G}: Until end of turn, this land becomes a black and green Plant Zombie creature " +
+        "with \"This creature's power and toughness are each equal to the number of creature " +
+        "cards in your graveyard.\" It's still a land."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}{G}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = DynamicAmount.Fixed(0),
+            toughness = DynamicAmount.Fixed(0),
+            creatureTypes = setOf(Subtype.PLANT.value, Subtype.ZOMBIE.value),
+            colors = setOf(Color.BLACK.name, Color.GREEN.name),
+            duration = Duration.EndOfTurn,
+            dynamicPower = DynamicAmounts.creatureCardsInYourGraveyard(),
+            dynamicToughness = DynamicAmounts.creatureCardsInYourGraveyard(),
+        )
+        description = "{3}{B}{G}: Until end of turn, this land becomes a black and green Plant " +
+            "Zombie creature with \"This creature's power and toughness are each equal to the " +
+            "number of creature cards in your graveyard.\" It's still a land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "283"
+        artist = "Martina Pilcerova"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg?1783943589"
+        ruling(
+            "2005-10-01",
+            "While animated, Svogthos's power and toughness changes each time a creature card " +
+                "enters or leaves its controller's graveyard."
+        )
+        ruling(
+            "2008-08-01",
+            "A noncreature permanent that turns into a creature can attack, and its {T} abilities " +
+                "can be activated, only if its controller has continuously controlled that " +
+                "permanent since the beginning of their most recent turn. It doesn't matter how " +
+                "long the permanent has been a creature."
+        )
+        ruling(
+            "2009-10-01",
+            "Activating the ability that turns it into a creature while it's already a creature " +
+                "will override any effects that set its power and/or toughness to a specific " +
+                "number. However, any effect that raises or lowers power and/or toughness (such " +
+                "as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will " +
+                "continue to apply."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoodwraithCorrupter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WoodwraithCorrupter.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Woodwraith Corrupter
+ * {3}{B}{B}{G}
+ * Creature — Elemental Horror
+ * 3/6
+ *
+ * {1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature.
+ * It's still a land.
+ *
+ * The animation has **no stated duration**, so it is [Duration.Permanent] — the 2005-10-01 ruling
+ * spells it out: "a land turned into a creature this way continues being a creature as long as the
+ * land is on the battlefield". Corrupting the same Forest twice is harmless; the later timestamp
+ * simply re-applies the identical Layer 4/5/7b effect.
+ *
+ * "It's still a land" is [Effects.BecomeCreature]'s default — CREATURE and the two subtypes are
+ * *added* without removing LAND or the Forest subtype, so the animated Forest still taps for {G}.
+ * Any Forest is a legal target, including an opponent's, and any land with the Forest subtype
+ * qualifies (a Stomping Ground, a Murmuring Bosk), not only the basic.
+ *
+ * Setting `colors` overwrites the land's colors in Layer 5 rather than adding to them — which is
+ * what "becomes a black and green … creature" says. The animated Forest can then be hit by a
+ * "destroy target black creature" and, being a creature that entered this turn, cannot attack or
+ * pay a {T} cost until its controller's next turn (the 2008-08-01 summoning-sickness ruling).
+ */
+val WoodwraithCorrupter = card("Woodwraith Corrupter") {
+    manaCost = "{3}{B}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elemental Horror"
+    power = 3
+    toughness = 6
+    oracleText = "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror " +
+        "creature. It's still a land."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}{G}"), Costs.Tap)
+        val forest = target(
+            "target Forest",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.withSubtype(Subtype.FOREST)))
+        )
+        effect = Effects.BecomeCreature(
+            target = forest,
+            power = 4,
+            toughness = 4,
+            creatureTypes = setOf(Subtype.ELEMENTAL.value, Subtype.HORROR.value),
+            colors = setOf(Color.BLACK.name, Color.GREEN.name),
+            duration = Duration.Permanent,
+        )
+        description = "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental " +
+            "Horror creature. It's still a land."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Greg Staples"
+        flavorText = "\"Its darkened sap penetrates natural fibers and spreads its own genes. " +
+            "Emulation experiments are underway.\"\n—Simic research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg?1783943608"
+        ruling(
+            "2005-10-01",
+            "The effect has no stated duration, so a land turned into a creature this way " +
+                "continues being a creature as long as the land is on the battlefield."
+        )
+        ruling(
+            "2008-08-01",
+            "A noncreature permanent that turns into a creature can attack, and its {T} abilities " +
+                "can be activated, only if its controller has continuously controlled that " +
+                "permanent since the beginning of their most recent turn. It doesn't matter how " +
+                "long the permanent has been a creature."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FiremaneAngelScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FiremaneAngelScenarioTest.kt
@@ -1,0 +1,182 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.FiremaneAngel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Firemane Angel (RAV #205) — 4/3 flying, first strike.
+ *
+ * "At the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield,
+ *  you may gain 1 life.
+ *  {6}{R}{R}{W}{W}: Return this card from your graveyard to the battlefield. Activate only during
+ *  your upkeep."
+ *
+ * The whole card turns on one thing: an ability that functions from **two** zones (CR 113.6b). A
+ * card whose trigger silently kept the default battlefield-only `activeZones` still looks correct
+ * on the battlefield and does nothing at all from the graveyard — which is the half that makes the
+ * Angel playable — so the graveyard case is asserted first and the battlefield case beside it. The
+ * "your upkeep" rider is asserted in both directions, because a trigger scoped to `Player.Each`
+ * would pass a positive-only test.
+ */
+class FiremaneAngelScenarioTest : FunSpec({
+
+    val returnAbility = FiremaneAngel.activatedAbilities.single().id
+
+    /**
+     * Player 2 takes the first turn, so the very next upkeep after turn 1's main phase belongs to
+     * player 1 — the seat every test below sets up.
+     */
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + FiremaneAngel)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            startingLife = 20,
+            startingPlayer = 1,
+            skipMulligans = true,
+        )
+        return driver
+    }
+
+    fun canActivate(driver: GameTestDriver, player: EntityId, angel: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        return enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .any { (it.action as? ActivateAbility)?.sourceId == angel }
+    }
+
+    fun GameTestDriver.drainStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    /** Pay for the {6}{R}{R}{W}{W} recursion. */
+    fun GameTestDriver.giveRecursionMana(player: EntityId) {
+        giveColorlessMana(player, 6)
+        giveMana(player, Color.RED, 2)
+        giveMana(player, Color.WHITE, 2)
+    }
+
+    test("the upkeep trigger fires while the Angel is in your graveyard") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+        driver.putCardInGraveyard(me, "Firemane Angel")
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe me
+
+        withClue("a battlefield-only activeZones would leave the stack empty here") {
+            driver.stackSize shouldBe 1
+        }
+        driver.bothPass()
+        driver.submitYesNo(me, true)
+        driver.drainStack()
+
+        driver.getLifeTotal(me) shouldBe 21
+    }
+
+    test("the same trigger fires from the battlefield") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+        driver.putPermanentOnBattlefield(me, "Firemane Angel")
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe me
+
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+        driver.submitYesNo(me, true)
+        driver.drainStack()
+
+        driver.getLifeTotal(me) shouldBe 21
+    }
+
+    test("declining the may gains nothing") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+        driver.putCardInGraveyard(me, "Firemane Angel")
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.bothPass()
+        driver.submitYesNo(me, false)
+        driver.drainStack()
+
+        driver.getLifeTotal(me) shouldBe 20
+    }
+
+    test("it does not trigger on an opponent's upkeep") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.UPKEEP)
+        val opponent = driver.activePlayer!!
+        val me = driver.getOpponent(opponent)
+        driver.putCardInGraveyard(me, "Firemane Angel")
+        driver.drainStack()
+
+        // Advance to the *next* upkeep — the opponent's again, two turns on — without ever
+        // reaching mine.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.getLifeTotal(me) shouldBe 20
+        withClue("nothing of mine goes on the stack during the active player's upkeep") {
+            driver.stackSize shouldBe 0
+        }
+    }
+
+    test("during your upkeep the Angel returns itself from the graveyard") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+        val angel = driver.putCardInGraveyard(me, "Firemane Angel")
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.bothPass()
+        driver.submitYesNo(me, false)
+        driver.drainStack()
+
+        driver.giveRecursionMana(me)
+        canActivate(driver, me, angel) shouldBe true
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = angel, abilityId = returnAbility))
+            .isSuccess shouldBe true
+        driver.drainStack()
+
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(angel) shouldBe false
+        driver.getCreatures(me).size shouldBe 1
+    }
+
+    test("the recursion can't be activated outside your upkeep") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+        val angel = driver.putCardInGraveyard(me, "Firemane Angel")
+        driver.giveRecursionMana(me)
+
+        withClue("wrong turn *and* wrong step") {
+            canActivate(driver, me, angel) shouldBe false
+        }
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.bothPass()
+        driver.submitYesNo(me, false)
+        driver.drainStack()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        withClue("right turn, wrong step") {
+            canActivate(driver, me, angel) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RaziasPurificationScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RaziasPurificationScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.RaziasPurification
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Razia's Purification (RAV #224) — "Each player chooses three permanents they control, then
+ * sacrifices the rest."
+ *
+ * Two things are worth proving about the `ChooseExactly(3)` keep. First that it is symmetric: the
+ * caster is a "player" too, so an implementation that quietly scoped the gather to opponents
+ * (or to the controller) leaves one board untouched. Second, the 2005-10-01 ruling — "if a player
+ * doesn't control three permanents, that player chooses all the permanents they do control and
+ * doesn't sacrifice anything" — which is exactly `ChooseExactly`'s clamp to the collection size,
+ * and would instead read as a *deadlock or a lost board* under a strict-N selection.
+ */
+class RaziasPurificationScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RaziasPurification)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            startingLife = 20,
+            startingPlayer = 0,
+            skipMulligans = true,
+        )
+        return driver
+    }
+
+    /** Every permanent [player] controls, in any zone-order the engine reports. */
+    fun GameTestDriver.permanentsOf(player: EntityId): List<EntityId> =
+        state.projectedState.getBattlefieldControlledBy(player)
+
+    /**
+     * Cast the Purification from [caster] and answer every keep-selection by taking the first
+     * options offered, which is all a count assertion needs.
+     */
+    fun GameTestDriver.castAndKeepFirst(caster: EntityId) {
+        val spell = putCardInHand(caster, "Razia's Purification")
+        giveColorlessMana(caster, 4)
+        giveMana(caster, Color.RED, 1)
+        giveMana(caster, Color.WHITE, 1)
+        castSpell(caster, spell).isSuccess shouldBe true
+        bothPass()
+
+        var guard = 0
+        while (isPaused && guard++ < 20) {
+            val decision = pendingDecision
+            if (decision is SelectCardsDecision) {
+                submitCardSelection(decision.playerId, decision.options.take(decision.minSelections))
+            } else {
+                autoResolveDecision()
+            }
+        }
+        guard = 0
+        while (stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    test("every player keeps exactly three permanents and sacrifices the rest") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        repeat(3) { driver.putCreatureOnBattlefield(me, "Grizzly Bears") }
+        driver.putLandOnBattlefield(me, "Mountain")
+        driver.putLandOnBattlefield(me, "Mountain")
+        repeat(4) { driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") }
+
+        driver.castAndKeepFirst(me)
+
+        withClue("the caster is a player too — their board is cut to three as well") {
+            driver.permanentsOf(me).size shouldBe 3
+        }
+        driver.permanentsOf(opponent).size shouldBe 3
+    }
+
+    test("a player controlling fewer than three permanents sacrifices nothing") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        repeat(4) { driver.putCreatureOnBattlefield(me, "Grizzly Bears") }
+        val survivor = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val survivor2 = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.castAndKeepFirst(me)
+
+        driver.permanentsOf(me).size shouldBe 3
+        withClue("two permanents means both are kept, per the 2005-10-01 ruling") {
+            driver.permanentsOf(opponent).toSet() shouldBe setOf(survivor, survivor2)
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/StasisCellScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/StasisCellScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.StasisCell
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stasis Cell (RAV #66) — "Enchant creature. Enchanted creature doesn't untap during its
+ * controller's untap step. {3}{U}: Attach this Aura to target creature."
+ *
+ * The lock is a granted [AbilityFlag.DOESNT_UNTAP], and the whole point of the second ability is
+ * that the lock **moves with the Aura**. An implementation that attached correctly but left the
+ * grant computed against the old host would pass a static "the enchanted creature doesn't untap"
+ * test and still be wrong, so the assertion that matters is the pair: the new host locked *and*
+ * the old host free, read off projected state after one activation.
+ */
+class StasisCellScenarioTest : FunSpec({
+
+    val moveAbility = StasisCell.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + StasisCell)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.enchant(caster: EntityId, creature: EntityId): EntityId {
+        val aura = putCardInHand(caster, "Stasis Cell")
+        giveColorlessMana(caster, 4)
+        giveMana(caster, Color.BLUE, 1)
+        castSpell(caster, aura, listOf(creature)).isSuccess shouldBe true
+        bothPass()
+        return aura
+    }
+
+    fun GameTestDriver.locked(creature: EntityId): Boolean =
+        state.projectedState.hasKeyword(creature, AbilityFlag.DOESNT_UNTAP)
+
+    test("the enchanted creature is locked and nothing else is") {
+        val d = driver()
+        val victim = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val bystander = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.enchant(d.player1, victim)
+
+        d.locked(victim) shouldBe true
+        d.locked(bystander) shouldBe false
+    }
+
+    test("moving the Aura moves the lock with it") {
+        val d = driver()
+        val first = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val second = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val aura = d.enchant(d.player1, first)
+
+        d.giveColorlessMana(d.player1, 3)
+        d.giveMana(d.player1, Color.BLUE, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = d.player1,
+                sourceId = aura,
+                abilityId = moveAbility,
+                targets = listOf(ChosenTarget.Permanent(second)),
+            )
+        ).isSuccess shouldBe true
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 20) d.bothPass()
+
+        withClue("the new host inherits the lock") { d.locked(second) shouldBe true }
+        withClue("the old host is released — the grant is not left computed against it") {
+            d.locked(first) shouldBe false
+        }
+    }
+
+    test("a locked creature stays tapped through its controller's untap step") {
+        val d = driver()
+        val victim = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.enchant(d.player1, victim)
+        d.tapPermanent(victim)
+
+        // Player 2's own untap step is the next one after player 1's turn ends.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.activePlayer shouldBe d.player2
+
+        d.isTapped(victim) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SvogthosTheRestlessTombScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SvogthosTheRestlessTombScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.SvogthosTheRestlessTomb
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Svogthos, the Restless Tomb (RAV #283) — "{3}{B}{G}: Until end of turn, this land becomes a black
+ * and green Plant Zombie creature with 'This creature's power and toughness are each equal to the
+ * number of creature cards in your graveyard.' It's still a land."
+ *
+ * The granted clause is a **characteristic-defining ability**, and that is the thing a test has to
+ * prove: the 2005-10-01 ruling says the size "changes each time a creature card enters or leaves
+ * its controller's graveyard", so a size frozen at resolution — the natural mistake, since
+ * `power`/`toughness` are right there — reads correct on the turn it is used and is wrong forever
+ * after. Hence the mid-turn re-read below. The other two claims are the ones a CDA can get subtly
+ * wrong: it counts **creature** cards only (Svogthos in the yard is a land card), and it counts
+ * **your** graveyard, not the table's.
+ */
+class SvogthosTheRestlessTombScenarioTest : FunSpec({
+
+    val animateAbility = SvogthosTheRestlessTomb.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + SvogthosTheRestlessTomb)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.animate(player: EntityId, land: EntityId) {
+        giveColorlessMana(player, 3)
+        giveMana(player, Color.BLACK, 1)
+        giveMana(player, Color.GREEN, 1)
+        submit(ActivateAbility(playerId = player, sourceId = land, abilityId = animateAbility))
+            .isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 20) bothPass()
+    }
+
+    test("power and toughness track your graveyard's creature cards, live") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val svogthos = d.putLandOnBattlefield(me, "Svogthos, the Restless Tomb")
+        repeat(2) { d.putCardInGraveyard(me, "Grizzly Bears") }
+
+        d.animate(me, svogthos)
+
+        val projected = d.state.projectedState
+        projected.isCreature(svogthos) shouldBe true
+        projected.getPower(svogthos) shouldBe 2
+        projected.getToughness(svogthos) shouldBe 2
+        withClue("\"It's still a land\", so it still taps for {C}") {
+            projected.hasType(svogthos, "LAND") shouldBe true
+        }
+        withClue("black and green Plant Zombie") {
+            projected.getColors(svogthos) shouldBe setOf(Color.BLACK.name, Color.GREEN.name)
+            projected.hasSubtype(svogthos, "Plant") shouldBe true
+            projected.hasSubtype(svogthos, "Zombie") shouldBe true
+        }
+
+        // A CDA, not a size frozen at resolution.
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.state.projectedState.getPower(svogthos) shouldBe 3
+    }
+
+    test("noncreature cards in your graveyard, and creature cards in theirs, do not count") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+        val svogthos = d.putLandOnBattlefield(me, "Svogthos, the Restless Tomb")
+
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.putCardInGraveyard(me, "Swamp")
+        repeat(3) { d.putCardInGraveyard(opponent, "Grizzly Bears") }
+
+        d.animate(me, svogthos)
+
+        d.state.projectedState.getPower(svogthos) shouldBe 1
+    }
+
+    test("the animation ends with the turn") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val svogthos = d.putLandOnBattlefield(me, "Svogthos, the Restless Tomb")
+        d.putCardInGraveyard(me, "Grizzly Bears")
+
+        d.animate(me, svogthos)
+        d.state.projectedState.isCreature(svogthos) shouldBe true
+
+        d.passPriorityUntil(Step.UPKEEP)
+        withClue("\"Until end of turn\" — unlike Woodwraith Corrupter's open-ended animation") {
+            d.state.projectedState.isCreature(svogthos) shouldBe false
+        }
+        withClue("it never stopped being a land") {
+            d.state.projectedState.hasType(svogthos, "LAND") shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoodwraithCorrupterScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoodwraithCorrupterScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.WoodwraithCorrupter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Woodwraith Corrupter (RAV #240) — "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green
+ * Elemental Horror creature. It's still a land."
+ *
+ * The claim worth pinning is the one the card's own ruling makes: the animation has **no stated
+ * duration**, so it survives the cleanup step. A `Duration.EndOfTurn` slip reads identically on the
+ * turn it is used and is invisible to the snapshot net, so the "still a 4/4 next turn" assertion is
+ * the whole point of this file. Beside it: the Forest keeps LAND and its Forest subtype ("it's
+ * still a land", so it still taps for {G}), and its colors are *replaced* with black and green
+ * rather than added to — an animated Forest is not green-only.
+ */
+class WoodwraithCorrupterScenarioTest : FunSpec({
+
+    val animateAbility = WoodwraithCorrupter.activatedAbilities.single().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + WoodwraithCorrupter)
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20,
+            startingPlayer = 0,
+            skipMulligans = true,
+        )
+        return driver
+    }
+
+    fun GameTestDriver.drainStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    /**
+     * A Corrupter that has been under [me]'s control since the turn began, plus a Forest, with the
+     * animation already paid for and resolved against that Forest.
+     */
+    fun animate(driver: GameTestDriver, me: EntityId, forestController: EntityId): EntityId {
+        val corrupter = driver.putPermanentOnBattlefield(me, "Woodwraith Corrupter")
+        driver.removeSummoningSickness(corrupter)
+        val forest = driver.putLandOnBattlefield(forestController, "Forest")
+
+        driver.giveColorlessMana(me, 1)
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = corrupter,
+                abilityId = animateAbility,
+                targets = listOf(ChosenTarget.Permanent(forest)),
+            )
+        ).isSuccess shouldBe true
+        driver.drainStack()
+        return forest
+    }
+
+    test("the targeted Forest becomes a 4/4 black and green Elemental Horror that is still a land") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val forest = animate(driver, me, me)
+        val projected = driver.state.projectedState
+
+        projected.isCreature(forest) shouldBe true
+        projected.getPower(forest) shouldBe 4
+        projected.getToughness(forest) shouldBe 4
+        withClue("both printed subtypes are granted") {
+            projected.hasSubtype(forest, "Elemental") shouldBe true
+            projected.hasSubtype(forest, "Horror") shouldBe true
+        }
+
+        withClue("\"It's still a land\" — LAND and the Forest subtype survive, so it still taps for {G}") {
+            projected.hasType(forest, "LAND") shouldBe true
+            projected.hasSubtype(forest, "Forest") shouldBe true
+        }
+        withClue("becomes black *and green*, replacing the land's colorlessness") {
+            projected.getColors(forest) shouldBe setOf(Color.BLACK.name, Color.GREEN.name)
+        }
+    }
+
+    test("the animation has no duration, so it survives into the next turn") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val forest = animate(driver, me, me)
+        val turnAnimated = driver.state.turnNumber
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.drainStack()
+        withClue("the test must actually have crossed a turn boundary") {
+            (driver.state.turnNumber != turnAnimated || driver.activePlayer != me) shouldBe true
+        }
+
+        val projected = driver.state.projectedState
+        withClue("a Duration.EndOfTurn slip is invisible until here") {
+            projected.isCreature(forest) shouldBe true
+            projected.getPower(forest) shouldBe 4
+            projected.getToughness(forest) shouldBe 4
+        }
+    }
+
+    test("an opponent's Forest is a legal target") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val forest = animate(driver, me, opponent)
+
+        driver.state.projectedState.isCreature(forest) shouldBe true
+        withClue("animating it does not steal it") {
+            driver.state.projectedState.getController(forest) shouldBe opponent
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SvogthosTheRestlessTombReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SvogthosTheRestlessTombReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Svogthos, the Restless Tomb reprint in Commander 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Ravnica: City of Guilds (`rav`) `cards/`
+ * package (the card's earliest real printing); this file contributes only per-printing
+ * presentation data.
+ */
+val SvogthosTheRestlessTombReprint = Printing(
+    oracleId = "a34a70b8-02e5-4e8c-a9e7-b21c5a11dddf",
+    name = "Svogthos, the Restless Tomb",
+    setCode = "CMD",
+    collectorNumber = "289",
+    scryfallId = "67259116-7b5e-4340-858f-9905a479084d",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67259116-7b5e-4340-858f-9905a479084d.jpg?1783941142",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3202,6 +3202,105 @@
     ]
 }
 
+// Firemane Angel
+{
+    "name": "Firemane Angel",
+    "manaCost": "{3}{R}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying, first strike\nAt the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield, you may gain 1 life.\n{6}{R}{R}{W}{W}: Return this card from your graveyard to the battlefield. Activate only during your upkeep.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "activeZones": [
+                    "Battlefield",
+                    "Graveyard"
+                ],
+                "interveningIf": {
+                    "type": "SourceInZone",
+                    "zones": [
+                        "Battlefield",
+                        "Graveyard"
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, if Firemane Angel is in your graveyard or on the battlefield, you may gain 1 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}{R}{R}{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationAll",
+                        "restrictions": [
+                            "OnlyDuringYourTurn",
+                            {
+                                "type": "DuringStep",
+                                "step": "UPKEEP"
+                            }
+                        ]
+                    }
+                ],
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "Return this card from your graveyard to the battlefield. Activate only during your upkeep."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/493730ab-c30d-4830-a188-0462426fc5bf.jpg?1783943621",
+        "rulings": [
+            {
+                "date": "2017-11-17",
+                "text": "If Firemane Angel is put into your graveyard from the battlefield or returned from your graveyard to the battlefield during your upkeep before its triggered ability resolves, you won't gain 1 life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Fists of Ironwood
 {
     "name": "Fists of Ironwood",
@@ -7055,6 +7154,84 @@
     ]
 }
 
+// Razia's Purification
+{
+    "name": "Razia's Purification",
+    "manaCost": "{4}{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player chooses three permanents they control, then sacrifices the rest.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Players",
+                "players": "Each"
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "GatherCards",
+                        "source": {
+                            "type": "ControlledPermanents",
+                            "filter": "permanent"
+                        },
+                        "storeAs": "permanents"
+                    },
+                    {
+                        "type": "SelectFromCollection",
+                        "from": "permanents",
+                        "selection": {
+                            "type": "ChooseExactly",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        "storeSelected": "kept",
+                        "storeRemainder": "sacrificed",
+                        "prompt": "Choose three permanents you control to keep; the rest are sacrificed.",
+                        "selectedLabel": "Keep",
+                        "remainderLabel": "Sacrifice",
+                        "useTargetingUI": true,
+                        "alwaysPrompt": true
+                    },
+                    {
+                        "type": "MoveCollection",
+                        "from": "sacrificed",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Graveyard"
+                        },
+                        "moveType": "Sacrifice"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "RARE",
+        "artist": "Shishizaru",
+        "flavorText": "Only the chosen ones are spared.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73bfefd3-bddd-47bb-92f3-9356a7bca637.jpg?1783943615",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If a player doesn't control three permanents, that player chooses all the permanents they do control and doesn't sacrifice anything."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Players choose permanents in turn order around the table, then simultaneously sacrifice all permanents not chosen."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Recollect
 {
     "name": "Recollect",
@@ -8455,6 +8632,59 @@
     ]
 }
 
+// Stasis Cell
+{
+    "name": "Stasis Cell",
+    "manaCost": "{4}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature doesn't untap during its controller's untap step.\n{3}{U}: Attach this Aura to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": "AttachEquipment",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{3}{U}: Attach this Aura to target creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Mark A. Nelson",
+        "flavorText": "The Simic created the cells to preserve their experiments. The Azorius put the cells to use on the guilty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e75611d2-6e87-4032-a71c-b46806798a29.jpg?1783943680"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Stone-Seeder Hierophant
 {
     "name": "Stone-Seeder Hierophant",
@@ -8883,6 +9113,97 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Svogthos, the Restless Tomb
+{
+    "name": "Svogthos, the Restless Tomb",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}{B}{G}: Until end of turn, this land becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "creatureTypes": [
+                        "Plant",
+                        "Zombie"
+                    ],
+                    "colors": [
+                        "BLACK",
+                        "GREEN"
+                    ],
+                    "dynamicPower": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "dynamicToughness": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    }
+                },
+                "descriptionOverride": "{3}{B}{G}: Until end of turn, this land becomes a black and green Plant Zombie creature with \"This creature's power and toughness are each equal to the number of creature cards in your graveyard.\" It's still a land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "283",
+        "rarity": "UNCOMMON",
+        "artist": "Martina Pilcerova",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cf3ba87-93a0-44db-83d9-92e23a677a62.jpg?1783943589",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "While animated, Svogthos's power and toughness changes each time a creature card enters or leaves its controller's graveyard."
+            },
+            {
+                "date": "2008-08-01",
+                "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of their most recent turn. It doesn't matter how long the permanent has been a creature."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -10716,6 +11037,93 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Woodwraith Corrupter
+{
+    "name": "Woodwraith Corrupter",
+    "manaCost": "{3}{B}{B}{G}",
+    "typeLine": "Creature — Elemental Horror",
+    "oracleText": "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Forest"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "creatureTypes": [
+                        "Elemental",
+                        "Horror"
+                    ],
+                    "colors": [
+                        "BLACK",
+                        "GREEN"
+                    ],
+                    "duration": "Permanent"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land Forest"
+                        },
+                        "id": "target Forest"
+                    }
+                ],
+                "descriptionOverride": "{1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "flavorText": "\"Its darkened sap penetrates natural fibers and spreads its own genes. Emulation experiments are underway.\"\n—Simic research notes",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1ee1ceb-61dd-4c98-bc48-a0763315a14f.jpg?1783943608",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The effect has no stated duration, so a land turned into a creature this way continues being a creature as long as the land is on the battlefield."
+            },
+            {
+                "date": "2008-08-01",
+                "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of their most recent turn. It doesn't matter how long the permanent has been a creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Five RAV cards, each built out of existing `Effects.*` / `Patterns.*` primitives — no new SDK vocabulary. RAV goes 201/291 → 206/291.

| Card | What it does | Composed from |
|---|---|---|
| **Stasis Cell** | Aura; enchanted creature doesn't untap during its controller's untap step; `{3}{U}` re-attaches it | `GrantKeyword(AbilityFlag.DOESNT_UNTAP)` (Shackles) + `Effects.AttachEquipment` on the ability's own target (Bound by Moonsilver — the effect is attachment-generic, not Equipment-specific) |
| **Woodwraith Corrupter** | `{1}{B}{G}, {T}`: target Forest becomes a 4/4 black and green Elemental Horror creature, still a land | `Effects.BecomeCreature(duration = Duration.Permanent)` (Elvish Branchbender's targeting, Stalking Stones' open-ended duration) |
| **Svogthos, the Restless Tomb** | Land; `{T}`: add `{C}`; `{3}{B}{G}` animates it into a black and green Plant Zombie whose P/T equal the creature cards in your graveyard | `Effects.BecomeCreature` with `dynamicPower`/`dynamicToughness = DynamicAmounts.creatureCardsInYourGraveyard()` (Beorn's Hospitality) |
| **Firemane Angel** | Flying, first strike; upkeep "you may gain 1 life" from graveyard *or* battlefield; `{6}{R}{R}{W}{W}` upkeep-only self-reanimation | `triggerZones = {BATTLEFIELD, GRAVEYARD}` + `Conditions.SourceInZone` (Edgar Markov) and `activateFromZone = GRAVEYARD` with the your-turn/upkeep restriction pair (Grim Reminder) |
| **Razia's Purification** | Each player chooses three permanents they control, then sacrifices the rest | `ForEachPlayerEffect(Each)` → gather → `SelectionMode.ChooseExactly(3)` → sacrifice the remainder (Global Ruin) |

Also adds the Commander 2011 `Printing` row for Svogthos (`just check-card-printing` flagged it).

## The two rules details worth a reviewer's eye

- **Woodwraith Corrupter's animation has no stated duration**, so it is `Duration.Permanent` per the card's own 2005-10-01 ruling. A `Duration.EndOfTurn` slip reads identically on the turn it is used and is invisible to the snapshot net, so `WoodwraithCorrupterScenarioTest` crosses a turn boundary and re-reads the P/T.
- **Svogthos grants a characteristic-defining ability**, not a size frozen at resolution — the count lives in `dynamicPower`/`dynamicToughness`, re-evaluated at Layer 7b. The test adds a creature card to the graveyard mid-turn and asserts the power moves.

Razia's Purification takes one documented liberty, called out in the card's KDoc: the second 2005-10-01 ruling wants all choices made in turn order and then a *single simultaneous* sacrifice, while the engine's per-player fold makes the sacrifices sequential. That is only observable through leaves-the-battlefield triggers counting other permanents mid-resolution, and it matches how Global Ruin already models the same shape.

## Verification

- `just build` — green (full suite).
- 18 new scenario assertions across five per-card test files, all passing.
- `just assay-differential --set RAV` — 103 compared, **0 divergent**.
- `just check-card-printing` — clean for all five (canonical in RAV; `psal` is a Salvat box product, not a real expansion, per the set's standing note).
- Image URIs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZnHARgWqThLUVUJKSzrC6