### PR TITLE
Add the four remaining Lorwyn Commands

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CrypticCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/CrypticCommand.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Cryptic Command
+ * {1}{U}{U}{U}
+ * Instant
+ * Choose two —
+ * • Counter target spell.
+ * • Return target permanent to its owner's hand.
+ * • Tap all creatures your opponents control.
+ * • Draw a card.
+ *
+ * The Lorwyn Command cycle's blue member, and the same `modal(chooseCount = 2)` shape as its
+ * white sibling [AustereCommand]. Two of the four modes target, so those two declare their
+ * requirement inside their own `mode` block and the other two declare none — the engine collects
+ * the chosen modes' requirements at cast time, which is what the 2017-11-17 ruling about "look at
+ * both chosen modes to determine how many targets" describes.
+ */
+val CrypticCommand = card("Cryptic Command") {
+    manaCost = "{1}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose two —\n" +
+        "• Counter target spell.\n" +
+        "• Return target permanent to its owner's hand.\n" +
+        "• Tap all creatures your opponents control.\n" +
+        "• Draw a card."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Counter target spell") {
+                target = Targets.Spell
+                effect = Effects.CounterSpell()
+            }
+            mode("Return target permanent to its owner's hand") {
+                val permanent = target("permanent to bounce", Targets.Permanent)
+                effect = Effects.ReturnToHand(permanent)
+            }
+            mode("Tap all creatures your opponents control") {
+                effect = Patterns.Group.tapAll(GroupFilter.AllCreaturesOpponentsControl)
+            }
+            mode("Draw a card") {
+                effect = Effects.DrawCards(1)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg?1783942904"
+        ruling("2017-11-17", "You choose both modes as you cast Cryptic Command. You must choose two different modes.")
+        ruling("2017-11-17", "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it won't resolve and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won't draw a card.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/IncendiaryCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/IncendiaryCommand.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Incendiary Command
+ * {3}{R}{R}
+ * Sorcery
+ * Choose two —
+ * • Incendiary Command deals 4 damage to target player or planeswalker.
+ * • Incendiary Command deals 2 damage to each creature.
+ * • Destroy target nonbasic land.
+ * • Each player discards all the cards in their hand, then draws that many cards.
+ *
+ * The red member of the Lorwyn Command cycle. The wheel mode is the only one worth a note: it is
+ * **per player**, not a shared count, so it runs inside a [ForEachPlayerEffect] over
+ * [Player.Each]. That rebinds `controllerId` per iteration and — crucially — gives each iteration
+ * fresh stored collections, so the `discardedHand_count` that
+ * [Patterns.Hand.discardHand] publishes is that player's own hand size. Hoisting the discard out
+ * of the loop would draw everyone the same number of cards.
+ */
+val IncendiaryCommand = card("Incendiary Command") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose two —\n" +
+        "• Incendiary Command deals 4 damage to target player or planeswalker.\n" +
+        "• Incendiary Command deals 2 damage to each creature.\n" +
+        "• Destroy target nonbasic land.\n" +
+        "• Each player discards all the cards in their hand, then draws that many cards."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Incendiary Command deals 4 damage to target player or planeswalker") {
+                val victim = target("damage player or planeswalker", Targets.PlayerOrPlaneswalker)
+                effect = Effects.DealDamage(4, victim)
+            }
+            mode("Incendiary Command deals 2 damage to each creature") {
+                effect = Patterns.Group.dealDamageToAll(2, GroupFilter.AllCreatures)
+            }
+            mode("Destroy target nonbasic land") {
+                val land = target(
+                    "nonbasic land to destroy",
+                    TargetPermanent(filter = TargetFilter.NonbasicLand)
+                )
+                effect = Effects.Destroy(land)
+            }
+            mode("Each player discards all the cards in their hand, then draws that many cards") {
+                effect = ForEachPlayerEffect(
+                    players = Player.Each,
+                    effects = listOf(
+                        Patterns.Hand.discardHand(),
+                        Effects.DrawCards(DynamicAmount.VariableReference("discardedHand_count"))
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "179"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg?1783942873"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PrimalCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PrimalCommand.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Primal Command
+ * {3}{G}{G}
+ * Sorcery
+ * Choose two —
+ * • Target player gains 7 life.
+ * • Put target noncreature permanent on top of its owner's library.
+ * • Target player shuffles their graveyard into their library.
+ * • Search your library for a creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * The green member of the Lorwyn Command cycle. Three of the four modes target; the search mode
+ * doesn't, and its "reveal it" is the `reveal = true` flag on the standard
+ * [Patterns.Library.searchLibrary] recipe rather than a separate reveal step.
+ *
+ * The 2017-03-14 rulings both fall out of the sequential mode resolution that
+ * [AustereCommand] documents — the graveyard shuffle happens after the tuck, so a permanent put on
+ * top of a library is shuffled away by a later mode, and Primal Command itself is still on the
+ * stack (not yet in a graveyard) when its own shuffle mode runs.
+ */
+val PrimalCommand = card("Primal Command") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose two —\n" +
+        "• Target player gains 7 life.\n" +
+        "• Put target noncreature permanent on top of its owner's library.\n" +
+        "• Target player shuffles their graveyard into their library.\n" +
+        "• Search your library for a creature card, reveal it, put it into your hand, then shuffle."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Target player gains 7 life") {
+                val player = target("player to gain life", Targets.Player)
+                effect = Effects.GainLife(7, player)
+            }
+            mode("Put target noncreature permanent on top of its owner's library") {
+                val permanent = target(
+                    "noncreature permanent to tuck",
+                    TargetPermanent(filter = TargetFilter.NoncreaturePermanent)
+                )
+                effect = Effects.PutOnTopOfLibrary(permanent)
+            }
+            mode("Target player shuffles their graveyard into their library") {
+                val player = target("player to shuffle their graveyard", Targets.Player)
+                effect = Patterns.Library.shuffleGraveyardIntoLibrary(player)
+            }
+            mode("Search your library for a creature card, reveal it, put it into your hand, then shuffle") {
+                effect = Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.Creature,
+                    count = 1,
+                    destination = SearchDestination.HAND,
+                    reveal = true
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "233"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg?1783942858"
+        ruling("2017-03-14", "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode.")
+        ruling("2017-03-14", "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle their graveyard into their library, that card is shuffled away.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProfaneCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProfaneCommand.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Profane Command
+ * {X}{B}{B}
+ * Sorcery
+ * Choose two —
+ * • Target player loses X life.
+ * • Return target creature card with mana value X or less from your graveyard to the battlefield.
+ * • Target creature gets -X/-X until end of turn.
+ * • Up to X target creatures gain fear until end of turn.
+ *
+ * The black member of the Lorwyn Command cycle, and the only one with an {X} in its cost. The
+ * 2007-10-01 ruling — "the value chosen for X applies to each X in the spell's effect. You pay {X}
+ * only once" — is exactly what falls out of every mode reading the *same* [DynamicAmount.XValue]:
+ * both chosen modes see the one X paid at cast time.
+ *
+ * X appears in three different grammatical positions, and each needs its own SDK spelling:
+ *  - as an **amount** (`LoseLife`) — [DynamicAmount.XValue] straight.
+ *  - as a **filter bound** ("mana value X or less") — `manaValueAtMostX()`, a card predicate that
+ *    reads the paid X, not a fixed number baked in at authoring time.
+ *  - as a **target count** ("up to X target creatures") — `dynamicMaxCount = XValue` with
+ *    `optional = true` for the "up to", the shape Word of Binding and Icy Blast use.
+ *
+ * The -X/-X mode negates through [DynamicAmount.Multiply] rather than a separate "negative amount"
+ * type, matching Chill Haunting.
+ */
+val ProfaneCommand = card("Profane Command") {
+    manaCost = "{X}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose two —\n" +
+        "• Target player loses X life.\n" +
+        "• Return target creature card with mana value X or less from your graveyard to the battlefield.\n" +
+        "• Target creature gets -X/-X until end of turn.\n" +
+        "• Up to X target creatures gain fear until end of turn. (They can't be blocked except " +
+        "by artifact creatures and/or black creatures.)"
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Target player loses X life") {
+                val player = target("player to lose life", Targets.Player)
+                effect = Effects.LoseLife(DynamicAmount.XValue, player)
+            }
+            mode("Return target creature card with mana value X or less from your graveyard to the battlefield") {
+                val creatureCard = target(
+                    "creature card with mana value X or less in your graveyard",
+                    TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMostX())
+                )
+                effect = Effects.PutOntoBattlefieldFromGraveyard(creatureCard)
+            }
+            mode("Target creature gets -X/-X until end of turn") {
+                val creature = target("creature to weaken", Targets.Creature)
+                val negX = DynamicAmount.Multiply(DynamicAmount.XValue, -1)
+                effect = Effects.ModifyStats(negX, negX, creature)
+            }
+            mode("Up to X target creatures gain fear until end of turn") {
+                target(
+                    "creatures to gain fear",
+                    TargetCreature(optional = true, dynamicMaxCount = DynamicAmount.XValue)
+                )
+                effect = ForEachTargetEffect(
+                    listOf(Effects.GrantKeyword(Keyword.FEAR, EffectTarget.ContextTarget(0)))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg?1783942885"
+        ruling("2007-10-01", "The value chosen for X applies to each X in the spell's effect. You pay {X} only once.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCommandScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.CrypticCommand
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cryptic Command (LRW #56) — {1}{U}{U}{U} Instant.
+ *
+ * Choose two —
+ * • Counter target spell.
+ * • Return target permanent to its owner's hand.
+ * • Tap all creatures your opponents control.
+ * • Draw a card.
+ *
+ * Two axes are worth pinning. The sweep is **one-sided** — "creatures your opponents control", not
+ * every creature — and a controller predicate that fell back to the implicit "you control" would
+ * look identical on the card while tapping exactly the wrong board, so the test puts creatures on
+ * both sides and checks both. And the counter mode has to work from the opponent's turn, since a
+ * sorcery-speed reading of an instant only shows up when there is a spell to answer.
+ */
+class CrypticCommandScenarioTest : FunSpec({
+
+    // Mode order follows the printed bullets.
+    val counterSpell = 0
+    val bounce = 1
+    val tapOpponents = 2
+    val drawCard = 3
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CrypticCommand))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCommand(
+        caster: EntityId,
+        modes: List<Int>,
+        modeTargets: List<List<ChosenTarget>>,
+    ): ExecutionResult {
+        giveMana(caster, Color.BLUE, 4)
+        val spell = putCardInHand(caster, "Cryptic Command")
+        return submit(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = modeTargets.flatten(),
+                chosenModes = modes,
+                modeTargetsOrdered = modeTargets,
+            )
+        )
+    }
+
+    test("the sweep taps only the opponents' creatures, never the caster's") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val mine = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        val theirs = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val alsoTheirs = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.castCommand(
+            me,
+            modes = listOf(tapOpponents, drawCard),
+            modeTargets = listOf(emptyList(), emptyList()),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.isTapped(theirs) shouldBe true
+        driver.isTapped(alsoTheirs) shouldBe true
+        driver.isTapped(mine) shouldBe false
+    }
+
+    test("bounce and draw — the permanent goes to its owner's hand and a card is drawn") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val bears = driver.findPermanent(opp, "Grizzly Bears")!!
+        val handBefore = driver.getHandSize(me)
+        val oppHandBefore = driver.getHandSize(opp)
+
+        driver.castCommand(
+            me,
+            modes = listOf(bounce, drawCard),
+            modeTargets = listOf(listOf(ChosenTarget.Permanent(bears)), emptyList()),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Grizzly Bears") shouldBe null
+        // "its owner's hand" — the opponent's, not the caster's.
+        driver.getHandSize(opp) shouldBe oppHandBefore + 1
+        // The Command was added to the caster's hand and left it on the cast, so only the draw
+        // shows up against the pre-cast count.
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+
+    test("counter and draw — the countered spell never resolves") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val target = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+
+        // The opponent casts a removal spell; the caster answers at instant speed.
+        driver.giveMana(opp, Color.RED, 1)
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.passPriority(me)
+        driver.submit(
+            CastSpell(playerId = opp, cardId = bolt, targets = listOf(ChosenTarget.Permanent(target)))
+        ).error shouldBe null
+
+        // The caster retains priority after casting, so the opponent has to release it before the
+        // Command can be cast in response.
+        driver.passPriority(opp)
+
+        val stackSpell = driver.getTopOfStack()!!
+        driver.castCommand(
+            me,
+            modes = listOf(counterSpell, drawCard),
+            modeTargets = listOf(listOf(ChosenTarget.Spell(stackSpell)), emptyList()),
+        ).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.assertInGraveyard(opp, "Lightning Bolt")
+        driver.findPermanent(me, "Centaur Courser") shouldBe target
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/IncendiaryCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/IncendiaryCommandScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.IncendiaryCommand
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Incendiary Command (LRW #179) — {3}{R}{R} Sorcery.
+ *
+ * Choose two —
+ * • Incendiary Command deals 4 damage to target player or planeswalker.
+ * • Incendiary Command deals 2 damage to each creature.
+ * • Destroy target nonbasic land.
+ * • Each player discards all the cards in their hand, then draws that many cards.
+ *
+ * The wheel mode is the one worth proving. "Each player discards all the cards in their hand, then
+ * draws **that many**" is per-player, not a shared count, so it runs inside a `ForEachPlayerEffect`
+ * whose fresh per-iteration stored collections are what make `discardedHand_count` mean *that*
+ * player's hand. Hoisting the discard out of the loop — or letting one iteration's count leak into
+ * the next — would draw everyone the same number of cards, which is invisible whenever the two
+ * hands happen to be the same size. So the test gives the two players deliberately *different*
+ * hand sizes, the one shape where the two readings disagree.
+ *
+ * The nonbasic-land mode gets its own test because "nonbasic" is a fail-open axis: a filter that
+ * dropped the supertype check would happily destroy a Mountain and nothing about the card would
+ * look wrong.
+ */
+class IncendiaryCommandScenarioTest : FunSpec({
+
+    // Mode order follows the printed bullets.
+    val damagePlayer = 0
+    val sweepCreatures = 1
+    val destroyLand = 2
+    val wheel = 3
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IncendiaryCommand))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCommand(
+        caster: EntityId,
+        modes: List<Int>,
+        modeTargets: List<List<ChosenTarget>> = emptyList(),
+    ): ExecutionResult {
+        giveMana(caster, Color.RED, 5)
+        val spell = putCardInHand(caster, "Incendiary Command")
+        return submit(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = modeTargets.flatten(),
+                chosenModes = modes,
+                modeTargetsOrdered = modeTargets,
+            )
+        )
+    }
+
+    test("each player wheels their own hand — unequal hands stay unequal") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Empty both hands, then deal deliberately different sizes. The Command itself is put into
+        // the caster's hand by castCommand and leaves it on the cast, so it is not counted here.
+        driver.getHand(me).forEach { driver.moveToGraveyard(it) }
+        driver.getHand(opp).forEach { driver.moveToGraveyard(it) }
+        repeat(4) { driver.putCardInHand(me, "Grizzly Bears") }
+        repeat(1) { driver.putCardInHand(opp, "Grizzly Bears") }
+
+        driver.castCommand(me, modes = listOf(wheel, sweepCreatures)).error shouldBe null
+        driver.bothPass()
+
+        driver.getHandSize(me) shouldBe 4
+        driver.getHandSize(opp) shouldBe 1
+        // The discarded hands went to each player's own graveyard.
+        driver.getGraveyardCardNames(me).count { it == "Grizzly Bears" } shouldBe 4
+        driver.getGraveyardCardNames(opp).count { it == "Grizzly Bears" } shouldBe 1
+    }
+
+    test("a player with an empty hand draws nothing rather than the other player's count") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.getHand(me).forEach { driver.moveToGraveyard(it) }
+        driver.getHand(opp).forEach { driver.moveToGraveyard(it) }
+        repeat(3) { driver.putCardInHand(me, "Grizzly Bears") }
+
+        driver.castCommand(me, modes = listOf(wheel, sweepCreatures)).error shouldBe null
+        driver.bothPass()
+
+        driver.getHandSize(me) shouldBe 3
+        driver.getHandSize(opp) shouldBe 0
+    }
+
+    test("2 damage to each creature is symmetric and kills only what it should") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCreatureOnBattlefield(me, "Savannah Lions")    // 1/1 — dies
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")   // 3/3 — survives
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")    // 2/2 — dies
+
+        driver.castCommand(me, modes = listOf(sweepCreatures, damagePlayer), modeTargets = listOf(
+            emptyList(),
+            listOf(ChosenTarget.Player(opp)),
+        )).error shouldBe null
+        driver.bothPass()
+
+        driver.getCreatures(me).map { driver.getCardName(it) } shouldBe listOf("Centaur Courser")
+        driver.getCreatures(opp).size shouldBe 0
+        driver.getLifeTotal(opp) shouldBe 16
+    }
+
+    test("the land mode takes a nonbasic land and leaves a basic alone") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putLandOnBattlefield(opp, "Mountain")
+        val nonbasic = driver.putLandOnBattlefield(opp, "Vivid Crag")
+
+        driver.castCommand(
+            me,
+            modes = listOf(destroyLand, damagePlayer),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(nonbasic)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getLands(opp).map { driver.getCardName(it) } shouldBe listOf("Mountain")
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PrimalCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PrimalCommandScenarioTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.PrimalCommand
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Primal Command (LRW #233) — {3}{G}{G} Sorcery.
+ *
+ * Choose two —
+ * • Target player gains 7 life.
+ * • Put target noncreature permanent on top of its owner's library.
+ * • Target player shuffles their graveyard into their library.
+ * • Search your library for a creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * Three of the four modes take a *player* or *owner* reference that can plausibly resolve to the
+ * caster instead of the chosen target, and every one of those mistakes reads correctly on the card.
+ * So each is aimed at the **opponent** — the one direction where "target player" and an implicit
+ * "you" give opposite answers: the opponent gains the life, the opponent's graveyard is the one
+ * that shuffles away, and the tucked permanent goes to *its owner's* library.
+ *
+ * The tuck mode is also a fail-open axis on its filter: a requirement that lost `noncreature`
+ * would happily take a creature, so the creature is offered and expected to be refused.
+ */
+class PrimalCommandScenarioTest : FunSpec({
+
+    // Mode order follows the printed bullets.
+    val gainLife = 0
+    val tuck = 1
+    val shuffleGraveyard = 2
+    val searchCreature = 3
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PrimalCommand))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCommand(
+        caster: EntityId,
+        modes: List<Int>,
+        modeTargets: List<List<ChosenTarget>>,
+    ): ExecutionResult {
+        giveMana(caster, Color.GREEN, 5)
+        val spell = putCardInHand(caster, "Primal Command")
+        return submit(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = modeTargets.flatten(),
+                chosenModes = modes,
+                modeTargetsOrdered = modeTargets,
+            )
+        )
+    }
+
+    test("the life goes to the chosen player, not automatically to the caster") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.castCommand(
+            me,
+            modes = listOf(gainLife, shuffleGraveyard),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Player(opp)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(opp) shouldBe 27
+        driver.getLifeTotal(me) shouldBe 20
+    }
+
+    test("the graveyard shuffle empties the chosen player's graveyard, not the caster's") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        driver.putCardInGraveyard(opp, "Grizzly Bears")
+        driver.putCardInGraveyard(opp, "Savannah Lions")
+        driver.putCardInGraveyard(me, "Centaur Courser")
+
+        driver.castCommand(
+            me,
+            modes = listOf(shuffleGraveyard, gainLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Player(opp)),
+                listOf(ChosenTarget.Player(me)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getGraveyardCardNames(opp) shouldBe emptyList()
+        // The caster's graveyard is untouched — and Primal Command itself lands in it afterwards,
+        // which is the 2017-03-14 ruling about targeting yourself with this mode.
+        driver.getGraveyardCardNames(me) shouldBe listOf("Centaur Courser", "Primal Command")
+    }
+
+    test("the spell itself is not shuffled away when the caster targets their own graveyard") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        driver.castCommand(
+            me,
+            modes = listOf(shuffleGraveyard, gainLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Player(me)),
+                listOf(ChosenTarget.Player(me)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        // A sorcery is put into its owner's graveyard only as the final part of its own
+        // resolution, so Primal Command is still on the stack while the shuffle runs and is not
+        // among the cards shuffled in — it lands in the graveyard afterwards.
+        driver.getGraveyardCardNames(me) shouldBe listOf("Primal Command")
+    }
+
+    test("a noncreature permanent is tucked onto its owner's library") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val enchantment = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+
+        driver.castCommand(
+            me,
+            modes = listOf(tuck, gainLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(enchantment)),
+                listOf(ChosenTarget.Player(me)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Test Enchantment") shouldBe null
+        driver.getGraveyardCardNames(opp).contains("Test Enchantment") shouldBe false
+    }
+
+    test("the tuck mode refuses a creature") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        driver.castCommand(
+            me,
+            modes = listOf(tuck, gainLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(bears)),
+                listOf(ChosenTarget.Player(me)),
+            ),
+        ).error shouldNotBe null
+
+        driver.findPermanent(opp, "Grizzly Bears") shouldBe bears
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProfaneCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProfaneCommandScenarioTest.kt
@@ -1,0 +1,208 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ProfaneCommand
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Profane Command (LRW #135) — {X}{B}{B} Sorcery.
+ *
+ * Choose two —
+ * • Target player loses X life.
+ * • Return target creature card with mana value X or less from your graveyard to the battlefield.
+ * • Target creature gets -X/-X until end of turn.
+ * • Up to X target creatures gain fear until end of turn.
+ *
+ * The single X paid at cast time has to reach three grammatically different places — an *amount*,
+ * a *filter bound*, and a *target count* — and each is a separate SDK spelling that can fail on its
+ * own without changing how the card reads. So each is aimed at the boundary the paid X draws:
+ *
+ *  - the reanimation filter, against a creature card sitting exactly on X and then against the same
+ *    card with X one lower, because `manaValueAtMostX` reading the wrong number is invisible;
+ *  - the fear count, by asking for X+1 targets and expecting the cast to be refused, because a
+ *    `dynamicMaxCount` that never resolved would accept any number of them;
+ *  - the -X/-X, which negates through `Multiply(XValue, -1)` — a sign error there reads as a pump.
+ *
+ * The 2007-10-01 ruling ("the value chosen for X applies to each X in the spell's effect. You pay
+ * {X} only once") is the first test: both chosen modes see the *same* X off one payment.
+ */
+class ProfaneCommandScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // Mode order follows the printed bullets.
+    val loseLife = 0
+    val reanimate = 1
+    val weaken = 2
+    val grantFear = 3
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ProfaneCommand))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCommand(
+        caster: EntityId,
+        x: Int,
+        modes: List<Int>,
+        modeTargets: List<List<ChosenTarget>>,
+    ): ExecutionResult {
+        giveMana(caster, Color.BLACK, x + 2)
+        val spell = putCardInHand(caster, "Profane Command")
+        return submit(
+            CastSpell(
+                playerId = caster,
+                cardId = spell,
+                targets = modeTargets.flatten(),
+                chosenModes = modes,
+                modeTargetsOrdered = modeTargets,
+                xValue = x,
+            )
+        )
+    }
+
+    test("one payment, one X — 4 life lost and -4/-4 come off the same cast") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bear = driver.putCreatureOnBattlefield(opp, "Grizzly Bears") // 2/2
+
+        driver.castCommand(
+            me,
+            x = 4,
+            modes = listOf(loseLife, weaken),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Player(opp)),
+                listOf(ChosenTarget.Permanent(bear)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(opp) shouldBe 16
+        // -4/-4 on a 2/2 is lethal, so the creature is gone rather than sitting at -2/-2.
+        driver.findPermanent(opp, "Grizzly Bears") shouldBe null
+    }
+
+    test("-X/-X shrinks — a creature that survives it sits at reduced stats, not raised ones") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val nature = driver.putCreatureOnBattlefield(opp, "Force of Nature") // 5/5
+
+        driver.castCommand(
+            me,
+            x = 3,
+            modes = listOf(weaken, loseLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(nature)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, nature) shouldBe 2
+        projector.getProjectedToughness(driver.state, nature) shouldBe 2
+    }
+
+    test("the reanimation filter reads the paid X — a card sitting exactly on X comes back") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val courser = driver.putCardInGraveyard(me, "Centaur Courser") // mana value 3
+
+        driver.castCommand(
+            me,
+            x = 3,
+            modes = listOf(reanimate, loseLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Card(courser, me, Zone.GRAVEYARD)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getCreatures(me).map { driver.getCardName(it) } shouldBe listOf("Centaur Courser")
+    }
+
+    test("the same card one point above the paid X is not a legal target") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val courser = driver.putCardInGraveyard(me, "Centaur Courser") // mana value 3
+
+        driver.castCommand(
+            me,
+            x = 2,
+            modes = listOf(reanimate, loseLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Card(courser, me, Zone.GRAVEYARD)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldNotBe null
+
+        driver.getGraveyardCardNames(me) shouldBe listOf("Centaur Courser")
+    }
+
+    test("'up to X target creatures' takes X of them and grants fear to each") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        driver.castCommand(
+            me,
+            x = 2,
+            modes = listOf(grantFear, loseLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(lions)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bears, Keyword.FEAR) shouldBe true
+        projected.hasKeyword(lions, Keyword.FEAR) shouldBe true
+    }
+
+    test("'up to X target creatures' refuses X + 1 of them") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        driver.castCommand(
+            me,
+            x = 1,
+            modes = listOf(grantFear, loseLife),
+            modeTargets = listOf(
+                listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(lions)),
+                listOf(ChosenTarget.Player(opp)),
+            ),
+        ).error shouldNotBe null
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/PrimalCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/PrimalCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primal Command reprint in Archenemy. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val PrimalCommandReprint = Printing(
+    oracleId = "350f5c0a-563f-41c5-8f7b-10f409bb4d3b",
+    name = "Primal Command",
+    setCode = "ARC",
+    collectorNumber = "66",
+    scryfallId = "8a8ba5d9-9c83-45ab-aacd-ba3c44df57ea",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a8ba5d9-9c83-45ab-aacd-ba3c44df57ea.jpg?1783941902",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/IncendiaryCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/IncendiaryCommandReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Incendiary Command reprint in Commander 2013. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val IncendiaryCommandReprint = Printing(
+    oracleId = "d45a4924-daa0-4ac3-afd7-b66f636ce870",
+    name = "Incendiary Command",
+    setCode = "C13",
+    collectorNumber = "113",
+    scryfallId = "925d6ae9-deb8-41a4-99de-fd6fc6924d3b",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/925d6ae9-deb8-41a4-99de-fd6fc6924d3b.jpg?1783939667",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ProfaneCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ProfaneCommandReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Profane Command reprint in Commander 2014. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val ProfaneCommandReprint = Printing(
+    oracleId = "6f9ecfc4-85bd-4171-9031-dbe0e39e0135",
+    name = "Profane Command",
+    setCode = "C14",
+    collectorNumber = "156",
+    scryfallId = "6cd829ca-408d-4898-977f-153803891a82",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6cd829ca-408d-4898-977f-153803891a82.jpg?1783938840",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/PrimalCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/PrimalCommandReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primal Command reprint in Duel Decks: Zendikar vs. Eldrazi. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val PrimalCommandReprint = Printing(
+    oracleId = "350f5c0a-563f-41c5-8f7b-10f409bb4d3b",
+    name = "Primal Command",
+    setCode = "DDP",
+    collectorNumber = "20",
+    scryfallId = "87d2ad86-5d74-4507-8faa-fc6124fd5a7f",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87d2ad86-5d74-4507-8faa-fc6124fd5a7f.jpg?1783938253",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/ProfaneCommandReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/ProfaneCommandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.hop.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Profane Command reprint in Planechase. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val ProfaneCommandReprint = Printing(
+    oracleId = "6f9ecfc4-85bd-4171-9031-dbe0e39e0135",
+    name = "Profane Command",
+    setCode = "HOP",
+    collectorNumber = "38",
+    scryfallId = "9b2d2119-8e7b-4994-bdca-04f63de5c7dc",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b2d2119-8e7b-4994-bdca-04f63de5c7dc.jpg?1783942327",
+    releaseDate = "2009-09-04",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ProfaneCommandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ProfaneCommandReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Profane Command reprint in Streets of New Capenna Commander. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Lorwyn's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val ProfaneCommandReprint = Printing(
+    oracleId = "6f9ecfc4-85bd-4171-9031-dbe0e39e0135",
+    name = "Profane Command",
+    setCode = "NCC",
+    collectorNumber = "256",
+    scryfallId = "7005bb21-0cec-4c19-a95b-99a1bac25aa4",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/7005bb21-0cec-4c19-a95b-99a1bac25aa4.jpg?1783923265",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1771,6 +1771,98 @@
     ]
 }
 
+// Cryptic Command
+{
+    "name": "Cryptic Command",
+    "manaCost": "{1}{U}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose two —\n• Counter target spell.\n• Return target permanent to its owner's hand.\n• Tap all creatures your opponents control.\n• Draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "permanent to bounce"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            },
+                            "id": "permanent to bounce"
+                        }
+                    ],
+                    "description": "Return target permanent to its owner's hand"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        },
+                        "body": {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Tap all creatures your opponents control"
+                },
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/829e3d6e-5d7c-4cc4-a7a6-7cbf5a7442ba.jpg?1783942904",
+        "rulings": [
+            {
+                "date": "2017-11-17",
+                "text": "You choose both modes as you cast Cryptic Command. You must choose two different modes."
+            },
+            {
+                "date": "2017-11-17",
+                "text": "Look at both chosen modes to determine how many targets Cryptic Command has, if any. If it has at least one target, and all its targets are illegal when it tries to resolve, then it won't resolve and none of its effects will happen. For example, if you choose the second and fourth modes, and the permanent is an illegal target when Cryptic Command tries to resolve, you won't draw a card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dauntless Dourbark
 {
     "name": "Dauntless Dourbark",
@@ -5276,6 +5368,144 @@
     ]
 }
 
+// Incendiary Command
+{
+    "name": "Incendiary Command",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose two —\n• Incendiary Command deals 4 damage to target player or planeswalker.\n• Incendiary Command deals 2 damage to each creature.\n• Destroy target nonbasic land.\n• Each player discards all the cards in their hand, then draws that many cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "damage player or planeswalker"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayerOrPlaneswalker",
+                            "id": "damage player or planeswalker"
+                        }
+                    ],
+                    "description": "Incendiary Command deals 4 damage to target player or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Incendiary Command deals 2 damage to each creature"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "nonbasic land to destroy"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsLand",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsBasicLand"
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "nonbasic land to destroy"
+                        }
+                    ],
+                    "description": "Destroy target nonbasic land"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "Each"
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "discardedHand"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discardedHand",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "VariableReference",
+                                        "variableName": "discardedHand_count"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "description": "Each player discards all the cards in their hand, then draws that many cards"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/512367a2-f8f6-4c28-9eb3-8e04d2694e4b.jpg?1783942873"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Incremental Growth
 {
     "name": "Incremental Growth",
@@ -7956,6 +8186,292 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Primal Command
+{
+    "name": "Primal Command",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose two —\n• Target player gains 7 life.\n• Put target noncreature permanent on top of its owner's library.\n• Target player shuffles their graveyard into their library.\n• Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 7
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "player to gain life"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "player to gain life"
+                        }
+                    ],
+                    "description": "Target player gains 7 life"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "noncreature permanent to tuck"
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "noncreature permanent"
+                            },
+                            "id": "noncreature permanent to tuck"
+                        }
+                    ],
+                    "description": "Put target noncreature permanent on top of its owner's library"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "graveyardCards"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "graveyardCards",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    },
+                                    "placement": "Shuffled"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "player to shuffle their graveyard"
+                        }
+                    ],
+                    "description": "Target player shuffles their graveyard into their library"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "description": "Search your library for a creature card, reveal it, put it into your hand, then shuffle"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40d2c5b9-cef9-4763-8e65-e3b1418c0ad3.jpg?1783942858",
+        "rulings": [
+            {
+                "date": "2017-03-14",
+                "text": "Primal Command won't be put into your graveyard until after it's finished resolving, which means it won't be shuffled into your library as part of its own effect if you target yourself with its third mode."
+            },
+            {
+                "date": "2017-03-14",
+                "text": "Primal Command's modes are performed in the order listed. If you put a noncreature permanent on top of its owner's library and have that player shuffle their graveyard into their library, that card is shuffled away."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Profane Command
+{
+    "name": "Profane Command",
+    "manaCost": "{X}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose two —\n• Target player loses X life.\n• Return target creature card with mana value X or less from your graveyard to the battlefield.\n• Target creature gets -X/-X until end of turn.\n• Up to X target creatures gain fear until end of turn. (They can't be blocked except by artifact creatures and/or black creatures.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": "XValue",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "player to lose life"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "player to lose life"
+                        }
+                    ],
+                    "description": "Target player loses X life"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature card with mana value X or less in your graveyard"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "ManaValueAtMostX"
+                                    ],
+                                    "controllerPredicate": "OwnedByYou"
+                                },
+                                "zone": "Graveyard"
+                            },
+                            "id": "creature card with mana value X or less in your graveyard"
+                        }
+                    ],
+                    "description": "Return target creature card with mana value X or less from your graveyard to the battlefield"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Multiply",
+                            "amount": "XValue",
+                            "multiplier": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Multiply",
+                            "amount": "XValue",
+                            "multiplier": -1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature to weaken"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "creature to weaken"
+                        }
+                    ],
+                    "description": "Target creature gets -X/-X until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "GrantKeyword",
+                            "keyword": "FEAR",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "creatures to gain fear",
+                            "dynamicMaxCount": "XValue"
+                        }
+                    ],
+                    "description": "Up to X target creatures gain fear until end of turn"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "RARE",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/752bf7fd-c49e-42fa-bbdd-8ca5d4c89b2b.jpg?1783942885",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The value chosen for X applies to each X in the spell's effect. You pay {X} only once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
@@ -315,6 +315,12 @@ internal fun processPreTargetedEffectQueue(
             sourceColors = sourceColors,
             sourceSubtypes = sourceSubtypes,
             sourceId = ctx.sourceId,
+            // The chosen X, threaded exactly as the cast and activation paths do. Without it an
+            // X-clamped mode ("up to X target creatures", Profane Command) re-validates against
+            // the *static* placeholder count of 1, so every legal cast declaring two or more
+            // targets fails this re-check — and because a failed re-check silently skips the
+            // mode rather than erroring, the mode simply did nothing.
+            xValue = ctx.xValue,
             // This path re-validates a mode whose targets were already chosen and already checked
             // at cast/activation time, and the effect context does not record whether the modal
             // came from a spell or an ability — so it declares ANY rather than guessing. A


### PR DESCRIPTION
Lorwyn's Command cycle was one card short of nothing — only Austere Command was implemented. This
finishes it: the four remaining Commands, all `modal(chooseCount = 2)` over existing primitives.

| Card | What it does | Built from |
|---|---|---|
| **Cryptic Command** {1}{U}{U}{U} | counter target spell / bounce target permanent / tap all creatures your opponents control / draw a card | `Effects.CounterSpell`, `Effects.ReturnToHand`, `Patterns.Group.tapAll(GroupFilter.AllCreaturesOpponentsControl)`, `Effects.DrawCards` |
| **Primal Command** {3}{G}{G} | target player gains 7 life / tuck target noncreature permanent / target player shuffles their graveyard in / tutor a creature to hand | `Effects.GainLife`, `Effects.PutOnTopOfLibrary`, `Patterns.Library.shuffleGraveyardIntoLibrary`, `Patterns.Library.searchLibrary(reveal = true)` |
| **Incendiary Command** {3}{R}{R} | 4 to a player or planeswalker / 2 to each creature / destroy a nonbasic land / each player wheels their hand | `Effects.DealDamage`, `Patterns.Group.dealDamageToAll`, `Effects.Destroy` over `TargetFilter.NonbasicLand`, `ForEachPlayerEffect` + `Patterns.Hand.discardHand` |
| **Profane Command** {X}{B}{B} | target player loses X / reanimate a creature card with mana value ≤ X / target creature gets -X/-X / up to X creatures gain fear | `DynamicAmount.XValue`, `manaValueAtMostX()`, `dynamicMaxCount = XValue`, `Multiply(XValue, -1)` |

Six `Printing` rows follow, for the reprints in already-scaffolded sets: Primal Command in ARC and
DDP, Incendiary Command in C13, Profane Command in HOP, C14 and NCC. `just check-card-printing`
is clean for all four.

## One engine fix, in its own commit

Profane Command's "up to X target creatures gain fear" did nothing whenever two or more creatures
were chosen — and did it silently, with no cast error and no event.

A modal spell re-validates each chosen mode's targets at resolution, but that call omitted the
`xValue` argument the cast and activation paths both pass. An X-clamped requirement therefore
re-validated against the *static* placeholder count of 1, so any legal cast declaring two or more
targets failed the re-check — and a failed re-check **skips the mode** rather than erroring, so the
mode just evaporated. One argument, threaded exactly as the other two paths do it.

Isolating it: the identical target shape non-modally (Word of Binding, `optional = true` +
`dynamicMaxCount = XValue`) already worked, which put the fault in the modal re-check rather than in
the requirement or the `ForEachTargetEffect` body.

The fix is the first commit so it can be reverted on its own.

## Tests

One scenario test per card, each aimed at the axis where a wrong reading and the right one produce
different boards rather than the same one:

- **Profane Command** — X in all three positions: a creature card sitting *exactly* on X comes back
  and the same card one point above X is refused; X+1 fear targets are refused and X of them are
  granted (the regression test for the fix above); -X/-X shrinks rather than pumps; and both chosen
  modes read the same X off one payment (the 2007-10-01 ruling).
- **Incendiary Command** — the wheel is given deliberately *unequal* hands, the one shape where
  "each player draws their own count" and "everyone draws the same count" disagree; plus an
  empty-handed player drawing nothing, and a nonbasic land dying while a Mountain does not.
- **Cryptic Command** — the sweep taps the opponents' board and not the caster's; bounce sends the
  permanent to *its owner's* hand; the counter mode answers a spell at instant speed.
- **Primal Command** — every player-referencing mode aimed at the opponent, so an implicit "you"
  would fail; the tuck mode refuses a creature; and the spell is not shuffled into its own target's
  library (the 2017-03-14 ruling).

## Verification

- `just test` — green.
- `just build` — green; `just rebless-cards` moved only the four new cards in the LRW golden.
- `just assay-differential --set LRW` — 10 DIVERGENT rows, all pre-existing (the Harbinger cycle,
  Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart); none of the four Commands.
- `just check-card-printing` — ok for all four.

Lorwyn goes 197/286 → 201/286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw