### PR TITLE
Add three Ravnica: City of Guilds cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2168,7 +2168,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `BlockPhaseManager.validateProjectedMustBlockRequirements` enforces it with no extra wiring and
   the generic end-of-turn cleanup expires it. Distinct from
   `Effects.ForceBlock(target, attacker = EffectTarget.Self)`, which pins the creature to blocking one
-  *named* attacker and requires that attacker to be attacking — this one is satisfied by blocking
+  *named* attacker and is only read while that creature is actually attacking (it may be created
+  before attackers are declared — Sisters of Stone Death's "{G}: Target creature blocks ~ this turn
+  if able" — and binds once the creature attacks) — this one is satisfied by blocking
   anything. `attacker` defaults to the ability's own source ("blocks **it**", Avalanche Tusker); pass
   `EffectTarget.TriggeringEntity` when an ANY-bound trigger pins the blocker to the creature that
   attacked instead (Tolsimir, Midnight's Light: "blocks **that Wolf** this combat if able"). A requirement, not a guarantee (CR 509.1c): a tapped creature, one

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -366,8 +366,10 @@ data class GrantCantBeBlockedByChosenColorEffect(
  * pins the blocker to that one instead passes [EffectTarget.TriggeringEntity]: Tolsimir, Midnight's
  * Light says "whenever a Wolf you control attacks … target creature an opponent controls blocks
  * **that Wolf** this combat if able", where the Wolf is the triggering entity and Tolsimir is the
- * source. Any attacking creature the effect context can name works; the executor requires only that
- * the resolved attacker is actually attacking.
+ * source. Any creature the effect context can name works. The named creature need not be attacking
+ * yet: an activated "blocks this creature this turn if able" (Sisters of Stone Death) may resolve
+ * before attackers are declared, and the requirement is then read once it attacks — the
+ * block-declaration validator ignores it while the named creature isn't attacking (CR 509.1c).
  *
  * @property target The creature forced to block
  * @property attacker The attacking creature that must be blocked

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BloodbondMarch.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BloodbondMarch.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bloodbond March — Ravnica: City of Guilds #192
+ * {2}{B}{G} · Enchantment · Rare
+ *
+ * Whenever a player casts a creature spell, each player returns all cards with the same name as
+ * that spell from their graveyard to the battlefield.
+ *
+ * Modelling notes:
+ * - The trigger is ANY-bound on every player's creature spells, so the spell on the stack is the
+ *   triggering entity and "the same name as that spell" is
+ *   `sharingNameWith(EntityReference.Triggering)` — the filter Spellweaver Helix reads against
+ *   its imprint pile, here read against every graveyard at once via `Player.Each`.
+ * - The spell itself is on the stack, not in a graveyard, so it is never among the gathered
+ *   cards; the trigger resolves before the spell does, which is why the freshly cast creature
+ *   does not return itself.
+ * - "Each player returns … from their graveyard" is one gather across every graveyard and one
+ *   move with `underOwnersControl`, so each returned card comes back under its own owner's
+ *   control — including the caster's opponents' copies. Nothing is chosen and nothing is tapped.
+ */
+val BloodbondMarch = card("Bloodbond March") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a player casts a creature spell, each player returns all cards with " +
+        "the same name as that spell from their graveyard to the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(spellFilter = GameObjectFilter.Creature)
+        effect = Effects.Pipeline {
+            val sameName = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.Each,
+                    filter = GameObjectFilter.Any.sharingNameWith(EntityReference.Triggering)
+                )
+            )
+            move(sameName, CardDestination.ToZone(Zone.BATTLEFIELD), underOwnersControl = true)
+        }
+        description = "Whenever a player casts a creature spell, each player returns all cards " +
+            "with the same name as that spell from their graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "192"
+        artist = "Jim Nelson"
+        flavorText = "The Golgari support a vast army because death never ends its soldiers' service."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg?1783943627"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RaziaBorosArchangel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RaziaBorosArchangel.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RedirectNextDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Razia, Boros Archangel — Ravnica: City of Guilds #223
+ * {4}{R}{R}{W}{W} · Legendary Creature — Angel 6/3 · Rare
+ *
+ * Flying, vigilance, haste
+ * {T}: The next 3 damage that would be dealt to target creature you control this turn is dealt
+ * to another target creature instead.
+ *
+ * Modelling notes:
+ * - A capacity-limited redirection shield (CR 615.7 / CR 614.9): `amount = 3` is what makes the
+ *   two rulings fall out of the engine's own bookkeeping — the 3 damage need not come from one
+ *   source or all at once, because the shield decrements per instance and survives until its
+ *   capacity is spent.
+ * - Two independent single-target requirements, the second wrapped in [TargetOther] so it cannot
+ *   be the same creature as the first (CR 601.2c "another"). Both are creatures — the recipient
+ *   may be any creature, including one Razia's controller owns.
+ * - "If either target creature leaves the battlefield before damage is dealt, that damage won't
+ *   be redirected": the protected creature leaving means nothing is dealt to it; the recipient
+ *   leaving is handled by the redirection check, which skips a shield whose recipient is gone so
+ *   the original creature takes the damage. Razia herself leaving doesn't matter — the shield is
+ *   a floating effect, not a static of hers.
+ */
+val RaziaBorosArchangel = card("Razia, Boros Archangel") {
+    manaCost = "{4}{R}{R}{W}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Angel"
+    power = 6
+    toughness = 3
+    oracleText = "Flying, vigilance, haste\n" +
+        "{T}: The next 3 damage that would be dealt to target creature you control this turn is " +
+        "dealt to another target creature instead."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE, Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val shielded = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        val recipient = target("another target creature", TargetOther(TargetCreature()))
+        effect = RedirectNextDamageEffect(
+            protectedTargets = listOf(shielded),
+            redirectTo = recipient,
+            amount = 3
+        )
+        description = "The next 3 damage that would be dealt to target creature you control this " +
+            "turn is dealt to another target creature instead."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Donato Giancola"
+        flavorText = "Her sword burns with such brightness that foes avert their eyes and arrows " +
+            "divert their paths."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg?1783943615"
+        ruling(
+            "2005-10-01",
+            "The 3 damage doesn't have to be from the same source, and it doesn't have to be all " +
+                "dealt at once. If only 2 damage is redirected, the next 1 damage will also be " +
+                "redirected."
+        )
+        ruling(
+            "2005-10-01",
+            "If either target creature leaves the battlefield before damage is dealt, that damage " +
+                "won't be redirected. It doesn't matter if Razia leaves the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SistersOfStoneDeath.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SistersOfStoneDeath.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sisters of Stone Death — Ravnica: City of Guilds #231
+ * {4}{B}{B}{G}{G} · Legendary Creature — Gorgon 7/5 · Rare
+ *
+ * {G}: Target creature blocks Sisters of Stone Death this turn if able.
+ * {B}{G}: Exile target creature blocking or blocked by Sisters of Stone Death.
+ * {2}{B}: Put a creature card exiled with Sisters of Stone Death onto the battlefield under your
+ * control.
+ *
+ * Modelling notes:
+ * - The first ability is [Effects.ForceBlock] with the default `attacker = Self` — the same
+ *   "blocks *it* this turn if able" requirement Avalanche Tusker's attack trigger creates, here
+ *   behind a mana cost instead. It is a requirement, not a guarantee (CR 509.1c): a creature that
+ *   can't legally block the Sisters simply doesn't, and the requirement is only read while the
+ *   Sisters are actually attacking. The ability may be activated before attackers are declared
+ *   (the effect lasts the turn), so the executor must not demand that the Sisters already be
+ *   attacking when it resolves.
+ * - "Blocking or blocked by" is [GameObjectFilter.blockingOrBlockedBySource] — the live
+ *   combat-pairing predicate Spitting Slug uses, read at targeting time and again on resolution.
+ * - The second and third abilities are *linked* (CR 607): the exile writes the Sisters' linked
+ *   exile pile and the return gathers from it, so nothing else that has ever been exiled is
+ *   reachable. Per the ruling, any creature card ever exiled by the second ability can come back,
+ *   whenever it was exiled, but a non-creature card (an animated land) never can — that is the
+ *   `filter = Creature` on the selection, not on the gather.
+ * - "Put a creature card" is one card, mandatory when one exists: `chooseExactly(1)` clamps to
+ *   zero when the pile holds no creature card, which is the printed behaviour of an empty pile.
+ */
+val SistersOfStoneDeath = card("Sisters of Stone Death") {
+    manaCost = "{4}{B}{B}{G}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Gorgon"
+    power = 7
+    toughness = 5
+    oracleText = "{G}: Target creature blocks Sisters of Stone Death this turn if able.\n" +
+        "{B}{G}: Exile target creature blocking or blocked by Sisters of Stone Death.\n" +
+        "{2}{B}: Put a creature card exiled with Sisters of Stone Death onto the battlefield " +
+        "under your control."
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        val blocker = target("target creature", TargetCreature())
+        effect = Effects.ForceBlock(target = blocker)
+        description = "Target creature blocks Sisters of Stone Death this turn if able."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{G}")
+        val paired = target(
+            "target creature blocking or blocked by Sisters of Stone Death",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.blockingOrBlockedBySource()))
+        )
+        effect = Effects.ExileLinkedToSource(paired)
+        description = "Exile target creature blocking or blocked by Sisters of Stone Death."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.Pipeline {
+            val exiled = gather(CardSource.FromLinkedExile())
+            val chosen = chooseExactly(
+                1,
+                from = exiled,
+                filter = GameObjectFilter.Creature,
+                prompt = "Choose a creature card exiled with Sisters of Stone Death to put onto the battlefield"
+            )
+            move(chosen, CardDestination.ToZone(Zone.BATTLEFIELD, Player.You))
+        }
+        description = "Put a creature card exiled with Sisters of Stone Death onto the battlefield " +
+            "under your control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg?1783943612"
+        ruling(
+            "2005-10-01",
+            "The third ability can get back any creature card exiled by the second ability, no " +
+                "matter when it was exiled. If a card that's not a creature card (such as " +
+                "Svogthos, the Restless Tomb) was exiled, the third ability can't return it."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodbondMarchScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodbondMarchScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.BloodbondMarch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bloodbond March (RAV #192) — "Whenever a player casts a creature spell, each player returns all
+ * cards with the same name as that spell from their graveyard to the battlefield."
+ *
+ * The assertions that matter: every graveyard is read (the caster's *and* the opponent's), the
+ * returned cards come back under their own owners' control, cards with another name stay put,
+ * and the trigger resolves before the spell so the freshly cast creature is never among them.
+ */
+class BloodbondMarchScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BloodbondMarch)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.countOnBattlefield(player: EntityId, name: String): Int =
+        state.getBattlefield(player).count { getCardName(it) == name }
+
+    test("casting a creature returns every same-named card from every graveyard under its owner's control") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        d.putPermanentOnBattlefield(me, "Bloodbond March")
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.putCardInGraveyard(opp, "Grizzly Bears")
+        d.putCardInGraveyard(opp, "Grizzly Bears")
+        d.putCardInGraveyard(opp, "Centaur Courser")
+
+        val bears = d.putCardInHand(me, "Grizzly Bears")
+        d.giveMana(me, Color.GREEN, 1)
+        d.giveColorlessMana(me, 1)
+        d.castSpell(me, bears).isSuccess shouldBe true
+
+        withClue("the trigger sits above the creature spell") { d.stackSize shouldBe 2 }
+        d.bothPass()
+        withClue("the trigger resolved first; the cast Bears is still on the stack") {
+            d.stackSize shouldBe 1
+            d.countOnBattlefield(me, "Grizzly Bears") shouldBe 1
+            d.countOnBattlefield(opp, "Grizzly Bears") shouldBe 2
+        }
+        d.bothPass()
+
+        withClue("each returned card is under its own owner's control, plus the cast one") {
+            d.countOnBattlefield(me, "Grizzly Bears") shouldBe 2
+            d.countOnBattlefield(opp, "Grizzly Bears") shouldBe 2
+        }
+        withClue("only same-named cards left the graveyards") {
+            d.getGraveyardCardNames(me) shouldNotContain "Grizzly Bears"
+            d.getGraveyardCardNames(opp) shouldNotContain "Grizzly Bears"
+            d.getGraveyardCardNames(opp) shouldContain "Centaur Courser"
+            d.countOnBattlefield(opp, "Centaur Courser") shouldBe 0
+        }
+    }
+
+    test("a noncreature spell does not trigger it") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        d.putPermanentOnBattlefield(me, "Bloodbond March")
+        d.putCardInGraveyard(opp, "Grizzly Bears")
+
+        val bolt = d.putCardInHand(me, "Lightning Bolt")
+        d.giveMana(me, Color.RED, 1)
+        d.castSpellWithTargets(me, bolt, listOf(ChosenTarget.Player(opp))).isSuccess shouldBe true
+        withClue("no trigger on the stack") { d.stackSize shouldBe 1 }
+        d.bothPass()
+
+        d.getGraveyardCardNames(opp) shouldContain "Grizzly Bears"
+        d.countOnBattlefield(opp, "Grizzly Bears") shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RaziaBorosArchangelScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RaziaBorosArchangelScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.RaziaBorosArchangel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Razia, Boros Archangel (RAV #223) — "{T}: The next 3 damage that would be dealt to target
+ * creature you control this turn is dealt to another target creature instead."
+ *
+ * The first test is the shield itself; the second is the ruling "if either target creature leaves
+ * the battlefield before damage is dealt, that damage won't be redirected" — before the recipient
+ * liveness check in `OptionalDamageRedirect.redirectShieldCovers`, damage aimed at the shielded
+ * creature was redirected into a recipient that no longer existed and silently vanished.
+ */
+class RaziaBorosArchangelScenarioTest : FunSpec({
+
+    val abilityId = RaziaBorosArchangel.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + RaziaBorosArchangel)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.damageOn(id: EntityId): Int = state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    fun GameTestDriver.shield(me: EntityId, razia: EntityId, shielded: EntityId, recipient: EntityId) {
+        submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = razia,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(shielded), ChosenTarget.Permanent(recipient)),
+            )
+        ).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    fun GameTestDriver.bolt(caster: EntityId, target: EntityId) {
+        giveMana(caster, Color.RED, 1)
+        val bolt = putCardInHand(caster, "Lightning Bolt")
+        castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(target))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("the next 3 damage to the shielded creature is dealt to the other creature instead") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val razia = d.putCreatureOnBattlefield(me, "Razia, Boros Archangel")
+        d.removeSummoningSickness(razia)
+        val bears = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val courser = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        d.shield(me, razia, shielded = bears, recipient = courser)
+        d.isTapped(razia) shouldBe true
+
+        d.bolt(me, bears)
+
+        withClue("the Bears took none of the damage") {
+            d.findPermanent(me, "Grizzly Bears").shouldNotBeNull()
+            d.damageOn(bears) shouldBe 0
+        }
+        withClue("the 3 damage went to the Courser, which is lethal for a 3/3") {
+            d.findPermanent(opp, "Centaur Courser") shouldBe null
+            d.getGraveyardCardNames(opp) shouldContain "Centaur Courser"
+        }
+    }
+
+    test("the recipient leaving the battlefield first means the damage is not redirected") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val razia = d.putCreatureOnBattlefield(me, "Razia, Boros Archangel")
+        d.removeSummoningSickness(razia)
+        val bears = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val oppBears = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        d.shield(me, razia, shielded = bears, recipient = oppBears)
+
+        // The recipient dies before any damage reaches the shielded creature.
+        d.bolt(me, oppBears)
+        d.findPermanent(opp, "Grizzly Bears") shouldBe null
+
+        // Now the shielded creature is bolted: nothing is left to redirect to, so it takes the 3.
+        d.bolt(me, bears)
+        withClue("the ruling: the damage is dealt to the shielded creature after all") {
+            d.findPermanent(me, "Grizzly Bears") shouldBe null
+            d.getGraveyardCardNames(me) shouldContain "Grizzly Bears"
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SistersOfStoneDeathScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SistersOfStoneDeathScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.SistersOfStoneDeath
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sisters of Stone Death (RAV #231) —
+ * "{G}: Target creature blocks Sisters of Stone Death this turn if able.
+ *  {B}{G}: Exile target creature blocking or blocked by Sisters of Stone Death.
+ *  {2}{B}: Put a creature card exiled with Sisters of Stone Death onto the battlefield under your
+ *  control."
+ *
+ * The first test is the one the executor change is for: the lure is activated in the precombat
+ * main phase, *before* the Sisters attack, and the requirement must still bind once they do.
+ * The second walks the linked pair — exile a blocker mid-combat, then reanimate it under the
+ * Sisters' controller.
+ */
+class SistersOfStoneDeathScenarioTest : FunSpec({
+
+    val lure = SistersOfStoneDeath.activatedAbilities[0].id
+    val petrify = SistersOfStoneDeath.activatedAbilities[1].id
+    val reanimate = SistersOfStoneDeath.activatedAbilities[2].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + SistersOfStoneDeath)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    fun GameTestDriver.activate(me: EntityId, sisters: EntityId, ability: AbilityId, targets: List<EntityId> = emptyList()) {
+        val result = submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = sisters,
+                abilityId = ability,
+                targets = targets.map { ChosenTarget.Permanent(it) },
+            )
+        )
+        withClue(result.error ?: "activation failed") { result.isSuccess shouldBe true }
+        resolveStack()
+    }
+
+    test("the lure activated before attackers are declared still binds once the Sisters attack") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val sisters = d.putCreatureOnBattlefield(me, "Sisters of Stone Death")
+        d.removeSummoningSickness(sisters)
+        val bear = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val free = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        // Precombat main: nothing is attacking yet.
+        d.giveMana(me, Color.GREEN, 1)
+        d.activate(me, sisters, lure, listOf(bear))
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(sisters), defendingPlayer = opp).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("the bear is under a requirement to block the Sisters") {
+            d.declareBlockers(opp, emptyMap()).isSuccess shouldBe false
+            d.declareBlockers(opp, mapOf(bear to listOf(sisters))).error shouldBe null
+        }
+        d.state.getEntity(free).shouldNotBeNull()
+    }
+
+    test("exile a creature blocking the Sisters, then put it onto the battlefield under your control") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val sisters = d.putCreatureOnBattlefield(me, "Sisters of Stone Death")
+        d.removeSummoningSickness(sisters)
+        val bear = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(sisters), defendingPlayer = opp).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(opp, mapOf(bear to listOf(sisters))).error shouldBe null
+        // Priority in the declare-blockers step may sit with the defender first; a single pass on
+        // an empty stack hands it to the active player without leaving the step.
+        if (d.priorityPlayer != me) d.passPriority(opp).error shouldBe null
+        d.priorityPlayer shouldBe me
+
+        // Before damage: exile the blocker, linked to the Sisters.
+        d.giveMana(me, Color.BLACK, 1)
+        d.giveMana(me, Color.GREEN, 1)
+        d.activate(me, sisters, petrify, listOf(bear))
+        withClue("the blocker is in its owner's exile, not the graveyard") {
+            d.findPermanent(opp, "Grizzly Bears") shouldBe null
+            d.getExileCardNames(opp) shouldContain "Grizzly Bears"
+            d.getGraveyardCardNames(opp) shouldNotContain "Grizzly Bears"
+        }
+
+        // The linked return: the only creature card in the pile comes back under my control.
+        d.giveMana(me, Color.BLACK, 1)
+        d.giveColorlessMana(me, 2)
+        d.activate(me, sisters, reanimate)
+        val returned = d.findPermanent(me, "Grizzly Bears")
+        withClue("the exiled creature is on the battlefield under the Sisters' controller") {
+            returned.shouldNotBeNull()
+            d.getController(returned) shouldBe me
+            d.getExileCardNames(opp) shouldNotContain "Grizzly Bears"
+        }
+    }
+
+    test("a creature only blocked by the Sisters is not a legal petrify target while not paired") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val sisters = d.putCreatureOnBattlefield(me, "Sisters of Stone Death")
+        d.removeSummoningSickness(sisters)
+        val bystander = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // Precombat main — nothing is blocking or blocked by the Sisters, so there is no target.
+        d.giveMana(me, Color.BLACK, 1)
+        d.giveMana(me, Color.GREEN, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = sisters,
+                abilityId = petrify,
+                targets = listOf(ChosenTarget.Permanent(bystander)),
+            )
+        ).isSuccess shouldBe false
+        d.findPermanent(opp, "Grizzly Bears").shouldNotBeNull()
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/RaziaBorosArchangelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hop/cards/RaziaBorosArchangelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.hop.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Razia, Boros Archangel reprint in HOP (Planechase). Canonical CardDefinition lives in
+ * Ravnica: City of Guilds.
+ */
+val RaziaBorosArchangelReprint = Printing(
+    oracleId = "d830a136-6fb9-42e7-81f1-97e1d713ee82",
+    name = "Razia, Boros Archangel",
+    setCode = "HOP",
+    collectorNumber = "92",
+    scryfallId = "87e80447-9572-43a7-8487-3249cd9ce596",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87e80447-9572-43a7-8487-3249cd9ce596.jpg?1783942314",
+    releaseDate = "2009-09-04",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -329,6 +329,74 @@
     ]
 }
 
