### PR TITLE
Add 58 Assay-ready cards to Return to Ravnica

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/GrislySalvageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/GrislySalvageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grisly Salvage reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val GrislySalvageReprint = Printing(
+    oracleId = "a89ebf63-63c9-42cd-98b4-ec852cd9b0a8",
+    name = "Grisly Salvage",
+    setCode = "C15",
+    collectorNumber = "222",
+    scryfallId = "854f2b34-0719-47de-b1da-ade517793371",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/854f2b34-0719-47de-b1da-ade517793371.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/LotlethTrollReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/LotlethTrollReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lotleth Troll reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val LotlethTrollReprint = Printing(
+    oracleId = "61b1d7e5-6155-4204-b110-35a890551ec8",
+    name = "Lotleth Troll",
+    setCode = "C15",
+    collectorNumber = "226",
+    scryfallId = "40438db7-5909-4975-9bbd-8c4021ac0aac",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40438db7-5909-4975-9bbd-8c4021ac0aac.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AbruptDecay.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AbruptDecay.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Abrupt Decay
+ * {B}{G}
+ * Instant
+ *
+ * This spell can't be countered.
+ * Destroy target nonland permanent with mana value 3 or less.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "This spell can't be countered" is the intrinsic [cantBeCountered] flag, not an effect. The
+ * mana-value ceiling rides the target filter — [TargetFilter.manaValueAtMost] — so an illegal
+ * choice is refused at targeting rather than fizzling on resolution.
+ */
+val AbruptDecay = card("Abrupt Decay") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered.\n" +
+        "Destroy target nonland permanent with mana value 3 or less."
+
+    cantBeCountered = true
+
+    spell {
+        val t = target(
+            "target nonland permanent with mana value 3 or less",
+            TargetPermanent(filter = TargetFilter.NonlandPermanent.manaValueAtMost(3))
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "141"
+        artist = "Svetlin Velinov"
+        flavorText = "The Izzet quickly suspended their policy of lifetime guarantees."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg?1783940344"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AerialPredation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AerialPredation.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerial Predation
+ * {2}{G}
+ * Instant
+ *
+ * Destroy target creature with flying. You gain 2 life.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Destroy-plus-rider: a [Effects.Composite] of [Effects.Destroy] on the bound target and an
+ * untargeted [Effects.GainLife]. "With flying" is a keyword predicate on the target filter
+ * ([Targets.CreatureWithKeyword]), which reads projected state, so a creature that only has
+ * flying from a continuous effect is a legal target.
+ */
+val AerialPredation = card("Aerial Predation") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with flying. You gain 2 life."
+
+    spell {
+        val t = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.GainLife(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "BD"
+        flavorText = "In the towering trees of the Samok Stand and the predators that guard them, the might of the Ravnican wild has returned."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg?1783940351"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AquusSteed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AquusSteed.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aquus Steed
+ * {3}{U}
+ * Creature — Beast
+ * 1/3
+ *
+ * {2}{U}, {T}: Target creature gets -2/-0 until end of turn.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A mana-plus-tap [Costs.Composite] over a plain [Effects.ModifyStats]. "-2/-0" is a negative
+ * power modifier and a zero toughness one, defaulting to end of turn.
+ */
+val AquusSteed = card("Aquus Steed") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Beast"
+    oracleText = "{2}{U}, {T}: Target creature gets -2/-0 until end of turn."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}"), Costs.Tap)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-2, 0, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Warren Mahy"
+        flavorText = "In water, it's as graceful as a dolphin. On land, it darts and jerks so unpredictably that few can ride it for long."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg?1783940371"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Archweaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Archweaver.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archweaver
+ * {5}{G}{G}
+ * Creature — Spider
+ * 5/5
+ *
+ * Reach, trample
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else — the pair is `keywords(...)`, which is the whole script.
+ */
+val Archweaver = card("Archweaver") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Reach, trample"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "114"
+        artist = "Jason Felix"
+        flavorText = "The silk of the archweavers adds structural integrity to otherwise unstable Izzet building sites."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg?1783940352"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ArmadaWurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ArmadaWurm.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armada Wurm
+ * {2}{G}{G}{W}{W}
+ * Creature — Wurm
+ * 5/5
+ *
+ * Trample
+ * When this creature enters, create a 5/5 green Wurm creature token with trample.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * An enters trigger over the plain [Effects.CreateToken] facade. The token copies the printed
+ * body's stats and keyword but is a separate object — it is not a copy of this permanent.
+ */
+val ArmadaWurm = card("Armada Wurm") {
+    manaCost = "{2}{G}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Wurm"
+    oracleText = "Trample\n" +
+        "When this creature enters, create a 5/5 green Wurm creature token with trample."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wurm"),
+            keywords = setOf(Keyword.TRAMPLE),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "143"
+        artist = "Volkan Baǵa"
+        flavorText = "No one in the Conclave acts alone."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg?1783940344"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AzoriusCharm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AzoriusCharm.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Azorius Charm
+ * {W}{U}
+ * Instant
+ *
+ * Choose one —
+ * • Creatures you control gain lifelink until end of turn.
+ * • Draw a card.
+ * • Put target attacking or blocking creature on top of its owner's library.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A plain choose-one `modal(chooseCount = 1)`. The mass grant is [Effects.ForEachInGroup] over
+ * [GroupFilter.AllCreaturesYouControl] with [EffectTarget.Self] as the per-iteration subject —
+ * the group iteration's "self", not the spell. Only the third mode targets, so only it
+ * declares one; a mode's targets are chosen when the mode is (CR 601.2c).
+ */
+val AzoriusCharm = card("Azorius Charm") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Creatures you control gain lifelink until end of turn.\n" +
+        "• Draw a card.\n" +
+        "• Put target attacking or blocking creature on top of its owner's library."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Creatures you control gain lifelink until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter.AllCreaturesYouControl,
+                    Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+                )
+            }
+            mode("Draw a card") {
+                effect = Effects.DrawCards(1)
+            }
+            mode("Put target attacking or blocking creature on top of its owner's library") {
+                val t = target(
+                    "target attacking or blocking creature",
+                    TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+                )
+                effect = Effects.PutOnTopOfLibrary(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Zoltan Boros"
+        flavorText = "\"The rules of logic and order have already made the choice for you.\"\n" +
+            "—Isperia"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg?1783940345"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Batterhorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Batterhorn.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Batterhorn
+ * {4}{R}
+ * Creature — Beast
+ * 4/3
+ *
+ * When this creature enters, you may destroy target artifact.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "You may" on a triggered ability is the builder's `optional = true`, which lowers to a
+ * `MayEffect` around the declared effect — one consent gate, asked at resolution. The target is
+ * still chosen when the ability goes on the stack, so declining wastes the choice (CR 603.3d).
+ */
+val Batterhorn = card("Batterhorn") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    oracleText = "When this creature enters, you may destroy target artifact."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target artifact", Targets.Artifact)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Dave Kendall"
+        flavorText = "Novice shopkeeps spend hours deciding how best to display their wares. Veterans focus on portability."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg?1783940357"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CallOfTheConclave.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CallOfTheConclave.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Call of the Conclave
+ * {G}{W}
+ * Sorcery
+ *
+ * Create a 3/3 green Centaur creature token.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The plain [Effects.CreateToken] facade and nothing else.
+ */
+val CallOfTheConclave = card("Call of the Conclave") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Sorcery"
+    oracleText = "Create a 3/3 green Centaur creature token."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Centaur"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Terese Nielsen"
+        flavorText = "Centaurs are sent to evangelize in Gruul territories where words of war speak louder than prayers of peace."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg?1783940344"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CentaurHealer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CentaurHealer.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Healer
+ * {1}{G}{W}
+ * Creature — Centaur Cleric
+ * 3/3
+ *
+ * When this creature enters, you gain 3 life.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * An enters trigger over [Effects.GainLife], whose default target is the controller.
+ */
+val CentaurHealer = card("Centaur Healer") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Centaur Cleric"
+    oracleText = "When this creature enters, you gain 3 life."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Mark Zug"
+        flavorText = "Instructors at the Kasarna training grounds are capable healers in case their students fail to grasp the subtleties of combat."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg?1783940343"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CentaursHerald.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CentaursHerald.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur's Herald
+ * {G}
+ * Creature — Elf Scout
+ * 0/1
+ *
+ * {2}{G}, Sacrifice this creature: Create a 3/3 green Centaur creature token.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * [Costs.SacrificeSelf] is the cost atom for "Sacrifice this creature" — paid on activation, so
+ * the token arrives whether or not the ability is countered.
+ */
+val CentaursHerald = card("Centaur's Herald") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    oracleText = "{2}{G}, Sacrifice this creature: Create a 3/3 green Centaur creature token."
+    power = 0
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}"), Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Centaur"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Howard Lyon"
+        flavorText = "The farther they go from Vitu-Ghazi, the less willing the crowd is to part for them."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg?1783940350"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CodexShredder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CodexShredder.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Codex Shredder
+ * {1}
+ * Artifact
+ *
+ * {T}: Target player mills a card. (They put the top card of their library into their graveyard.)
+ * {5}, {T}, Sacrifice this artifact: Return target card from your graveyard to your hand.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two activated abilities. The mill is [Patterns.Library.mill] pointed at the bound player, which
+ * lowers to the gather-then-move pipeline that marks the move as a mill (so mill-watchers see
+ * it). The recursion targets a card in the *graveyard* zone, which is a zoned [TargetObject]
+ * rather than a permanent target.
+ */
+val CodexShredder = card("Codex Shredder") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "{T}: Target player mills a card. (They put the top card of their library into their graveyard.)\n" +
+        "{5}, {T}, Sacrifice this artifact: Return target card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val p = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(1, p)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.SacrificeSelf)
+        val c = target(
+            "target card in your graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.ReturnToHand(c)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "228"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg?1783940324"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CollectiveBlessing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CollectiveBlessing.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Collective Blessing
+ * {3}{G}{G}{W}
+ * Enchantment
+ *
+ * Creatures you control get +3/+3.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A layer-7c lord: one static [ModifyStats] over [GroupFilter.AllCreaturesYouControl]. The group
+ * is re-read every projection, so a creature that enters later gets the bonus without a trigger.
+ */
+val CollectiveBlessing = card("Collective Blessing") {
+    manaCost = "{3}{G}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control get +3/+3."
+
+    staticAbility {
+        ability = ModifyStats(3, 3, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Svetlin Velinov"
+        flavorText = "Senators of Azorius often hired agents to spy on the Selesnya. They were told to record every spore and root they saw, as each could become a deadly foe."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg?1783940342"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DaggerdromeImp.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DaggerdromeImp.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daggerdrome Imp
+ * {1}{B}
+ * Creature — Imp
+ * 1/1
+ *
+ * Flying
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val DaggerdromeImp = card("Daggerdrome Imp") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    oracleText = "Flying\n" +
+        "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Jack Wang"
+        flavorText = "One of the many reasons why open-air markets close at dusk."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg?1783940364"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DarkRevenant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DarkRevenant.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dark Revenant
+ * {3}{B}
+ * Creature — Spirit
+ * 2/2
+ *
+ * Flying
+ * When this creature dies, put it on top of its owner's library.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A dies trigger that moves the card on from the graveyard it has already reached — the engine
+ * resolves [EffectTarget.Self] against the card's new object, so no last-known-information
+ * plumbing is needed for the move itself.
+ */
+val DarkRevenant = card("Dark Revenant") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "When this creature dies, put it on top of its owner's library."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.PutOnTopOfLibrary(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Daarken"
+        flavorText = "The murderer faced justice in the Azorius courts, but his soul was set free on a technicality."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg?1783940364"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DeviantGlee.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DeviantGlee.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deviant Glee
+ * {B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+1 and has "{R}: This creature gains trample until end of turn."
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Trollhide's shape: the stat bonus is a static [ModifyStats] on the attached creature, and the
+ * quoted ability is a [GrantActivatedAbility] whose [EffectTarget.Self] resolves to the host
+ * (CR 113.7), so "this creature" inside the quotes means the enchanted creature and not the Aura.
+ */
+val DeviantGlee = card("Deviant Glee") {
+    manaCost = "{B}"
+    colorIdentity = "BR"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+1 and has \"{R}: This creature gains trample until end of turn.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 1)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{R}"),
+                effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Michael C. Hayes"
+        flavorText = "\"You just need the right incentive to fulfill my dreams.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg?1783940363"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DramaticRescue.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DramaticRescue.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dramatic Rescue
+ * {W}{U}
+ * Instant
+ *
+ * Return target creature to its owner's hand. You gain 2 life.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A bounce plus an untargeted life rider, composed.
+ */
+val DramaticRescue = card("Dramatic Rescue") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Instant"
+    oracleText = "Return target creature to its owner's hand. You gain 2 life."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ReturnToHand(t),
+            Effects.GainLife(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Ryan Pancoast"
+        flavorText = "\"I never thought I'd be so glad to see two tons of beak and claws bearing down on me at the speed of an arrow.\"\n" +
+            "—Mirela, Azorius hussar"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg?1783940342"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Dreadbore.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Dreadbore.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dreadbore
+ * {B}{R}
+ * Sorcery
+ *
+ * Destroy target creature or planeswalker.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * [Targets.CreatureOrPlaneswalker] is one requirement over both types rather than two targets —
+ * the card chooses a single object.
+ */
+val Dreadbore = card("Dreadbore") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature or planeswalker."
+
+    spell {
+        val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "157"
+        artist = "Wayne Reynolds"
+        flavorText = "In Rakdos-controlled neighborhoods, everyone is part of the show."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg?1783940341"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ExplosiveImpact.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ExplosiveImpact.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Explosive Impact
+ * {5}{R}
+ * Instant
+ *
+ * Explosive Impact deals 5 damage to any target.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "Any target" is [Targets.Any] — creature, player or planeswalker in one requirement.
+ */
+val ExplosiveImpact = card("Explosive Impact") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Explosive Impact deals 5 damage to any target."
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Steve Argyle"
+        flavorText = "\"Such boorish noise is what passes for subtlety among the Boros.\"\n" +
+            "—Vraska"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg?1783940356"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/FallOfTheGavel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/FallOfTheGavel.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fall of the Gavel
+ * {3}{W}{U}
+ * Instant
+ *
+ * Counter target spell. You gain 5 life.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * [Effects.CounterSpell] reads the spell from the bound target itself, so the composite's second
+ * half still runs when the counter does nothing (the spell left the stack another way).
+ */
+val FallOfTheGavel = card("Fall of the Gavel") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. You gain 5 life."
+
+    spell {
+        val t = target("target spell", Targets.Spell)
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.GainLife(5),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Matt Stewart"
+        flavorText = "\"My ruling is final. Order is upheld. Justice is done.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg?1783940341"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/FrostburnWeird.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/FrostburnWeird.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frostburn Weird
+ * {U/R}{U/R}
+ * Creature — Weird
+ * 1/4
+ *
+ * {U/R}: This creature gets +1/-1 until end of turn.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A hybrid-mana pump on itself. The negative toughness modifier is a layer-7c effect like any
+ * other, so repeated activations can kill the Weird.
+ */
+val FrostburnWeird = card("Frostburn Weird") {
+    manaCost = "{U/R}{U/R}"
+    colorIdentity = "RU"
+    typeLine = "Creature — Weird"
+    oracleText = "{U/R}: This creature gets +1/-1 until end of turn."
+    power = 1
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{U/R}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "215"
+        artist = "Mike Bierek"
+        flavorText = "Many chemisters are oblivious to the innumerable machinations of their guild, instead focusing obsessively on creating the perfect weird."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg?1783940327"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GobblingOoze.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GobblingOoze.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gobbling Ooze
+ * {4}{G}
+ * Creature — Ooze
+ * 3/3
+ *
+ * {G}, Sacrifice another creature: Put a +1/+1 counter on this creature.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "Another creature" is [Costs.SacrificeAnother], which is [Costs.Sacrifice] with the source
+ * excluded — the Ooze can never eat itself to grow.
+ */
+val GobblingOoze = card("Gobbling Ooze") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ooze"
+    oracleText = "{G}, Sacrifice another creature: Put a +1/+1 counter on this creature."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "126"
+        artist = "Johann Bodin"
+        flavorText = "The furious citizens blamed the Simic for releasing it in their district. The Simic pointed out that rats were no longer a problem."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg?1783940348"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GrislySalvage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GrislySalvage.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Grisly Salvage
+ * {B}{G}
+ * Instant
+ *
+ * Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * [Patterns.Library.lookAtTopAndTakeMatching] is the gather → filtered up-to-one select → move
+ * pipeline this sentence names. The defaults it overrides are the two the card prints: the
+ * cards are *revealed* rather than looked at privately, and the remainder goes to the graveyard
+ * in order rather than to the bottom of the library at random.
+ */
+val GrislySalvage = card("Grisly Salvage") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndTakeMatching(
+            count = DynamicAmount.Fixed(5),
+            filter = GameObjectFilter.CreatureOrLand,
+            prompt = "You may put a creature or land card from among them into your hand",
+            revealed = true,
+            restDestination = CardDestination.ToZone(Zone.GRAVEYARD),
+            restOrder = CardOrder.Preserve,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Dave Kendall"
+        flavorText = "To the Golgari, anything buried is treasure."
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg?1783940339"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/HoverBarrier.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/HoverBarrier.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hover Barrier
+ * {2}{U}
+ * Creature — Illusion Wall
+ * 0/6
+ *
+ * Defender, flying
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val HoverBarrier = card("Hover Barrier") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion Wall"
+    oracleText = "Defender, flying"
+    power = 0
+    toughness = 6
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Mathias Kollros"
+        flavorText = "As whispers and rumors increased, so did the demand for fail-safe barriers."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg?1783940369"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/HussarPatrol.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/HussarPatrol.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hussar Patrol
+ * {2}{W}{U}
+ * Creature — Human Knight
+ * 2/4
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Vigilance
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val HussarPatrol = card("Hussar Patrol") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Vigilance"
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.FLASH, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Seb McKinnon"
+        flavorText = "\"You think no one is watching, you think you're smart enough to escape, and most foolish of all, you think no one cares.\"\n" +
+            "—Arrester Lavinia, Tenth Precinct"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg?1783940338"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/KeeningApparition.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/KeeningApparition.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Keening Apparition
+ * {1}{W}
+ * Creature — Spirit
+ * 2/2
+ *
+ * Sacrifice this creature: Destroy target enchantment.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A free sacrifice ability — [Costs.SacrificeSelf] with no mana beside it.
+ */
+val KeeningApparition = card("Keening Apparition") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Sacrifice this creature: Destroy target enchantment."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target enchantment", Targets.Enchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Terese Nielsen"
+        flavorText = "Some souls are too damaged to be of use to the Orzhov."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg?1783940375"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/LobberCrew.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/LobberCrew.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lobber Crew
+ * {2}{R}
+ * Creature — Goblin Warrior
+ * 0/4
+ *
+ * Defender
+ * {T}: This creature deals 1 damage to each opponent.
+ * Whenever you cast a multicolored spell, untap this creature.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The untapper is the guild payoff: [Triggers.youCastSpell] with a multicolored spell filter
+ * already carries `TriggerBinding.ANY`, because the triggering object is the spell rather than
+ * this permanent. The payoff still names the source, so it is [EffectTarget.Self].
+ */
+val LobberCrew = card("Lobber Crew") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    oracleText = "Defender\n" +
+        "{T}: This creature deals 1 damage to each opponent.\n" +
+        "Whenever you cast a multicolored spell, untap this creature."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Multicolored)
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Greg Staples"
+        flavorText = "It's easier to just aim at everything."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg?1783940355"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/LotlethTroll.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/LotlethTroll.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lotleth Troll
+ * {B}{G}
+ * Creature — Zombie Troll
+ * 2/1
+ *
+ * Trample
+ * Discard a creature card: Put a +1/+1 counter on this creature.
+ * {B}: Regenerate this creature.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The growth ability's whole cost is a filtered discard — no mana at all — which is
+ * [Costs.Discard] with a creature filter. There is no `Effects.Regenerate` facade;
+ * [RegenerateEffect] is the shipped spelling (Wolfir Avenger).
+ */
+val LotlethTroll = card("Lotleth Troll") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Zombie Troll"
+    oracleText = "Trample\n" +
+        "Discard a creature card: Put a +1/+1 counter on this creature.\n" +
+        "{B}: Regenerate this creature."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.Discard(GameObjectFilter.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "177"
+        artist = "Vincent Proce"
+        flavorText = "He lurks in the undercity, eager for the corpse haulers to unload their rotting cargo."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg?1783940336"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/MinotaurAggressor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/MinotaurAggressor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Minotaur Aggressor
+ * {6}{R}
+ * Creature — Minotaur Berserker
+ * 6/2
+ *
+ * First strike, haste
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val MinotaurAggressor = card("Minotaur Aggressor") {
+    manaCost = "{6}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Berserker"
+    oracleText = "First strike, haste"
+    power = 6
+    toughness = 2
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Lucas Graciano"
+        flavorText = "The smelting district is home to many who see the guilds as not for them."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg?1783940354"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PerilousShadow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PerilousShadow.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Perilous Shadow
+ * {2}{B}{B}
+ * Creature — Insect Shade
+ * 0/4
+ *
+ * {1}{B}: This creature gets +2/+2 until end of turn.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The Shade firebreathing pattern: a repeatable self-pump, defaulting to end of turn.
+ */
+val PerilousShadow = card("Perilous Shadow") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Shade"
+    oracleText = "{1}{B}: This creature gets +2/+2 until end of turn."
+    power = 0
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Clint Cearley"
+        flavorText = "There are some shadows that even the Dimir fear."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg?1783940361"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PrecinctCaptain.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PrecinctCaptain.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Precinct Captain
+ * {W}{W}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * First strike
+ * Whenever this creature deals combat damage to a player, create a 1/1 white Soldier creature token.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * First strike and a combat-damage trigger interact through the engine's two damage steps: the
+ * Captain's damage lands in the first-strike step, so the token is on the battlefield before
+ * regular combat damage is dealt.
+ */
+val PrecinctCaptain = card("Precinct Captain") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "First strike\n" +
+        "Whenever this creature deals combat damage to a player, create a 1/1 white Soldier creature token."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Steve Prescott"
+        flavorText = "\"In troubled times, we all need someone to watch our back.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg?1783940375"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PursuitOfFlight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/PursuitOfFlight.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pursuit of Flight
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has "{U}: This creature gains flying until end of turn."
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Deviant Glee's shape in the other guild's colours — see that card for why the granted ability's
+ * [EffectTarget.Self] is the enchanted creature and not the Aura.
+ */
+val PursuitOfFlight = card("Pursuit of Flight") {
+    manaCost = "{1}{R}"
+    colorIdentity = "RU"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 and has \"{U}: This creature gains flying until end of turn.\""
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Mana("{U}"),
+                effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Christopher Moeller"
+        flavorText = "\"Watch the voltage. We don't need another charred, crashing viashino.\"\n" +
+            "—Bori Andon, Izzet blastseeker"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg?1783940354"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Pyroconvergence.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Pyroconvergence.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Pyroconvergence
+ * {4}{R}
+ * Enchantment
+ *
+ * Whenever you cast a multicolored spell, this enchantment deals 2 damage to any target.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Lobber Crew's trigger with a targeted payoff. The target is chosen when the ability goes on the
+ * stack, which is *above* the multicolored spell that triggered it, so the damage resolves first.
+ */
+val Pyroconvergence = card("Pyroconvergence") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a multicolored spell, this enchantment deals 2 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Multicolored)
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Jack Wang"
+        flavorText = "\"The Izzet are an equation that turns lunacy into explosions.\"\n" +
+            "—Leonos, Azorius arbiter"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg?1783940353"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RakdosRagemutt.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RakdosRagemutt.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakdos Ragemutt
+ * {3}{B}{R}
+ * Creature — Elemental Dog
+ * 3/3
+ *
+ * Lifelink, haste
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val RakdosRagemutt = card("Rakdos Ragemutt") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Elemental Dog"
+    oracleText = "Lifelink, haste"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.LIFELINK, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "185"
+        artist = "Ryan Barger"
+        flavorText = "Ragemutts pull the chariots of the Butcher Clowns, a trio of wingless, zombified faeries formerly of the Izzet."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg?1783940334"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RakdosShredFreak.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RakdosShredFreak.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakdos Shred-Freak
+ * {B/R}{B/R}
+ * Creature — Human Berserker
+ * 2/1
+ *
+ * Haste
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else. The hybrid mana cost is data on the card, not script.
+ */
+val RakdosShredFreak = card("Rakdos Shred-Freak") {
+    manaCost = "{B/R}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Human Berserker"
+    oracleText = "Haste"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "221"
+        artist = "Wayne Reynolds"
+        flavorText = "\"If there were such a thing as a soul, I think it would be behind the gallbladder but above the kidneys.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg?1783940326"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ReturnToRavnicaBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ReturnToRavnicaBasicLands.kt
@@ -1,0 +1,180 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Return to Ravnica Basic Lands
+ *
+ * Return to Ravnica contains 5 art variants of each basic land type.
+ * Cards 250-274 (Plains 250-254, Island 255-259, Swamp 260-264, Mountain 265-269, Forest 270-274)
+ */
+
+// =============================================================================
+// Plains (Cards 250-254)
+// =============================================================================
+
+val ReturnToRavnicaPlains250 = basicLand("Plains") {
+    collectorNumber = "250"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac754820-343e-4c01-bcfa-89fa5c8c7e1d.jpg?1783940320"
+}
+
+val ReturnToRavnicaPlains251 = basicLand("Plains") {
+    collectorNumber = "251"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34044cf5-79ed-479c-abdc-3718ec193dd3.jpg?1783940319"
+}
+
+val ReturnToRavnicaPlains252 = basicLand("Plains") {
+    collectorNumber = "252"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0b9bcca-b41a-4a6a-b380-36bfea9f0715.jpg?1783940319"
+}
+
+val ReturnToRavnicaPlains253 = basicLand("Plains") {
+    collectorNumber = "253"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d293ea0f-8b87-4d8a-ad8f-650131c83c20.jpg?1783940319"
+}
+
+val ReturnToRavnicaPlains254 = basicLand("Plains") {
+    collectorNumber = "254"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be0334fe-3de3-4779-a31d-d021db50b62b.jpg?1783940319"
+}
+
+// =============================================================================
+// Island (Cards 255-259)
+// =============================================================================
+
+val ReturnToRavnicaIsland255 = basicLand("Island") {
+    collectorNumber = "255"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78f35064-c662-48ff-a2a9-d26f594500f5.jpg?1783940319"
+}
+
+val ReturnToRavnicaIsland256 = basicLand("Island") {
+    collectorNumber = "256"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8dc5e0d9-1c8f-4d38-9915-40469988983d.jpg?1783940318"
+}
+
+val ReturnToRavnicaIsland257 = basicLand("Island") {
+    collectorNumber = "257"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f10e5b17-6099-445d-9a7b-484eeff7cea8.jpg?1783940318"
+}
+
+val ReturnToRavnicaIsland258 = basicLand("Island") {
+    collectorNumber = "258"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/7869f14e-d1d5-4a99-bc2c-f3a0d63077a5.jpg?1783940317"
+}
+
+val ReturnToRavnicaIsland259 = basicLand("Island") {
+    collectorNumber = "259"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e070e97c-142a-4d5d-ae89-c0c6d85a97ac.jpg?1783940317"
+}
+
+// =============================================================================
+// Swamp (Cards 260-264)
+// =============================================================================
+
+val ReturnToRavnicaSwamp260 = basicLand("Swamp") {
+    collectorNumber = "260"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d8c3f29-121e-42d1-be21-29f403f97708.jpg?1783940317"
+}
+
+val ReturnToRavnicaSwamp261 = basicLand("Swamp") {
+    collectorNumber = "261"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be73b50e-8230-41e5-8492-db8f749d00a4.jpg?1783940317"
+}
+
+val ReturnToRavnicaSwamp262 = basicLand("Swamp") {
+    collectorNumber = "262"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46908606-f572-4b2d-9562-ed9c6f50f1ad.jpg?1783940316"
+}
+
+val ReturnToRavnicaSwamp263 = basicLand("Swamp") {
+    collectorNumber = "263"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7cd375e-f41c-42b1-bbd4-36032d4fb92d.jpg?1783940316"
+}
+
+val ReturnToRavnicaSwamp264 = basicLand("Swamp") {
+    collectorNumber = "264"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/745b1731-af31-44d2-ad50-b3e43b620913.jpg?1783940316"
+}
+
+// =============================================================================
+// Mountain (Cards 265-269)
+// =============================================================================
+
+val ReturnToRavnicaMountain265 = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b4a196f-de7e-4100-ad65-56cf8b0a8b23.jpg?1783940316"
+}
+
+val ReturnToRavnicaMountain266 = basicLand("Mountain") {
+    collectorNumber = "266"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5b2d0ed-0b47-459a-8f5c-554dd816c03a.jpg?1783940316"
+}
+
+val ReturnToRavnicaMountain267 = basicLand("Mountain") {
+    collectorNumber = "267"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/5353e8b2-3280-48ec-9bc2-8c8e7a15b460.jpg?1783940317"
+}
+
+val ReturnToRavnicaMountain268 = basicLand("Mountain") {
+    collectorNumber = "268"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24b61852-860e-4f89-a1b2-6429168f0c02.jpg?1783940316"
+}
+
+val ReturnToRavnicaMountain269 = basicLand("Mountain") {
+    collectorNumber = "269"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96614dc1-9386-4861-b792-b83bcc6c5811.jpg?1783940315"
+}
+
+// =============================================================================
+// Forest (Cards 270-274)
+// =============================================================================
+
+val ReturnToRavnicaForest270 = basicLand("Forest") {
+    collectorNumber = "270"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f00849dd-c1ba-4171-a503-603fe77c0a43.jpg?1783940315"
+}
+
+val ReturnToRavnicaForest271 = basicLand("Forest") {
+    collectorNumber = "271"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/1428575c-f18e-41a0-b58a-259d2feafd06.jpg?1783940315"
+}
+
+val ReturnToRavnicaForest272 = basicLand("Forest") {
+    collectorNumber = "272"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e6850740-6219-4f82-a705-2e7b20ede751.jpg?1783940314"
+}
+
+val ReturnToRavnicaForest273 = basicLand("Forest") {
+    collectorNumber = "273"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/edc50993-1fd4-4dba-9d2f-ae7a18559829.jpg?1783940315"
+}
+
+val ReturnToRavnicaForest274 = basicLand("Forest") {
+    collectorNumber = "274"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddfcde62-1b20-48ce-8ba0-7929edcd26fc.jpg?1783940313"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RisenSanctuary.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RisenSanctuary.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Risen Sanctuary
+ * {5}{G}{W}
+ * Creature — Elemental
+ * 8/8
+ *
+ * Vigilance
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else.
+ */
+val RisenSanctuary = card("Risen Sanctuary") {
+    manaCost = "{5}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elemental"
+    oracleText = "Vigilance"
+    power = 8
+    toughness = 8
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Chase Stone"
+        flavorText = "When one of the great guardians arises, it sweeps enemies aside like chaff yet takes care not to crush a single insect underfoot."
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg?1783940334"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RubblebackRhino.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/RubblebackRhino.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rubbleback Rhino
+ * {4}{G}
+ * Creature — Rhino
+ * 3/4
+ *
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else.
+ */
+val RubblebackRhino = card("Rubbleback Rhino") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino"
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Johann Bodin"
+        flavorText = "The trouble started when a street urchin bet a goblin he could ride one until the clock on Shilbo's Tower struck thirteen."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg?1783940347"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Runewing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Runewing.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Runewing
+ * {3}{U}
+ * Creature — Bird
+ * 2/2
+ *
+ * Flying
+ * When this creature dies, draw a card.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * A dies trigger over the plain draw facade.
+ */
+val Runewing = card("Runewing") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying\n" +
+        "When this creature dies, draw a card."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Martina Pilcerova"
+        flavorText = "In the hands of the open-minded, a runewing quill writes wisdom of its own."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg?1783940366"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SelesnyaSentry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SelesnyaSentry.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Selesnya Sentry
+ * {2}{W}
+ * Creature — Elephant Soldier
+ * 3/2
+ *
+ * {5}{G}: Regenerate this creature.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * An off-colour regeneration ability — the activation cost's colour has nothing to do with the
+ * card's own. There is no `Effects.Regenerate` facade; [RegenerateEffect] is the spelling.
+ */
+val SelesnyaSentry = card("Selesnya Sentry") {
+    manaCost = "{2}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elephant Soldier"
+    oracleText = "{5}{G}: Regenerate this creature."
+    power = 3
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Wesley Burt"
+        flavorText = "Ravnicans still tell tales about the Battle of Sumala where four Selesnya sentries held off an entire clan of Gruul warriors."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg?1783940374"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SkylinePredator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SkylinePredator.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyline Predator
+ * {4}{U}{U}
+ * Creature — Drake
+ * 3/4
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Flying
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords and nothing else.
+ */
+val SkylinePredator = card("Skyline Predator") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Flying"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Wesley Burt"
+        flavorText = "\"It will dodge your first arrow and flatten you before there's a second.\"\n" +
+            "—Alcarus, Selesnya archer"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg?1783940366"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SlumReaper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SlumReaper.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slum Reaper
+ * {3}{B}
+ * Creature — Horror
+ * 4/2
+ *
+ * When this creature enters, each player sacrifices a creature of their choice.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "Each player sacrifices" names a player, so it is [Effects.Sacrifice]'s three-argument form —
+ * a `ForceSacrificeEffect` — and not the bare imperative that makes the *controller* sacrifice.
+ * The Reaper's own controller is included, and may well have to feed it the Reaper.
+ */
+val SlumReaper = card("Slum Reaper") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    oracleText = "When this creature enters, each player sacrifices a creature of their choice."
+    power = 4
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Sacrifice(GameObjectFilter.Creature, 1, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "77"
+        artist = "Karl Kopinski"
+        flavorText = "It's sent into unguilded districts by the Orzhov to collect the souls of those no one will miss."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg?1783940361"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/StealerOfSecrets.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/StealerOfSecrets.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stealer of Secrets
+ * {2}{U}
+ * Creature — Human Rogue
+ * 2/2
+ *
+ * Whenever this creature deals combat damage to a player, draw a card.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The plain combat-damage-to-a-player trigger over a draw.
+ */
+val StealerOfSecrets = card("Stealer of Secrets") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "Whenever this creature deals combat damage to a player, draw a card."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Michael C. Hayes"
+        flavorText = "The Dimir would hire her, if only they knew where she lived. The Azorius would condemn her, if only they knew her name."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg?1783940366"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/StonefareCrocodile.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/StonefareCrocodile.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stonefare Crocodile
+ * {2}{G}
+ * Creature — Crocodile
+ * 3/2
+ *
+ * {2}{B}: This creature gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * An off-colour keyword grant on itself, defaulting to end of turn.
+ */
+val StonefareCrocodile = card("Stonefare Crocodile") {
+    manaCost = "{2}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Crocodile"
+    oracleText = "{2}{B}: This creature gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)"
+    power = 3
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Tomasz Jedruszek"
+        flavorText = "The Izzet's plans to exploit the undercity ran into a few stubborn obstacles."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg?1783940346"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SunspireGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SunspireGriffin.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunspire Griffin
+ * {1}{W}{W}
+ * Creature — Griffin
+ * 2/3
+ *
+ * Flying
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else.
+ */
+val SunspireGriffin = card("Sunspire Griffin") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    oracleText = "Flying"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Johannes Voss"
+        flavorText = "\"For each griffin wounded by an arrow, there's a corpse with a bow nearby.\"\n" +
+            "—Pel Javya, Wojek investigator"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg?1783940373"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SupremeVerdict.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SupremeVerdict.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Supreme Verdict
+ * {1}{W}{W}{U}
+ * Sorcery
+ *
+ * This spell can't be countered.
+ * Destroy all creatures.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * [Effects.DestroyAll] rather than an iteration: it lowers to the gather-then-move pipeline, and
+ * the gather reads *projected* state, so a permanent that is a creature only because of a
+ * continuous effect is swept too. "Can't be countered" is the intrinsic [cantBeCountered] flag.
+ */
+val SupremeVerdict = card("Supreme Verdict") {
+    manaCost = "{1}{W}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Sorcery"
+    oracleText = "This spell can't be countered.\n" +
+        "Destroy all creatures."
+
+    cantBeCountered = true
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "201"
+        artist = "Sam Burley"
+        flavorText = "Leonos had no second thoughts about the abolishment edict. He'd left skyrunes warning of the eviction, even though it was cloudy."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg?1783940331"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SurveyTheWreckage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SurveyTheWreckage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Survey the Wreckage
+ * {4}{R}
+ * Sorcery
+ *
+ * Destroy target land. Create a 1/1 red Goblin creature token.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Land destruction plus a consolation token. The token is created by *this* spell's controller —
+ * the printed text names nobody, so it is the default.
+ */
+val SurveyTheWreckage = card("Survey the Wreckage") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target land. Create a 1/1 red Goblin creature token."
+
+    spell {
+        val t = target("target land", Targets.Land)
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Goblin"),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Warren Mahy"
+        flavorText = "Goblins and architects seldom get along."
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg?1783940353"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SwiftJustice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SwiftJustice.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swift Justice
+ * {W}
+ * Instant
+ *
+ * Until end of turn, target creature gets +1/+0 and gains first strike and lifelink.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Three end-of-turn effects on one bound target. Each keyword is its own grant — the SDK has no
+ * multi-keyword facade, and one per grant keeps the layer-6 read simple.
+ */
+val SwiftJustice = card("Swift Justice") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature gets +1/+0 and gains first strike and lifelink."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+            Effects.GrantKeyword(Keyword.LIFELINK, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Karl Kopinski"
+        flavorText = "\"Having conviction is more important than being righteous.\"\n" +
+            "—Aurelia"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg?1783940373"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TenementCrasher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TenementCrasher.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tenement Crasher
+ * {5}{R}
+ * Creature — Beast
+ * 5/4
+ *
+ * Haste
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else.
+ */
+val TenementCrasher = card("Tenement Crasher") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    oracleText = "Haste"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Warren Mahy"
+        flavorText = "Nothing was going to stop it—not the narrow alleys, not the Boros garrison, and certainly not the four-story Orzhov cathedral."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg?1783940353"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Thoughtflare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Thoughtflare.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thoughtflare
+ * {3}{U}{R}
+ * Instant
+ *
+ * Draw four cards, then discard two cards.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * "Draw, then discard" is sequenced by the composite, which matters: the two discarded cards may
+ * be among the four just drawn.
+ */
+val Thoughtflare = card("Thoughtflare") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Instant"
+    oracleText = "Draw four cards, then discard two cards."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(4),
+            Patterns.Hand.discardCards(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "David Rapoza"
+        flavorText = "\"If this is thinking, I don't know what I was doing before.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg?1783940331"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ToweringIndrik.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ToweringIndrik.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Towering Indrik
+ * {3}{G}
+ * Creature — Beast
+ * 2/4
+ *
+ * Reach (This creature can block creatures with flying.)
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else.
+ */
+val ToweringIndrik = card("Towering Indrik") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "Reach (This creature can block creatures with flying.)"
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Lars Grant-West"
+        flavorText = "It chases its airborne prey relentlessly, heedless to what it pulverizes beneath its hooves."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg?1783940346"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TreasuredFind.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TreasuredFind.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Treasured Find
+ * {B}{G}
+ * Sorcery
+ *
+ * Return target card from your graveyard to your hand. Exile Treasured Find.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * The self-exile rider is a second move in the composite, on [EffectTarget.Self]. Because it is
+ * part of the resolution rather than a replacement, a Treasured Find countered on the stack goes
+ * to the graveyard normally.
+ */
+val TreasuredFind = card("Treasured Find") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Sorcery"
+    oracleText = "Return target card from your graveyard to your hand. Exile Treasured Find."
+
+    spell {
+        val c = target(
+            "target card in your graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(c),
+            Effects.Exile(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "204"
+        artist = "Jason Chan"
+        flavorText = "Gorgons crave beautiful things: gems, exquisite amulets, the alabaster corpses of the petrified dead . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg?1783940330"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TrestleTroll.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TrestleTroll.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trestle Troll
+ * {1}{B}{G}
+ * Creature — Troll
+ * 1/4
+ *
+ * Defender
+ * Reach (This creature can block creatures with flying.)
+ * {1}{B}{G}: Regenerate this creature.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Two evergreen keywords plus the regeneration ability — [RegenerateEffect] is the shipped
+ * spelling; there is no `Effects.Regenerate` facade.
+ */
+val TrestleTroll = card("Trestle Troll") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Troll"
+    oracleText = "Defender\n" +
+        "Reach (This creature can block creatures with flying.)\n" +
+        "{1}{B}{G}: Regenerate this creature."
+    power = 1
+    toughness = 4
+
+    keywords(Keyword.DEFENDER, Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Peter Mohrbacher"
+        flavorText = "Unwelcome in Golgari colonies, he found his own dark place from which to represent the Swarm."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg?1783940330"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/VassalSoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/VassalSoul.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vassal Soul
+ * {1}{W/U}{W/U}
+ * Creature — Spirit
+ * 2/2
+ *
+ * Flying
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * One evergreen keyword and nothing else. The hybrid mana cost is data on the card, not script.
+ */
+val VassalSoul = card("Vassal Soul") {
+    manaCost = "{1}{W/U}{W/U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Dan Murayama Scott"
+        flavorText = "For the Azorius, the opportunity to serve the law is too great an honor for death to interrupt."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg?1783940325"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Voidwielder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Voidwielder.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voidwielder
+ * {4}{U}
+ * Creature — Human Wizard
+ * 1/4
+ *
+ * When this creature enters, you may return target creature to its owner's hand.
+ *
+ * Canonical printing: Return to Ravnica, the card's earliest real printing.
+ *
+ * Batterhorn's shape in blue: `optional = true` lowers to one `MayEffect` consent gate, asked at
+ * resolution after the target was locked in on announcement.
+ */
+val Voidwielder = card("Voidwielder") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "When this creature enters, you may return target creature to its owner's hand."
+    power = 1
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Chase Stone"
+        flavorText = "\"He makes up his own laws, and that's dangerous to all who love peace and prosperity. Kill him on sight.\"\n" +
+            "—Mirela, Azorius hussar"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg?1783940365"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/CodexShredderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/CodexShredderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Codex Shredder reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val CodexShredderReprint = Printing(
+    oracleId = "ef7b11ab-24e7-4e7c-91a7-920bade6e60b",
+    name = "Codex Shredder",
+    setCode = "CMR",
+    collectorNumber = "304",
+    scryfallId = "4f5a3293-f3e7-4f68-af6a-b478959226c1",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f5a3293-f3e7-4f68-af6a-b478959226c1.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -1,3 +1,235 @@
+// Abrupt Decay
+{
+    "name": "Abrupt Decay",
+    "manaCost": "{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered.\nDestroy target nonland permanent with mana value 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent with mana value 3 or less"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent mv<=3"
+                },
+                "id": "target nonland permanent with mana value 3 or less"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "The Izzet quickly suspended their policy of lifetime guarantees.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b1e92b4-6e53-4dba-a572-c67e01965ac5.jpg?1783940344"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Aerial Predation
+{
+    "name": "Aerial Predation",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with flying. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with flying"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "BD",
+        "flavorText": "In the towering trees of the Samok Stand and the predators that guard them, the might of the Ravnican wild has returned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec3c023c-037e-495a-b7df-32be42a75f36.jpg?1783940351"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Aquus Steed
+{
+    "name": "Aquus Steed",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{2}{U}, {T}: Target creature gets -2/-0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "flavorText": "In water, it's as graceful as a dolphin. On land, it darts and jerks so unpredictably that few can ride it for long.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af643949-7a9b-4195-8ab8-d43b1928b85a.jpg?1783940371"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Archweaver
+{
+    "name": "Archweaver",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach, trample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "The silk of the archweavers adds structural integrity to otherwise unstable Izzet building sites.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f99dc8ff-932c-4d56-9253-99ce9e145306.jpg?1783940352"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Armada Wurm
+{
+    "name": "Armada Wurm",
+    "manaCost": "{2}{G}{G}{W}{W}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Trample\nWhen this creature enters, create a 5/5 green Wurm creature token with trample.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wurm"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "flavorText": "No one in the Conclave acts alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50cb4bf3-70d1-4acc-a1fb-49f4ea74ca16.jpg?1783940344"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Auger Spree
 {
     "name": "Auger Spree",
@@ -61,6 +293,92 @@
     ]
 }
 
+// Azorius Charm
+{
+    "name": "Azorius Charm",
+    "manaCost": "{W}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Creatures you control gain lifelink until end of turn.\n• Draw a card.\n• Put target attacking or blocking creature on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control gain lifelink until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target attacking or blocking creature"
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "StateOr",
+                                            "predicates": [
+                                                "IsAttacking",
+                                                "IsBlocking"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target attacking or blocking creature"
+                        }
+                    ],
+                    "description": "Put target attacking or blocking creature on top of its owner's library"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"The rules of logic and order have already made the choice for you.\"\n—Isperia",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26adc211-d089-4102-91e5-225bbeb5f382.jpg?1783940345"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Azorius Guildgate
 {
     "name": "Azorius Guildgate",
@@ -103,6 +421,58 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Batterhorn
+{
+    "name": "Batterhorn",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature enters, you may destroy target artifact.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact"
+                    },
+                    "id": "target artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Dave Kendall",
+        "flavorText": "Novice shopkeeps spend hours deciding how best to display their wares. Veterans focus on portability.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7b40f74-893f-4bfc-87b2-7f8df4c912d8.jpg?1783940357"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -178,6 +548,38 @@
     ]
 }
 
+// Call of the Conclave
+{
+    "name": "Call of the Conclave",
+    "manaCost": "{G}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 3/3 green Centaur creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 3,
+            "toughness": 3,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Centaur"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "flavorText": "Centaurs are sent to evangelize in Gruul territories where words of war speak louder than prayers of peace.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6df8f4d-a07a-4664-878d-efec8b2affb9.jpg?1783940344"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Catacomb Slug
 {
     "name": "Catacomb Slug",
@@ -195,6 +597,98 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Centaur Healer
+{
+    "name": "Centaur Healer",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Centaur Cleric",
+    "oracleText": "When this creature enters, you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Mark Zug",
+        "flavorText": "Instructors at the Kasarna training grounds are capable healers in case their students fail to grasp the subtleties of combat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/833835d1-9beb-4ad8-b675-7adebdbd7d82.jpg?1783940343"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Centaur's Herald
+{
+    "name": "Centaur's Herald",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "{2}{G}, Sacrifice this creature: Create a 3/3 green Centaur creature token.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Centaur"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Howard Lyon",
+        "flavorText": "The farther they go from Vitu-Ghazi, the less willing the crowd is to part for them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08598b2b-6fd2-4a1d-8d74-7ca6d93ad382.jpg?1783940350"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -259,6 +753,133 @@
     ]
 }
 
+// Codex Shredder
+{
+    "name": "Codex Shredder",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Target player mills a card. (They put the top card of their library into their graveyard.)\n{5}, {T}, Sacrifice this artifact: Return target card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card in your graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f7b632b-ee20-4082-8376-1dae53f91b70.jpg?1783940324"
+    }
+}
+
+// Collective Blessing
+{
+    "name": "Collective Blessing",
+    "manaCost": "{3}{G}{G}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control get +3/+3.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Senators of Azorius often hired agents to spy on the Selesnya. They were told to record every spore and root they saw, as each could become a deadly foe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53c84c4d-e6d6-4eac-9d14-5b6cba914c3d.jpg?1783940342"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Concordia Pegasus
 {
     "name": "Concordia Pegasus",
@@ -280,6 +901,74 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Daggerdrome Imp
+{
+    "name": "Daggerdrome Imp",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Jack Wang",
+        "flavorText": "One of the many reasons why open-air markets close at dusk.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70639887-bdba-4879-a3f8-c716f97fc325.jpg?1783940364"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dark Revenant
+{
+    "name": "Dark Revenant",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhen this creature dies, put it on top of its owner's library.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Library",
+                    "placement": "Top"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "The murderer faced justice in the Azorius courts, but his soul was set free on a technicality.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/2167cc6d-ddb5-4f13-8905-a0c5123b852a.jpg?1783940364"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -343,6 +1032,57 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Deviant Glee
+{
+    "name": "Deviant Glee",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+1 and has \"{R}: This creature gains trample until end of turn.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{R}"
+                        }
+                    },
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Michael C. Hayes",
+        "flavorText": "\"You just need the right incentive to fulfill my dreams.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e150896e-8745-42ac-894b-8f42a92bd7a7.jpg?1783940363"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -438,6 +1178,91 @@
     ]
 }
 
+// Dramatic Rescue
+{
+    "name": "Dramatic Rescue",
+    "manaCost": "{W}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature to its owner's hand. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "artist": "Ryan Pancoast",
+        "flavorText": "\"I never thought I'd be so glad to see two tons of beak and claws bearing down on me at the speed of an arrow.\"\n—Mirela, Azorius hussar",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/041afd23-1ecc-4cca-9244-fe42203ad689.jpg?1783940342"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Dreadbore
+{
+    "name": "Dreadbore",
+    "manaCost": "{B}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature or planeswalker"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "flavorText": "In Rakdos-controlled neighborhoods, everyone is part of the show.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a83945c6-4dc6-4d9a-9bc2-2d4a264e5422.jpg?1783940341"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Dryad Militant
 {
     "name": "Dryad Militant",
@@ -474,6 +1299,86 @@
     ]
 }
 
+// Explosive Impact
+{
+    "name": "Explosive Impact",
+    "manaCost": "{5}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Explosive Impact deals 5 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "any target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Such boorish noise is what passes for subtlety among the Boros.\"\n—Vraska",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a3e2b45-b086-4ffd-aa1a-1d03046e0d61.jpg?1783940356"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fall of the Gavel
+{
+    "name": "Fall of the Gavel",
+    "manaCost": "{3}{W}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. You gain 5 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "flavorText": "\"My ruling is final. Order is upheld. Justice is done.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64f42848-963b-4b16-aeec-66d0f349758b.jpg?1783940341"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Fencing Ace
 {
     "name": "Fencing Ace",
@@ -496,6 +1401,109 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Frostburn Weird
+{
+    "name": "Frostburn Weird",
+    "manaCost": "{U/R}{U/R}",
+    "typeLine": "Creature — Weird",
+    "oracleText": "{U/R}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U/R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "artist": "Mike Bierek",
+        "flavorText": "Many chemisters are oblivious to the innumerable machinations of their guild, instead focusing obsessively on creating the perfect weird.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba5a68d3-6bc9-4de8-bc06-e1106cf9b3d4.jpg?1783940327"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Gobbling Ooze
+{
+    "name": "Gobbling Ooze",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "{G}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "flavorText": "The furious citizens blamed the Simic for releasing it in their district. The Simic pointed out that rats were no longer a problem.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/465d8a63-0ced-4aec-be34-2098b72c8af6.jpg?1783940348"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -601,6 +1609,75 @@
     ]
 }
 
+// Grisly Salvage
+{
+    "name": "Grisly Salvage",
+    "manaCost": "{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Reveal the top five cards of your library. You may put a creature or land card from among them into your hand. Put the rest into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "looked",
+                    "revealed": true
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature|land",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may put a creature or land card from among them into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Dave Kendall",
+        "flavorText": "To the Golgari, anything buried is treasure.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcb5eb2a-ae7a-4416-970c-6e9306689c88.jpg?1783940339"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Guttersnipe
 {
     "name": "Guttersnipe",
@@ -656,6 +1733,58 @@
     ]
 }
 
+// Hover Barrier
+{
+    "name": "Hover Barrier",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Illusion Wall",
+    "oracleText": "Defender, flying",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "flavorText": "As whispers and rumors increased, so did the demand for fail-safe barriers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/884afdb3-0d5f-45a1-b57e-6c3760aa0031.jpg?1783940369"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Hussar Patrol
+{
+    "name": "Hussar Patrol",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"You think no one is watching, you think you're smart enough to escape, and most foolish of all, you think no one cares.\"\n—Arrester Lavinia, Tenth Precinct",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd775231-e1e0-41e2-ad9a-0726624f57f9.jpg?1783940338"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Izzet Guildgate
 {
     "name": "Izzet Guildgate",
@@ -698,6 +1827,53 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Keening Apparition
+{
+    "name": "Keening Apparition",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Sacrifice this creature: Destroy target enchantment.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "enchantment"
+                        },
+                        "id": "target enchantment"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Terese Nielsen",
+        "flavorText": "Some souls are too damaged to be of use to the Orzhov.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/657b242c-46cb-44d1-86fd-fb2485144a5b.jpg?1783940375"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -760,6 +1936,349 @@
     ]
 }
 
+// Lobber Crew
+{
+    "name": "Lobber Crew",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Defender\n{T}: This creature deals 1 damage to each opponent.\nWhenever you cast a multicolored spell, untap this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Greg Staples",
+        "flavorText": "It's easier to just aim at everything.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9d4aa15-a3c2-42a3-a87a-443e7dd20c04.jpg?1783940355"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lotleth Troll
+{
+    "name": "Lotleth Troll",
+    "manaCost": "{B}{G}",
+    "typeLine": "Creature — Zombie Troll",
+    "oracleText": "Trample\nDiscard a creature card: Put a +1/+1 counter on this creature.\n{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "RARE",
+        "artist": "Vincent Proce",
+        "flavorText": "He lurks in the undercity, eager for the corpse haulers to unload their rotting cargo.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b628197-f26c-457a-b9a4-c1f1d3e02f3d.jpg?1783940336"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Minotaur Aggressor
+{
+    "name": "Minotaur Aggressor",
+    "manaCost": "{6}{R}",
+    "typeLine": "Creature — Minotaur Berserker",
+    "oracleText": "First strike, haste",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "The smelting district is home to many who see the guilds as not for them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e22959dc-8759-454e-80b9-623a799af354.jpg?1783940354"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Perilous Shadow
+{
+    "name": "Perilous Shadow",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Insect Shade",
+    "oracleText": "{1}{B}: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Clint Cearley",
+        "flavorText": "There are some shadows that even the Dimir fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c101171-a988-4c1d-9954-634e2f1c6f01.jpg?1783940361"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Precinct Captain
+{
+    "name": "Precinct Captain",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike\nWhenever this creature deals combat damage to a player, create a 1/1 white Soldier creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "\"In troubled times, we all need someone to watch our back.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f1f6178-4071-401f-bd0d-cac0c5967661.jpg?1783940375"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pursuit of Flight
+{
+    "name": "Pursuit of Flight",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has \"{U}: This creature gains flying until end of turn.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{U}"
+                        }
+                    },
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Watch the voltage. We don't need another charred, crashing viashino.\"\n—Bori Andon, Izzet blastseeker",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37a6290c-a0a8-4032-972b-84a7eef04dae.jpg?1783940354"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Pyroconvergence
+{
+    "name": "Pyroconvergence",
+    "manaCost": "{4}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a multicolored spell, this enchantment deals 2 damage to any target.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "Jack Wang",
+        "flavorText": "\"The Izzet are an equation that turns lunacy into explosions.\"\n—Leonos, Azorius arbiter",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6cff95b7-79eb-4796-9a01-31ff355681ab.jpg?1783940353"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rakdos Guildgate
 {
     "name": "Rakdos Guildgate",
@@ -798,6 +2317,58 @@
         "artist": "Eytan Zana",
         "flavorText": "Enter and indulge your darkest fantasies, for you may never pass this way again.",
         "imageUri": "https://cards.scryfall.io/normal/front/2/0/207048f5-268b-4cdb-b4e7-c8282cac1b28.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Rakdos Ragemutt
+{
+    "name": "Rakdos Ragemutt",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "Lifelink, haste",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Barger",
+        "flavorText": "Ragemutts pull the chariots of the Butcher Clowns, a trio of wingless, zombified faeries formerly of the Izzet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb36840a-3f85-4fca-87ab-379dfce8e542.jpg?1783940334"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Rakdos Shred-Freak
+{
+    "name": "Rakdos Shred-Freak",
+    "manaCost": "{B/R}{B/R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "221",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"If there were such a thing as a soul, I think it would be behind the gallbladder but above the kidneys.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06899549-5534-4d11-86c1-afd1796e18b1.jpg?1783940326"
     },
     "colorIdentityOverride": [
         "BLACK",
@@ -866,6 +2437,32 @@
     ]
 }
 
+// Risen Sanctuary
+{
+    "name": "Risen Sanctuary",
+    "manaCost": "{5}{G}{W}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Chase Stone",
+        "flavorText": "When one of the great guardians arises, it sweeps enemies aside like chaff yet takes care not to crush a single insect underfoot.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0b6c136-2bbe-48c1-ac53-2a8221b96936.jpg?1783940334"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Rogue's Passage
 {
     "name": "Rogue's Passage",
@@ -930,6 +2527,73 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/4/f416e36a-15cb-43c8-b27f-82f65a95ddef.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Rubbleback Rhino
+{
+    "name": "Rubbleback Rhino",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Rhino",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Johann Bodin",
+        "flavorText": "The trouble started when a street urchin bet a goblin he could ride one until the clock on Shilbo's Tower struck thirteen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51daaf9b-d8a8-49a6-94e1-0c8be2c6188b.jpg?1783940347"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Runewing
+{
+    "name": "Runewing",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Martina Pilcerova",
+        "flavorText": "In the hands of the open-minded, a runewing quill writes wisdom of its own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/749961e6-b135-4629-ae9d-124de0d70db9.jpg?1783940366"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Savage Surge
@@ -1135,6 +2799,46 @@
     ]
 }
 
+// Selesnya Sentry
+{
+    "name": "Selesnya Sentry",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "oracleText": "{5}{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Wesley Burt",
+        "flavorText": "Ravnicans still tell tales about the Battle of Sumala where four Selesnya sentries held off an entire clan of Gruul warriors.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c34c1f5-d509-4c66-ba41-c7958ef5ee44.jpg?1783940374"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Seller of Songbirds
 {
     "name": "Seller of Songbirds",
@@ -1179,6 +2883,455 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Skyline Predator
+{
+    "name": "Skyline Predator",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Wesley Burt",
+        "flavorText": "\"It will dodge your first arrow and flatten you before there's a second.\"\n—Alcarus, Selesnya archer",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/5839556c-6635-44c4-96ed-666e4466b929.jpg?1783940366"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Slum Reaper
+{
+    "name": "Slum Reaper",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "When this creature enters, each player sacrifices a creature of their choice.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "UNCOMMON",
+        "artist": "Karl Kopinski",
+        "flavorText": "It's sent into unguilded districts by the Orzhov to collect the souls of those no one will miss.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f0fea13-63cf-4574-8752-3c357eee4524.jpg?1783940361"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Stealer of Secrets
+{
+    "name": "Stealer of Secrets",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Whenever this creature deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Michael C. Hayes",
+        "flavorText": "The Dimir would hire her, if only they knew where she lived. The Azorius would condemn her, if only they knew her name.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30ae7001-4d0f-4160-b41c-2fcb83fdb60b.jpg?1783940366"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stonefare Crocodile
+{
+    "name": "Stonefare Crocodile",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Crocodile",
+    "oracleText": "{2}{B}: This creature gains lifelink until end of turn. (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "The Izzet's plans to exploit the undercity ran into a few stubborn obstacles.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2517d74-0589-49dc-88f1-1fc02b27bc9d.jpg?1783940346"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Sunspire Griffin
+{
+    "name": "Sunspire Griffin",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Johannes Voss",
+        "flavorText": "\"For each griffin wounded by an arrow, there's a corpse with a bow nearby.\"\n—Pel Javya, Wojek investigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1388ce6e-8199-46c1-8ee3-71266b0929bf.jpg?1783940373"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Supreme Verdict
+{
+    "name": "Supreme Verdict",
+    "manaCost": "{1}{W}{W}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell can't be countered.\nDestroy all creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        },
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "RARE",
+        "artist": "Sam Burley",
+        "flavorText": "Leonos had no second thoughts about the abolishment edict. He'd left skyrunes warning of the eviction, even though it was cloudy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e9648f9-7a67-4717-bca1-861d1f7fed43.jpg?1783940331"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Survey the Wreckage
+{
+    "name": "Survey the Wreckage",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target land. Create a 1/1 red Goblin creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "target land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Warren Mahy",
+        "flavorText": "Goblins and architects seldom get along.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6e750f9-ad86-4d60-98a3-78d11cd52cd1.jpg?1783940353"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Swift Justice
+{
+    "name": "Swift Justice",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature gets +1/+0 and gains first strike and lifelink.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"Having conviction is more important than being righteous.\"\n—Aurelia",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a94801ba-0295-4611-abda-4c6508d69cc3.jpg?1783940373"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tenement Crasher
+{
+    "name": "Tenement Crasher",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Warren Mahy",
+        "flavorText": "Nothing was going to stop it—not the narrow alleys, not the Boros garrison, and certainly not the four-story Orzhov cathedral.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44af9170-bd99-4fde-b673-62d988312b2d.jpg?1783940353"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Thoughtflare
+{
+    "name": "Thoughtflare",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Draw four cards, then discard two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 2 cards to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "David Rapoza",
+        "flavorText": "\"If this is thinking, I don't know what I was doing before.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d90514aa-e356-4502-9e0e-76ab7644a07a.jpg?1783940331"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Towering Indrik
+{
+    "name": "Towering Indrik",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Reach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Lars Grant-West",
+        "flavorText": "It chases its airborne prey relentlessly, heedless to what it pulverizes beneath its hooves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6049e92-6c52-44be-a3c7-aa8e8bf9c10a.jpg?1783940346"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1252,4 +3405,173 @@
         "imageUri": "https://cards.scryfall.io/normal/front/9/0/90ce8115-41fe-44c2-8719-741ba87bcb17.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Treasured Find
+{
+    "name": "Treasured Find",
+    "manaCost": "{B}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target card from your graveyard to your hand. Exile Treasured Find.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Exile"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target card in your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Chan",
+        "flavorText": "Gorgons crave beautiful things: gems, exquisite amulets, the alabaster corpses of the petrified dead . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2c0e00b-2290-493f-a3fc-3b9bff2830cc.jpg?1783940330"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Trestle Troll
+{
+    "name": "Trestle Troll",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Creature — Troll",
+    "oracleText": "Defender\nReach (This creature can block creatures with flying.)\n{1}{B}{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER",
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Peter Mohrbacher",
+        "flavorText": "Unwelcome in Golgari colonies, he found his own dark place from which to represent the Swarm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d224279-83f3-4a29-9fd9-86b72407b87a.jpg?1783940330"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Vassal Soul
+{
+    "name": "Vassal Soul",
+    "manaCost": "{1}{W/U}{W/U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "For the Azorius, the opportunity to serve the law is too great an honor for death to interrupt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfc61748-029f-4bae-a7ec-e08b7059226d.jpg?1783940325"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Voidwielder
+{
+    "name": "Voidwielder",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, you may return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Chase Stone",
+        "flavorText": "\"He makes up his own laws, and that's dangerous to all who love peace and prosperity. Kill him on sight.\"\n—Mirela, Azorius hussar",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23723bc7-a68e-4810-bc87-60df916cbb8a.jpg?1783940365"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Return to Ravnica had not authored yet. The set's ⚡ Assay-ready count goes **58 → 0**.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 53 | canonical authored in RTR — it *is* the earliest real printing for all 53 |
| `basic` | 5 | `basicLand(...)` vals in `ReturnToRavnicaBasicLands.kt` (5 art variants each, #250–274) |
| `elsewhere` | 0 | — |
| `row-only` | 0 | — |
| `unscaffolded` | 0 | — |
| **reprint tail** | **3** | `Printing` rows the new canonicals owe elsewhere: C15 ×2 (Grisly Salvage, Lotleth Troll), CMR ×1 (Codex Shredder) |

RTR is the clean shape for this job: a premier set that is the first printing of nearly its whole Assay-ready list, so there was no scatter across a dozen old sets and no collision with other agents' in-flight work.

## Capability pre-flight

Every mechanic in the list traced to a live `rules-engine` consumer before authoring. The batch's whole keyword vocabulary is evergreen — defender, first strike, flash, flying, haste, hexproof, lifelink, reach, trample, vigilance — and its effect vocabulary is all shipped primitives (`DestroyAll`, `CreateToken`, `ModifyStats`, `GrantKeyword`, `GrantActivatedAbility`, `RegenerateEffect`, `CounterSpell`, `ForceSacrifice`, `TapUntap`, `Patterns.Library.mill` / `.lookAtTopAndTakeMatching`, `Patterns.Hand.discardCards`). **No new SDK vocabulary, no engine change, no doc update owed.** RTR's own new mechanics — overload, populate, detain, unleash, scavenge — put a declining word on every card that isn't here, which is why the remaining 152 are grammar work rather than authoring work.

## Authored to `assay compile`, not to the oracle text

All 53 canonicals were written against the `CardDefinition` JSON `oracle-assay compile` prints, so the two models agree by construction rather than by luck. Metadata (collector number, rarity, artist, flavour, art) comes from RTR's own Scryfall payload, not from the compile — `compile` tags whichever printing the Oracle bulk happened to carry, and it handed back CLU for Supreme Verdict, MM3 for Abrupt Decay, IMA for Azorius Charm, CMR for Codex Shredder.

## Verification

| Gate | Before | After |
|---|---|---|
| `just assay-ready RTR` | 58 Assay-ready | **0 Assay-ready** |
| `just assay-differential` | 6325 compared / 6271 confirmed / **54 divergent** | 6378 / 6324 / **54** |

The differential delta is **+53 compared, +53 confirmed, 0 new divergences** — every card in the batch round-trips. Both readings were taken with the same freshly-built binary in this checkout, so the A/B is clean.

Also run:
- `just build` — green (the one failure was `CardDefinitionSnapshotTest` on `snapshots/cards/RTR.json`; re-blessed with `just rebless-cards`, and **only** that golden moved).
- `just check-card-printing` per authored canonical — all "ok: canonical is in the card's earliest real printing and all scaffolded reprints have rows."
- `scripts/generate-reprints.py --since main` scoped to this branch's 53 canonicals, with the printing caches refreshed first so nothing was silently dropped on a stale TTL. It offered exactly the 3 predicted tail rows and nothing else.

## Nothing dropped, nothing found

No card left the batch. The sweep surfaced no parser bug and no defect in existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9L9dP5Cbgnqaq7cLpTuWM