### PR TITLE
Add four Lorwyn planeswalkers

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AjaniGoldmane.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AjaniGoldmane.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ajani Goldmane - {2}{W}{W}
+ * Legendary Planeswalker — Ajani
+ * Starting Loyalty: 4
+ *
+ * +1: You gain 2 life.
+ *
+ * −1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until
+ * end of turn.
+ *
+ * −6: Create a white Avatar creature token. It has "This token's power and toughness are each
+ * equal to your life total."
+ *
+ * The −1 fans out over the creatures you control at resolution, giving each its counter and its
+ * vigilance in one pass — the 2007-10-01 ruling says the vigilance stays until end of turn even
+ * if the counter is later removed, which the independent `GrantKeyword` floating effect honors.
+ * The Avatar's P/T is a characteristic-defining ability, not a snapshot: it is modelled as a
+ * [SetBasePowerToughnessDynamicStatic] on the token so it tracks your life total continuously
+ * (the second 2007-10-01 ruling).
+ */
+val AjaniGoldmane = card("Ajani Goldmane") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Planeswalker — Ajani"
+    startingLoyalty = 4
+    oracleText = "+1: You gain 2 life.\n" +
+        "−1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n" +
+        "−6: Create a white Avatar creature token. It has \"This token's power and toughness are each equal to your life total.\""
+
+    // +1: You gain 2 life.
+    loyaltyAbility(+1) {
+        effect = Effects.GainLife(2)
+    }
+
+    // −1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.
+    loyaltyAbility(-1) {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+            )
+        )
+    }
+
+    // −6: Create a white Avatar creature token with P/T each equal to your life total.
+    loyaltyAbility(-6) {
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Avatar"),
+            imageUri = "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg?1783942843",
+            staticAbilities = listOf(
+                SetBasePowerToughnessDynamicStatic(
+                    power = DynamicAmount.YourLifeTotal,
+                    toughness = DynamicAmount.YourLifeTotal
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg?1783942919"
+        ruling(
+            "2007-10-01",
+            "The vigilance granted to a creature by the second ability remains until the end of " +
+                "the turn even if the +1/+1 counter is removed.",
+        )
+        ruling(
+            "2007-10-01",
+            "The power and toughness of the Avatar created by the third ability will change as " +
+                "your life total changes.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GarrukWildspeaker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/GarrukWildspeaker.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Garruk Wildspeaker - {2}{G}{G}
+ * Legendary Planeswalker — Garruk
+ * Starting Loyalty: 3
+ *
+ * +1: Untap two target lands.
+ *
+ * −1: Create a 3/3 green Beast creature token.
+ *
+ * −4: Creatures you control get +3/+3 and gain trample until end of turn.
+ *
+ * The +1 needs exactly two land targets — any two lands, tapped or not (2009-10-01 ruling) — so it
+ * is a `count = 2` [TargetPermanent] fanned out through [Effects.UntapEachTarget]. The −4 is the
+ * Overrun shape: a [Effects.ForEachInGroup] over the creatures you control *at resolution*, which
+ * is exactly the set the other 2009-10-01 ruling says it affects.
+ */
+val GarrukWildspeaker = card("Garruk Wildspeaker") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Planeswalker — Garruk"
+    startingLoyalty = 3
+    oracleText = "+1: Untap two target lands.\n" +
+        "−1: Create a 3/3 green Beast creature token.\n" +
+        "−4: Creatures you control get +3/+3 and gain trample until end of turn."
+
+    // +1: Untap two target lands.
+    loyaltyAbility(+1) {
+        target("two target lands", TargetPermanent(count = 2, filter = TargetFilter.Land))
+        effect = Effects.UntapEachTarget()
+    }
+
+    // −1: Create a 3/3 green Beast creature token.
+    loyaltyAbility(-1) {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Beast"),
+            imageUri = "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg?1783942838"
+        )
+    }
+
+    // −4: Creatures you control get +3/+3 and gain trample until end of turn.
+    loyaltyAbility(-4) {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(3, 3, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "213"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg?1783942863"
+        ruling(
+            "2009-10-01",
+            "The third ability affects only creatures you control at the time it resolves. It " +
+                "won't affect creatures that come under your control later in the turn.",
+        )
+        ruling(
+            "2009-10-01",
+            "The first ability can target any two lands. They don't have to be tapped.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/JaceBeleren.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/JaceBeleren.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jace Beleren - {1}{U}{U}
+ * Legendary Planeswalker — Jace
+ * Starting Loyalty: 3
+ *
+ * +2: Each player draws a card.
+ *
+ * −1: Target player draws a card.
+ *
+ * −10: Target player mills twenty cards.
+ *
+ * The +2 is symmetric — Jace's controller draws too — so it is a draw aimed at [Player.Each], not
+ * at each opponent. The −1 and −10 both target a *player*, which is what lets the −1 be pointed
+ * at yourself and the −10 at an opponent whose library is short (they simply mill what's left,
+ * per the 2009-10-01 ruling).
+ */
+val JaceBeleren = card("Jace Beleren") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Planeswalker — Jace"
+    startingLoyalty = 3
+    oracleText = "+2: Each player draws a card.\n" +
+        "−1: Target player draws a card.\n" +
+        "−10: Target player mills twenty cards."
+
+    // +2: Each player draws a card.
+    loyaltyAbility(+2) {
+        effect = Effects.DrawCards(1, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    // −1: Target player draws a card.
+    loyaltyAbility(-1) {
+        val player = target("target player", Targets.Player)
+        effect = Effects.DrawCards(1, player)
+    }
+
+    // −10: Target player mills twenty cards.
+    loyaltyAbility(-10) {
+        val player = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(20, player)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg?1783942901"
+        ruling(
+            "2009-10-01",
+            "If there are fewer than twenty cards in the targeted player's library, that player " +
+                "puts all the cards from their library into their graveyard.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LilianaVess.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LilianaVess.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Liliana Vess - {3}{B}{B}
+ * Legendary Planeswalker — Liliana
+ * Starting Loyalty: 5
+ *
+ * +1: Target player discards a card.
+ *
+ * −2: Search your library for a card, then shuffle and put that card on top.
+ *
+ * −8: Put all creature cards from all graveyards onto the battlefield under your control.
+ *
+ * The +1 targets a *player*, who chooses what to discard. The −2 is the Vampiric Tutor shape —
+ * [SearchDestination.TOP_OF_LIBRARY] shuffles first and then places the found card on top. The
+ * −8 is the Rise of the Dark Realms gather: every graveyard ([Player.Each]) is read, and the
+ * collection moves to the battlefield under the resolving player's control.
+ */
+val LilianaVess = card("Liliana Vess") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Planeswalker — Liliana"
+    startingLoyalty = 5
+    oracleText = "+1: Target player discards a card.\n" +
+        "−2: Search your library for a card, then shuffle and put that card on top.\n" +
+        "−8: Put all creature cards from all graveyards onto the battlefield under your control."
+
+    // +1: Target player discards a card.
+    loyaltyAbility(+1) {
+        val player = target("target player", Targets.Player)
+        effect = Effects.Discard(1, player)
+    }
+
+    // −2: Search your library for a card, then shuffle and put that card on top.
+    loyaltyAbility(-2) {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Any,
+            destination = SearchDestination.TOP_OF_LIBRARY
+        )
+    }
+
+    // −8: Put all creature cards from all graveyards onto the battlefield under your control.
+    loyaltyAbility(-8) {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.Each,
+                    filter = GameObjectFilter.Creature
+                ),
+                storeAs = "creatureCardsInAllGraveyards"
+            ),
+            MoveCollectionEffect(
+                from = "creatureCardsInAllGraveyards",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg?1783942888"
+        ruling(
+            "2009-10-01",
+            "A \"creature card\" is any card with the type creature, even if it has other types " +
+                "such as artifact, enchantment, or land. Older cards of type summon are also " +
+                "creature cards.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AjaniGoldmaneScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AjaniGoldmaneScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AjaniGoldmane
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ajani Goldmane {2}{W}{W} — Legendary Planeswalker — Ajani (loyalty 4)
+ *   +1: You gain 2 life.
+ *   −1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until
+ *       end of turn.
+ *   −6: Create a white Avatar creature token. It has "This token's power and toughness are each
+ *       equal to your life total."
+ *
+ * The −1 is aimed at the *opponent's* creature as well, which is the shape where a "you control"
+ * filter dropped by mistake would show. The Avatar's P/T is a CDA, so the test moves the life
+ * total *after* the token exists and checks the token followed it — a snapshot would not.
+ */
+class AjaniGoldmaneScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AjaniGoldmane))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun putAjani(driver: GameTestDriver, playerId: EntityId, loyalty: Int): EntityId {
+        val ajani = driver.putPermanentOnBattlefield(playerId, "Ajani Goldmane")
+        driver.addComponent(ajani, CountersComponent(mapOf(CounterType.LOYALTY to loyalty)))
+        return ajani
+    }
+
+    fun loyalty(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    fun plusCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    val abilities = AjaniGoldmane.script.activatedAbilities
+
+    test("+1 gains 2 life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val ajani = putAjani(driver, me, 4)
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = ajani, abilityId = abilities[0].id))
+        driver.bothPass()
+
+        driver.getLifeTotal(me) shouldBe 22
+        loyalty(driver, ajani) shouldBe 5
+    }
+
+    test("−1 puts a +1/+1 counter on each creature you control and grants them vigilance — not the opponent's") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val ajani = putAjani(driver, me, 4)
+        val mine1 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val mine2 = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val theirs = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = ajani, abilityId = abilities[1].id))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        withClue("both of my creatures got a counter") {
+            plusCounters(driver, mine1) shouldBe 1
+            plusCounters(driver, mine2) shouldBe 1
+        }
+        withClue("and vigilance") {
+            projected.hasKeyword(mine1, Keyword.VIGILANCE) shouldBe true
+            projected.hasKeyword(mine2, Keyword.VIGILANCE) shouldBe true
+        }
+        withClue("the opponent's creature is untouched") {
+            plusCounters(driver, theirs) shouldBe 0
+            projected.hasKeyword(theirs, Keyword.VIGILANCE) shouldBe false
+        }
+        loyalty(driver, ajani) shouldBe 3
+    }
+
+    test("−6 creates a white Avatar whose power and toughness track your life total") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val ajani = putAjani(driver, me, 6)
+        driver.setLifeTotal(me, 13)
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = ajani, abilityId = abilities[2].id))
+        driver.bothPass()
+
+        val avatars = driver.getCreatures(me).filter { driver.getCardName(it)?.contains("Avatar") == true }
+        avatars.size shouldBe 1
+        val avatar = avatars.single()
+        withClue("the Avatar reads the life total at creation") {
+            driver.state.projectedState.getPower(avatar) shouldBe 13
+            driver.state.projectedState.getToughness(avatar) shouldBe 13
+        }
+
+        driver.setLifeTotal(me, 5)
+        withClue("it is a CDA, so it follows the life total afterwards") {
+            driver.state.projectedState.getPower(avatar) shouldBe 5
+            driver.state.projectedState.getToughness(avatar) shouldBe 5
+        }
+        loyalty(driver, ajani) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GarrukWildspeakerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GarrukWildspeakerScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.GarrukWildspeaker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Garruk Wildspeaker {2}{G}{G} — Legendary Planeswalker — Garruk (loyalty 3)
+ *   +1: Untap two target lands.
+ *   −1: Create a 3/3 green Beast creature token.
+ *   −4: Creatures you control get +3/+3 and gain trample until end of turn.
+ *
+ * The +1 untaps two tapped lands and leaves a third tapped, so a "untap all lands" slip would
+ * show. The −4 is aimed at an opponent's creature too, the one shape where a dropped "you
+ * control" disagrees with the card.
+ */
+class GarrukWildspeakerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GarrukWildspeaker))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun putGarruk(driver: GameTestDriver, playerId: EntityId, loyalty: Int): EntityId {
+        val garruk = driver.putPermanentOnBattlefield(playerId, "Garruk Wildspeaker")
+        driver.addComponent(garruk, CountersComponent(mapOf(CounterType.LOYALTY to loyalty)))
+        return garruk
+    }
+
+    fun loyalty(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    val abilities = GarrukWildspeaker.script.activatedAbilities
+
+    test("+1 untaps the two targeted lands and no other") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val garruk = putGarruk(driver, me, 3)
+        val forest1 = driver.putLandOnBattlefield(me, "Forest")
+        val forest2 = driver.putLandOnBattlefield(me, "Forest")
+        val forest3 = driver.putLandOnBattlefield(me, "Forest")
+        listOf(forest1, forest2, forest3).forEach { driver.tapPermanent(it) }
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = garruk,
+                abilityId = abilities[0].id,
+                targets = listOf(ChosenTarget.Permanent(forest1), ChosenTarget.Permanent(forest2))
+            )
+        )
+        driver.bothPass()
+
+        withClue("the two targets untapped") {
+            driver.isTapped(forest1) shouldBe false
+            driver.isTapped(forest2) shouldBe false
+        }
+        withClue("the third land is still tapped") { driver.isTapped(forest3) shouldBe true }
+        loyalty(driver, garruk) shouldBe 4
+    }
+
+    test("−1 creates a 3/3 green Beast token") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val garruk = putGarruk(driver, me, 3)
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = garruk, abilityId = abilities[1].id))
+        driver.bothPass()
+
+        val beasts = driver.getCreatures(me).filter { driver.getCardName(it)?.contains("Beast") == true }
+        beasts.size shouldBe 1
+        val beast = beasts.single()
+        val projected = driver.state.projectedState
+        projected.getPower(beast) shouldBe 3
+        projected.getToughness(beast) shouldBe 3
+        projected.getColors(beast) shouldBe setOf(Color.GREEN.name)
+        loyalty(driver, garruk) shouldBe 2
+    }
+
+    test("−4 gives creatures you control +3/+3 and trample until end of turn — not the opponent's") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val garruk = putGarruk(driver, me, 4)
+        val mine = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val theirs = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = garruk, abilityId = abilities[2].id))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        withClue("my creature is pumped and tramples") {
+            projected.getPower(mine) shouldBe 5
+            projected.getToughness(mine) shouldBe 5
+            projected.hasKeyword(mine, Keyword.TRAMPLE) shouldBe true
+        }
+        withClue("the opponent's creature is untouched") {
+            projected.getPower(theirs) shouldBe 2
+            projected.hasKeyword(theirs, Keyword.TRAMPLE) shouldBe false
+        }
+        loyalty(driver, garruk) shouldBe 0
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        withClue("the pump wore off at end of turn") {
+            driver.state.projectedState.getPower(mine) shouldBe 2
+            driver.state.projectedState.hasKeyword(mine, Keyword.TRAMPLE) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JaceBelerenScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JaceBelerenScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.JaceBeleren
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.ZoneKey
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Jace Beleren {1}{U}{U} — Legendary Planeswalker — Jace (loyalty 3)
+ *   +2: Each player draws a card.
+ *   −1: Target player draws a card.
+ *   −10: Target player mills twenty cards.
+ *
+ * The +2 is symmetric, so the test checks *both* hands grew — an "each opponent" slip would leave
+ * Jace's controller unchanged. The −1 is aimed at the opponent, the one shape where a defaulted
+ * "you draw" disagrees with the card.
+ */
+class JaceBelerenScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JaceBeleren))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun putJace(driver: GameTestDriver, playerId: EntityId, loyalty: Int): EntityId {
+        val jace = driver.putPermanentOnBattlefield(playerId, "Jace Beleren")
+        driver.addComponent(jace, CountersComponent(mapOf(CounterType.LOYALTY to loyalty)))
+        return jace
+    }
+
+    fun loyalty(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    fun librarySize(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size
+
+    val abilities = JaceBeleren.script.activatedAbilities
+
+    test("+2 has each player draw a card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val jace = putJace(driver, me, 3)
+        val myHand = driver.getHandSize(me)
+        val theirHand = driver.getHandSize(opp)
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = jace, abilityId = abilities[0].id))
+        driver.bothPass()
+
+        withClue("Jace's controller drew too") { driver.getHandSize(me) shouldBe myHand + 1 }
+        withClue("and so did the opponent") { driver.getHandSize(opp) shouldBe theirHand + 1 }
+        loyalty(driver, jace) shouldBe 5
+    }
+
+    test("−1 has only the targeted player draw") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val jace = putJace(driver, me, 3)
+        val myHand = driver.getHandSize(me)
+        val theirHand = driver.getHandSize(opp)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = jace,
+                abilityId = abilities[1].id,
+                targets = listOf(ChosenTarget.Player(opp))
+            )
+        )
+        driver.bothPass()
+
+        withClue("the targeted opponent drew") { driver.getHandSize(opp) shouldBe theirHand + 1 }
+        withClue("Jace's controller did not") { driver.getHandSize(me) shouldBe myHand }
+        loyalty(driver, jace) shouldBe 2
+    }
+
+    test("−10 mills the targeted player twenty cards") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val jace = putJace(driver, me, 10)
+        val theirLibrary = librarySize(driver, opp)
+        val theirGraveyard = driver.getGraveyard(opp).size
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = jace,
+                abilityId = abilities[2].id,
+                targets = listOf(ChosenTarget.Player(opp))
+            )
+        )
+        driver.bothPass()
+
+        librarySize(driver, opp) shouldBe theirLibrary - 20
+        driver.getGraveyard(opp).size shouldBe theirGraveyard + 20
+        loyalty(driver, jace) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LilianaVessScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LilianaVessScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.LilianaVess
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.ZoneKey
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Liliana Vess {3}{B}{B} — Legendary Planeswalker — Liliana (loyalty 5)
+ *   +1: Target player discards a card.
+ *   −2: Search your library for a card, then shuffle and put that card on top.
+ *   −8: Put all creature cards from all graveyards onto the battlefield under your control.
+ *
+ * The +1 is aimed at the opponent, who picks the card. The −2 plants a lone non-land in a
+ * library of Swamps and checks it ends up on *top* after the shuffle. The −8 seeds both
+ * graveyards with a creature and a non-creature each; the creatures — including the opponent's —
+ * must come back under Liliana's controller, and the instants must stay put.
+ */
+class LilianaVessScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LilianaVess))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun putLiliana(driver: GameTestDriver, playerId: EntityId, loyalty: Int): EntityId {
+        val liliana = driver.putPermanentOnBattlefield(playerId, "Liliana Vess")
+        driver.addComponent(liliana, CountersComponent(mapOf(CounterType.LOYALTY to loyalty)))
+        return liliana
+    }
+
+    fun loyalty(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    val abilities = LilianaVess.script.activatedAbilities
+
+    test("+1 makes the targeted opponent discard a card of their choice") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val liliana = putLiliana(driver, me, 5)
+        val myHand = driver.getHandSize(me)
+        val theirHand = driver.getHandSize(opp)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = liliana,
+                abilityId = abilities[0].id,
+                targets = listOf(ChosenTarget.Player(opp))
+            )
+        )
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        if (decision is SelectCardsDecision) {
+            withClue("the discarding player chooses") { decision.playerId shouldBe opp }
+            driver.submitDecision(opp, CardsSelectedResponse(decision.id, listOf(decision.options.first())))
+        }
+
+        withClue("the opponent discarded") { driver.getHandSize(opp) shouldBe theirHand - 1 }
+        withClue("Liliana's controller did not") { driver.getHandSize(me) shouldBe myHand }
+        driver.getGraveyard(opp).size shouldBe 1
+        loyalty(driver, liliana) shouldBe 6
+    }
+
+    test("−2 finds a card and puts it on top of the library after shuffling") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val liliana = putLiliana(driver, me, 5)
+        val bears = driver.putCardOnTopOfLibrary(me, "Grizzly Bears")
+        // Bury it: a handful of Swamps above it so "on top" is not where it already was.
+        repeat(5) { driver.putCardOnTopOfLibrary(me, "Swamp") }
+        val librarySize = driver.state.getZone(ZoneKey(me, Zone.LIBRARY)).size
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = liliana, abilityId = abilities[1].id))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        withClue("any card may be chosen") { decision.options.size shouldBe librarySize }
+        driver.submitDecision(me, CardsSelectedResponse(decision.id, listOf(bears)))
+
+        val library = driver.state.getZone(ZoneKey(me, Zone.LIBRARY))
+        withClue("the found card is on top") { library.first() shouldBe bears }
+        withClue("nothing left the library") { library.size shouldBe librarySize }
+        loyalty(driver, liliana) shouldBe 3
+    }
+
+    test("−8 puts every creature card from every graveyard onto the battlefield under your control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val liliana = putLiliana(driver, me, 8)
+        val myBears = driver.putCardInGraveyard(me, "Grizzly Bears")
+        val myBolt = driver.putCardInGraveyard(me, "Lightning Bolt")
+        val theirCourser = driver.putCardInGraveyard(opp, "Centaur Courser")
+        val theirBolt = driver.putCardInGraveyard(opp, "Lightning Bolt")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = liliana, abilityId = abilities[2].id))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        withClue("both creatures are on the battlefield under Liliana's controller") {
+            driver.getCreatures(me).toSet() shouldBe setOf(myBears, theirCourser)
+            projected.getController(theirCourser) shouldBe me
+            driver.getCreatures(opp) shouldBe emptyList()
+        }
+        withClue("the non-creature cards stayed in their graveyards") {
+            driver.getGraveyard(me) shouldContain myBolt
+            driver.getGraveyard(opp) shouldBe listOf(theirBolt)
+        }
+        withClue("Liliana went to 0 loyalty and was put into the graveyard by state-based actions") {
+            driver.getGraveyard(me) shouldContain liliana
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GarrukWildspeakerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/GarrukWildspeakerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Garruk Wildspeaker reprint in Commander (CMD). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val GarrukWildspeakerReprint = Printing(
+    oracleId = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9",
+    name = "Garruk Wildspeaker",
+    setCode = "CMD",
+    collectorNumber = "157",
+    scryfallId = "08cf7ee6-ba30-42cd-a5b3-fd2fe7252f11",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/08cf7ee6-ba30-42cd-a5b3-fd2fe7252f11.jpg?1783941195",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/AjaniGoldmaneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/AjaniGoldmaneReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ajani Goldmane reprint in Magic 2010 (M10). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val AjaniGoldmaneReprint = Printing(
+    oracleId = "dfb5f660-fd8b-4b7b-934c-6a71cd182f15",
+    name = "Ajani Goldmane",
+    setCode = "M10",
+    collectorNumber = "1",
+    scryfallId = "46c50891-af21-4427-a495-0e66aef54809",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46c50891-af21-4427-a495-0e66aef54809.jpg?1783942405",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/GarrukWildspeakerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/GarrukWildspeakerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Garruk Wildspeaker reprint in Magic 2010 (M10). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val GarrukWildspeakerReprint = Printing(
+    oracleId = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9",
+    name = "Garruk Wildspeaker",
+    setCode = "M10",
+    collectorNumber = "183",
+    scryfallId = "799315b8-19ab-474e-bbe2-f928d4969daf",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/799315b8-19ab-474e-bbe2-f928d4969daf.jpg?1783942363",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/JaceBelerenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/JaceBelerenReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jace Beleren reprint in Magic 2010 (M10). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val JaceBelerenReprint = Printing(
+    oracleId = "cc2b6e58-2d6f-495e-95f3-9496105c4cba",
+    name = "Jace Beleren",
+    setCode = "M10",
+    collectorNumber = "58",
+    scryfallId = "a771996a-0097-4fe5-a9c0-22a047f9cf2e",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a771996a-0097-4fe5-a9c0-22a047f9cf2e.jpg?1783942391",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/LilianaVessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/LilianaVessReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liliana Vess reprint in Magic 2010 (M10). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val LilianaVessReprint = Printing(
+    oracleId = "a6c05941-2cfb-4dac-a7c0-ab808187eb7c",
+    name = "Liliana Vess",
+    setCode = "M10",
+    collectorNumber = "102",
+    scryfallId = "d6045789-a75b-4b7f-acde-0fdf7f3f262c",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6045789-a75b-4b7f-acde-0fdf7f3f262c.jpg?1783942382",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AjaniGoldmaneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AjaniGoldmaneReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ajani Goldmane reprint in Magic 2011 (M11). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val AjaniGoldmaneReprint = Printing(
+    oracleId = "dfb5f660-fd8b-4b7b-934c-6a71cd182f15",
+    name = "Ajani Goldmane",
+    setCode = "M11",
+    collectorNumber = "1",
+    scryfallId = "2d911053-a026-4b20-ba2d-dbcc367c1413",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg?1783941838",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GarrukWildspeakerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GarrukWildspeakerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Garruk Wildspeaker reprint in Magic 2011 (M11). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val GarrukWildspeakerReprint = Printing(
+    oracleId = "186b4def-4fff-4a2b-bcbf-5318b0ac5fa9",
+    name = "Garruk Wildspeaker",
+    setCode = "M11",
+    collectorNumber = "175",
+    scryfallId = "0135ada3-e5ae-4382-a717-872839bf1d5a",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/0135ada3-e5ae-4382-a717-872839bf1d5a.jpg?1783941798",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/JaceBelerenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/JaceBelerenReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jace Beleren reprint in Magic 2011 (M11). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val JaceBelerenReprint = Printing(
+    oracleId = "cc2b6e58-2d6f-495e-95f3-9496105c4cba",
+    name = "Jace Beleren",
+    setCode = "M11",
+    collectorNumber = "58",
+    scryfallId = "441af393-2f70-4765-ae95-730c1e1d864f",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/441af393-2f70-4765-ae95-730c1e1d864f.jpg?1783941824",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/LilianaVessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/LilianaVessReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liliana Vess reprint in Magic 2011 (M11). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val LilianaVessReprint = Printing(
+    oracleId = "a6c05941-2cfb-4dac-a7c0-ab808187eb7c",
+    name = "Liliana Vess",
+    setCode = "M11",
+    collectorNumber = "102",
+    scryfallId = "8a15e31c-b208-4a52-b450-c058a75da9f7",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a15e31c-b208-4a52-b450-c058a75da9f7.jpg?1783941814",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/LilianaVessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/LilianaVessReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liliana Vess reprint in Magic 2015 (M15). The canonical CardDefinition lives in
+ * Lorwyn (`lrw`), the card's earliest real printing; this file contributes only
+ * per-printing presentation data.
+ */
+val LilianaVessReprint = Printing(
+    oracleId = "a6c05941-2cfb-4dac-a7c0-ab808187eb7c",
+    name = "Liliana Vess",
+    setCode = "M15",
+    collectorNumber = "103",
+    scryfallId = "6087f146-f468-472a-b248-fc7386ea3e63",
+    artist = "Aleksi Briclot",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg?1783939183",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -54,6 +54,116 @@
     ]
 }
 
+// Ajani Goldmane
+{
+    "name": "Ajani Goldmane",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Planeswalker — Ajani",
+    "oracleText": "+1: You gain 2 life.\n−1: Put a +1/+1 counter on each creature you control. Those creatures gain vigilance until end of turn.\n−6: Create a white Avatar creature token. It has \"This token's power and toughness are each equal to your life total.\"",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -1
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -6
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Avatar"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/6/f669cb99-be79-413b-8266-1dfd6a15cb41.jpg?1783942843",
+                    "staticAbilities": [
+                        {
+                            "type": "SetBasePowerToughnessDynamicStatic",
+                            "power": "YourLifeTotal",
+                            "toughness": "YourLifeTotal"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a1470a6-d09d-4a2a-84a6-d56e32ed237a.jpg?1783942919",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The vigilance granted to a creature by the second ability remains until the end of the turn even if the +1/+1 counter is removed."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The power and toughness of the Avatar created by the third ability will change as your life total changes."
+            }
+        ]
+    },
+    "startingLoyalty": 4,
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Amoeboid Changeling
 {
     "name": "Amoeboid Changeling",
@@ -3899,6 +4009,130 @@
     ]
 }
 