+// Bloodbond March
+{
+    "name": "Bloodbond March",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a player casts a creature spell, each player returns all cards with the same name as that spell from their graveyard to the battlefield.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "SharesNameWith",
+                                            "entity": "Triggering"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a player casts a creature spell, each player returns all cards with the same name as that spell from their graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "RARE",
+        "artist": "Jim Nelson",
+        "flavorText": "The Golgari support a vast army because death never ends its soldiers' service.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb977f5b-2202-43c1-a8c0-7fba8c093fa2.jpg?1783943627"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Bloodletter Quill
 {
     "name": "Bloodletter Quill",
@@ -7458,6 +7526,86 @@
     ]
 }
 
+// Razia, Boros Archangel
+{
+    "name": "Razia, Boros Archangel",
+    "manaCost": "{4}{R}{R}{W}{W}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flying, vigilance, haste\n{T}: The next 3 damage that would be dealt to target creature you control this turn is dealt to another target creature instead.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE",
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "RedirectNextDamage",
+                    "protectedTargets": [
+                        {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    ],
+                    "redirectTo": {
+                        "type": "BoundVariable",
+                        "name": "another target creature"
+                    },
+                    "amount": 3
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    },
+                    {
+                        "type": "TargetOther",
+                        "baseRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "id": "another target creature"
+                    }
+                ],
+                "descriptionOverride": "The next 3 damage that would be dealt to target creature you control this turn is dealt to another target creature instead."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "RARE",
+        "artist": "Donato Giancola",
+        "flavorText": "Her sword burns with such brightness that foes avert their eyes and arrows divert their paths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4580cc4-ee26-41d9-a81c-91505c9e2a99.jpg?1783943615",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The 3 damage doesn't have to be from the same source, and it doesn't have to be all dealt at once. If only 2 damage is redirected, the next 1 damage will also be redirected."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If either target creature leaves the battlefield before damage is dealt, that damage won't be redirected. It doesn't matter if Razia leaves the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Recollect
 {
     "name": "Recollect",
@@ -8781,6 +8929,144 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae199825-563e-4837-a6d2-7b009b93cd4d.jpg"
     },
     "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sisters of Stone Death
