### PR TITLE
Add five Ravnica: City of Guilds cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CloudstoneCurio.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CloudstoneCurio.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Cloudstone Curio — Ravnica: City of Guilds #257
+ * {3} · Artifact · Rare
+ *
+ * Whenever a nonartifact permanent you control enters, you may return another permanent you
+ * control that shares a permanent type with it to its owner's hand.
+ *
+ * The bounce is a non-targeted choice made on resolution, so it is a battlefield pipeline: gather
+ * every permanent you control that `sharingCardTypeWith(EntityReference.Triggering)` — both sides
+ * read projected types, so an animated land that enters can bounce a creature — with
+ * `excludeTriggering` carrying the printed "another", then `chooseUpTo(1)` is the "you may"
+ * (zero picks is the decline) and the move routes the card to its *owner's* hand, as printed.
+ * `useTargetingUI` puts the pick on the battlefield rather than in an overlay.
+ *
+ * "Permanent type" is spelled with the card-type predicate. The two differ only for Kindred,
+ * which the Comprehensive Rules list as a card type but not as a permanent type; the Curio would let a
+ * Kindred creature bounce a Kindred enchantment where the printed card would not. Nothing in the
+ * SDK narrows a card-type comparison to permanent types yet, and the case is rare enough that
+ * the card ships with the wider reading rather than waiting on it.
+ *
+ * The Curio never triggers on itself (it is an artifact) and `TriggerBinding.ANY` is what lets
+ * it see the *other* permanents entering; a token entering under your control counts too.
+ */
+val CloudstoneCurio = card("Cloudstone Curio") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a nonartifact permanent you control enters, you may return another " +
+        "permanent you control that shares a permanent type with it to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.nonartifact().youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Pipeline {
+            val candidates = gather(
+                filter = GameObjectFilter.Permanent.sharingCardTypeWith(EntityReference.Triggering),
+                player = Player.You,
+                excludeTriggering = true,
+                name = "candidates",
+            )
+            val returned = chooseUpTo(
+                1,
+                candidates,
+                prompt = "You may return another permanent you control that shares a permanent " +
+                    "type with the one that entered to its owner's hand",
+                useTargetingUI = true,
+                name = "returned",
+            )
+            toHand(returned)
+        }
+        description = "Whenever a nonartifact permanent you control enters, you may return " +
+            "another permanent you control that shares a permanent type with it to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Heather Hudson"
+        flavorText = "It *wants* to remain a mystery, banishing the curious in favor of less " +
+            "inquisitive company."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg?1783943601"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Gleancrawler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Gleancrawler.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Gleancrawler — Ravnica: City of Guilds #247
+ * {3}{B/G}{B/G}{B/G} · Creature — Insect Horror · 6/6 · Rare
+ *
+ * Trample
+ * At the beginning of your end step, return to your hand all creature cards in your graveyard
+ * that were put there from the battlefield this turn.
+ *
+ * One Gather → Move pipeline over your own graveyard, the Second Sunrise shape narrowed to
+ * creature cards. `putIntoGraveyardFromBattlefieldThisTurn()` is the whole clause: it reads the
+ * per-card marker `ZoneTransitionService` stamps on every graveyard arrival from the battlefield
+ * and wipes at the untap step, so a creature milled this turn or one that died last turn stays
+ * put, and one that died before Gleancrawler arrived still comes back (the 2005 ruling).
+ *
+ * The move sends each card to its owner's hand: the zone transition routes non-battlefield
+ * destinations to the card's owner, so a stolen creature that died under your control goes home
+ * even though it sat in *your* graveyard — CR 400.3 puts it there, and "return to your hand" for
+ * an opponent's card is impossible, so the engine's owner routing is the correct reading.
+ */
+val Gleancrawler = card("Gleancrawler") {
+    manaCost = "{3}{B/G}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Insect Horror"
+    power = 6
+    toughness = 6
+    oracleText = "({B/G} can be paid with either {B} or {G}.)\n" +
+        "Trample\n" +
+        "At the beginning of your end step, return to your hand all creature cards in your " +
+        "graveyard that were put there from the battlefield this turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Pipeline {
+            val fallen = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature.putIntoGraveyardFromBattlefieldThisTurn(),
+                ),
+                name = "fallen",
+            )
+            toHand(fallen)
+        }
+        description = "At the beginning of your end step, return to your hand all creature cards " +
+            "in your graveyard that were put there from the battlefield this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Dave Allsop"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg?1783943604"
+        ruling(
+            "2005-10-01",
+            "When this ability resolves, it returns all creature cards currently in your graveyard " +
+                "that were put there directly from the battlefield sometime during the turn. This " +
+                "includes cards that were put into your graveyard before Gleancrawler entered the " +
+                "battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MoonlightBargain.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/MoonlightBargain.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Moonlight Bargain — Ravnica: City of Guilds #95
+ * {3}{B}{B} · Instant · Rare
+ *
+ * Look at the top five cards of your library. For each card, put that card into your graveyard
+ * unless you pay 2 life. Then put the rest into your hand.
+ *
+ * The look is a top-of-library gather (a private look, so the five are revealed to you and the
+ * client can show each one as it comes up), and "for each card … unless you pay 2 life" is one
+ * [OptionalCostEffect] per card inside a [ForEachInCollectionEffect]: `PayLifeEffect(2)` is the
+ * cost, so a player at 1 life cannot pay (CR 119.4) and the card goes to the graveyard; the
+ * prompt carries the card being decided as its subject. Each payment is its own decision, made
+ * in library order — five separate "pay 2 life?" questions, exactly as the card is played.
+ *
+ * "Then put the rest into your hand" is folded into the pay branch: a card you paid for goes to
+ * your hand as its own decision resolves rather than after the fifth. Nothing can observe the
+ * difference — the cards never leave your library except into your own hand or graveyard, and
+ * nothing triggers on a card entering a hand — while a trailing "move the rest" step would have
+ * to re-find the cards still in the library, which the collection cannot do once some of it has
+ * moved. The `fromZone` gate on both moves keeps a card that somehow left the library mid-loop
+ * from being dragged along.
+ */
+val MoonlightBargain = card("Moonlight Bargain") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Look at the top five cards of your library. For each card, put that card into " +
+        "your graveyard unless you pay 2 life. Then put the rest into your hand."
+
+    spell {
+        effect = Effects.Pipeline {
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(5)), name = "looked")
+            run(
+                ForEachInCollectionEffect(
+                    collection = looked.key,
+                    effect = OptionalCostEffect(
+                        cost = PayLifeEffect(2),
+                        ifPaid = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.LIBRARY),
+                        ifNotPaid = Effects.Move(EffectTarget.Self, Zone.GRAVEYARD, fromZone = Zone.LIBRARY),
+                        descriptionOverride = "Pay 2 life to put this card into your hand? " +
+                            "If you don't, it goes to your graveyard.",
+                    ),
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "95"
+        artist = "Nick Percival"
+        flavorText = "At every fifth full moon, the Moon Market convenes to peddle Ravnica's most " +
+            "forbidden wares."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg?1783943667"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NullstoneGargoyle.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/NullstoneGargoyle.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nullstone Gargoyle — Ravnica: City of Guilds #266
+ * {9} · Artifact Creature — Gargoyle · 4/5 · Rare
+ *
+ * Flying
+ * Whenever the first noncreature spell of a turn is cast, counter that spell.
+ *
+ * "The first noncreature spell **of a turn**" is a per-turn count across every player, which is
+ * why this is not `Triggers.NthSpellCast(1, …)`: that event counts the *caster's* own history, so
+ * the second player's first noncreature spell of the turn would also trigger it. Instead the
+ * trigger is the plain "a player casts a noncreature spell" event with a `triggerRestriction`
+ * that reads the whole table's cast history — `SpellsCastThisTurn(Player.Each, Noncreature)`
+ * sums every player's records, and the triggering spell is already recorded when the event is
+ * examined, so "equals 1" is exactly "this is the turn's first".
+ *
+ * The count is a `triggerRestriction`, not an intervening-"if": it qualifies the *event* (CR
+ * 603.2) and is never re-checked on resolution, so a second noncreature spell cast in response
+ * neither rescues the first nor gets countered itself — both 2005 rulings. And because the
+ * history counts casts rather than resolutions, a noncreature spell cast before the Gargoyle
+ * arrived still closes the window for the turn.
+ */
+val NullstoneGargoyle = card("Nullstone Gargoyle") {
+    manaCost = "{9}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\nWhenever the first noncreature spell of a turn is cast, counter that spell."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Noncreature)
+        triggerRestriction = Conditions.CompareAmounts(
+            DynamicAmount.SpellsCastThisTurn(player = Player.Each, filter = GameObjectFilter.Noncreature),
+            ComparisonOperator.EQ,
+            DynamicAmount.Fixed(1),
+        )
+        effect = Effects.CounterTriggeringSpell()
+        description = "Whenever the first noncreature spell of a turn is cast, counter that spell."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "266"
+        artist = "Glenn Fabry"
+        flavorText = "Nullstone absorbs and dampens most forms of magical energy, as well as light, " +
+            "sound, and heat."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg?1783943597"
+        ruling(
+            "2005-10-01",
+            "Nullstone Gargoyle cares about the first noncreature spell cast during a turn, not the " +
+                "first one it \"sees.\" If a noncreature spell was cast before Nullstone Gargoyle " +
+                "entered the battlefield, it won't counter the next one."
+        )
+        ruling(
+            "2005-10-01",
+            "If another spell is cast in response to the first spell, Nullstone Gargoyle doesn't " +
+                "affect that second spell."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Reroute.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Reroute.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Reroute — Ravnica: City of Guilds #139
+ * {1}{R} · Instant · Uncommon
+ *
+ * Change the target of target activated ability with a single target. (Mana abilities can't be
+ * targeted.)
+ * Draw a card.
+ *
+ * The Willbender / Bolt Bend redirect narrowed to activated abilities: `TargetFilter.
+ * ActivatedAbilityOnStack` admits only activated abilities (a mana ability never uses the stack,
+ * so the reminder text is free), and [Effects.ChangeTarget] asks the caster for a new target
+ * drawn from the ability's *own* requirement — the redirect can never make an illegal choice
+ * legal. The draw follows unconditionally, as printed: an ability with no other legal target is
+ * left alone and you still draw.
+ *
+ * "With a single target" is enforced where the shared redirect shape enforces it — at
+ * resolution, where an ability carrying two targets is left untouched — rather than as a
+ * targeting restriction; the same reading Willbender and Bolt Bend already ship with.
+ */
+val Reroute = card("Reroute") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Change the target of target activated ability with a single target. (Mana " +
+        "abilities can't be targeted.)\nDraw a card."
+
+    spell {
+        target(
+            "activated ability with a single target",
+            TargetObject(filter = TargetFilter.ActivatedAbilityOnStack)
+        )
+        effect = Effects.ChangeTarget().then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Christopher Rush"
+        flavorText = "Three hundred years of practice thwarted by an instant of mischief."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg?1783943648"
+        ruling(
+            "2016-06-08",
+            "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" " +
+                "Some keywords are activated abilities and will have colons in their reminder text."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudstoneCurioScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudstoneCurioScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.CloudstoneCurio
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Cloudstone Curio — {3} Artifact (Ravnica: City of Guilds #257)
+ *
+ * "Whenever a nonartifact permanent you control enters, you may return another permanent you
+ *  control that shares a permanent type with it to its owner's hand."
+ *
+ * The bounce is a battlefield pick over `sharingCardTypeWith(Triggering)` with the entering
+ * permanent excluded, so the cases are: a creature entering offers the other creature and not
+ * the enchantment; the entering creature itself is never on offer; "you may" is declinable; and
+ * an enchantment entering with only creatures around asks nothing at all.
+ */
+class CloudstoneCurioScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + CloudstoneCurio)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(d.player1, "Cloudstone Curio")
+        return d
+    }
+
+    fun GameTestDriver.castCourser(): com.wingedsheep.sdk.model.EntityId {
+        val courser = putCardInHand(player1, "Centaur Courser")
+        giveMana(player1, Color.GREEN, 1)
+        giveColorlessMana(player1, 2)
+        castSpell(player1, courser).error shouldBe null
+        bothPass() // the creature spell resolves; the Curio trigger goes on the stack
+        bothPass() // the trigger resolves and asks
+        return courser
+    }
+
+    test("a creature entering may bounce another creature you control, never the enchantment or itself") {
+        val d = driver()
+        val lions = d.putCreatureOnBattlefield(d.player1, "Savannah Lions")
+        val enchantment = d.putPermanentOnBattlefield(d.player1, "Test Enchantment")
+        val courser = d.castCourser()
+
+        withClue("the Curio asks which permanent to return") {
+            d.state.pendingDecision shouldNotBe null
+        }
+        withClue("the enchantment shares no permanent type with a creature") {
+            d.submitCardSelection(d.player1, listOf(enchantment)).error shouldNotBe null
+        }
+        withClue("the entering creature is not 'another' permanent") {
+            d.submitCardSelection(d.player1, listOf(courser)).error shouldNotBe null
+        }
+
+        d.submitCardSelection(d.player1, listOf(lions)).error shouldBe null
+        withClue("the Lions went back to hand; the Courser and the enchantment stayed") {
+            (lions in d.getHand(d.player1)) shouldBe true
+            (courser in d.state.getBattlefield()) shouldBe true
+            (enchantment in d.state.getBattlefield()) shouldBe true
+        }
+    }
+
+    test("\"you may\" — choosing nothing returns nothing") {
+        val d = driver()
+        val lions = d.putCreatureOnBattlefield(d.player1, "Savannah Lions")
+        d.castCourser()
+
+        d.submitCardSelection(d.player1, emptyList()).error shouldBe null
+        (lions in d.state.getBattlefield()) shouldBe true
+        d.state.pendingDecision shouldBe null
+    }
+
+    test("an entering permanent with nothing sharing its type asks nothing") {
+        val d = driver()
+        val lions = d.putCreatureOnBattlefield(d.player1, "Savannah Lions")
+        val enchantment = d.putCardInHand(d.player1, "Test Enchantment")
+        d.giveMana(d.player1, Color.WHITE, 1)
+        d.giveColorlessMana(d.player1, 1)
+        d.castSpell(d.player1, enchantment).error shouldBe null
+        d.bothPass()
+        d.bothPass()
+
+        withClue("only creatures on the battlefield — no candidate, no prompt") {
+            d.state.pendingDecision shouldBe null
+            (lions in d.state.getBattlefield()) shouldBe true
+            (enchantment in d.state.getBattlefield()) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GleancrawlerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GleancrawlerScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Gleancrawler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gleancrawler — {3}{B/G}{B/G}{B/G} 6/6 Trample (Ravnica: City of Guilds #247)
+ *
+ * "At the beginning of your end step, return to your hand all creature cards in your graveyard
+ *  that were put there from the battlefield this turn."
+ *
+ * The clause is `putIntoGraveyardFromBattlefieldThisTurn()` over your graveyard, so the test
+ * pairs a creature that actually died this turn with one that was simply put into the graveyard
+ * and checks only the first comes back. The 2005 ruling — creatures that died *before*
+ * Gleancrawler arrived still return — is the second case.
+ */
+class GleancrawlerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + Gleancrawler)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.bolt(target: com.wingedsheep.sdk.model.EntityId) {
+        val bolt = putCardInHand(player1, "Lightning Bolt")
+        giveMana(player1, Color.RED, 1)
+        castSpell(player1, bolt, targets = listOf(target)).error shouldBe null
+        bothPass()
+    }
+
+    test("a creature that died this turn returns at your end step; a card merely in the graveyard stays") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Gleancrawler")
+        val courser = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        val neverOnBattlefield = d.putCardInGraveyard(d.player1, "Savannah Lions")
+
+        d.bolt(courser)
+        withClue("the Courser died") {
+            (courser in d.getGraveyard(d.player1)) shouldBe true
+        }
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+
+        withClue("the creature that was put there from the battlefield this turn is back in hand") {
+            (courser in d.getHand(d.player1)) shouldBe true
+        }
+        withClue("a creature card that never left the graveyard from the battlefield stays put") {
+            (neverOnBattlefield in d.getGraveyard(d.player1)) shouldBe true
+            (neverOnBattlefield in d.getHand(d.player1)) shouldBe false
+        }
+    }
+
+    test("a creature that died before Gleancrawler arrived still returns (2005 ruling)") {
+        val d = driver()
+        val courser = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        d.bolt(courser)
+        d.putCreatureOnBattlefield(d.player1, "Gleancrawler")
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+
+        (courser in d.getHand(d.player1)) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlightBargainScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlightBargainScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.MoonlightBargain
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Moonlight Bargain — {3}{B}{B} Instant (Ravnica: City of Guilds #95)
+ *
+ * "Look at the top five cards of your library. For each card, put that card into your graveyard
+ *  unless you pay 2 life. Then put the rest into your hand."
+ *
+ * One pay-2-life gate per looked-at card, in library order. The test answers the five prompts
+ * pay / decline / pay / decline / decline and checks each card landed where its answer sent it,
+ * then repeats at 3 life to show the third prompt is skipped outright once 2 life can't be paid.
+ */
+class MoonlightBargainScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + MoonlightBargain)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Stack five Bears on top of player 1's library; the returned list runs top-down. */
+    fun GameTestDriver.stackFive() = (1..5).map { putCardOnTopOfLibrary(player1, "Grizzly Bears") }.reversed()
+
+    fun GameTestDriver.castBargain() {
+        val bargain = putCardInHand(player1, "Moonlight Bargain")
+        giveMana(player1, Color.BLACK, 2)
+        giveColorlessMana(player1, 3)
+        castSpell(player1, bargain).error shouldBe null
+        bothPass()
+    }
+
+    test("each card is kept for 2 life or binned, top of library first") {
+        val d = driver()
+        val top = d.stackFive()
+        val librarySizeBefore = d.state.getLibrary(d.player1).size
+        d.castBargain()
+
+        listOf(true, false, true, false, false).forEach { pay ->
+            withClue("a pay-2-life prompt is pending") { (d.state.pendingDecision != null) shouldBe true }
+            d.submitYesNo(d.player1, pay).error shouldBe null
+        }
+
+        withClue("the two paid-for cards are in hand") {
+            (top[0] in d.getHand(d.player1)) shouldBe true
+            (top[2] in d.getHand(d.player1)) shouldBe true
+        }
+        withClue("the three declined cards are in the graveyard") {
+            (top[1] in d.getGraveyard(d.player1)) shouldBe true
+            (top[3] in d.getGraveyard(d.player1)) shouldBe true
+            (top[4] in d.getGraveyard(d.player1)) shouldBe true
+        }
+        withClue("2 life per kept card") {
+            d.getLifeTotal(d.player1) shouldBe 16
+        }
+        withClue("exactly five cards left the library") {
+            d.state.getLibrary(d.player1).size shouldBe librarySizeBefore - 5
+        }
+        withClue("no prompt is left over") {
+            d.state.pendingDecision shouldBe null
+        }
+    }
+
+    test("once 2 life can't be paid the remaining cards go to the graveyard without a prompt") {
+        val d = driver()
+        val top = d.stackFive()
+        d.setLifeTotal(d.player1, 3)
+        d.castBargain()
+
+        d.submitYesNo(d.player1, true).error shouldBe null
+        withClue("at 1 life nothing more can be paid, so the loop finishes on its own") {
+            d.state.pendingDecision shouldBe null
+        }
+        d.getLifeTotal(d.player1) shouldBe 1
+        (top[0] in d.getHand(d.player1)) shouldBe true
+        top.drop(1).forEach { (it in d.getGraveyard(d.player1)) shouldBe true }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NullstoneGargoyleScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NullstoneGargoyleScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.NullstoneGargoyle
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nullstone Gargoyle — {9} 4/5 Flying (Ravnica: City of Guilds #266)
+ *
+ * "Whenever the first noncreature spell of a turn is cast, counter that spell."
+ *
+ * The trigger is "a player casts a noncreature spell" with a `triggerRestriction` reading the
+ * whole table's cast history, so the cases that matter are the ones a per-player count would get
+ * wrong: the turn's first noncreature spell is countered whoever cast it, the *second* is not
+ * even if a different player casts it, a creature spell never opens or closes the window, and a
+ * spell cast in response to the trigger is untouched (the 2005 rulings).
+ */
+class NullstoneGargoyleScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + NullstoneGargoyle)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(d.player1, "Nullstone Gargoyle")
+        return d
+    }
+
+    fun GameTestDriver.boltInHand(playerId: com.wingedsheep.sdk.model.EntityId): com.wingedsheep.sdk.model.EntityId {
+        giveMana(playerId, Color.RED, 1)
+        return putCardInHand(playerId, "Lightning Bolt")
+    }
+
+    test("the first noncreature spell of the turn is countered, the second is not, creatures don't count") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        val courser = d.putCardInHand(d.player1, "Centaur Courser")
+        d.giveMana(d.player1, Color.GREEN, 1)
+        d.giveColorlessMana(d.player1, 2)
+        d.castSpell(d.player1, courser).error shouldBe null
+        d.bothPass()
+        withClue("a creature spell resolves and does not open the window") {
+            (courser in d.state.getBattlefield()) shouldBe true
+        }
+
+        val bolt1 = d.boltInHand(d.player1)
+        d.castSpell(d.player1, bolt1, targets = listOf(opponent)).error shouldBe null
+        d.bothPass()
+        withClue("the first noncreature spell is countered") {
+            d.getLifeTotal(opponent) shouldBe 20
+            (bolt1 in d.getGraveyard(d.player1)) shouldBe true
+        }
+
+        val bolt2 = d.boltInHand(d.player1)
+        d.castSpell(d.player1, bolt2, targets = listOf(opponent)).error shouldBe null
+        d.bothPass()
+        withClue("the second noncreature spell resolves untouched") {
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+    }
+
+    test("the count is per turn, not per player: an opponent's first noncreature spell is the turn's second") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        val bolt1 = d.boltInHand(d.player1)
+        d.castSpell(d.player1, bolt1, targets = listOf(opponent)).error shouldBe null
+        d.bothPass()
+        d.getLifeTotal(opponent) shouldBe 20
+
+        // Hand priority to the opponent in our main phase; their Bolt is the turn's second
+        // noncreature spell even though it is *their* first.
+        d.passPriority(d.player1)
+        val oppBolt = d.boltInHand(opponent)
+        d.castSpell(opponent, oppBolt, targets = listOf(d.player1)).error shouldBe null
+        d.bothPass()
+        d.getLifeTotal(d.player1) shouldBe 17
+    }
+
+    test("a spell cast in response to the trigger is not affected, and the first is still countered") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        val bolt1 = d.boltInHand(d.player1)
+        d.castSpell(d.player1, bolt1, targets = listOf(opponent)).error shouldBe null
+
+        // Respond to the trigger with a second Bolt: the turn's second noncreature spell.
+        val bolt2 = d.boltInHand(d.player1)
+        d.castSpell(d.player1, bolt2, targets = listOf(opponent)).error shouldBe null
+
+        d.bothPass()
+        withClue("the response resolves normally") {
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+        d.bothPass()
+        withClue("the trigger then counters the turn's first noncreature spell") {
+            d.getLifeTotal(opponent) shouldBe 17
+            (bolt1 in d.getGraveyard(d.player1)) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RerouteScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RerouteScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GolgariGuildmage
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Reroute
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Reroute — {1}{R} Instant (Ravnica: City of Guilds #139)
+ *
+ * "Change the target of target activated ability with a single target. Draw a card."
+ *
+ * The opponent's Golgari Guildmage aims its "{4}{G}: put a +1/+1 counter on target creature"
+ * at their own creature; Reroute redirects it onto ours and draws. The second case checks the
+ * redirect only offers targets the ability's own requirement allows, and the third that a spell
+ * on the stack is not a legal Reroute target.
+ */
+class RerouteScenarioTest : FunSpec({
+
+    val counterAbility = GolgariGuildmage.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + Reroute + GolgariGuildmage)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** The opponent activates the Guildmage at [target] and passes priority back to us. */
+    fun GameTestDriver.opponentPumps(mage: EntityId, target: EntityId): EntityId {
+        val opponent = getOpponent(player1)
+        giveMana(opponent, Color.GREEN, 1)
+        giveColorlessMana(opponent, 4)
+        passPriority(player1)
+        submit(ActivateAbility(opponent, mage, counterAbility, targets = listOf(ChosenTarget.Permanent(target))))
+            .isSuccess shouldBe true
+        val ability = getTopOfStack()!!
+        passPriority(opponent)
+        return ability
+    }
+
+    fun GameTestDriver.rerouteInHand(): EntityId {
+        giveMana(player1, Color.RED, 1)
+        giveColorlessMana(player1, 1)
+        return putCardInHand(player1, "Reroute")
+    }
+
+    test("redirects an activated ability onto our creature and draws a card") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        val mage = d.putCreatureOnBattlefield(opponent, "Golgari Guildmage")
+        val theirs = d.putCreatureOnBattlefield(opponent, "Savannah Lions")
+        val ours = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+
+        val ability = d.opponentPumps(mage, theirs)
+        val reroute = d.rerouteInHand()
+        val handBefore = d.getHandSize(d.player1)
+        d.castSpellWithTargets(d.player1, reroute, listOf(ChosenTarget.Spell(ability))).error shouldBe null
+        d.bothPass()
+
+        withClue("Reroute asks for the new target") {
+            d.state.pendingDecision shouldNotBe null
+        }
+        d.submitCardSelection(d.player1, listOf(ours)).error shouldBe null
+        withClue("Reroute drew a card (its own cast is already out of hand)") {
+            d.getHandSize(d.player1) shouldBe handBefore
+        }
+
+        d.bothPass()
+        withClue("the counter landed on our creature, not theirs") {
+            d.plusOneCounters(ours) shouldBe 1
+            d.plusOneCounters(theirs) shouldBe 0
+        }
+    }
+
+    test("the new target must satisfy the ability's own requirement — a player is not offered") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        val mage = d.putCreatureOnBattlefield(opponent, "Golgari Guildmage")
+        val theirs = d.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        val ability = d.opponentPumps(mage, theirs)
+        val reroute = d.rerouteInHand()
+        d.castSpellWithTargets(d.player1, reroute, listOf(ChosenTarget.Spell(ability))).error shouldBe null
+        d.bothPass()
+
+        d.state.pendingDecision shouldNotBe null
+        withClue("a player is never a legal target for 'target creature'") {
+            d.submitCardSelection(d.player1, listOf(d.player1)).error shouldNotBe null
+        }
+        withClue("the Guildmage itself is the only other creature, so it is the only offer") {
+            d.submitCardSelection(d.player1, listOf(mage)).error shouldBe null
+        }
+        d.bothPass()
+        d.plusOneCounters(mage) shouldBe 1
+    }
+
+    test("a spell on the stack is not an activated ability and can't be targeted") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.passPriority(d.player1)
+        val bolt = d.putCardInHand(opponent, "Lightning Bolt")
+        d.giveMana(opponent, Color.RED, 1)
+        d.castSpell(opponent, bolt, targets = listOf(d.player1)).error shouldBe null
+        d.passPriority(opponent)
+
+        val reroute = d.rerouteInHand()
+        withClue("Reroute can't target a spell") {
+            d.castSpellWithTargets(d.player1, reroute, listOf(ChosenTarget.Spell(bolt))).error shouldNotBe null
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1379,6 +1379,81 @@
     ]
 }
 
+// Cloudstone Curio
+{
+    "name": "Cloudstone Curio",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a nonartifact permanent you control enters, you may return another permanent you control that shares a permanent type with it to its owner's hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent nonartifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsPermanent",
+                                        {
+                                            "type": "SharesCardTypeWith",
+                                            "entity": "Triggering"
+                                        }
+                                    ]
+                                },
+                                "player": "You",
+                                "excludeTriggering": true
+                            },
+                            "storeAs": "candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "returned",
+                            "prompt": "You may return another permanent you control that shares a permanent type with the one that entered to its owner's hand",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "returned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a nonartifact permanent you control enters, you may return another permanent you control that shares a permanent type with it to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Heather Hudson",
+        "flavorText": "It *wants* to remain a mystery, banishing the curious in favor of less inquisitive company.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/47cbda17-d368-4dc3-b41c-95b146468b44.jpg?1783943601"
+    },
+    "colorIdentityOverride": []
+}
+
 // Coalhauler Swine
 {
     "name": "Coalhauler Swine",
@@ -3973,6 +4048,79 @@
     "colorIdentityOverride": []
 }
 
+// Gleancrawler
+{
+    "name": "Gleancrawler",
+    "manaCost": "{3}{B/G}{B/G}{B/G}",
+    "typeLine": "Creature — Insect Horror",
+    "oracleText": "({B/G} can be paid with either {B} or {G}.)\nTrample\nAt the beginning of your end step, return to your hand all creature cards in your graveyard that were put there from the battlefield this turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        "PutIntoGraveyardFromBattlefieldThisTurn"
+                                    ]
+                                }
+                            },
+                            "storeAs": "fallen"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "fallen",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, return to your hand all creature cards in your graveyard that were put there from the battlefield this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Dave Allsop",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69ebb44b-bf3e-4b9e-b568-c20970bb969d.jpg?1783943604",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "When this ability resolves, it returns all creature cards currently in your graveyard that were put there directly from the battlefield sometime during the turn. This includes cards that were put into your graveyard before Gleancrawler entered the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Glimpse the Unthinkable
 {
     "name": "Glimpse the Unthinkable",
@@ -6214,6 +6362,72 @@
     ]
 }
 