+// Garruk Wildspeaker
+{
+    "name": "Garruk Wildspeaker",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Planeswalker — Garruk",
+    "oracleText": "+1: Untap two target lands.\n−1: Create a 3/3 green Beast creature token.\n−4: Creatures you control get +3/+3 and gain trample until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "two target lands"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -1
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Beast"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3cbd01b-dbf5-424a-855d-f9a9d7e7e414.jpg?1783942838"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -4
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca6f13a2-9243-4ce9-9f71-bed74355b781.jpg?1783942863",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "The third ability affects only creatures you control at the time it resolves. It won't affect creatures that come under your control later in the turn."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "The first ability can target any two lands. They don't have to be tapped."
+            }
+        ]
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Ghostly Changeling
 {
     "name": "Ghostly Changeling",
@@ -6127,6 +6361,128 @@
     ]
 }
 
+// Jace Beleren
+{
+    "name": "Jace Beleren",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Planeswalker — Jace",
+    "oracleText": "+2: Each player draws a card.\n−1: Target player draws a card.\n−10: Target player mills twenty cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 2
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -1
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -10
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 20
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdffb058-1af0-41bb-956a-ae10e092c389.jpg?1783942901",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "If there are fewer than twenty cards in the targeted player's library, that player puts all the cards from their library into their graveyard."
+            }
+        ]
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Jagged-Scar Archers
 {
     "name": "Jagged-Scar Archers",
@@ -6839,6 +7195,170 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Liliana Vess
+{
+    "name": "Liliana Vess",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Planeswalker — Liliana",
+    "oracleText": "+1: Target player discards a card.\n−2: Search your library for a card, then shuffle and put that card on top.\n−8: Put all creature cards from all graveyards onto the battlefield under your control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        "ShuffleLibrary",
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            }
+                        },
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -8
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each",
+                                "filter": "creature"
+                            },
+                            "storeAs": "creatureCardsInAllGraveyards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "creatureCardsInAllGraveyards",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/1662fcb1-f142-43ff-b682-6827dea2ff7e.jpg?1783942888",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "A \"creature card\" is any card with the type creature, even if it has other types such as artifact, enchantment, or land. Older cards of type summon are also creature cards."
+            }
+        ]
+    },
+    "startingLoyalty": 5,
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Four of the original five Lorwyn planeswalkers, all pure composition over existing primitives. Chandra Nalaar was left out: her −X loyalty ability has no SDK spelling (`AbilityCost.Loyalty` takes an `Int`), so she is `add-feature` territory.