+{
+    "name": "Sisters of Stone Death",
+    "manaCost": "{4}{B}{B}{G}{G}",
+    "typeLine": "Legendary Creature — Gorgon",
+    "oracleText": "{G}: Target creature blocks Sisters of Stone Death this turn if able.\n{B}{G}: Exile target creature blocking or blocked by Sisters of Stone Death.\n{2}{B}: Put a creature card exiled with Sisters of Stone Death onto the battlefield under your control.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ForceBlock",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature blocks Sisters of Stone Death this turn if able."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature blocking or blocked by Sisters of Stone Death"
+                    },
+                    "destination": "Exile",
+                    "linkToSource": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsCombatPairedWithSource"
+                                ]
+                            }
+                        },
+                        "id": "target creature blocking or blocked by Sisters of Stone Death"
+                    }
+                ],
+                "descriptionOverride": "Exile target creature blocking or blocked by Sisters of Stone Death."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "selected1",
+                            "prompt": "Choose a creature card exiled with Sisters of Stone Death to put onto the battlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Put a creature card exiled with Sisters of Stone Death onto the battlefield under your control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "RARE",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d214d25b-96c3-4479-88f0-3996805d6e6f.jpg?1783943612",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The third ability can get back any creature card exiled by the second ability, no matter when it was exiled. If a card that's not a creature card (such as Svogthos, the Restless Tomb) was exiled, the third ability can't return it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "GREEN"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ForceBlockExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ForceBlockExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.ForceBlockEffect
@@ -49,12 +48,13 @@ class ForceBlockExecutor : EffectExecutor<ForceBlockEffect> {
         val attackerId = context.resolveTarget(effect.attacker)
             ?: return EffectResult.error(state, "No valid attacker for force block effect")
 
-        // Verify the attacker is actually attacking — CR 509.1c can only be satisfied against a
-        // declared attacker, and the block-declaration validator reads the requirement per combat.
-        val attackerContainer = state.getEntity(attackerId)
-            ?: return EffectResult.error(state, "Attacking creature no longer exists")
-        if (!attackerContainer.has<AttackingComponent>()) {
-            return EffectResult.error(state, "Named creature is not attacking")
+        // The named creature need not be attacking *yet*: an activated "blocks this creature this
+        // turn if able" (Sisters of Stone Death) can resolve in the precombat main phase, and the
+        // requirement then applies once the creature attacks. The block-declaration validator
+        // reads the requirement per combat and ignores it while the named creature isn't
+        // attacking (CR 509.1c), so a requirement created early is simply dormant, not wrong.
+        if (state.getEntity(attackerId) == null) {
+            return EffectResult.error(state, "Named creature no longer exists")
         }
 
         // Create a floating effect forcing the target to block that attacker

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/OptionalDamageRedirect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/OptionalDamageRedirect.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.Effect
 import java.util.UUID
@@ -100,16 +101,25 @@ object OptionalDamageRedirect {
      * arrived after the shield was created is covered, an animated land counts while it is one, and a
      * player never is. Any other shield protects the entities it was created with (an empty list
      * meaning "anything").
+     *
+     * A shield whose **recipient** has since left the battlefield covers nothing: there is no
+     * object left for the damage to be dealt to "instead", so the original recipient takes it
+     * (CR 614.9; Razia, Boros Archangel's ruling "if either target creature leaves the battlefield
+     * before damage is dealt, that damage won't be redirected"). A player recipient never leaves.
      */
     fun redirectShieldCovers(
         state: GameState,
         floating: ActiveFloatingEffect,
         mod: SerializableModification.RedirectNextDamage,
         targetId: EntityId
-    ): Boolean = if (mod.creaturesOnly) {
-        state.projectedState.isCreature(targetId)
-    } else {
-        floating.effect.affectedEntities.isEmpty() || targetId in floating.effect.affectedEntities
+    ): Boolean {
+        val recipient = state.getEntity(mod.redirectToId) ?: return false
+        if (!recipient.has<PlayerComponent>() && mod.redirectToId !in state.getBattlefield()) return false
+        return if (mod.creaturesOnly) {
+            state.projectedState.isCreature(targetId)
+        } else {
+            floating.effect.affectedEntities.isEmpty() || targetId in floating.effect.affectedEntities
+        }
     }
 
     /**


### PR DESCRIPTION
Three Ravnica: City of Guilds cards, all on existing primitives, plus two small engine fixes their rulings exposed. RAV goes 210 → 213 / 291.

- **Razia, Boros Archangel** — `RedirectNextDamageEffect(amount = 3)` shield with two single-target requirements (`TargetCreature(CreatureYouControl)` + `TargetOther(TargetCreature())`). Planechase (HOP) gets a `Printing` row.
- **Sisters of Stone Death** — `Effects.ForceBlock` behind `{G}`, `Effects.ExileLinkedToSource` on a `blockingOrBlockedBySource()` target, and a `FromLinkedExile` gather → `chooseExactly(1, filter = Creature)` → battlefield pipeline for the linked return (the ruling's "no matter when it was exiled" / "not a creature card can't return" both fall out of the pile + filter).
- **Bloodbond March** — `anyPlayerCasts(Creature)` → `FromZone(GRAVEYARD, Player.Each, sharingNameWith(Triggering))` → `move(BATTLEFIELD, underOwnersControl = true)`.

**Engine fixes (behaviour, not vocabulary):**
- `ForceBlockExecutor` no longer errors when the named creature isn't attacking yet. Sisters' lure is activated in the precombat main phase and must bind once she attacks; `BlockPhaseManager` already ignores the requirement while the named creature isn't attacking (CR 509.1c). Tolsimir / Avalanche Tusker paths unchanged (tests pass).
- `OptionalDamageRedirect.redirectShieldCovers` skips a shield whose recipient has left the battlefield. Before, damage aimed at the protected creature was redirected into a missing object and silently vanished; now the original recipient takes it (CR 614.9; Razia's ruling "if either target creature leaves the battlefield before damage is dealt, that damage won't be redirected"). Affects Glarecaster / Zealous Inquisitor / Karona's Zealot only in that same case; their tests pass.

**Dropped during triage (each needs `add-feature`):**
- Circu, Dimir Lobotomist — `sharingNameWith(EntityReference.LinkedExiledCard())` resolves to *one* card (the oldest still exiled); "the same name as **a** card exiled with Circu" needs a pile-wide name predicate (the `SharesCardTypeWithLinkedExile` shape, for names).
- Tunnel Vision — no "reveal until a card with the chosen name" gather.
- Concerted Effort — "protection" / "landwalk" of *each type* a creature you control has; protection is a parameterised `KeywordAbility`, not a grantable `Keyword`.
- Auratouched Mage — no "Aura that could enchant it" predicate for the library search.
- Dimir Doppelganger — `CopyExceptions` has no "except it has this ability".

**Verification:** `just build` green (full suite), `just rebless-cards` moved only the three new cards in `RAV.json`, `just assay-differential --set RAV` 0 divergent (all three decline, so no independent reading), `just check-card-printing` ok for all three. New scenario tests: `RaziaBorosArchangelScenarioTest` (2), `SistersOfStoneDeathScenarioTest` (3), `BloodbondMarchScenarioTest` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vMQoG8Q3SfJQyEv2XnJgq
