### PR TITLE
Add four Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BottledCloister.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BottledCloister.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Bottled Cloister — Ravnica: City of Guilds #256
+ * {4} · Artifact
+ *
+ * At the beginning of each opponent's upkeep, exile all cards from your hand face down.
+ * At the beginning of your upkeep, return all cards you own exiled with this artifact to your
+ * hand, then draw a card.
+ *
+ * The two halves are a *linked* pair (CR 607): the exile writes the cards onto the Cloister's own
+ * `LinkedExileComponent` (`linkToSource = true`, the Shared Fate shape) and the upkeep half reads
+ * that same pile back with `CardSource.FromLinkedExile`. That linkage is what makes "exiled with
+ * this artifact" mean *this* Cloister's pile and not every card in exile.
+ *
+ * [FaceDownMode.HIDDEN] is a face-down exile with no turn-up: opponents can't read the hand they
+ * just made you put away.
+ *
+ * The `ownedByYou()` filter on the return is the 2006 errata ("only the cards you own go into your
+ * hand"): if control of the Cloister changes mid-turn the pile can hold two players' cards, and
+ * only the current controller's own cards come back. Everything left in the pile stays exiled —
+ * including everything in it if the Cloister leaves the battlefield before your upkeep.
+ */
+val BottledCloister = card("Bottled Cloister") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of each opponent's upkeep, exile all cards from your hand face down.\n" +
+        "At the beginning of your upkeep, return all cards you own exiled with this artifact to your " +
+        "hand, then draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EachOpponentUpkeep
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.Any),
+                storeAs = "cloisterHand"
+            ),
+            MoveCollectionEffect(
+                from = "cloisterHand",
+                destination = CardDestination.ToZone(Zone.EXILE),
+                faceDown = FaceDownMode.HIDDEN,
+                linkToSource = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromLinkedExile(),
+                storeAs = "cloisterExiled"
+            ),
+            FilterCollectionEffect(
+                from = "cloisterExiled",
+                filter = CollectionFilter.MatchesFilter(GameObjectFilter.Any.ownedByYou()),
+                storeMatching = "cloisterMine"
+            ),
+            MoveCollectionEffect(
+                from = "cloisterMine",
+                destination = CardDestination.ToZone(Zone.HAND)
+            ),
+            // "then draw a card" — unconditional; it happens even with an empty pile.
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Luca Zontini"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg?1783943601"
+
+        ruling(
+            "2006-02-01",
+            "Errata'd to make it clear that only the cards you own go into your hand, so if you " +
+                "somehow gain control of the Cloister, your opponent's cards won't go to your hand."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlameFusillade.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlameFusillade.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.GrantActivatedAbilityEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flame Fusillade — Ravnica: City of Guilds #123
+ * {3}{R} · Sorcery
+ *
+ * Until end of turn, permanents you control gain "{T}: This permanent deals 1 damage to any target."
+ *
+ * The Viridian Longbow grant, fanned over a group and time-boxed: `ForEachInGroup` snapshots the
+ * permanents you control *as this resolves* (CR 611.2c — a permanent that enters later does not
+ * gain the ability) and hands each one the same `{T}` pinger for the turn. `EffectTarget.Self`
+ * means the iterated permanent at grant time, and the *host* again inside the granted ability, so
+ * the `{T}` taps that permanent and it is the source of the damage (CR 113.7).
+ *
+ * Summoning sickness gates only creatures, so a land or artifact that entered this turn can shoot
+ * immediately — the card's own ruling.
+ */
+val FlameFusillade = card("Flame Fusillade") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Until end of turn, permanents you control gain \"{T}: This permanent deals 1 damage to any target.\""
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllPermanentsYouControl,
+            GrantActivatedAbilityEffect(
+                ability = ActivatedAbility(
+                    id = AbilityId.generate(),
+                    cost = Costs.Tap,
+                    effect = Effects.DealDamage(
+                        amount = 1,
+                        target = EffectTarget.ContextTarget(0),
+                        damageSource = EffectTarget.Self
+                    ),
+                    targetRequirements = listOf(AnyTarget())
+                ),
+                target = EffectTarget.Self,
+                duration = Duration.EndOfTurn
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Dany Orizio"
+        flavorText = "\"A single item acting as lantern and lance? Now *that's* military efficiency.\"\n" +
+            "—Brev Grezar, Boros lieutenant"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg?1783943654"
+
+        ruling(
+            "2005-10-01",
+            "\"Summoning sickness\" applies only to creatures, not to other permanents. You may tap a " +
+                "noncreature permanent to pay for an ability with {T} in its cost even if the permanent " +
+                "entered that turn."
+        )
+        ruling(
+            "2005-10-01",
+            "Tapping an Aura or Equipment doesn't tap the creature it's attached to and vice versa. " +
+                "Tapped enchantments work normally. Tapped artifacts work normally unless they say otherwise."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PariahsShield.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PariahsShield.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.RedirectDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pariah's Shield — Ravnica: City of Guilds #267
+ * {5} · Artifact — Equipment
+ *
+ * All damage that would be dealt to you is dealt to equipped creature instead.
+ * Equip {3}
+ *
+ * The Equipment half of the Pariah shape (With Great Power . . . is the Aura half): a static
+ * [RedirectDamage] whose `redirectTo` is [EffectTarget.EquippedCreature], resolved by
+ * `DamageUtils.resolveRedirectTarget` off the Equipment's own `AttachedToComponent`.
+ *
+ * `RecipientFilter.You` is the Shield's *controller*, so a control change moves the shield with
+ * the Equipment. With nothing attached the redirect target resolves to null and damage is dealt to
+ * you normally — the card's own ruling.
+ */
+val PariahsShield = card("Pariah's Shield") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "All damage that would be dealt to you is dealt to equipped creature instead.\nEquip {3}"
+
+    replacementEffect(
+        RedirectDamage(
+            redirectTo = EffectTarget.EquippedCreature,
+            appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.You)
+        )
+    )
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "267"
+        artist = "Doug Chaffee"
+        flavorText = "To bear the shield of the pariah is the highest honor a Boros can receive—and the last."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg?1783943596"
+
+        ruling(
+            "2005-10-01",
+            "If Pariah's Shield isn't attached to a creature, all damage that would be dealt to you " +
+                "is dealt to you normally."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThreeDreams.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ThreeDreams.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Three Dreams — Ravnica: City of Guilds #32
+ * {4}{W} · Sorcery
+ *
+ * Search your library for up to three Aura cards with different names, reveal them, put them
+ * into your hand, then shuffle.
+ *
+ * The Reach the Horizon pipeline with a different filter and cap: gather the library's Auras →
+ * `ChooseUpTo(3)` under [SelectionRestriction.OnePerCardName] ("with different names") → move to
+ * hand revealed → shuffle. "Up to three" means finding fewer — or none — is legal, so the
+ * selection never forces a pick.
+ */
+val ThreeDreams = card("Three Dreams") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for up to three Aura cards with different names, reveal them, " +
+        "put them into your hand, then shuffle."
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    Zone.LIBRARY,
+                    Player.You,
+                    GameObjectFilter.Enchantment.withSubtype("Aura")
+                ),
+                storeAs = "searchable"
+            ),
+            SelectFromCollectionEffect(
+                from = "searchable",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(3)),
+                storeSelected = "found",
+                restrictions = listOf(SelectionRestriction.OnePerCardName),
+                prompt = "Search for up to three Aura cards with different names"
+            ),
+            MoveCollectionEffect(
+                from = "found",
+                destination = CardDestination.ToZone(Zone.HAND),
+                revealed = true
+            ),
+            ShuffleLibraryEffect(),
+            // CR 701.23 — the search happened whether or not anything was found.
+            EmitLibrarySearchedEventEffect
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "32"
+        artist = "Shishizaru"
+        flavorText = "\"Choose one to heal, one to harm, and one to grant you the prudence to use them.\"\n" +
+            "—Miotri, auratouched mage"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg?1783943695"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BottledCloisterScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BottledCloisterScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.BottledCloister
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bottled Cloister — {4} Artifact (Ravnica: City of Guilds #256)
+ *
+ * "At the beginning of each opponent's upkeep, exile all cards from your hand face down.
+ *  At the beginning of your upkeep, return all cards you own exiled with this artifact to your
+ *  hand, then draw a card."
+ *
+ * The two halves are a linked pair (CR 607) — the exile writes the Cloister's own
+ * `LinkedExileComponent` and the upkeep half reads that same pile back. What needs proving is
+ * that the round trip closes: the hand really leaves face down on the opponent's upkeep, and the
+ * same cards really come back (plus a draw) on yours — and that when the Cloister is gone, so is
+ * the way home.
+ */
+class BottledCloisterScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BottledCloister)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("the hand is exiled face down on the opponent's upkeep and returned on yours, plus a draw") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Bottled Cloister")
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+
+        // Player 2's upkeep — passPriorityUntil stops the moment the step begins, so the trigger
+        // is still on the stack until both players pass.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.bothPass()
+
+        // Measured here rather than at setup: player 1's own cleanup step discarded down to seven
+        // on the way past, so the pile is whatever was actually in hand at the opponent's upkeep.
+        val exiled = d.state.getExile(d.player1).size
+
+        withClue("\"exile all cards from your hand\" — the Cloister's controller's hand empties") {
+            d.getHandSize(d.player1) shouldBe 0
+            (exiled > 0) shouldBe true
+        }
+        withClue("face down, so the opponent can't read what was put away") {
+            d.state.getEntity(bolt)?.has<FaceDownComponent>() shouldBe true
+        }
+        withClue("the opponent's own hand is untouched") {
+            (d.getHandSize(d.player2) > 0) shouldBe true
+        }
+
+        // Player 1's next upkeep.
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.bothPass()
+
+        withClue("the whole linked pile comes back, and \"then draw a card\" adds one more") {
+            d.getHandSize(d.player1) shouldBe exiled + 1
+            d.state.getExile(d.player1).size shouldBe 0
+        }
+        withClue("and it is a real card in hand again, not a face-down one") {
+            (bolt in d.state.getHand(d.player1)) shouldBe true
+            d.state.getEntity(bolt)?.has<FaceDownComponent>() shouldBe false
+        }
+    }
+
+    test("cards exiled with a Cloister that has left the battlefield stay exiled") {
+        val d = driver()
+        val cloister = d.putPermanentOnBattlefield(d.player1, "Bottled Cloister")
+        d.putCardInHand(d.player1, "Lightning Bolt")
+
+        d.passPriorityUntil(Step.UPKEEP)
+        d.bothPass()
+        d.getHandSize(d.player1) shouldBe 0
+        val exiled = d.state.getExile(d.player1).size
+
+        // The return trigger lives on the Cloister; with it gone nothing reads the pile back.
+        d.moveToGraveyard(cloister)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.bothPass()
+
+        withClue("nothing came home — with no Cloister there is no trigger to read the pile back") {
+            d.getExileCardNames(d.player1).contains("Lightning Bolt") shouldBe true
+            d.state.getExile(d.player1).size shouldBe exiled
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameFusilladeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameFusilladeScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.FlameFusillade
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.GrantActivatedAbilityEffect
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Flame Fusillade — {3}{R} Sorcery (Ravnica: City of Guilds #123)
+ *
+ * "Until end of turn, permanents you control gain "{T}: This permanent deals 1 damage to any target.""
+ *
+ * The card is a `ForEachInGroup` fan-out of a [GrantActivatedAbilityEffect] onto
+ * `EffectTarget.Self`, so everything worth proving is about where "Self" lands:
+ *  - every permanent you control receives the grant — lands included, and a land that entered this
+ *    turn can still pay `{T}` because summoning sickness gates only creatures (the card's ruling);
+ *  - the `{T}` taps *that* permanent, and it is the source of the damage (CR 113.7);
+ *  - permanents an opponent controls receive nothing, and the grant is gone next turn.
+ */
+class FlameFusilladeScenarioTest : FunSpec({
+
+    // The pinger granted by the spell's ForEachInGroup body.
+    val grantedAbilityId =
+        ((FlameFusillade.spellEffect as ForEachEffect).body as GrantActivatedAbilityEffect).ability.id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + FlameFusillade)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("every permanent you control gains the pinger — a land can shoot the turn it resolves") {
+        val d = driver()
+        val fusillade = d.putCardInHand(d.player1, "Flame Fusillade")
+        val shooter = d.putLandOnBattlefield(d.player1, "Mountain")
+
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveColorlessMana(d.player1, 3)
+        d.castSpell(d.player1, fusillade).error shouldBe null
+        d.bothPass()
+
+        d.submit(
+            ActivateAbility(
+                playerId = d.player1,
+                sourceId = shooter,
+                abilityId = grantedAbilityId,
+                targets = listOf(ChosenTarget.Player(d.player2))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("\"permanents you control\" includes lands, and {T} isn't gated by summoning sickness") {
+            d.getLifeTotal(d.player2) shouldBe 19
+        }
+        withClue("the {T} taps the granted permanent itself") {
+            d.state.getEntity(shooter)?.get<TappedComponent>() shouldNotBe null
+        }
+    }
+
+    test("the granted permanent is the damage source, and opponents' permanents get nothing") {
+        val d = driver()
+        val fusillade = d.putCardInHand(d.player1, "Flame Fusillade")
+        val mine = d.putCreatureOnBattlefield(d.player1, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(mine)
+        val theirs = d.putCreatureOnBattlefield(d.player2, "Savannah Lions") // 1/1
+        d.removeSummoningSickness(theirs)
+
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveColorlessMana(d.player1, 3)
+        d.castSpell(d.player1, fusillade).error shouldBe null
+        d.bothPass()
+
+        d.submit(
+            ActivateAbility(
+                playerId = d.player1,
+                sourceId = mine,
+                abilityId = grantedAbilityId,
+                targets = listOf(ChosenTarget.Permanent(theirs))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("1 damage is lethal to a 1/1, so the damage demonstrably landed") {
+            d.findPermanent(d.player2, "Savannah Lions") shouldBe null
+        }
+        withClue("\"permanents you control\" — the opponent's board was never granted anything") {
+            val alsoTheirs = d.putCreatureOnBattlefield(d.player2, "Savannah Lions")
+            d.removeSummoningSickness(alsoTheirs)
+            d.submit(
+                ActivateAbility(
+                    playerId = d.player2,
+                    sourceId = alsoTheirs,
+                    abilityId = grantedAbilityId,
+                    targets = listOf(ChosenTarget.Player(d.player1))
+                )
+            ).isSuccess shouldBe false
+            d.getLifeTotal(d.player1) shouldBe 20
+        }
+    }
+
+    test("the grant expires at end of turn") {
+        val d = driver()
+        val fusillade = d.putCardInHand(d.player1, "Flame Fusillade")
+        val shooter = d.putLandOnBattlefield(d.player1, "Mountain")
+
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveColorlessMana(d.player1, 3)
+        d.castSpell(d.player1, fusillade).error shouldBe null
+        d.bothPass()
+
+        // Round the table back to player 1's own main phase, so priority isn't the reason it fails.
+        // (Step the cursor off PRECOMBAT_MAIN first, or the passes are a no-op.)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.submit(
+            ActivateAbility(
+                playerId = d.player1,
+                sourceId = shooter,
+                abilityId = grantedAbilityId,
+                targets = listOf(ChosenTarget.Player(d.player2))
+            )
+        ).isSuccess shouldBe false
+        d.getLifeTotal(d.player2) shouldBe 20
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PariahsShieldScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PariahsShieldScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.PariahsShield
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pariah's Shield — {5} Artifact — Equipment (Ravnica: City of Guilds #267)
+ *
+ * "All damage that would be dealt to you is dealt to equipped creature instead.
+ *  Equip {3}"
+ *
+ * The whole card is one static `RedirectDamage` pointed at `EffectTarget.EquippedCreature`, so
+ * the two things worth proving are that the redirect fires at all, and that it stops firing when
+ * the Shield has nothing to redirect *to* — the card's own ruling: "If Pariah's Shield isn't
+ * attached to a creature, all damage that would be dealt to you is dealt to you normally."
+ */
+class PariahsShieldScenarioTest : FunSpec({
+
+    val equipAbilityId = PariahsShield.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + PariahsShield)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Puts the Shield and [creatureName] on player 1's battlefield and equips them. */
+    fun GameTestDriver.equipTo(creatureName: String): Pair<EntityId, EntityId> {
+        val shield = putPermanentOnBattlefield(player1, "Pariah's Shield")
+        val creature = putCreatureOnBattlefield(player1, creatureName)
+        giveColorlessMana(player1, 3)
+        submit(
+            ActivateAbility(
+                playerId = player1,
+                sourceId = shield,
+                abilityId = equipAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creature))
+            )
+        ).isSuccess shouldBe true
+        bothPass()
+        state.getEntity(shield)?.get<AttachedToComponent>()?.targetId shouldBe creature
+        return shield to creature
+    }
+
+    test("damage aimed at you lands on the equipped creature instead") {
+        val d = driver()
+        d.equipTo("Savannah Lions") // 1/1
+
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        d.giveMana(d.player1, Color.RED, 1)
+        d.castSpell(d.player1, bolt, listOf(d.player1)).error shouldBe null
+        d.bothPass()
+
+        withClue("the 3 damage never reached the player") {
+            d.getLifeTotal(d.player1) shouldBe 20
+        }
+        withClue("it went to the equipped creature, which 3 damage kills") {
+            d.findPermanent(d.player1, "Savannah Lions") shouldBe null
+        }
+    }
+
+    test("with nothing equipped the damage is dealt to you normally") {
+        val d = driver()
+        // On the battlefield but never equipped: the redirect has nowhere to point.
+        val shield = d.putPermanentOnBattlefield(d.player1, "Pariah's Shield")
+
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        d.giveMana(d.player1, Color.RED, 1)
+        d.castSpell(d.player1, bolt, listOf(d.player1)).error shouldBe null
+        d.bothPass()
+
+        d.state.getEntity(shield)?.get<AttachedToComponent>() shouldBe null
+        withClue("no equipped creature, so nothing absorbs the damage") {
+            d.getLifeTotal(d.player1) shouldBe 17
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreeDreamsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreeDreamsScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.ClingingDarkness
+import com.wingedsheep.mtg.sets.definitions.rav.cards.ConclavesBlessing
+import com.wingedsheep.mtg.sets.definitions.rav.cards.ThreeDreams
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Three Dreams — {4}{W} Sorcery (Ravnica: City of Guilds #32)
+ *
+ * "Search your library for up to three Aura cards with different names, reveal them, put them
+ *  into your hand, then shuffle."
+ *
+ * The pipeline is gather → `ChooseUpTo(3)` under `SelectionRestriction.OnePerCardName` → move to
+ * hand. "With different names" is the whole point of the restriction, and it is enforced
+ * server-side, so the test asks for two copies of one Aura and checks only one comes back.
+ */
+class ThreeDreamsScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ThreeDreams + ClingingDarkness + ConclavesBlessing)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.handNames() =
+        state.getHand(player1).mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    test("finds Auras with different names and refuses a second copy of one") {
+        val d = driver()
+        val darkness1 = d.putCardOnTopOfLibrary(d.player1, "Clinging Darkness")
+        val darkness2 = d.putCardOnTopOfLibrary(d.player1, "Clinging Darkness")
+        val blessing = d.putCardOnTopOfLibrary(d.player1, "Conclave's Blessing")
+
+        val threeDreams = d.putCardInHand(d.player1, "Three Dreams")
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.giveColorlessMana(d.player1, 4)
+        d.castSpell(d.player1, threeDreams).error shouldBe null
+        d.bothPass()
+
+        withClue("\"with different names\" caps the search at the number of distinct names on offer") {
+            d.submitCardSelection(d.player1, listOf(darkness1, darkness2, blessing))
+                .error shouldBe "Too many cards selected: maximum is 2"
+        }
+
+        d.submitCardSelection(d.player1, listOf(darkness1, blessing)).error shouldBe null
+
+        withClue("one of each name reaches hand") {
+            d.handNames().count { it == "Clinging Darkness" } shouldBe 1
+            d.handNames().count { it == "Conclave's Blessing" } shouldBe 1
+        }
+        withClue("the second copy stays in the library") {
+            (darkness2 in d.state.getLibrary(d.player1)) shouldBe true
+        }
+    }
+
+    test("\"up to three\" allows finding nothing") {
+        val d = driver()
+        val threeDreams = d.putCardInHand(d.player1, "Three Dreams")
+        val handBefore = d.getHandSize(d.player1)
+
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.giveColorlessMana(d.player1, 4)
+        d.castSpell(d.player1, threeDreams).error shouldBe null
+        d.bothPass()
+
+        withClue("an all-Plains library holds no Auras, so the spell simply finds nothing") {
+            d.getHandSize(d.player1) shouldBe handBefore - 1
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThreeDreamsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThreeDreamsReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Three Dreams reprint in Planechase 2012. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Ravnica: City of Guilds (`rav`)
+ * `cards/` package (the card's earliest real printing); this file contributes only
+ * per-printing presentation data.
+ */
+val ThreeDreamsReprint = Printing(
+    oracleId = "b3f9da94-c822-49b8-a1fc-be82189206af",
+    name = "Three Dreams",
+    setCode = "PC2",
+    collectorNumber = "13",
+    scryfallId = "5181dab4-1256-40d4-ab86-20f366ba3b10",
+    artist = "Shishizaru",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/5181dab4-1256-40d4-ab86-20f366ba3b10.jpg?1783940635",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ThreeDreamsReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/ThreeDreamsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Three Dreams reprint in TLE. Canonical CardDefinition lives in its earliest set
+ * (Ravnica: City of Guilds).
+ */
+val ThreeDreamsReprint = Printing(
+    oracleId = "b3f9da94-c822-49b8-a1fc-be82189206af",
+    name = "Three Dreams",
+    setCode = "TLE",
+    collectorNumber = "8",
+    scryfallId = "06221eef-465c-467f-9cb5-d59529bff56f",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06221eef-465c-467f-9cb5-d59529bff56f.jpg?1783904859",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3356,6 +3356,68 @@
     ]
 }
 
+// Flame Fusillade
+{
+    "name": "Flame Fusillade",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Until end of turn, permanents you control gain \"{T}: This permanent deals 1 damage to any target.\"",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "permanent ctrl:you"
+                }
+            },
+            "body": {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    },
+                    "targetRequirements": [
+                        "AnyTarget"
+                    ]
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Dany Orizio",
+        "flavorText": "\"A single item acting as lantern and lance? Now *that's* military efficiency.\"\n—Brev Grezar, Boros lieutenant",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg?1783943654",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "\"Summoning sickness\" applies only to creatures, not to other permanents. You may tap a noncreature permanent to pay for an ability with {T} in its cost even if the permanent entered that turn."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Tapping an Aura or Equipment doesn't tap the creature it's attached to and vice versa. Tapped enchantments work normally. Tapped artifacts work normally unless they say otherwise."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flame-Kin Zealot
 {
     "name": "Flame-Kin Zealot",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -9638,6 +9638,67 @@
     ]
 }
 
+// Three Dreams
+{
+    "name": "Three Dreams",
+    "manaCost": "{4}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for up to three Aura cards with different names, reveal them, put them into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "enchantment Aura"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeSelected": "found",
+                    "prompt": "Search for up to three Aura cards with different names",
+                    "restrictions": [
+                        "OnePerCardName"
+                    ]
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "RARE",
+        "artist": "Shishizaru",
+        "flavorText": "\"Choose one to heal, one to harm, and one to grant you the prudence to use them.\"\n—Miotri, auratouched mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fb144b8-f2ee-4d35-814d-ceb728b2ab75.jpg?1783943695"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thundersong Trumpeter
 {
     "name": "Thundersong Trumpeter",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -752,6 +752,105 @@
     ]
 }
 
+// Bottled Cloister
+{
+    "name": "Bottled Cloister",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of each opponent's upkeep, exile all cards from your hand face down.\nAt the beginning of your upkeep, return all cards you own exiled with this artifact to your hand, then draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "cloisterHand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "cloisterHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "cloisterExiled"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "cloisterExiled",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "own:you"
+                            },
+                            "storeMatching": "cloisterMine"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "cloisterMine",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "RARE",
+        "artist": "Luca Zontini",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bf42acc-d2d3-4165-b257-6885df2d1ba4.jpg?1783943601",
+        "rulings": [
+            {
+                "date": "2006-02-01",
+                "text": "Errata'd to make it clear that only the cards you own go into your hand, so if you somehow gain control of the Cloister, your opponent's cards won't go to your hand."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Bramble Elemental
 {
     "name": "Bramble Elemental",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -6612,6 +6612,71 @@
     ]
 }
 
+// Pariah's Shield
+{
+    "name": "Pariah's Shield",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "All damage that would be dealt to you is dealt to equipped creature instead.\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectDamage",
+                "redirectTo": "EquippedCreature",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "You"
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "267",
+        "rarity": "RARE",
+        "artist": "Doug Chaffee",
+        "flavorText": "To bear the shield of the pariah is the highest honor a Boros can receive—and the last.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc316f1e-84ce-4013-a150-d537f964a604.jpg?1783943596",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If Pariah's Shield isn't attached to a creature, all damage that would be dealt to you is dealt to you normally."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Peel from Reality
 {
     "name": "Peel from Reality",


### PR DESCRIPTION
Four Ravnica: City of Guilds cards, each composed entirely from existing `Effects.*` /
`Patterns.*` primitives — no new SDK vocabulary — and each with its own scenario test.

| Card | What it does | Composes |
|---|---|---|
| **Three Dreams** `{4}{W}` | Search for up to three Aura cards with different names → hand | The Reach the Horizon pipeline: gather → `ChooseUpTo(3)` under `SelectionRestriction.OnePerCardName` → move to hand revealed → shuffle |
| **Flame Fusillade** `{3}{R}` | Until EOT, permanents you control gain `{T}`: 1 damage to any target | `ForEachInGroup(AllPermanentsYouControl)` fanning the Viridian Longbow `GrantActivatedAbilityEffect` onto `EffectTarget.Self` |
| **Bottled Cloister** `{4}` | Hand goes to exile face down on each opponent's upkeep, comes back plus a draw on yours | `MoveCollection(faceDown = HIDDEN, linkToSource = true)` paired with `CardSource.FromLinkedExile` (CR 607) |
| **Pariah's Shield** `{5}` | All damage that would be dealt to you hits equipped creature instead | Static `RedirectDamage(EquippedCreature, DamageEvent(recipient = You))` — the Equipment half of the With Great Power . . . shape |

### Notes

- **Canonical placement.** All four are RAV-canonical. Three Dreams' earlier `psal` printing is a box
  set, not a real expansion; its scaffolded `pc2` and `tle` reprints get `Printing` rows.
- **Three Dreams' "different names"** turns out to be stricter than a silent de-dupe: the restriction
  tightens the effective maximum to the number of distinct names on offer, so asking for two copies of
  one Aura is rejected outright. The test pins that.
- **Flame Fusillade** is the one that needed proving. `EffectTarget.Self` has to mean the iterated
  permanent at grant time and the *host* again inside the granted ability, or the card silently does
  nothing useful. Tests cover a land shooting the turn the spell resolves (summoning sickness gates
  only creatures — the card's ruling), the granted permanent being the damage source, opponents'
  permanents getting nothing, and the grant expiring at end of turn.
- **Bottled Cloister's** `ownedByYou()` filter on the return is the 2006 errata — after a control
  change the linked pile can hold two players' cards and only your own come home.

### Cards researched and dropped

Each needs new SDK vocabulary, so per `CONTRIBUTING.md` they don't batch. Recorded here so the next
pass over RAV's tail doesn't re-derive them:

| Card | Gap |
|---|---|
| Quickchange | "the color **or colors** of your choice" — only a single-colour `ChooseColorThen` exists |
| Spawnbroker, Belltower Sphinx | `EntityReference.Target` resolves to `null` in `PredicateEvaluator` (targeting-time), and there is no `Player` reference for a damage source's controller |
| Mausoleum Turnkey | `TargetChooser.Opponent` is `CardLinter`-rejected outside an activated ability; neither triggered-ability chooser names an opponent |
| Dream Leash | Its tapped restriction is cast-time only, but `auraTarget` is re-checked by `UnattachedAurasCheck`, so the Aura would fall off when the permanent untaps — contradicting its ruling |
| Molten Sentry | No random (coin-flip) as-enters mode; `EntersWithChoice` is a choice |
| Remand | No `CounterDestination.Hand` |
| Leashling | No put-a-card-from-hand-on-top-of-library cost atom |
| Suppression Field | `ReduceActivatedAbilityCost` has no increase counterpart, and no "unless they're mana abilities" axis |
| Ghosts of the Innocent | No general damage halving (only `PreventDamage.halvePreventedDamage`, a single-instance shield) |

RAV's remaining tail is still mostly dredge / transmute / radiance, all three confirmed absent from the
SDK by grep.

### Verification

- `just build` green (full gate, including `:mtg-sets:test` and every era's scenario suite).
- `just rebless-cards` — only these four cards moved in `RAV.json`.
- `just assay-differential --set RAV` — 103 compared, 103 confirmed, **0 divergent**.
- `just check-card-printing` clean for all four.
- 9 new scenario tests across 4 files, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpyp2Bf9SmLduQWzwtgUbw