- **Ajani Goldmane** — `+1` GainLife; `−1` ForEachInGroup over creatures you control (AddCounters + GrantKeyword VIGILANCE); `−6` CreateToken with a `SetBasePowerToughnessDynamicStatic(YourLifeTotal)` so the Avatar's P/T is a real CDA that follows your life total, not a snapshot. Printing rows in M10, M11.
- **Jace Beleren** — `+2` DrawCards for `Player.Each`; `−1` DrawCards at a target player; `−10` `Patterns.Library.mill(20)` at a target player. Printing rows in M10, M11.
- **Liliana Vess** — `+1` Discard at a target player; `−2` the Vampiric Tutor `searchLibrary(TOP_OF_LIBRARY)`; `−8` the Rise of the Dark Realms gather over `Player.Each` graveyards moved to the battlefield. Printing rows in M10, M11, M15.
- **Garruk Wildspeaker** — `+1` `TargetPermanent(count = 2, Land)` + UntapEachTarget; `−1` 3/3 Beast token; `−4` the Overrun ForEachInGroup (ModifyStats + TRAMPLE). Printing rows in M10, M11, CMD.

Each card has its own scenario test (12 tests total). The tests aim the "you control" abilities at an opponent's creature too, check the CDA Avatar follows a later life-total change, and assert the −2 tutor lands on *top* after the shuffle.

Verification: `just build` green, `just rebless-cards` moved only the four new LRW entries, `just check-card-printing` ok for all four, `just assay-differential --set LRW` shows no new divergences (the 10 listed are the pre-existing Harbinger-cycle rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vMQoG8Q3SfJQyEv2XnJgq