### PR TITLE
Add five Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BrionStoutarm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BrionStoutarm.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Brion Stoutarm
+ * {2}{R}{W}
+ * Legendary Creature — Giant Warrior
+ * 4/4
+ * Lifelink
+ * {R}, {T}, Sacrifice another creature: Brion Stoutarm deals damage equal to the sacrificed
+ * creature's power to target player or planeswalker.
+ *
+ * Bloodshot Cyclops' shape with two differences read straight off the text: the sacrifice is
+ * "another creature" ([Costs.SacrificeAnother], which excludes Brion itself), and the target is a
+ * player or planeswalker rather than any target. [DynamicAmounts.sacrificedPower] reads the
+ * sacrificed creature's last-known power off the paid cost.
+ */
+val BrionStoutarm = card("Brion Stoutarm") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Giant Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "Lifelink\n" +
+        "{R}, {T}, Sacrifice another creature: Brion Stoutarm deals damage equal to the sacrificed " +
+        "creature's power to target player or planeswalker."
+
+    keywords(Keyword.LIFELINK)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Creature),
+        )
+        val victim = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(DynamicAmounts.sacrificedPower(), victim)
+        description = "Brion Stoutarm deals damage equal to the sacrificed creature's power to target player or planeswalker."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "246"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg?1783942854"
+        ruling("2018-03-16", "If Brion Stoutarm leaves the battlefield after its ability has been activated but before it resolves, the game uses its last known information to determine that it had lifelink and you'll gain life for the damage it deals.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NathOfTheGiltLeaf.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NathOfTheGiltLeaf.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nath of the Gilt-Leaf
+ * {3}{B}{G}
+ * Legendary Creature — Elf Warrior
+ * 4/4
+ * At the beginning of your upkeep, you may have target opponent discard a card at random.
+ * Whenever an opponent discards a card, you may create a 1/1 green Elf Warrior creature token.
+ *
+ * The upkeep trigger is a targeted optional trigger: `optional = true` on a trigger with a player
+ * target — with a single opponent the target is auto-chosen and the "may" is asked when the trigger
+ * resolves. The random discard is [Patterns.Hand.discardRandom] aimed at the chosen opponent —
+ * Hypnotic Specter's shape.
+ *
+ * The token trigger is [Triggers.AnyOpponentDiscards], which fires once per discarded card, so
+ * an opponent discarding three cards offers three tokens. It fires off Nath's own upkeep discard
+ * too, which is the card's point.
+ */
+val NathOfTheGiltLeaf = card("Nath of the Gilt-Leaf") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Elf Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "At the beginning of your upkeep, you may have target opponent discard a card at " +
+        "random.\n" +
+        "Whenever an opponent discards a card, you may create a 1/1 green Elf Warrior creature token."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        optional = true
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Patterns.Hand.discardRandom(1, opponent)
+        description = "you may have target opponent discard a card at random."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.AnyOpponentDiscards
+        optional = true
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf", "Warrior"),
+            imageUri = "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1783942838",
+        )
+        description = "you may create a 1/1 green Elf Warrior creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "250"
+        artist = "Kev Walker"
+        flavorText = "A savage hunter with a prince's bearing."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg?1783942852"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Shriekmaw.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Shriekmaw.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Shriekmaw
+ * {4}{B}
+ * Creature — Elemental
+ * 3/2
+ * Fear
+ * When this creature enters, destroy target nonartifact, nonblack creature.
+ * Evoke {1}{B}
+ *
+ * Same shape as Mulldrifter: `evoke = "{1}{B}"` is the alternative cost and the engine adds the
+ * "sacrifice it when it enters" trigger itself. The destroy trigger is a plain enters trigger with a
+ * nonartifact-nonblack target; when evoked, both triggers go on the stack together and the
+ * controller orders them (the 2021-03-19 ruling).
+ */
+val Shriekmaw = card("Shriekmaw") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 2
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black " +
+        "creatures.)\n" +
+        "When this creature enters, destroy target nonartifact, nonblack creature.\n" +
+        "Evoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed " +
+        "when it enters.)"
+
+    keywords(Keyword.FEAR)
+
+    evoke = "{1}{B}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target nonartifact, nonblack creature",
+            TargetCreature(filter = TargetFilter.Creature.nonartifact().notColor(Color.BLACK)),
+        )
+        effect = Effects.Destroy(t)
+        description = "destroy target nonartifact, nonblack creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg?1783942884"
+        ruling("2021-03-19", "If you pay the evoke cost, you can have Shriekmaw's own triggered ability resolve before the evoke triggered ability. You can cast spells after that ability resolves but before you have to sacrifice Shriekmaw.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SyggRiverGuide.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SyggRiverGuide.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sygg, River Guide
+ * {W}{U}
+ * Legendary Creature — Merfolk Wizard
+ * 2/2
+ * Islandwalk
+ * {1}{W}: Target Merfolk you control gains protection from the color of your choice until end of turn.
+ *
+ * The colour is chosen on resolution (Thornscape Master's shape): [Effects.ChooseColorThen] wraps
+ * [Effects.GrantProtectionFromChosenColor], so the choice is made after targeting rather than at
+ * activation. Sygg is a Merfolk itself, so it can target itself.
+ */
+val SyggRiverGuide = card("Sygg, River Guide") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Merfolk Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls " +
+        "an Island.)\n" +
+        "{1}{W}: Target Merfolk you control gains protection from the color of your choice until " +
+        "end of turn."
+
+    keywords(Keyword.ISLANDWALK)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val t = target(
+            "target Merfolk you control",
+            TargetCreature(filter = TargetFilter.Creature.youControl().withSubtype(Subtype.MERFOLK)),
+        )
+        effect = Effects.ChooseColorThen(Effects.GrantProtectionFromChosenColor(t))
+        description = "Target Merfolk you control gains protection from the color of your choice until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Larry MacDougall"
+        flavorText = "\"If there's a place worth going, the Merrow Lanes already do. And if there's a route worth taking, yours truly already has.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg?1783942852"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThousandYearElixir.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ThousandYearElixir.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thousand-Year Elixir
+ * {3}
+ * Artifact
+ * You may activate abilities of creatures you control as though those creatures had haste.
+ * {1}, {T}: Untap target creature.
+ *
+ * The static is deliberately *not* a haste grant (the 2007-10-01 ruling): it lifts only the
+ * `{T}`/`{Q}` half of CR 302.6, never the attack half. Shang-Chi, Master of Kung Fu carries the
+ * identical permission as [GrantKeyword]([AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY],
+ * creatures you control), which only `SummoningSicknessRules` reads.
+ */
+val ThousandYearElixir = card("Thousand-Year Elixir") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "You may activate abilities of creatures you control as though those creatures " +
+        "had haste.\n" +
+        "{1}, {T}: Untap target creature."
+
+    staticAbility {
+        ability = GrantKeyword(
+            AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY.name,
+            GroupFilter.AllCreaturesYouControl,
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Untap(t)
+        description = "Untap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "263"
+        artist = "Richard Sardinha"
+        flavorText = "Paradoxically, to tilt the massive jug for a sip, you'd need the energy of the giant's tonic."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg?1783942851"
+        ruling("2007-10-01", "Thousand-Year Elixir doesn't actually grant haste to creatures you control, nor does it let you attack with them as though they had haste.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrionStoutarmScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrionStoutarmScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.BrionStoutarm
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Brion Stoutarm (LRW #246) — "Lifelink. {R}, {T}, Sacrifice another creature: Brion Stoutarm
+ * deals damage equal to the sacrificed creature's power to target player or planeswalker."
+ *
+ * The damage amount is read off the *sacrificed* creature (not Brion), the sacrifice must be
+ * *another* creature, and because Brion is the damage source its lifelink applies to the ability's
+ * damage too.
+ */
+class BrionStoutarmScenarioTest : ScenarioTestBase() {
+
+    private val flingAbility = BrionStoutarm.activatedAbilities.single().id
+
+    private fun TestGame.drain() {
+        var guard = 0
+        while (guard++ < 15) {
+            when (val decision = getPendingDecision()) {
+                is SelectCardsDecision -> selectCards(decision.options.take(decision.minSelections))
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                is YesNoDecision -> answerYesNo(true)
+                null -> if (state.stack.isNotEmpty()) resolveStack() else break
+                else -> error("unexpected decision $decision")
+            }
+        }
+    }
+
+    init {
+        context("Brion Stoutarm") {
+
+            test("throws the sacrificed creature's power at the opponent and gains that much life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brion Stoutarm", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant") // 3/3 — the fodder
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brion = game.findPermanent("Brion Stoutarm")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = brion,
+                        abilityId = flingAbility,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.drain()
+
+                withClue("the 3/3 was sacrificed as a cost") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                withClue("Brion tapped to pay") {
+                    game.state.getEntity(brion)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("damage equals the sacrificed creature's power (3), not Brion's (4)") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("Brion is the damage source, so its lifelink applies") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+
+            test("Brion can't sacrifice itself — with no other creature the ability can't be activated") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brion Stoutarm", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val brion = game.findPermanent("Brion Stoutarm")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = brion,
+                        abilityId = flingAbility,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                )
+                withClue("'sacrifice another creature' excludes Brion itself") {
+                    result.error shouldNotBe null
+                }
+                game.findPermanent("Brion Stoutarm") shouldNotBe null
+                game.getLifeTotal(2) shouldBe 20
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NathOfTheGiltLeafScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NathOfTheGiltLeafScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nath of the Gilt-Leaf (LRW #250) —
+ *   "At the beginning of your upkeep, you may have target opponent discard a card at random."
+ *   "Whenever an opponent discards a card, you may create a 1/1 green Elf Warrior creature token."
+ *
+ * Two things worth proving: the upkeep trigger is a *targeted optional* trigger — the sole
+ * opponent is auto-targeted and the "may" is asked on resolution — so declining it must leave the
+ * opponent's hand alone; and the discard it causes feeds Nath's own second ability, so accepting
+ * both yields exactly one discard and one token.
+ */
+class NathOfTheGiltLeafScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Resolve everything the upkeep put on the stack, answering every yes/no with [acceptDiscard]
+     * and any target prompt with the opponent. Returns how many yes/no prompts were asked.
+     */
+    private fun TestGame.driveUpkeep(acceptDiscard: Boolean): Int {
+        var yesNoPrompts = 0
+        var guard = 0
+        while (guard++ < 20) {
+            when (val decision = getPendingDecision()) {
+                is ChooseTargetsDecision -> selectTargets(listOf(player2Id))
+                is YesNoDecision -> {
+                    yesNoPrompts++
+                    answerYesNo(acceptDiscard)
+                }
+                is SelectCardsDecision -> selectCards(decision.options.take(decision.minSelections))
+                null -> if (state.stack.isNotEmpty()) resolveStack() else break
+                else -> error("unexpected decision $decision")
+            }
+        }
+        return yesNoPrompts
+    }
+
+    init {
+        context("Nath of the Gilt-Leaf") {
+
+            test("accepting the upkeep trigger discards one card at random and offers an Elf Warrior") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nath of the Gilt-Leaf")
+                    .withCardsInHand(2, "Grizzly Bears", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                // The sole opponent is auto-targeted; the "may" is asked when the trigger resolves,
+                // and the discard it causes raises the second trigger's own "may".
+                val decisions = game.driveUpkeep(acceptDiscard = true)
+
+                withClue("the opponent discarded exactly one card") {
+                    game.handSize(2) shouldBe 2
+                    game.graveyardSize(2) shouldBe 1
+                }
+                withClue("both 'may's were asked — the discard, then the token") {
+                    decisions shouldBe 2
+                }
+                withClue("one 1/1 Elf Warrior token was created") {
+                    game.findPermanents("Elf Warrior Token").size shouldBe 1
+                }
+            }
+
+            test("declining the upkeep trigger leaves the opponent's hand alone and makes no token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nath of the Gilt-Leaf")
+                    .withCardsInHand(2, "Grizzly Bears", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                val decisions = game.driveUpkeep(acceptDiscard = false)
+
+                withClue("only the discard 'may' was asked; nothing was discarded, so no token trigger") {
+                    decisions shouldBe 1
+                }
+                game.handSize(2) shouldBe 3
+                game.graveyardSize(2) shouldBe 0
+                game.findPermanents("Elf Warrior Token").size shouldBe 0
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandYearElixirScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandYearElixirScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ThousandYearElixir
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thousand-Year Elixir (LRW #263) —
+ *   "You may activate abilities of creatures you control as though those creatures had haste."
+ *   "{1}, {T}: Untap target creature."
+ *
+ * The permission itself is engine-tested in `ActivateAbilitiesAsThoughHastyTest`; these cover the
+ * card — that a summoning-sick creature's `{T}` ability is offered only while the Elixir is out,
+ * that it grants no attack rights, and that the untap ability untaps its target.
+ */
+class ThousandYearElixirScenarioTest : ScenarioTestBase() {
+
+    private val dummy = card("Elixir Test Dummy") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(1)
+            description = "{T}: You gain 1 life."
+        }
+    }
+
+    private val dummyTapAbilityId = dummy.activatedAbilities.single().id
+    private val untapAbilityId = ThousandYearElixir.activatedAbilities.single().id
+
+    private fun activationsOf(game: TestGame, sourceId: EntityId, abilityId: AbilityId) =
+        game.getLegalActions(1)
+            .mapNotNull { it.action as? ActivateAbility }
+            .filter { it.sourceId == sourceId && it.abilityId == abilityId }
+
+    init {
+        cardRegistry.register(dummy)
+
+        context("Thousand-Year Elixir — the as-though-haste permission") {
+
+            test("a summoning-sick creature's {T} ability is activatable with the Elixir out") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thousand-Year Elixir")
+                    .withCardOnBattlefield(1, "Elixir Test Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummyId = game.findPermanent("Elixir Test Dummy")!!
+                activationsOf(game, dummyId, dummyTapAbilityId).size shouldBe 1
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = dummyId, abilityId = dummyTapAbilityId)
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+                game.getLifeTotal(1) shouldBe 21
+            }
+
+            test("without the Elixir the same {T} ability is not offered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Elixir Test Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummyId = game.findPermanent("Elixir Test Dummy")!!
+                activationsOf(game, dummyId, dummyTapAbilityId).size shouldBe 0
+            }
+
+            test("it grants no attack rights") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thousand-Year Elixir")
+                    .withCardOnBattlefield(1, "Elixir Test Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val offeredAttackers = game.getLegalActions(1)
+                    .firstOrNull { it.actionType == "DeclareAttackers" }
+                    ?.validAttackers.orEmpty()
+                withClue("the 2007-10-01 ruling: it doesn't let you attack as though they had haste") {
+                    offeredAttackers shouldBe emptyList()
+                }
+            }
+        }
+
+        context("Thousand-Year Elixir — {1}, {T}: Untap target creature") {
+
+            test("untaps the targeted creature and taps the Elixir") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Thousand-Year Elixir")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elixir = game.findPermanent("Thousand-Year Elixir")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = elixir,
+                        abilityId = untapAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+                game.state.getEntity(elixir)?.has<TappedComponent>() shouldBe true
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ShriekmawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ShriekmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shriekmaw reprint in ARC. Canonical CardDefinition lives in Lorwyn.
+ */
+val ShriekmawReprint = Printing(
+    oracleId = "717bbb9d-0a5b-4979-a24b-9d54aac7657a",
+    name = "Shriekmaw",
+    setCode = "ARC",
+    collectorNumber = "24",
+    scryfallId = "133c5079-0cd7-445a-9256-08f0c4ebe462",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/133c5079-0cd7-445a-9256-08f0c4ebe462.jpg?1783941912",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ThousandYearElixirReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ThousandYearElixirReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thousand-Year Elixir reprint in C13. Canonical CardDefinition lives in Lorwyn.
+ */
+val ThousandYearElixirReprint = Printing(
+    oracleId = "4dc5726e-2f7e-4c2b-9616-c3301d212f78",
+    name = "Thousand-Year Elixir",
+    setCode = "C13",
+    collectorNumber = "266",
+    scryfallId = "2b6ccfdc-acfb-4e73-a583-0c6964b86083",
+    artist = "Richard Sardinha",
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2b6ccfdc-acfb-4e73-a583-0c6964b86083.jpg?1783939633",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ShriekmawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/ShriekmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shriekmaw reprint in C14. Canonical CardDefinition lives in Lorwyn.
+ */
+val ShriekmawReprint = Printing(
+    oracleId = "717bbb9d-0a5b-4979-a24b-9d54aac7657a",
+    name = "Shriekmaw",
+    setCode = "C14",
+    collectorNumber = "160",
+    scryfallId = "eaca59c9-6a7f-4487-b1a9-e088b97378da",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/eaca59c9-6a7f-4487-b1a9-e088b97378da.jpg?1783938840",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ShriekmawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/ShriekmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shriekmaw reprint in C15. Canonical CardDefinition lives in Lorwyn.
+ */
+val ShriekmawReprint = Printing(
+    oracleId = "717bbb9d-0a5b-4979-a24b-9d54aac7657a",
+    name = "Shriekmaw",
+    setCode = "C15",
+    collectorNumber = "137",
+    scryfallId = "a6955188-ed17-47af-95d2-34212939e2d0",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6955188-ed17-47af-95d2-34212939e2d0.jpg?1783938081",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/NathOfTheGiltLeafReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/NathOfTheGiltLeafReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nath of the Gilt-Leaf reprint in C16. Canonical CardDefinition lives in Lorwyn.
+ */
+val NathOfTheGiltLeafReprint = Printing(
+    oracleId = "87a44a87-a2a5-4193-a163-e4846e5b8387",
+    name = "Nath of the Gilt-Leaf",
+    setCode = "C16",
+    collectorNumber = "213",
+    scryfallId = "294ccc67-6fc9-411b-9100-ae6a9b7fadfc",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/294ccc67-6fc9-411b-9100-ae6a9b7fadfc.jpg?1783937045",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BrionStoutarmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BrionStoutarmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brion Stoutarm reprint in CMD. Canonical CardDefinition lives in Lorwyn.
+ */
+val BrionStoutarmReprint = Printing(
+    oracleId = "b816b3cc-ae4b-4fb7-8b1a-e01ab83459a3",
+    name = "Brion Stoutarm",
+    setCode = "CMD",
+    collectorNumber = "187",
+    scryfallId = "21574f79-0a89-49c2-9ab0-d2ac7e3953ae",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/21574f79-0a89-49c2-9ab0-d2ac7e3953ae.jpg?1783941184",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ShriekmawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ShriekmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shriekmaw reprint in CMD. Canonical CardDefinition lives in Lorwyn.
+ */
+val ShriekmawReprint = Printing(
+    oracleId = "717bbb9d-0a5b-4979-a24b-9d54aac7657a",
+    name = "Shriekmaw",
+    setCode = "CMD",
+    collectorNumber = "100",
+    scryfallId = "64094fda-c6f9-4177-9a21-c919b8dfbf9f",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/64094fda-c6f9-4177-9a21-c919b8dfbf9f.jpg?1783941216",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1477,6 +1477,84 @@
     ]
 }
 
+// Brion Stoutarm
+{
+    "name": "Brion Stoutarm",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Giant Warrior",
+    "oracleText": "Lifelink\n{R}, {T}, Sacrifice another creature: Brion Stoutarm deals damage equal to the sacrificed creature's power to target player or planeswalker.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Sacrificed",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ],
+                "descriptionOverride": "Brion Stoutarm deals damage equal to the sacrificed creature's power to target player or planeswalker."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa21cfc2-9671-4bf3-b922-2f436f284cb1.jpg?1783942854",
+        "rulings": [
+            {
+                "date": "2018-03-16",
+                "text": "If Brion Stoutarm leaves the battlefield after its ability has been activated but before it resolves, the game uses its last known information to determine that it had lifelink and you'll gain life for the damage it deals."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Caterwauling Boggart
 {
     "name": "Caterwauling Boggart",
@@ -8633,6 +8711,120 @@
     ]
 }
 
+// Nath of the Gilt-Leaf
+{
+    "name": "Nath of the Gilt-Leaf",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Legendary Creature — Elf Warrior",
+    "oracleText": "At the beginning of your upkeep, you may have target opponent discard a card at random.\nWhenever an opponent discards a card, you may create a 1/1 green Elf Warrior creature token.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "Random",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "you may have target opponent discard a card at random."
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "you may have target opponent discard a card at random."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Elf",
+                            "Warrior"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27b171ac-b2ef-4a80-92d1-6d9e71f3e3ca.jpg?1783942838"
+                    },
+                    "descriptionOverride": "you may create a 1/1 green Elf Warrior creature token."
+                },
+                "descriptionOverride": "you may create a 1/1 green Elf Warrior creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "A savage hunter with a prince's bearing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c6c69bd-a8bf-4085-85fa-364b8e92b88a.jpg?1783942852"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Nath's Buffoon
 {
     "name": "Nath's Buffoon",
@@ -10078,6 +10270,80 @@
     "colorIdentityOverride": []
 }
 
+// Shriekmaw
+{
+    "name": "Shriekmaw",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhen this creature enters, destroy target nonartifact, nonblack creature.\nEvoke {1}{B} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FEAR",
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{1}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonartifact, nonblack creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsNonartifact",
+                                {
+                                    "type": "NotColor",
+                                    "color": "BLACK"
+                                }
+                            ]
+                        }
+                    },
+                    "id": "target nonartifact, nonblack creature"
+                },
+                "descriptionOverride": "destroy target nonartifact, nonblack creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea19eb5e-0d70-42e6-bda2-b13757e08ca6.jpg?1783942884",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "If you pay the evoke cost, you can have Shriekmaw's own triggered ability resolve before the evoke triggered ability. You can cast spells after that ability resolves but before you have to sacrifice Shriekmaw."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Silvergill Douser
 {
     "name": "Silvergill Douser",
@@ -11070,6 +11336,66 @@
     ]
 }
 
+// Sygg, River Guide
+{
+    "name": "Sygg, River Guide",
+    "manaCost": "{W}{U}",
+    "typeLine": "Legendary Creature — Merfolk Wizard",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n{1}{W}: Target Merfolk you control gains protection from the color of your choice until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ChooseColorThen",
+                    "then": {
+                        "type": "GrantProtectionFromChosenColor",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target Merfolk you control"
+                        }
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Merfolk ctrl:you"
+                        },
+                        "id": "target Merfolk you control"
+                    }
+                ],
+                "descriptionOverride": "Target Merfolk you control gains protection from the color of your choice until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "RARE",
+        "artist": "Larry MacDougall",
+        "flavorText": "\"If there's a place worth going, the Merrow Lanes already do. And if there's a route worth taking, yours truly already has.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb1aefaf-1b96-4c08-a73e-98e401655965.jpg?1783942852"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Tar Pitcher
 {
     "name": "Tar Pitcher",
@@ -11456,6 +11782,75 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Thousand-Year Elixir
+{
+    "name": "Thousand-Year Elixir",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "You may activate abilities of creatures you control as though those creatures had haste.\n{1}, {T}: Untap target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Untap target creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "RARE",
+        "artist": "Richard Sardinha",
+        "flavorText": "Paradoxically, to tilt the massive jug for a sip, you'd need the energy of the giant's tonic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18743fd4-2a15-40a2-ac90-e3f0fef07e37.jpg?1783942851",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Thousand-Year Elixir doesn't actually grant haste to creatures you control, nor does it let you attack with them as though they had haste."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Thundercloud Shaman

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1359,7 +1359,26 @@ class ActivateAbilityHandler(
         // Snapshot projected subtypes and P/T of sacrifice targets before zone change
         // (Rule 113.7a / 608.2h — "as it last existed on the battlefield"). Covers both the
         // fixed-count sacrifice cost and a variable-count one, which moves permanents just the same.
-        val sacrificeTargetIds = (action.costPayment?.sacrificedPermanents ?: emptyList()) +
+        //
+        // A *forced* sacrifice (candidates <= count) never pauses for a choice, so the action
+        // arrives with no chosen permanents and CostHandler auto-picks them during payment. Snapshot
+        // that same set here, or "deals damage equal to the sacrificed creature's power" (Brion
+        // Stoutarm with exactly one other creature) resolves EntityReference.Sacrificed to nothing
+        // and deals 0.
+        val chosenSacrifices = action.costPayment?.sacrificedPermanents ?: emptyList()
+        val forcedSacrifices = if (chosenSacrifices.isEmpty() && sacrificeCost != null) {
+            costHandler
+                .findMatchingCardsUnified(
+                    currentState, currentState.getBattlefield(action.playerId), sacrificeCost.filter,
+                    action.playerId, sourceId = action.sourceId,
+                )
+                .let { if (sacrificeCost.excludeSelf) it.filter { id -> id != action.sourceId } else it }
+                .takeIf { it.size <= sacrificeCost.count && !sacrificeCost.distinctNames }
+                .orEmpty()
+        } else {
+            emptyList()
+        }
+        val sacrificeTargetIds = chosenSacrifices + forcedSacrifices +
             (action.costPayment?.variableCostPermanents ?: emptyList())
         val sacrificedSnapshots = captureEntitySnapshots(sacrificeTargetIds, currentState.projectedState)
 


### PR DESCRIPTION
Five Lorwyn cards, all composition over existing primitives, plus one engine fix a scenario test surfaced. Lorwyn goes 210/286 → 215/286.

## Cards

- **Shriekmaw** — Fear, evoke {1}{B}, enters trigger destroying target nonartifact, nonblack creature. Mulldrifter's evoke shape with Expunge's `TargetFilter.Creature.nonartifact().notColor(BLACK)`. `Printing` rows for ARC, CMD, C14, C15.
- **Sygg, River Guide** — Islandwalk; `{1}{W}`: target Merfolk you control gains protection from the color of your choice until end of turn. `ChooseColorThen(GrantProtectionFromChosenColor)`, Thornscape Master's shape.
- **Brion Stoutarm** — Lifelink; `{R}, {T}, Sacrifice another creature`: damage equal to the sacrificed creature's power to target player or planeswalker. Bloodshot Cyclops' shape with `Costs.SacrificeAnother` and `Targets.PlayerOrPlaneswalker`. `Printing` row for CMD. Scenario test.
- **Nath of the Gilt-Leaf** — optional upkeep trigger: target opponent discards a card at random (`Patterns.Hand.discardRandom`); `Triggers.AnyOpponentDiscards` offering a 1/1 green Elf Warrior token. `Printing` row for C16. Scenario test (accept, decline, and that Nath's own discard feeds its token trigger).
- **Thousand-Year Elixir** — `GrantKeyword(MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY, creatures you control)`, the same static Shang-Chi carries, plus `{1}, {T}`: untap target creature. `Printing` row for C13. Scenario test (tap ability offered only with the Elixir out, no attack rights, untap).

## Engine fix — forced sacrifice costs lost their last-known information

Brion's test dealt 0 damage with exactly one other creature on the board. A sacrifice cost with no real choice (candidates ≤ count) never pauses, so the `ActivateAbility` action arrives with no chosen permanents and `CostHandler` auto-picks them during payment — but the LKI snapshot in `ActivateAbilityHandler` only read the action's chosen list, so `EntityReference.Sacrificed` resolved to nothing. The handler now snapshots the auto-picked set too. A real choice still goes through the pause and the resumed action, unchanged. Every "equal to the sacrificed creature's power/toughness/mana value" activated ability (Bloodshot Cyclops, Bosh, Priest of Yawgmoth's non-mana cousins) had this hole whenever exactly one permanent was eligible.

## Verification

- `just build` — green apart from the expected LRW golden diff (re-blessed; only `LRW.json` moved) and three coroutine-timeout failures in `PodArenaHarnessTest` / `AIPlayerTest` that are unrelated to card definitions (the machine was saturated; the build took 28 minutes).
- `just test-class` for the three new scenario tests — 8/8 pass.
- `just test-rules` — see the checks on this PR.
- `just check-card-printing` for all five cards — ok.
- `just assay-differential --set LRW` — the 10 `DIVERGENT` rows are all pre-existing (the Harbinger cycle, Kithkin Greatheart, Epic Proportions, Boggart Sprite-Chaser); none of the new cards diverges.

## Dropped during triage

Hunt Down ("target creature blocks target creature this turn if able") — `ForceBlockEffect` requires the attacker to already be attacking at resolution, which a main-phase sorcery can't satisfy; it needs a turn-scoped pairing, `add-feature` territory. Gaddock Teeg (no filter-based global cast restriction) and Oona's Prowler (no "any player may activate") were also skipped for missing vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WS9WqKjNVFMbYpznX38Qt