+// Moonlight Bargain
+{
+    "name": "Moonlight Bargain",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Look at the top five cards of your library. For each card, put that card into your graveyard unless you pay 2 life. Then put the rest into your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "looked"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.MayPay",
+                            "cost": {
+                                "type": "PayLife",
+                                "amount": 2
+                            }
+                        },
+                        "then": {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Hand",
+                            "fromZone": "Library"
+                        },
+                        "otherwise": {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Graveyard",
+                            "fromZone": "Library"
+                        },
+                        "descriptionOverride": "Pay 2 life to put this card into your hand? If you don't, it goes to your graveyard."
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "RARE",
+        "artist": "Nick Percival",
+        "flavorText": "At every fifth full moon, the Moon Market convenes to peddle Ravnica's most forbidden wares.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/7957c37f-96da-4b7e-9581-afdf73a85edd.jpg?1783943667"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Moroii
 {
     "name": "Moroii",
@@ -6440,6 +6654,74 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Nullstone Gargoyle
+{
+    "name": "Nullstone Gargoyle",
+    "manaCost": "{9}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "Flying\nWhenever the first noncreature spell of a turn is cast, counter that spell.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Counter",
+                    "targetSource": "CounterTargetSource.TriggeringEntity"
+                },
+                "triggerRestriction": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "SpellsCastThisTurn",
+                        "player": "Each",
+                        "filter": "noncreature"
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever the first noncreature spell of a turn is cast, counter that spell."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "RARE",
+        "artist": "Glenn Fabry",
+        "flavorText": "Nullstone absorbs and dampens most forms of magical energy, as well as light, sound, and heat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1dc3aa88-2555-4862-a771-e9d5b9eab3ad.jpg?1783943597",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "Nullstone Gargoyle cares about the first noncreature spell cast during a turn, not the first one it \"sees.\" If a noncreature spell was cast before Nullstone Gargoyle entered the battlefield, it won't counter the next one."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If another spell is cast in response to the first spell, Nullstone Gargoyle doesn't affect that second spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Oathsworn Giant
@@ -7493,6 +7775,59 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Reroute
+{
+    "name": "Reroute",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Change the target of target activated ability with a single target. (Mana abilities can't be targeted.)\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "ChangeTarget",
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsActivatedAbility"
+                        ]
+                    },
+                    "zone": "Stack"
+                },
+                "id": "activated ability with a single target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "Three hundred years of practice thwarted by an instant of mischief.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42794e10-ddcd-4d2d-ab0c-a6b99b6d4662.jpg?1783943648",
+        "rulings": [
+            {
+                "date": "2016-06-08",
+                "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Five RAV cards, each composed from existing primitives, each with its own scenario test. RAV goes 210 → 215/291.

- **Gleancrawler** — end-step Gather → Move over your graveyard with `putIntoGraveyardFromBattlefieldThisTurn()` (the Second Sunrise shape narrowed to creature cards). Tests: a creature that died this turn returns while a card merely in the graveyard stays; one that died before Gleancrawler arrived still returns (2005 ruling).
- **Reroute** — `Effects.ChangeTarget` over `TargetFilter.ActivatedAbilityOnStack`, then draw; the Willbender / Bolt Bend redirect narrowed to activated abilities. Tests: redirects an opponent's Guildmage pump onto our creature and draws; the new target is drawn from the ability's own requirement; a spell is not a legal target.
- **Nullstone Gargoyle** — "the first noncreature spell *of a turn*" is a per-turn count across every player, so this is `anyPlayerCasts(Noncreature)` with a `triggerRestriction` comparing `SpellsCastThisTurn(Player.Each, Noncreature)` to 1 — not `NthSpellCast`, which counts the caster's own history and would also fire on the second player's first spell. Tests: first countered / second not / creatures don't count; opponent's first is the turn's second; a spell cast in response is untouched while the first is still countered (both 2005 rulings).
- **Cloudstone Curio** — battlefield gather with `sharingCardTypeWith(Triggering)` + `excludeTriggering`, `chooseUpTo(1)` picked on the battlefield as the "you may", move to owner's hand. Tests: only a same-type permanent is offered and never the entering one; declining bounces nothing; nothing sharing the type asks nothing. Noted in the card: "permanent type" is spelled with the card-type predicate, which differs only for Kindred.
- **Moonlight Bargain** — top-five gather, then one `OptionalCostEffect(PayLifeEffect(2))` per card inside `ForEachInCollectionEffect` (pay → hand, decline → graveyard); each prompt carries the card as its decision subject. Tests: five prompts in library order land each card where its answer sent it; at 3 life the loop skips the unaffordable prompts and bins the rest.

Triaged and left out (each needs new vocabulary, `add-feature` territory): Sins of the Past (free-cast grant is exile-only — `MayPlayPermission` is enumerated from exile), Szadek (needs counters *and* mill from one replacement; the two existing replacements are separate), Chant of Vitu-Ghazi (group-source prevention with life gain equal to the total prevented), Blood Funnel (no counter-unless-sacrifice condition), Crown of Convergence (no top-of-library entity reference), Shadow of Doubt (no can't-search effect), Sunforger (no unattach cost).

Verification: the five scenario tests (13 cases) pass; `:mtg-sets:test` green after `just rebless-cards` (only the five new cards moved in `RAV.json`); `just check-card-printing` ok for all five; `just assay-differential --set RAV` reports zero divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WS9WqKjNVFMbYpznX38Qt