### PR TITLE
Add 58 Assay-ready cards to Strixhaven: School of Mages

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PillardropRescuerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PillardropRescuerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pillardrop Rescuer reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val PillardropRescuerReprint = Printing(
+    oracleId = "5cf9002d-6c04-420b-8c3b-0a17f674bb09",
+    name = "Pillardrop Rescuer",
+    setCode = "J22",
+    collectorNumber = "226",
+    scryfallId = "55e4175b-d498-4f89-9dd0-559b22690312",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55e4175b-d498-4f89-9dd0-559b22690312.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/StrixhavenSchoolOfMagesSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/StrixhavenSchoolOfMagesSet.kt
@@ -26,6 +26,10 @@ object StrixhavenSchoolOfMagesSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AccessTunnel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AccessTunnel.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Access Tunnel — Strixhaven: School of Mages #262 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * {T}: Add {C}.
+ * {3}, {T}: Target creature with power 3 or less can't be blocked this turn.
+ *
+ * A colourless utility land in the Rogue's Passage shape. The first ability is a plain colourless
+ * mana ability; the second targets, so it is a regular activated ability that grants the
+ * [AbilityFlag.CANT_BE_BLOCKED] flag until end of turn to a creature picked through
+ * [Targets.CreatureWithPowerAtMost] — the power check is a targeting restriction, not a resolution
+ * condition.
+ */
+val AccessTunnel = card("Access Tunnel") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText =
+        "{T}: Add {C}.\n" +
+        "{3}, {T}: Target creature with power 3 or less can't be blocked this turn."
+
+    // {T}: Add {C}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {3}, {T}: Target creature with power 3 or less can't be blocked this turn.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val creature = target("target", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "262"
+        artist = "Alayna Danner"
+        flavorText = "Oriq agents stick to the dark corners of Arcavios, unseen yet ever-present."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg?1783927277"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AetherHelix.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AetherHelix.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Aether Helix — Strixhaven: School of Mages #162 (canonical printing)
+ * {3}{G}{U} · Sorcery
+ *
+ * Return target permanent to its owner's hand. Return target permanent card from your graveyard to your hand.
+ *
+ * Two independent targets, each bounced by [Effects.ReturnToHand] in printed order: the first is
+ * any permanent on the battlefield ([Targets.Permanent]), the second is the Nature's Spiral shape —
+ * a permanent card you own, zoned to your graveyard. Both are required targets, so the spell needs
+ * a legal choice for each to be cast (CR 601.2c).
+ */
+val AetherHelix = card("Aether Helix") {
+    manaCost = "{3}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Sorcery"
+    oracleText =
+        "Return target permanent to its owner's hand. Return target permanent card from your graveyard to your hand."
+
+    spell {
+        val permanent = target("target", Targets.Permanent)
+        val graveyardCard = target(
+            "target 1",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Permanent.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.ReturnToHand(permanent) then Effects.ReturnToHand(graveyardCard)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Torstein Nordstrand"
+        flavorText = "Some Quandrix mages prefer to study at twilight, watching their experimental equations trace glowing trails against the encroaching darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg?1783927325"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ArchwayCommons.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ArchwayCommons.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Archway Commons — Strixhaven: School of Mages #263 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * This land enters tapped.
+ * When this land enters, sacrifice it unless you pay {1}.
+ * {T}: Add one mana of any color.
+ *
+ * The Gateway Plaza / Rupture Spire shape: an unconditional [EntersTapped], an enters trigger whose
+ * "sacrifice it unless you pay {1}" is a [PayOrSufferEffect] with a mana atom for the pay half and
+ * [SacrificeSelfEffect] for the suffer half, and a five-colour mana ability via
+ * [Effects.AddManaOfChoice].
+ */
+val ArchwayCommons = card("Archway Commons") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText =
+        "This land enters tapped.\n" +
+        "When this land enters, sacrifice it unless you pay {1}.\n" +
+        "{T}: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+
+    // When this land enters, sacrifice it unless you pay {1}.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{1}"), suffer = SacrificeSelfEffect)
+    }
+
+    // {T}: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "263"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg?1783927276"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BasicConjuration.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BasicConjuration.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Basic Conjuration — Strixhaven: School of Mages #120 (canonical printing)
+ * {1}{G}{G} · Sorcery — Lesson
+ *
+ * Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.
+ *
+ * The look-at-the-top dig is [Patterns.Library.lookAtTopRevealMatchingToHand] — a private look at
+ * six, an optional filtered pick that is revealed as it goes to hand, and the rest to the bottom in
+ * a random order (its defaults). The life gain follows as a plain [Effects.GainLife] in printed
+ * order. Lesson is only a subtype.
+ */
+val BasicConjuration = card("Basic Conjuration") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life."
+
+    spell {
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(6),
+            filter = GameObjectFilter.Creature,
+            prompt = "You may reveal a creature card from among them and put it into your hand"
+        ) then Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Randy Vargas"
+        flavorText = "\"I made that! It's mine! Did you see that?\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg?1783927348"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BeamingDefiance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BeamingDefiance.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beaming Defiance — Strixhaven: School of Mages #9 (canonical printing)
+ * {1}{W} · Instant
+ *
+ * Target creature you control gets +2/+2 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)
+ *
+ * One target, two until-end-of-turn effects in printed order: [Effects.ModifyStats] for the +2/+2,
+ * then [Effects.GrantKeyword] for hexproof, both bound to the same [Targets.CreatureYouControl].
+ */
+val BeamingDefiance = card("Beaming Defiance") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Target creature you control gets +2/+2 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)"
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 2, creature) then
+            Effects.GrantKeyword(Keyword.HEXPROOF, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Manuel Castañón"
+        flavorText = "\"I've lived too long in my father's shadow. It's time to find my own light.\"\n—Killian, Silverquill mage-student"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg?1783927395"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BigPlay.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BigPlay.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Big Play — Strixhaven: School of Mages #122 (canonical printing)
+ * {1}{G} · Instant
+ *
+ * Target creature gets +2/+2 and gains reach until end of turn. Put a +1/+1 counter on it. (A creature with reach can block creatures with flying.)
+ *
+ * The Snare the Skies pump with a counter rider, all on one target. The first sentence is its own
+ * [Effects.Composite] of [Effects.ModifyStats] and [Effects.GrantKeyword] (both until end of
+ * turn), and that composite is then followed by the permanent [Effects.AddCounters] — nested
+ * explicitly rather than chained with `then`, which would flatten the first sentence away.
+ */
+val BigPlay = card("Big Play") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText =
+        "Target creature gets +2/+2 and gains reach until end of turn. Put a +1/+1 counter on it. (A creature with reach can block creatures with flying.)"
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Composite(
+                Effects.ModifyStats(2, 2, creature),
+                Effects.GrantKeyword(Keyword.REACH, creature)
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Nicholas Gregory"
+        flavorText = "\"Quandrix is running out of time. If they're going to capture the Witherbloom mascot, they need something big here.\"\n—Cremik, Mage Tower commentator"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg?1783927347"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BladeHistorian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BladeHistorian.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blade Historian — Strixhaven: School of Mages #165 (canonical printing)
+ * {R/W}{R/W}{R/W}{R/W} · Creature — Human Cleric · 2/3
+ *
+ * Attacking creatures you control have double strike.
+ *
+ * The Berserkers' Onslaught shape: a single Layer 6 [GrantKeyword] static whose group filter is
+ * creatures you control that are attacking — the attacking state is part of the filter, so the
+ * grant appears and disappears with combat rather than needing a trigger.
+ */
+val BladeHistorian = card("Blade Historian") {
+    manaCost = "{R/W}{R/W}{R/W}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Cleric"
+    oracleText =
+        "Attacking creatures you control have double strike."
+    power = 2
+    toughness = 3
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.DOUBLE_STRIKE,
+            filter = GroupFilter(GameObjectFilter.Creature.attacking().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Cristi Balanescu"
+        flavorText = "\"So you see, the reckless battle strategy of the Kathorran orcs was effective, but ultimately proved to be a double-edged sword. As did their double-edged swords.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg?1783927324"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BloodResearcher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BloodResearcher.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blood Researcher — Strixhaven: School of Mages #166 (canonical printing)
+ * {1}{B}{G} · Creature — Vampire Druid · 2/2
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Whenever you gain life, put a +1/+1 counter on this creature.
+ *
+ * The Ajani's Pridemate shape: [Triggers.YouGainLife] fires once per life-gain event (CR 603.2c —
+ * gaining 4 life at once is one trigger), and the payoff is [Effects.AddCounters] on
+ * [EffectTarget.Self].
+ */
+val BloodResearcher = card("Blood Researcher") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Vampire Druid"
+    oracleText =
+        "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Whenever you gain life, put a +1/+1 counter on this creature."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "166"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Dean Valentin warns us not to consume the samples for our safety, but I think he's just being greedy.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg?1783927323"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BrackishTrudge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/BrackishTrudge.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brackish Trudge — Strixhaven: School of Mages #65 (canonical printing)
+ * {2}{B} · Creature — Fungus Beast · 4/2
+ *
+ * This creature enters tapped.
+ * {1}{B}: Return this card from your graveyard to your hand. Activate only if you gained life this turn.
+ *
+ * An unconditional [EntersTapped] replacement, plus an activated ability that functions from the
+ * graveyard (`activateFromZone = Zone.GRAVEYARD`). The return is
+ * [Effects.ReturnToHandFromGraveyard] — a `MoveToZone` to hand that carries the graveyard guard,
+ * so a Trudge exiled from the graveyard in response does not come back from exile. "Activate only
+ * if you gained life this turn" is an [ActivationRestriction.OnlyIfCondition] over
+ * [Conditions.YouGainedLifeThisTurn], the `LIFE_GAINED` turn tracker read at 1 or more.
+ */
+val BrackishTrudge = card("Brackish Trudge") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Fungus Beast"
+    oracleText =
+        "This creature enters tapped.\n" +
+        "{1}{B}: Return this card from your graveyard to your hand. Activate only if you gained life this turn."
+    power = 4
+    toughness = 2
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(Conditions.YouGainedLifeThisTurn)
+        )
+        description = "{1}{B}: Return this card from your graveyard to your hand. Activate only if " +
+            "you gained life this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Most trudges are covered with decaying plant matter, making them ideal breeding grounds for fungal spores."
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg?1783927369"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DaemogothTitan.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DaemogothTitan.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Daemogoth Titan — Strixhaven: School of Mages #174 (canonical printing)
+ * {B/G}{B/G}{B/G}{B/G} · Creature — Demon · 11/10
+ *
+ * Whenever this creature attacks or blocks, sacrifice a creature.
+ *
+ * "Attacks or blocks" is two triggered abilities sharing one effect — [Triggers.Attacks] and
+ * [Triggers.Blocks] are separate events, the Elder Gargaroth shape. The bare imperative
+ * "sacrifice a creature" is [Effects.SacrificeOwn]: the Titan's controller chooses, and the Titan
+ * itself is a legal choice.
+ */
+val DaemogothTitan = card("Daemogoth Titan") {
+    manaCost = "{B/G}{B/G}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Demon"
+    oracleText =
+        "Whenever this creature attacks or blocks, sacrifice a creature."
+    power = 11
+    toughness = 10
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "174"
+        artist = "Chris Cold"
+        flavorText = "\"Of course it offered you power. Demons always do. But trust me—the sweeter the prize, the more ruinous the price.\"\n—Professor Onyx"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg?1783927319"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DefendTheCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DefendTheCampus.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Defend the Campus — Strixhaven: School of Mages #12 (canonical printing)
+ * {3}{W} · Instant
+ *
+ * Choose one —
+ * • Creatures you control get +1/+1 until end of turn.
+ * • Destroy target creature with power 4 or greater.
+ *
+ * An ordinary "choose one" `modal`. The first mode is the untargeted team pump,
+ * [Patterns.Group.modifyStatsForAll] over the creatures you control; the second is [Effects.Destroy]
+ * whose target is narrowed to `powerAtLeast(4)`, which the legality check reads off projected state
+ * so a creature pumped to 4 this turn is a legal target.
+ */
+val DefendTheCampus = card("Defend the Campus") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Choose one —\n" +
+        "• Creatures you control get +1/+1 until end of turn.\n" +
+        "• Destroy target creature with power 4 or greater."
+
+    spell {
+        modal {
+            mode(
+                "Creatures you control get +1/+1 until end of turn",
+                Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+            )
+            mode("Destroy target creature with power 4 or greater") {
+                val victim = target(
+                    "target",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(4)))
+                )
+                effect = Effects.Destroy(victim)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Izzy"
+        flavorText = "Professors scrambled to push the mage hunters back, leaving the heart of Strixhaven undefended."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg?1783927394"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ElementalSummoning.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ElementalSummoning.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elemental Summoning — Strixhaven: School of Mages #183 (canonical printing)
+ * {3}{U/R}{U/R} · Sorcery — Lesson
+ *
+ * Create a 4/4 blue and red Elemental creature token.
+ *
+ * A single [Effects.CreateToken]: a 4/4 blue-and-red Elemental with no keywords. Token art
+ * resolves through STX's synced token printings, so none is declared here. Lesson is only a
+ * subtype.
+ */
+val ElementalSummoning = card("Elemental Summoning") {
+    manaCost = "{3}{U/R}{U/R}"
+    colorIdentity = "RU"
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Create a 4/4 blue and red Elemental creature token."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.BLUE, Color.RED),
+            creatureTypes = setOf("Elemental")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Marta Nael"
+        flavorText = "\"You've made a splash. Now show me a torrent.\"\n—Uvilda, Prismari dean"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg?1783927316"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EnvironmentalSciences.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EnvironmentalSciences.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Environmental Sciences — Strixhaven: School of Mages #1 (canonical printing)
+ * {2} · Sorcery — Lesson
+ *
+ * Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 2 life.
+ *
+ * The search is [Patterns.Library.searchLibrary] with the basic-land filter, the hand as its
+ * default destination, the found card revealed, and the shuffle plus the "library searched" event
+ * it always appends. The life gain follows as a plain [Effects.GainLife] in printed order. Lesson
+ * is only a subtype.
+ */
+val EnvironmentalSciences = card("Environmental Sciences") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 2 life."
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            reveal = true
+        ) then Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Jokubas Uogintas"
+        flavorText = "First-years quickly learn how the Vastlands earned its name."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg?1783927397"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EssenceInfusion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EssenceInfusion.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Essence Infusion — Strixhaven: School of Mages #69 (canonical printing)
+ * {1}{B} · Sorcery
+ *
+ * Put two +1/+1 counters on target creature. It gains lifelink until end of turn.
+ *
+ * One target, two clauses in printed order: [Effects.AddCounters] of two +1/+1 counters, `then`
+ * [Effects.GrantKeyword] of lifelink with the default until-end-of-turn duration. The counters are
+ * permanent; only the lifelink expires.
+ */
+val EssenceInfusion = card("Essence Infusion") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText =
+        "Put two +1/+1 counters on target creature. It gains lifelink until end of turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, creature) then
+            Effects.GrantKeyword(Keyword.LIFELINK, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Randy Vargas"
+        flavorText = "\"I'd say it's still a fair fight—now my friend is about the size of your ego.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg?1783927368"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ExcavatedWall.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ExcavatedWall.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Excavated Wall — Strixhaven: School of Mages #255 (canonical printing)
+ * {1} · Artifact Creature — Wall · 0/4
+ *
+ * Defender
+ * {1}, {T}: Mill a card. (Put the top card of your library into your graveyard.)
+ *
+ * A colourless Wall with a repeatable self-mill. Defender is the bare keyword; the activation is
+ * [Patterns.Library.mill] — the Gather → Move pipeline whose top-of-library source is flagged as a
+ * mill so "whenever you mill" watchers see it.
+ */
+val ExcavatedWall = card("Excavated Wall") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Wall"
+    oracleText =
+        "Defender\n" +
+        "{1}, {T}: Mill a card. (Put the top card of your library into your graveyard.)"
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    // {1}, {T}: Mill a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Patterns.Library.mill(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "255"
+        artist = "Zezhou Chen"
+        flavorText = "\"Don't be fooled by the quiet. These old stones are trying to talk to you.\"\n—Augusta, Lorehold dean"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg?1783927281"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ExpandedAnatomy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ExpandedAnatomy.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Expanded Anatomy — Strixhaven: School of Mages #2 (canonical printing)
+ * {3} · Sorcery — Lesson
+ *
+ * Put two +1/+1 counters on target creature. It gains vigilance until end of turn.
+ *
+ * One target, two effects in printed order: [Effects.AddCounters] for the two +1/+1 counters, then
+ * [Effects.GrantKeyword] for the until-end-of-turn vigilance, both bound to the same creature.
+ * Lesson is only a subtype.
+ */
+val ExpandedAnatomy = card("Expanded Anatomy") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Put two +1/+1 counters on target creature. It gains vigilance until end of turn."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, creature) then
+            Effects.GrantKeyword(Keyword.VIGILANCE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Slawomir Maniak"
+        flavorText = "\"Changing the equation from incremental to exponential was a stroke of genius on my part.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg?1783927396"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Expel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Expel.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Expel — Strixhaven: School of Mages #18 (canonical printing)
+ * {2}{W} · Instant
+ *
+ * Exile target tapped creature.
+ *
+ * A plain [Effects.Exile] whose tapped restriction lives in the target requirement
+ * ([Targets.TappedCreature]), so an untapped creature is not a legal target at all rather than
+ * being targeted and then spared.
+ */
+val Expel = card("Expel") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Exile target tapped creature."
+
+    spell {
+        val victim = target("target tapped creature", Targets.TappedCreature)
+        effect = Effects.Exile(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Billy Christian"
+        flavorText = "Quintorius was a daydreamer, far happier digging through history books than practicing battle tactics. He agreed with the military academy on only one thing: he did not belong in their ranks."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg?1783927392"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FumingEffigy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FumingEffigy.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fuming Effigy — Strixhaven: School of Mages #103 (canonical printing)
+ * {3}{R} · Creature — Spirit · 4/3
+ *
+ * Whenever one or more cards leave your graveyard, this creature deals 1 damage to each opponent.
+ *
+ * "One or more … leave" is CR 603.2c batch wording, so the trigger is the batching
+ * [Triggers.CardsLeaveYourGraveyard] with its default any-card filter: a mass reanimation or a
+ * graveyard-exiling sweep fires it exactly once. The damage is a single [Effects.DealDamage]
+ * aimed at [Player.EachOpponent].
+ */
+val FumingEffigy = card("Fuming Effigy") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    oracleText =
+        "Whenever one or more cards leave your graveyard, this creature deals 1 damage to each opponent."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Ryan Alexander Lee"
+        flavorText = "Some spirits share ancient wisdom. Others just get mad you touched their stuff."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg?1783927355"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GalazethPrismari.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GalazethPrismari.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Galazeth Prismari — Strixhaven: School of Mages #189 (canonical printing)
+ * {2}{U}{R} · Legendary Creature — Elder Dragon · 3/4
+ *
+ * Flying
+ * When Galazeth Prismari enters, create a Treasure token.
+ * Artifacts you control have "{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell."
+ *
+ * The ETB is [Effects.CreateTreasure]. The granted ability is the Gemhide Sliver shape — a
+ * [GrantActivatedAbility] static handing every artifact you control a tap mana ability — with
+ * [Effects.AddManaOfChoice] carrying [ManaRestriction.InstantOrSorceryOnly], the Vodalian Arcanist
+ * restriction. The Treasure the ETB makes is itself an artifact, so it gains the untap-free version
+ * of its own ability alongside the printed sacrifice one.
+ */
+val GalazethPrismari = card("Galazeth Prismari") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Legendary Creature — Elder Dragon"
+    oracleText =
+        "Flying\n" +
+        "When Galazeth Prismari enters, create a Treasure token.\n" +
+        "Artifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\""
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(1)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Tap,
+                effect = Effects.AddManaOfChoice(restriction = ManaRestriction.InstantOrSorceryOnly),
+                timing = TimingRule.ManaAbility,
+                isManaAbility = true
+            ),
+            filter = GroupFilter(GameObjectFilter.Artifact.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "189"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg?1783927311"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HallMonitor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HallMonitor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hall Monitor — Strixhaven: School of Mages #105 (canonical printing)
+ * {R} · Creature — Lizard Shaman · 1/1
+ *
+ * Haste
+ * {1}{R}, {T}: Target creature can't block this turn.
+ *
+ * The activated ability is the Blood Aspirant shape: a [Costs.Composite] of mana plus tap, and
+ * [Effects.CantBlock] over the single bound creature target, which defaults to end-of-turn.
+ */
+val HallMonitor = card("Hall Monitor") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Shaman"
+    oracleText =
+        "Haste\n" +
+        "{1}{R}, {T}: Target creature can't block this turn."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.Tap)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.CantBlock(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Forrest Imel"
+        flavorText = "\"No unauthorized summoning. No writing in the library books. And absolutely no indoor dueling!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg?1783927354"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HeatedDebate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HeatedDebate.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heated Debate — Strixhaven: School of Mages #106 (canonical printing)
+ * {2}{R} · Instant
+ *
+ * This spell can't be countered. (This includes by the ward ability.)
+ * Heated Debate deals 4 damage to target creature or planeswalker.
+ *
+ * The Urza's Rage shape without the kicker: `cantBeCountered` is a flag on the card itself — the
+ * engine reads it wherever a spell would be countered, which is what makes it beat ward — and the
+ * body is a single [Effects.DealDamage] of 4 to a [Targets.CreatureOrPlaneswalker] target.
+ */
+val HeatedDebate = card("Heated Debate") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText =
+        "This spell can't be countered. (This includes by the ward ability.)\n" +
+        "Heated Debate deals 4 damage to target creature or planeswalker."
+
+    cantBeCountered = true
+
+    spell {
+        val victim = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(4, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Bayard Wu"
+        flavorText = "\"While you were wasting time with abstract equations, I mastered ancient Oggyar fire magic. Your move.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg?1783927353"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/InklingSummoning.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/InklingSummoning.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inkling Summoning — Strixhaven: School of Mages #195 (canonical printing)
+ * {1}{W/B}{W/B} · Sorcery — Lesson
+ *
+ * Create a 2/1 white and black Inkling creature token with flying.
+ *
+ * A single [Effects.CreateToken]: a 2/1 white-and-black Inkling with flying. Token art resolves
+ * through STX's synced token printings, so none is declared here. Lesson is only a subtype.
+ */
+val InklingSummoning = card("Inkling Summoning") {
+    manaCost = "{1}{W/B}{W/B}"
+    colorIdentity = "BW"
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Create a 2/1 white and black Inkling creature token with flying."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.WHITE, Color.BLACK),
+            creatureTypes = setOf("Inkling"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Scott Murphy"
+        flavorText = "\"Think of an insult so vicious, so vulgar, that you hesitate to speak it aloud. The strongest, most aggressive inklings are born from such scorn.\"\n—Embrose, Silverquill dean"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg?1783927310"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/IntroductionToProphecy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/IntroductionToProphecy.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Introduction to Prophecy — Strixhaven: School of Mages #4 (canonical printing)
+ * {3} · Sorcery — Lesson
+ *
+ * Scry 2, then draw a card.
+ *
+ * Printed order matters: [Effects.Scry] resolves first so the [Effects.DrawCards] that follows
+ * takes the card the scry left on top. Lesson is only a subtype.
+ */
+val IntroductionToProphecy = card("Introduction to Prophecy") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Scry 2, then draw a card."
+
+    spell {
+        effect = Effects.Scry(2) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Micah Epstein"
+        flavorText = "Final grades are posted on the first day of class."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg?1783927395"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LashOfMalice.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LashOfMalice.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lash of Malice — Strixhaven: School of Mages #74 (canonical printing)
+ * {B} · Instant
+ *
+ * Target creature gets +2/-2 until end of turn.
+ *
+ * The Flowstone Infusion shape: a single [Effects.ModifyStats] of +2/-2 on the targeted creature
+ * with the default until-end-of-turn duration. Nothing restricts the target's controller, so the
+ * bare [Targets.Creature] requirement is correct — it kills an X/2 as readily as it pumps.
+ */
+val LashOfMalice = card("Lash of Malice") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText =
+        "Target creature gets +2/-2 until end of turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, -2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Slawomir Maniak"
+        flavorText = "\"The strongest shadow spells come from disdain for someone else, not frustration with yourself.\"\n—Embrose, Silverquill dean"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg?1783927367"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LetterOfAcceptance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LetterOfAcceptance.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Letter of Acceptance — Strixhaven: School of Mages #256 (canonical printing)
+ * {3} · Artifact
+ *
+ * {T}: Add one mana of any color.
+ * {2}, {T}, Sacrifice this artifact: Draw a card.
+ *
+ * A mana rock in the Guild Globe shape: a five-colour mana ability via [Effects.AddManaOfChoice],
+ * and a cash-out whose cost is a [Costs.Composite] of mana, tap and [Costs.SacrificeSelf] paying
+ * for a plain [Effects.DrawCards].
+ */
+val LetterOfAcceptance = card("Letter of Acceptance") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText =
+        "{T}: Add one mana of any color.\n" +
+        "{2}, {T}, Sacrifice this artifact: Draw a card."
+
+    // {T}: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {2}, {T}, Sacrifice this artifact: Draw a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "256"
+        artist = "Daniel Ljunggren"
+        flavorText = "The letter unfolded, inviting the twins to Strixhaven. Will saw a chance for arcane study. Rowan saw a chance for power."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg?1783927280"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LoreholdCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LoreholdCampus.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Lorehold Campus — Strixhaven: School of Mages #268 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * This land enters tapped.
+ * {T}: Add {R} or {W}.
+ * {4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The Campus cycle (see [PrismariCampus]): an unconditional [EntersTapped] plus "Add {R} or {W}"
+ * written as two separate one-colour mana abilities — the player picks a colour by picking which
+ * ability to activate — and a plain [Effects.Scry] behind the {4} activation.
+ */
+val LoreholdCampus = card("Lorehold Campus") {
+    manaCost = ""
+    colorIdentity = "RW"
+    typeLine = "Land"
+    oracleText =
+        "This land enters tapped.\n" +
+        "{T}: Add {R} or {W}.\n" +
+        "{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {R} or {W}. — modeled as one ability per colour.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {4}, {T}: Scry 1.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Scry(1)
+        description = "{4}, {T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "268"
+        artist = "Titus Lunter"
+        flavorText = "Mage-students obsessed with the secrets of the past choose Lorehold, the college of archaeomancy."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg?1783927272"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LoreholdCommand.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/LoreholdCommand.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lorehold Command — Strixhaven: School of Mages #199 (canonical printing)
+ * {3}{R}{W} · Instant
+ *
+ * Choose two —
+ * • Create a 3/2 red and white Spirit creature token.
+ * • Creatures you control get +1/+0 and gain indestructible and haste until end of turn.
+ * • Lorehold Command deals 3 damage to any target. Target player gains 3 life.
+ * • Sacrifice a permanent, then draw two cards.
+ *
+ * A `modal(chooseCount = 2)` spell with per-mode targets. The pump mode is the Overrun shape — one
+ * [Effects.ForEachInGroup] over creatures you control carrying a single composite of the stat bump
+ * and both keyword grants, so the group is gathered exactly once. The damage mode binds two targets
+ * (any target, then a player); the sacrifice mode is the bare imperative [Effects.SacrificeOwn]
+ * followed by the draw.
+ */
+val LoreholdCommand = card("Lorehold Command") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Instant"
+    oracleText =
+        "Choose two —\n" +
+        "• Create a 3/2 red and white Spirit creature token.\n" +
+        "• Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n" +
+        "• Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n" +
+        "• Sacrifice a permanent, then draw two cards."
+
+    spell {
+        modal(chooseCount = 2) {
+            mode("Create a 3/2 red and white Spirit creature token") {
+                effect = Effects.CreateToken(
+                    power = 3,
+                    toughness = 2,
+                    colors = setOf(Color.RED, Color.WHITE),
+                    creatureTypes = setOf("Spirit")
+                )
+            }
+            mode("Creatures you control get +1/+0 and gain indestructible and haste until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter.AllCreaturesYouControl,
+                    Effects.Composite(
+                        Effects.ModifyStats(1, 0, EffectTarget.Self),
+                        Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self),
+                        Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+                    )
+                )
+            }
+            mode("Lorehold Command deals 3 damage to any target. Target player gains 3 life") {
+                val victim = target("any target", Targets.Any)
+                val player = target("target player", Targets.Player)
+                effect = Effects.DealDamage(3, victim) then Effects.GainLife(3, player)
+            }
+            mode("Sacrifice a permanent, then draw two cards") {
+                effect = Effects.SacrificeOwn(GameObjectFilter.Permanent) then Effects.DrawCards(2)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "199"
+        artist = "Jason Rainville"
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg?1783927309"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/MolderingKarok.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/MolderingKarok.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moldering Karok — Strixhaven: School of Mages #206 (canonical printing)
+ * {2}{B}{G} · Creature — Zombie Crocodile · 3/3
+ *
+ * Trample, lifelink
+ *
+ * Two plain evergreen keywords, nothing else — both are simple [Keyword] markers the engine
+ * reads directly.
+ */
+val MolderingKarok = card("Moldering Karok") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Zombie Crocodile"
+    oracleText =
+        "Trample, lifelink"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "206"
+        artist = "Nicholas Gregory"
+        flavorText = "Necroluminescence is common among the undead creatures of Sedgemoor, giving the midnight swamp an eerie glow. It's comforting—from a distance."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg?1783927305"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/MortalitySpear.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/MortalitySpear.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Mortality Spear — Strixhaven: School of Mages #207 (canonical printing)
+ * {2}{B}{G} · Instant
+ *
+ * This spell costs {2} less to cast if you gained life this turn.
+ * Destroy target nonland permanent.
+ *
+ * The discount is a [ModifySpellCost] static on the spell itself ([SpellCostTarget.SelfCast]),
+ * gated on the per-turn life-gained tracker via [Conditions.YouGainedLifeThisTurn], so it rides
+ * the existing spell-cost rail and shows in the client's cost preview. The body is a plain
+ * [Effects.Destroy] of a nonland permanent.
+ */
+val MortalitySpear = card("Mortality Spear") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText =
+        "This spell costs {2} less to cast if you gained life this turn.\n" +
+        "Destroy target nonland permanent."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.YouGainedLifeThisTurn)
+        )
+    }
+
+    spell {
+        val victim = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "PINDURSKI"
+        flavorText = "\"Death is my life's work.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg?1783927305"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/NeedlethornDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/NeedlethornDrake.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Needlethorn Drake — Strixhaven: School of Mages #208 (canonical printing)
+ * {G}{U} · Creature — Drake · 1/1
+ *
+ * Flying, deathtouch
+ *
+ * Two plain evergreen keywords, nothing else — both are simple [Keyword] markers the engine
+ * reads directly.
+ */
+val NeedlethornDrake = card("Needlethorn Drake") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Drake"
+    oracleText =
+        "Flying, deathtouch"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "208"
+        artist = "Donato Giancola"
+        flavorText = "As they learn to fly, young drakes have a tendency to accidentally impale trees, cliffs, and unsuspecting students."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg?1783927304"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/NoviceDissector.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/NoviceDissector.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Novice Dissector — Strixhaven: School of Mages #79 (canonical printing)
+ * {3}{B} · Creature — Troll Warlock · 3/3
+ *
+ * {1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery.
+ *
+ * The Gobbling Ooze cost with a targeted payoff: [Costs.Composite] of the mana and
+ * [Costs.SacrificeAnother] — [Costs.Sacrifice] with the source excluded, so the Dissector can never
+ * feed itself to the ability — then [Effects.AddCounters] of one +1/+1 counter on any target
+ * creature. "Activate only as a sorcery" is [TimingRule.SorcerySpeed].
+ */
+val NoviceDissector = card("Novice Dissector") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Troll Warlock"
+    oracleText =
+        "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature),
+        )
+        val creature = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        timing = TimingRule.SorcerySpeed
+        description = "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. " +
+            "Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Mads Ahm"
+        flavorText = "\"The professor said to first extract the venom glands, then the acid sac. Next up, the . . . meeping organ?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg?1783927363"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OggyarBattleSeer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OggyarBattleSeer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oggyar Battle-Seer — Strixhaven: School of Mages #209 (canonical printing)
+ * {3}{U}{R} · Creature — Ogre Shaman · 3/4
+ *
+ * Haste
+ * {T}: Scry 1.
+ *
+ * Haste is a plain [Keyword] marker; the tap ability is [Costs.Tap] paying for a bare
+ * [Effects.Scry].
+ */
+val OggyarBattleSeer = card("Oggyar Battle-Seer") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Creature — Ogre Shaman"
+    oracleText =
+        "Haste\n" +
+        "{T}: Scry 1."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Scry(1)
+        description = "{T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "209"
+        artist = "Karl Kopinski"
+        flavorText = "\"May Ganathog bless us with bloody visions of glory restored!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg?1783927304"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OwlinShieldmage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OwlinShieldmage.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Owlin Shieldmage — Strixhaven: School of Mages #210 (canonical printing)
+ * {3}{W}{B} · Creature — Bird Warlock · 3/3
+ *
+ * Flying
+ * Ward—Pay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)
+ *
+ * Flying is a plain [Keyword] marker. Ward with a life payment is the parameterized
+ * [KeywordAbility.wardLife] (CR 702.21a); the bare `Keyword.WARD` marker is derived from that
+ * ability by the builder, so it is not restated here.
+ */
+val OwlinShieldmage = card("Owlin Shieldmage") {
+    manaCost = "{3}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Bird Warlock"
+    oracleText =
+        "Flying\n" +
+        "Ward—Pay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.wardLife(3))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Raoul Vitale"
+        flavorText = "\"Aim higher next time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg?1783927304"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PillardropRescuer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PillardropRescuer.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pillardrop Rescuer — Strixhaven: School of Mages #23 (canonical printing)
+ * {4}{W} · Creature — Spirit Cleric · 2/2
+ *
+ * Flying
+ * When this creature enters, return target creature card with mana value 3 or less from your graveyard to your hand.
+ *
+ * Flying is the bare keyword. The ETB is a non-optional [Triggers.EntersBattlefield] whose target is
+ * [TargetFilter.CreatureInYourGraveyard] narrowed to `manaValueAtMost(3)`, returned with a plain
+ * [Effects.ReturnToHand] — the graveyard restriction lives in the target's zone, not in the move.
+ */
+val PillardropRescuer = card("Pillardrop Rescuer") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Cleric"
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, return target creature card with mana value 3 or less from your graveyard to your hand."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val rescued = target(
+            "target",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3))
+        )
+        effect = Effects.ReturnToHand(rescued)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Jason A. Engle"
+        flavorText = "Gentle hands of stone whisk the careless from the crumbling ruins of Pillardrop."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg?1783927388"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ProfessorsWarning.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ProfessorsWarning.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Professor's Warning — Strixhaven: School of Mages #84 (canonical printing)
+ * {B} · Instant
+ *
+ * Choose one —
+ * • Put a +1/+1 counter on target creature.
+ * • Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+ *
+ * A choose-one modal (the Valorous Stance shape) where each mode carries its own creature target:
+ * the first is [Effects.AddCounters] of a single +1/+1 counter, the second [Effects.GrantKeyword]
+ * of indestructible with the default until-end-of-turn duration.
+ */
+val ProfessorsWarning = card("Professor's Warning") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText =
+        "Choose one —\n" +
+        "• Put a +1/+1 counter on target creature.\n" +
+        "• Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Put a +1/+1 counter on target creature.") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            }
+            mode("Target creature gains indestructible until end of turn.") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Kieran Yanner"
+        flavorText = "Professor Onyx urged the twins to prepare for the dark mage Extus, sounding very much like someone familiar with the rise of tyrants."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg?1783927363"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/QuandrixCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/QuandrixCampus.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Quandrix Campus — Strixhaven: School of Mages #271 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * This land enters tapped.
+ * {T}: Add {G} or {U}.
+ * {4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The Campus cycle (see [PrismariCampus]): an unconditional [EntersTapped] plus "Add {G} or {U}"
+ * written as two separate one-colour mana abilities — the player picks a colour by picking which
+ * ability to activate — and a plain [Effects.Scry] behind the {4} activation.
+ */
+val QuandrixCampus = card("Quandrix Campus") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Land"
+    oracleText =
+        "This land enters tapped.\n" +
+        "{T}: Add {G} or {U}.\n" +
+        "{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {G} or {U}. — modeled as one ability per colour.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {4}, {T}: Scry 1.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Scry(1)
+        description = "{4}, {T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "271"
+        artist = "Piotr Dura"
+        flavorText = "Mage-students who see the beauty in patterns and equations choose Quandrix, the college of numeromancy."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg?1783927273"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/QuintoriusFieldHistorian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/QuintoriusFieldHistorian.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Quintorius, Field Historian — Strixhaven: School of Mages #220 (canonical printing)
+ * {3}{R}{W} · Legendary Creature — Elephant Cleric · 2/4
+ *
+ * Spirits you control get +1/+0.
+ * Whenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token.
+ *
+ * "Spirits you control" is a bare tribal noun, so the anthem is a static [ModifyStats] over
+ * *permanents* with the Spirit subtype, not creatures. "One or more … leave" is CR 603.2c batch
+ * wording, so [Triggers.CardsLeaveYourGraveyard] fires once per event batch however many cards
+ * moved.
+ */
+val QuintoriusFieldHistorian = card("Quintorius, Field Historian") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Elephant Cleric"
+    oracleText =
+        "Spirits you control get +1/+0.\n" +
+        "Whenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token."
+    power = 2
+    toughness = 4
+
+    staticAbility {
+        ability = ModifyStats(1, 0, GroupFilter(GameObjectFilter.Permanent.withSubtype("Spirit").youControl()))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 2,
+            colors = setOf(Color.RED, Color.WHITE),
+            creatureTypes = setOf("Spirit")
+        )
+        description = "Whenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Bryan Sola"
+        flavorText = "\"Every life has a story to tell. I won't let them be forgotten.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg?1783927298"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RelicSloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RelicSloth.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Relic Sloth — Strixhaven: School of Mages #223 (canonical printing)
+ * {3}{R}{W} · Creature — Sloth Beast · 4/4
+ *
+ * Vigilance
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ *
+ * Two plain evergreen keywords, nothing else — both are simple [Keyword] markers the engine
+ * reads directly.
+ */
+val RelicSloth = card("Relic Sloth") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Sloth Beast"
+    oracleText =
+        "Vigilance\n" +
+        "Menace (This creature can't be blocked except by two or more creatures.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE, Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "223"
+        artist = "Ilse Gort"
+        flavorText = "When it comes to transporting priceless, delicate artifacts, safety is more important than speed."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg?1783927297"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RipApart.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RipApart.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rip Apart — Strixhaven: School of Mages #225 (canonical printing)
+ * {R}{W} · Sorcery
+ *
+ * Choose one —
+ * • Rip Apart deals 3 damage to target creature or planeswalker.
+ * • Destroy target artifact or enchantment.
+ *
+ * A choose-one `modal` spell whose two modes each carry their own target: the burn mode binds
+ * [Targets.CreatureOrPlaneswalker], the removal mode binds [Targets.ArtifactOrEnchantment] and
+ * resolves as a plain [Effects.Destroy].
+ */
+val RipApart = card("Rip Apart") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText =
+        "Choose one —\n" +
+        "• Rip Apart deals 3 damage to target creature or planeswalker.\n" +
+        "• Destroy target artifact or enchantment."
+
+    spell {
+        modal {
+            mode("Rip Apart deals 3 damage to target creature or planeswalker") {
+                val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+                effect = Effects.DealDamage(3, victim)
+            }
+            mode("Destroy target artifact or enchantment") {
+                val permanent = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+                effect = Effects.Destroy(permanent)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Anna Podedworna"
+        flavorText = "Torn from history. Torn from memory. Torn from reality."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg?1783927298"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ScurridColony.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ScurridColony.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Scurrid Colony — Strixhaven: School of Mages #142 (canonical printing)
+ * {1}{G} · Creature — Squirrel · 2/2
+ *
+ * Reach
+ * This creature gets +2/+2 as long as you control eight or more lands.
+ *
+ * The Woodborn Behemoth shape: one self-scoped [ModifyStats] static in Layer 7c, gated by
+ * [Conditions.ControlLandsAtLeast]`(8)` — the builder wraps the pair into a conditional static.
+ */
+val ScurridColony = card("Scurrid Colony") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Squirrel"
+    oracleText =
+        "Reach\n" +
+        "This creature gets +2/+2 as long as you control eight or more lands."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.REACH)
+
+    staticAbility {
+        ability = ModifyStats(2, 2, Filters.Self)
+        condition = Conditions.ControlLandsAtLeast(8)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Lars Grant-West"
+        flavorText = "Scurrid teeth evolved to crack open nuts, but they work just as well for crushing bones if the nest is threatened."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg?1783927338"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SilverquillCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SilverquillCampus.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Silverquill Campus — Strixhaven: School of Mages #273 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * This land enters tapped.
+ * {T}: Add {W} or {B}.
+ * {4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The Campus cycle (see [PrismariCampus]): an unconditional [EntersTapped] plus "Add {W} or {B}"
+ * written as two separate one-colour mana abilities — the player picks a colour by picking which
+ * ability to activate — and a plain [Effects.Scry] behind the {4} activation.
+ */
+val SilverquillCampus = card("Silverquill Campus") {
+    manaCost = ""
+    colorIdentity = "BW"
+    typeLine = "Land"
+    oracleText =
+        "This land enters tapped.\n" +
+        "{T}: Add {W} or {B}.\n" +
+        "{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {W} or {B}. — modeled as one ability per colour.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {4}, {T}: Scry 1.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Scry(1)
+        description = "{4}, {T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "273"
+        artist = "Titus Lunter"
+        flavorText = "Mage-students drawn to the power of language choose Silverquill, the college of eloquence."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg?1783927270"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SoothsayerAdept.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SoothsayerAdept.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soothsayer Adept — Strixhaven: School of Mages #55 (canonical printing)
+ * {1}{U} · Creature — Merfolk Wizard · 1/3
+ *
+ * {1}{U}, {T}: Draw a card, then discard a card.
+ *
+ * The Merfolk Looter loot with a mana rider: [Costs.Composite] of the mana and the tap, and the
+ * effect is [Effects.DrawCards] `then` [Patterns.Hand.discardCards] — the discard is the standard
+ * Gather → Select → Move pipeline over your hand, so the freshly drawn card is itself a legal
+ * discard.
+ */
+val SoothsayerAdept = card("Soothsayer Adept") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    oracleText =
+        "{1}{U}, {T}: Draw a card, then discard a card."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        effect = Effects.DrawCards(1) then Patterns.Hand.discardCards(1)
+        description = "{1}{U}, {T}: Draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Cristi Balanescu"
+        flavorText = "One of the first lessons divination students learn is how to recognize the difference between a portent and a simple surface ripple."
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg?1783927374"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpiritSummoning.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpiritSummoning.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spirit Summoning — Strixhaven: School of Mages #236 (canonical printing)
+ * {1}{R/W}{R/W} · Sorcery — Lesson
+ *
+ * Create a 3/2 red and white Spirit creature token.
+ *
+ * A single [Effects.CreateToken]: a 3/2 red-and-white Spirit with no keywords. Token art resolves
+ * through STX's synced token printings, so none is declared here. Lesson is only a subtype.
+ */
+val SpiritSummoning = card("Spirit Summoning") {
+    manaCost = "{1}{R/W}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Create a 3/2 red and white Spirit creature token."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 2,
+            colors = setOf(Color.RED, Color.WHITE),
+            creatureTypes = setOf("Spirit")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "236"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Books are fantastic, but if you're really curious about the distant past, why not ask someone who was there?\"\n—Augusta, Lorehold dean"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg?1783927289"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpringmaneCervin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpringmaneCervin.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Springmane Cervin — Strixhaven: School of Mages #144 (canonical printing)
+ * {2}{G} · Creature — Elk · 3/2
+ *
+ * When this creature enters, you gain 2 life.
+ *
+ * A plain ETB trigger ([Triggers.EntersBattlefield]) whose effect is [Effects.GainLife] for the
+ * controller.
+ */
+val SpringmaneCervin = card("Springmane Cervin") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elk"
+    oracleText =
+        "When this creature enters, you gain 2 life."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Ilse Gort"
+        flavorText = "Cervins feed on the mana-rich plants around the star arches, imbuing their bodies with extraordinary grace and vitality."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg?1783927337"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StartFromScratch.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StartFromScratch.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Start from Scratch — Strixhaven: School of Mages #114 (canonical printing)
+ * {2}{R} · Sorcery — Lesson
+ *
+ * Choose one —
+ * • Start from Scratch deals 1 damage to any target.
+ * • Destroy target artifact.
+ *
+ * An ordinary "choose one" `modal` with per-mode targeting: the first mode is [Effects.DealDamage]
+ * at [Targets.Any], the second [Effects.Destroy] at [Targets.Artifact]. Lesson is only a subtype.
+ */
+val StartFromScratch = card("Start from Scratch") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery — Lesson"
+    oracleText =
+        "Choose one —\n" +
+        "• Start from Scratch deals 1 damage to any target.\n" +
+        "• Destroy target artifact."
+
+    spell {
+        modal {
+            mode("Start from Scratch deals 1 damage to any target") {
+                val victim = target("target", Targets.Any)
+                effect = Effects.DealDamage(1, victim)
+            }
+            mode("Destroy target artifact") {
+                val artifact = target("target", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "114"
+        artist = "Bayard Wu"
+        flavorText = "\"I don't care what they think!\" Rootha snapped. \"I know I can do better.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg?1783927350"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StoneboundMentor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StoneboundMentor.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stonebound Mentor — Strixhaven: School of Mages #239 (canonical printing)
+ * {1}{R}{W} · Creature — Spirit Advisor · 3/3
+ *
+ * Whenever one or more cards leave your graveyard, scry 1.
+ *
+ * "One or more … leave" is CR 603.2c batch wording, so the batching
+ * [Triggers.CardsLeaveYourGraveyard] is the right shape: a mass reanimation or a graveyard-exiling
+ * sweep fires this exactly once. The payoff is a bare [Effects.Scry].
+ */
+val StoneboundMentor = card("Stonebound Mentor") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Spirit Advisor"
+    oracleText =
+        "Whenever one or more cards leave your graveyard, scry 1."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard()
+        effect = Effects.Scry(1)
+        description = "Whenever one or more cards leave your graveyard, scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Svetlin Velinov"
+        flavorText = "Quintorius beamed, his mind eager to absorb every historical fact the spirit wanted to divulge."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg?1783927289"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StoneriseSpirit.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StoneriseSpirit.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stonerise Spirit — Strixhaven: School of Mages #32 (canonical printing)
+ * {1}{W} · Creature — Spirit Bird · 1/2
+ *
+ * Flying
+ * {4}, Exile a card from your graveyard: Target creature gains flying until end of turn.
+ *
+ * Flying is the bare keyword. The activation's cost is a [Costs.Composite] of {4} and
+ * [Costs.ExileFromGraveyard] (one card, any kind, chosen by the player); its effect is
+ * [Effects.GrantKeyword] flying until end of turn on [Targets.Creature].
+ */
+val StoneriseSpirit = card("Stonerise Spirit") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Bird"
+    oracleText =
+        "Flying\n" +
+        "{4}, Exile a card from your graveyard: Target creature gains flying until end of turn."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    // {4}, Exile a card from your graveyard: Target creature gains flying until end of turn.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.ExileFromGraveyard(1))
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Uriah Voth"
+        flavorText = "The carved cliffs of Pillardrop thrum with the sounds of ancient spirits rising from the past."
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg?1783927384"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StrixhavenBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StrixhavenBasicLands.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Strixhaven: School of Mages Basic Lands
+ *
+ * Strixhaven's ten basics, cards 366-375: two illustrations of each type, one per pair of the
+ * five colleges' grounds. All are the plain, non-snow basics, so each is a [basicLand] val that
+ * [StrixhavenSchoolOfMagesSet.basicLands] discovers by package — never a `Printing` row.
+ */
+
+val StrixhavenPlains366 = basicLand("Plains") {
+    collectorNumber = "366"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/abadcf9e-46ed-4a8b-888c-0cd3756bc8ab.jpg"
+}
+
+val StrixhavenPlains367 = basicLand("Plains") {
+    collectorNumber = "367"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/49f7e5de-1fa8-406e-a411-fc8a11937000.jpg"
+}
+
+val StrixhavenIsland368 = basicLand("Island") {
+    collectorNumber = "368"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c96f9fb6-ef52-43f9-a458-8602a7c83333.jpg"
+}
+
+val StrixhavenIsland369 = basicLand("Island") {
+    collectorNumber = "369"
+    artist = "Lucas Staniec"
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/849a217f-d532-4a7c-bcbf-d127641f6edf.jpg"
+}
+
+val StrixhavenSwamp370 = basicLand("Swamp") {
+    collectorNumber = "370"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13bd1c69-2561-4ff1-af00-bb519b3897c2.jpg"
+}
+
+val StrixhavenSwamp371 = basicLand("Swamp") {
+    collectorNumber = "371"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/11093e3f-092e-49d9-aef9-b9855b040bf2.jpg"
+}
+
+val StrixhavenMountain372 = basicLand("Mountain") {
+    collectorNumber = "372"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/9660fb20-f499-4f7a-9f25-e463f095ab90.jpg"
+}
+
+val StrixhavenMountain373 = basicLand("Mountain") {
+    collectorNumber = "373"
+    artist = "Grady Frederick"
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb8fffd1-aff1-4aad-bfa0-9907adb5ce25.jpg"
+}
+
+val StrixhavenForest374 = basicLand("Forest") {
+    collectorNumber = "374"
+    artist = "Grady Frederick"
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/dfaf517f-86a1-45eb-bd71-e0bffb610396.jpg"
+}
+
+val StrixhavenForest375 = basicLand("Forest") {
+    collectorNumber = "375"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/659a7d45-af0d-4a4a-a878-e8e40b732bfa.jpg"
+}
+
+/**
+ * All Strixhaven basic land variants.
+ */
+val StrixhavenBasicLands = listOf(
+    StrixhavenPlains366,
+    StrixhavenPlains367,
+    StrixhavenIsland368,
+    StrixhavenIsland369,
+    StrixhavenSwamp370,
+    StrixhavenSwamp371,
+    StrixhavenMountain372,
+    StrixhavenMountain373,
+    StrixhavenForest374,
+    StrixhavenForest375
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Tangletrap.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Tangletrap.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tangletrap — Strixhaven: School of Mages #145 (canonical printing)
+ * {1}{G} · Instant
+ *
+ * Choose one —
+ * • Tangletrap deals 5 damage to target creature with flying.
+ * • Destroy target artifact.
+ *
+ * Each mode declares its own target, so the mode is chosen first and only that mode's target is
+ * announced (CR 601.2b) — picking the artifact mode never requires a legal flyer. The first mode is
+ * [Effects.DealDamage] over [Targets.CreatureWithKeyword]`(FLYING)`, the second [Effects.Destroy]
+ * over [Targets.Artifact].
+ */
+val Tangletrap = card("Tangletrap") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText =
+        "Choose one —\n" +
+        "• Tangletrap deals 5 damage to target creature with flying.\n" +
+        "• Destroy target artifact."
+
+    spell {
+        modal {
+            mode("Tangletrap deals 5 damage to target creature with flying.") {
+                val flyer = target("target", Targets.CreatureWithKeyword(Keyword.FLYING))
+                effect = Effects.DealDamage(5, flyer)
+            }
+            mode("Destroy target artifact.") {
+                val artifact = target("target", Targets.Artifact)
+                effect = Effects.Destroy(artifact)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Suzanne Helmigh"
+        flavorText = "\"It's like that old saying: what goes up . . . feeds the arboretum.\"\n—Lisette, Witherbloom dean"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg?1783927337"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/TwinscrollShaman.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/TwinscrollShaman.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Twinscroll Shaman — Strixhaven: School of Mages #118 (canonical printing)
+ * {2}{R} · Creature — Dwarf Shaman · 1/2
+ *
+ * Double strike
+ *
+ * A vanilla-plus-keyword creature: the printed keyword is the whole script.
+ */
+val TwinscrollShaman = card("Twinscroll Shaman") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Shaman"
+    oracleText =
+        "Double strike"
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Chris Seaman"
+        flavorText = "\"May your wretched name never grace the annals of history, you ignorant buffoon!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg?1783927350"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/UmbralJuke.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/UmbralJuke.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Umbral Juke — Strixhaven: School of Mages #89 (canonical printing)
+ * {2}{B} · Instant
+ *
+ * Choose one —
+ * • Target player sacrifices a creature or planeswalker of their choice.
+ * • Create a 2/1 white and black Inkling creature token with flying.
+ *
+ * A choose-one modal whose first mode is the only one with a target: an edict —
+ * [Effects.Sacrifice] over [GameObjectFilter.CreatureOrPlaneswalker] naming the targeted player,
+ * who picks what to give up. The second mode is a plain [Effects.CreateToken]; token art resolves
+ * through STX's synced token printings, so none is declared here.
+ */
+val UmbralJuke = card("Umbral Juke") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText =
+        "Choose one —\n" +
+        "• Target player sacrifices a creature or planeswalker of their choice.\n" +
+        "• Create a 2/1 white and black Inkling creature token with flying."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target player sacrifices a creature or planeswalker of their choice.") {
+                val player = target("target", Targets.Player)
+                effect = Effects.Sacrifice(GameObjectFilter.CreatureOrPlaneswalker, target = player)
+            }
+            mode("Create a 2/1 white and black Inkling creature token with flying.") {
+                effect = Effects.CreateToken(
+                    power = 2,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE, Color.BLACK),
+                    creatureTypes = setOf("Inkling"),
+                    keywords = setOf(Keyword.FLYING)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Bram Sels"
+        flavorText = "The sport of Mage Tower was conceived as a playful testing ground for young spellcasters."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg?1783927361"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WaterfallAerialist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WaterfallAerialist.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Waterfall Aerialist — Strixhaven: School of Mages #61 (canonical printing)
+ * {3}{U} · Creature — Djinn Wizard · 3/1
+ *
+ * Flying
+ * Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)
+ *
+ * Two keywords and nothing else: a plain [Keyword.FLYING] marker plus `Ward {2}` as
+ * [KeywordAbility.ward] (CR 702.21a) — the bare `Keyword.WARD` marker is derived from that ability
+ * by the builder, so it is not restated.
+ */
+val WaterfallAerialist = card("Waterfall Aerialist") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Djinn Wizard"
+    oracleText =
+        "Flying\n" +
+        "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)"
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Lie Setiawan"
+        flavorText = "Form and function in perfect unity."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg?1783927372"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WitherbloomCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WitherbloomCampus.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Witherbloom Campus — Strixhaven: School of Mages #275 (canonical printing)
+ * (no mana cost) · Land
+ *
+ * This land enters tapped.
+ * {T}: Add {B} or {G}.
+ * {4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The Campus cycle (see [PrismariCampus]): an unconditional [EntersTapped] plus "Add {B} or {G}"
+ * written as two separate one-colour mana abilities — the player picks a colour by picking which
+ * ability to activate — and a plain [Effects.Scry] behind the {4} activation.
+ */
+val WitherbloomCampus = card("Witherbloom Campus") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Land"
+    oracleText =
+        "This land enters tapped.\n" +
+        "{T}: Add {B} or {G}.\n" +
+        "{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {B} or {G}. — modeled as one ability per colour.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {4}, {T}: Scry 1.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Scry(1)
+        description = "{4}, {T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "275"
+        artist = "Alayna Danner"
+        flavorText = "Mage-students fascinated by the energies of life and death choose Witherbloom, the college of essence studies."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg?1783927269"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WormholeSerpent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/WormholeSerpent.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wormhole Serpent — Strixhaven: School of Mages #62 (canonical printing)
+ * {4}{U} · Creature — Serpent · 3/5
+ *
+ * {3}{U}: Target creature can't be blocked this turn.
+ *
+ * "Can't be blocked" is an [AbilityFlag], not a keyword, so the ability is
+ * [Effects.GrantKeyword] over [AbilityFlag.CANT_BE_BLOCKED] on the targeted creature with the
+ * default until-end-of-turn duration. Nothing restricts the target's controller, so the bare
+ * [Targets.Creature] requirement is correct.
+ */
+val WormholeSerpent = card("Wormhole Serpent") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    oracleText =
+        "{3}{U}: Target creature can't be blocked this turn."
+    power = 3
+    toughness = 5
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+        description = "{3}{U}: Target creature can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Tomasz Jedruszek"
+        flavorText = "After drownings, devourings, and one highly unpleasant algae infestation, unsupervised portal use on campus was banned."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg?1783927371"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/RipApartReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/RipApartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rip Apart reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val RipApartReprint = Printing(
+    oracleId = "cbdbf18f-0180-4ade-a79e-1e644dd42d6f",
+    name = "Rip Apart",
+    setCode = "MSC",
+    collectorNumber = "187",
+    scryfallId = "b4964c78-b9ca-43c2-bcaa-bf75d92b9065",
+    artist = "Marco Turini",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4964c78-b9ca-43c2-bcaa-bf75d92b9065.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -134,6 +134,131 @@
     ]
 }
 
+// Access Tunnel
+{
+    "name": "Access Tunnel",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}: Target creature with power 3 or less can't be blocked this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=3"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "rarity": "UNCOMMON",
+        "artist": "Alayna Danner",
+        "flavorText": "Oriq agents stick to the dark corners of Arcavios, unseen yet ever-present.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edf8eb51-9643-4c54-b38e-e7abea92bbe1.jpg?1783927277"
+    },
+    "colorIdentityOverride": []
+}
+
+// Aether Helix
+{
+    "name": "Aether Helix",
+    "manaCost": "{3}{G}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target permanent to its owner's hand. Return target permanent card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target 1"
+                    },
+                    "destination": "Hand"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "id": "target"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target 1"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Torstein Nordstrand",
+        "flavorText": "Some Quandrix mages prefer to study at twilight, watching their experimental equations trace glowing trails against the encroaching darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d1c653e-f629-4105-a52c-379c5cd78208.jpg?1783927325"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Ageless Guardian
 {
     "name": "Ageless Guardian",
@@ -281,6 +406,397 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Archway Commons
+{
+    "name": "Archway Commons",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{1}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6f6a2ff-7eb7-4680-af2b-e69ac88a65c9.jpg?1783927276"
+    },
+    "colorIdentityOverride": []
+}
+
+// Basic Conjuration
+{
+    "name": "Basic Conjuration",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Look at the top six cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 6
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may reveal a creature card from among them and put it into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Randy Vargas",
+        "flavorText": "\"I made that! It's mine! Did you see that?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg?1783927348"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Beaming Defiance
+{
+    "name": "Beaming Defiance",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature you control gets +2/+2 and gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Manuel Castañón",
+        "flavorText": "\"I've lived too long in my father's shadow. It's time to find my own light.\"\n—Killian, Silverquill mage-student",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e22411c-11c1-4770-8491-7952dd406e01.jpg?1783927395"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Big Play
+{
+    "name": "Big Play",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains reach until end of turn. Put a +1/+1 counter on it. (A creature with reach can block creatures with flying.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "REACH",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"Quandrix is running out of time. If they're going to capture the Witherbloom mascot, they need something big here.\"\n—Cremik, Mage Tower commentator",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/9016d667-50a9-4093-9a99-b34dcdafe60b.jpg?1783927347"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Blade Historian
+{
+    "name": "Blade Historian",
+    "manaCost": "{R/W}{R/W}{R/W}{R/W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Attacking creatures you control have double strike.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE",
+                "filter": {
+                    "baseFilter": "creature attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"So you see, the reckless battle strategy of the Kathorran orcs was effective, but ultimately proved to be a double-edged sword. As did their double-edged swords.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a46d64ec-aca4-428e-bce6-66cd755c8cc3.jpg?1783927324"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Blood Researcher
+{
+    "name": "Blood Researcher",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Creature — Vampire Druid",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever you gain life, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"Dean Valentin warns us not to consume the samples for our safety, but I think he's just being greedy.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e35e9ba-a10e-4926-a7a6-3a65efc2a730.jpg?1783927323"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Brackish Trudge
+{
+    "name": "Brackish Trudge",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Fungus Beast",
+    "oracleText": "This creature enters tapped.\n{1}{B}: Return this card from your graveyard to your hand. Activate only if you gained life this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "LIFE_GAINED"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                ],
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{1}{B}: Return this card from your graveyard to your hand. Activate only if you gained life this turn."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "Most trudges are covered with decaying plant matter, making them ideal breeding grounds for fungal spores.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90ba37ee-159f-421f-8d37-a7b5f1b562f0.jpg?1783927369"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -598,6 +1114,49 @@
     ]
 }
 
+// Daemogoth Titan
+{
+    "name": "Daemogoth Titan",
+    "manaCost": "{B/G}{B/G}{B/G}{B/G}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Whenever this creature attacks or blocks, sacrifice a creature.",
+    "creatureStats": {
+        "power": 11,
+        "toughness": 10
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "RARE",
+        "artist": "Chris Cold",
+        "flavorText": "\"Of course it offered you power. Demons always do. But trust me—the sweeter the prize, the more ruinous the price.\"\n—Professor Onyx",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2f18828-ade7-4b99-97b2-e34bc2fdb68c.jpg?1783927319"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Deadly Brew
 {
     "name": "Deadly Brew",
@@ -672,6 +1231,75 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Defend the Campus
+{
+    "name": "Defend the Campus",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Creatures you control get +1/+1 until end of turn.\n• Destroy target creature with power 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +1/+1 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature pow>=4"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target creature with power 4 or greater"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Izzy",
+        "flavorText": "Professors scrambled to push the mage hunters back, leaving the heart of Strixhaven undefended.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85e4e1b5-77d6-4af4-b22e-6f6b4d129f5d.jpg?1783927394"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -942,6 +1570,38 @@
     ]
 }
 
+// Elemental Summoning
+{
+    "name": "Elemental Summoning",
+    "manaCost": "{3}{U/R}{U/R}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Create a 4/4 blue and red Elemental creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 4,
+            "toughness": 4,
+            "colors": [
+                "BLUE",
+                "RED"
+            ],
+            "creatureTypes": [
+                "Elemental"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Marta Nael",
+        "flavorText": "\"You've made a splash. Now show me a torrent.\"\n—Uvilda, Prismari dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea51991c-1589-4c62-965b-5ae8d233520b.jpg?1783927316"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Enthusiastic Study
 {
     "name": "Enthusiastic Study",
@@ -1077,6 +1737,268 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Environmental Sciences
+{
+    "name": "Environmental Sciences",
+    "manaCost": "{2}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Search your library for a basic land card, reveal it, put it into your hand, then shuffle. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent",
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Jokubas Uogintas",
+        "flavorText": "First-years quickly learn how the Vastlands earned its name.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46b394fc-a99c-44e7-9226-da0699167541.jpg?1783927397"
+    },
+    "colorIdentityOverride": []
+}
+
+// Essence Infusion
+{
+    "name": "Essence Infusion",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put two +1/+1 counters on target creature. It gains lifelink until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Randy Vargas",
+        "flavorText": "\"I'd say it's still a fair fight—now my friend is about the size of your ego.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71a48d0c-1e5b-43f2-8974-e2e5bb06310d.jpg?1783927368"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Excavated Wall
+{
+    "name": "Excavated Wall",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{1}, {T}: Mill a card. (Put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "artist": "Zezhou Chen",
+        "flavorText": "\"Don't be fooled by the quiet. These old stones are trying to talk to you.\"\n—Augusta, Lorehold dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fed54d00-b11f-4529-864c-63a114617b36.jpg?1783927281"
+    },
+    "colorIdentityOverride": []
+}
+
+// Expanded Anatomy
+{
+    "name": "Expanded Anatomy",
+    "manaCost": "{3}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Put two +1/+1 counters on target creature. It gains vigilance until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"Changing the equation from incremental to exponential was a stroke of genius on my part.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5642b9d-0daa-4e6b-ad48-f88dd37d6574.jpg?1783927396"
+    },
+    "colorIdentityOverride": []
+}
+
+// Expel
+{
+    "name": "Expel",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target tapped creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target tapped creature"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature tapped"
+                },
+                "id": "target tapped creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Billy Christian",
+        "flavorText": "Quintorius was a daydreamer, far happier digging through history books than practicing battle tactics. He agreed with the military academy on only one thing: he did not belong in their ranks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be517a58-b7ee-4213-98a5-8c19e1b2def6.jpg?1783927392"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1583,6 +2505,105 @@
     ]
 }
 
+// Fuming Effigy
+{
+    "name": "Fuming Effigy",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever one or more cards leave your graveyard, this creature deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CardsLeftYourGraveyardEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Ryan Alexander Lee",
+        "flavorText": "Some spirits share ancient wisdom. Others just get mad you touched their stuff.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7ce76a38-fc5f-4e29-ba24-4a877179a62c.jpg?1783927355"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Galazeth Prismari
+{
+    "name": "Galazeth Prismari",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Legendary Creature — Elder Dragon",
+    "oracleText": "Flying\nWhen Galazeth Prismari enters, create a Treasure token.\nArtifacts you control have \"{T}: Add one mana of any color. Spend this mana only to cast an instant or sorcery spell.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddManaOfChoice",
+                        "restriction": "InstantOrSorceryOnly"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "artifact ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "rarity": "MYTHIC",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06c9158c-064b-4d12-b860-d2c1450d1897.jpg?1783927311"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Gnarled Professor
 {
     "name": "Gnarled Professor",
@@ -1825,6 +2846,104 @@
     ]
 }
 
+// Hall Monitor
+{
+    "name": "Hall Monitor",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard Shaman",
+    "oracleText": "Haste\n{1}{R}, {T}: Target creature can't block this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Forrest Imel",
+        "flavorText": "\"No unauthorized summoning. No writing in the library books. And absolutely no indoor dueling!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02fdc551-0b22-49f4-8765-143ad82f16a3.jpg?1783927354"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Heated Debate
+{
+    "name": "Heated Debate",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered. (This includes by the ward ability.)\nHeated Debate deals 4 damage to target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Bayard Wu",
+        "flavorText": "\"While you were wasting time with abstract equations, I mastered ancient Oggyar fire magic. Your move.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f40c88e2-28ed-4e5b-bcb3-4397d6a15a6f.jpg?1783927353"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hunt for Specimens
 {
     "name": "Hunt for Specimens",
@@ -2059,6 +3178,594 @@
     ]
 }
 
+// Inkling Summoning
+{
+    "name": "Inkling Summoning",
+    "manaCost": "{1}{W/B}{W/B}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Create a 2/1 white and black Inkling creature token with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 2,
+            "toughness": 1,
+            "colors": [
+                "WHITE",
+                "BLACK"
+            ],
+            "creatureTypes": [
+                "Inkling"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Think of an insult so vicious, so vulgar, that you hesitate to speak it aloud. The strongest, most aggressive inklings are born from such scorn.\"\n—Embrose, Silverquill dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04a8a5b8-9743-4d1a-89e9-61bdf180b2e0.jpg?1783927310"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Introduction to Prophecy
+{
+    "name": "Introduction to Prophecy",
+    "manaCost": "{3}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Scry 2, then draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Micah Epstein",
+        "flavorText": "Final grades are posted on the first day of class.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/7820923e-bad2-4d6a-92b3-97b9737d2ca9.jpg?1783927395"
+    },
+    "colorIdentityOverride": []
+}
+
+// Lash of Malice
+{
+    "name": "Lash of Malice",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/-2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"The strongest shadow spells come from disdain for someone else, not frustration with yourself.\"\n—Embrose, Silverquill dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af3da2c6-29ed-4563-8bae-d1cc05df8897.jpg?1783927367"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Letter of Acceptance
+{
+    "name": "Letter of Acceptance",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add one mana of any color.\n{2}, {T}, Sacrifice this artifact: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "The letter unfolded, inviting the twins to Strixhaven. Will saw a chance for arcane study. Rowan saw a chance for power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34750231-34aa-401c-b192-47b56588923a.jpg?1783927280"
+    },
+    "colorIdentityOverride": []
+}
+
+// Lorehold Campus
+{
+    "name": "Lorehold Campus",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {W}.\n{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{4}, {T}: Scry 1."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "artist": "Titus Lunter",
+        "flavorText": "Mage-students obsessed with the secrets of the past choose Lorehold, the college of archaeomancy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d35461cf-becf-4399-8329-64b4496b7fc2.jpg?1783927272"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Lorehold Command
+{
+    "name": "Lorehold Command",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose two —\n• Create a 3/2 red and white Spirit creature token.\n• Creatures you control get +1/+0 and gain indestructible and haste until end of turn.\n• Lorehold Command deals 3 damage to any target. Target player gains 3 life.\n• Sacrifice a permanent, then draw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 3,
+                        "toughness": 2,
+                        "colors": [
+                            "RED",
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ]
+                    }
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "INDESTRUCTIBLE",
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "HASTE",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    },
+                    "description": "Creatures you control get +1/+0 and gain indestructible and haste until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "any target"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target player"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "id": "any target"
+                        },
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Lorehold Command deals 3 damage to any target. Target player gains 3 life"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "permanent"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Sacrifice a permanent, then draw two cards"
+                }
+            ],
+            "chooseCount": 2
+        }
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "RARE",
+        "artist": "Jason Rainville",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4f0885f-1049-4a19-853d-f4e6d4bec29e.jpg?1783927309"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Moldering Karok
+{
+    "name": "Moldering Karok",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Creature — Zombie Crocodile",
+    "oracleText": "Trample, lifelink",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "206",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Necroluminescence is common among the undead creatures of Sedgemoor, giving the midnight swamp an eerie glow. It's comforting—from a distance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70c2ef30-0db5-4ef5-999c-7ffa48769421.jpg?1783927305"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Mortality Spear
+{
+    "name": "Mortality Spear",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if you gained life this turn.\nDestroy target nonland permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "LIFE_GAINED"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "PINDURSKI",
+        "flavorText": "\"Death is my life's work.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1f39fe7-dc12-49c9-80ac-4135dc1f8f08.jpg?1783927305"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Needlethorn Drake
+{
+    "name": "Needlethorn Drake",
+    "manaCost": "{G}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying, deathtouch",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "208",
+        "artist": "Donato Giancola",
+        "flavorText": "As they learn to fly, young drakes have a tendency to accidentally impale trees, cliffs, and unsuspecting students.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c0cf2c4-723e-46c4-b2aa-4c957177209a.jpg?1783927304"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Novice Dissector
+{
+    "name": "Novice Dissector",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Troll Warlock",
+    "oracleText": "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{1}, Sacrifice another creature: Put a +1/+1 counter on target creature. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Mads Ahm",
+        "flavorText": "\"The professor said to first extract the venom glands, then the acid sac. Next up, the . . . meeping organ?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c4677bc-736b-4bf2-851e-b158718a4224.jpg?1783927363"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Oggyar Battle-Seer
+{
+    "name": "Oggyar Battle-Seer",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Creature — Ogre Shaman",
+    "oracleText": "Haste\n{T}: Scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{T}: Scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"May Ganathog bless us with bloody visions of glory restored!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a38329f1-af6e-47b8-86e4-f2a39e1edbf8.jpg?1783927304"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Overgrown Arch
 {
     "name": "Overgrown Arch",
@@ -2193,6 +3900,92 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Owlin Shieldmage
+{
+    "name": "Owlin Shieldmage",
+    "manaCost": "{3}{W}{B}",
+    "typeLine": "Creature — Bird Warlock",
+    "oracleText": "Flying\nWard—Pay 3 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 3 life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 3
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Raoul Vitale",
+        "flavorText": "\"Aim higher next time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3350367-42bd-44af-be13-ad31c002f8ac.jpg?1783927304"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Pillardrop Rescuer
+{
+    "name": "Pillardrop Rescuer",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Spirit Cleric",
+    "oracleText": "Flying\nWhen this creature enters, return target creature card with mana value 3 or less from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Jason A. Engle",
+        "flavorText": "Gentle hands of stone whisk the careless from the crumbling ruins of Pillardrop.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0884666e-8f9b-44b1-a1e3-c1c8941e2152.jpg?1783927388"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -2642,6 +4435,285 @@
     ]
 }
 
+// Professor's Warning
+{
+    "name": "Professor's Warning",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Put a +1/+1 counter on target creature.\n• Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Put a +1/+1 counter on target creature."
+                },
+                {
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gains indestructible until end of turn."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Kieran Yanner",
+        "flavorText": "Professor Onyx urged the twins to prepare for the dark mage Extus, sounding very much like someone familiar with the rise of tyrants.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/862fded6-e474-4b20-86d8-fd9af5f25b1a.jpg?1783927363"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Quandrix Campus
+{
+    "name": "Quandrix Campus",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {U}.\n{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{4}, {T}: Scry 1."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "artist": "Piotr Dura",
+        "flavorText": "Mage-students who see the beauty in patterns and equations choose Quandrix, the college of numeromancy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f788da28-481b-41fa-a70c-b53db6b0f068.jpg?1783927273"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Quintorius, Field Historian
+{
+    "name": "Quintorius, Field Historian",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Legendary Creature — Elephant Cleric",
+    "oracleText": "Spirits you control get +1/+0.\nWhenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CardsLeftYourGraveyardEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 2,
+                    "colors": [
+                        "RED",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more cards leave your graveyard, create a 3/2 red and white Spirit creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "permanent Spirit ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Bryan Sola",
+        "flavorText": "\"Every life has a story to tell. I won't let them be forgotten.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06c55ef1-8e62-4d43-bd4c-b2c3c5203338.jpg?1783927298"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Relic Sloth
+{
+    "name": "Relic Sloth",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Creature — Sloth Beast",
+    "oracleText": "Vigilance\nMenace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "223",
+        "artist": "Ilse Gort",
+        "flavorText": "When it comes to transporting priceless, delicate artifacts, safety is more important than speed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1cb483f-c567-4cfd-9fe8-1503e7b40542.jpg?1783927297"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Rip Apart
+{
+    "name": "Rip Apart",
+    "manaCost": "{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Rip Apart deals 3 damage to target creature or planeswalker.\n• Destroy target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature or planeswalker"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "target creature or planeswalker"
+                        }
+                    ],
+                    "description": "Rip Apart deals 3 damage to target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment"
+                            },
+                            "id": "target artifact or enchantment"
+                        }
+                    ],
+                    "description": "Destroy target artifact or enchantment"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Podedworna",
+        "flavorText": "Torn from history. Torn from memory. Torn from reality.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3b5b510-fd5c-415d-98b0-386e7508f7af.jpg?1783927298"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Rise of Extus
 {
     "name": "Rise of Extus",
@@ -2780,6 +4852,214 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Scurrid Colony
+{
+    "name": "Scurrid Colony",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Squirrel",
+    "oracleText": "Reach\nThis creature gets +2/+2 as long as you control eight or more lands.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Lars Grant-West",
+        "flavorText": "Scurrid teeth evolved to crack open nuts, but they work just as well for crushing bones if the nest is threatened.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9c0a096-870d-443c-92d3-f7ec1f362616.jpg?1783927338"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Silverquill Campus
+{
+    "name": "Silverquill Campus",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {B}.\n{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{4}, {T}: Scry 1."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "273",
+        "artist": "Titus Lunter",
+        "flavorText": "Mage-students drawn to the power of language choose Silverquill, the college of eloquence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42583850-ba5c-4a71-8717-406b5c6d048f.jpg?1783927270"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Soothsayer Adept
+{
+    "name": "Soothsayer Adept",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{1}{U}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}{U}, {T}: Draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Cristi Balanescu",
+        "flavorText": "One of the first lessons divination students learn is how to recognize the difference between a portent and a simple surface ripple.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb93c9d2-88eb-403d-bb67-8e8b0462ac27.jpg?1783927374"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -2947,6 +5227,246 @@
     ]
 }
 
+// Spirit Summoning
+{
+    "name": "Spirit Summoning",
+    "manaCost": "{1}{R/W}{R/W}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Create a 3/2 red and white Spirit creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 3,
+            "toughness": 2,
+            "colors": [
+                "RED",
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Spirit"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Books are fantastic, but if you're really curious about the distant past, why not ask someone who was there?\"\n—Augusta, Lorehold dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74be6236-4095-419c-9927-fbd874df21f8.jpg?1783927289"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Springmane Cervin
+{
+    "name": "Springmane Cervin",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elk",
+    "oracleText": "When this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Ilse Gort",
+        "flavorText": "Cervins feed on the mana-rich plants around the star arches, imbuing their bodies with extraordinary grace and vitality.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5b0eac4-0262-4eed-97d4-0f2e6f06c8e1.jpg?1783927337"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Start from Scratch
+{
+    "name": "Start from Scratch",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery — Lesson",
+    "oracleText": "Choose one —\n• Start from Scratch deals 1 damage to any target.\n• Destroy target artifact.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Start from Scratch deals 1 damage to any target"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "UNCOMMON",
+        "artist": "Bayard Wu",
+        "flavorText": "\"I don't care what they think!\" Rootha snapped. \"I know I can do better.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55c99486-ae64-4293-81fb-a4b02e8fcae6.jpg?1783927350"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Stonebound Mentor
+{
+    "name": "Stonebound Mentor",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Creature — Spirit Advisor",
+    "oracleText": "Whenever one or more cards leave your graveyard, scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CardsLeftYourGraveyardEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "Whenever one or more cards leave your graveyard, scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Quintorius beamed, his mind eager to absorb every historical fact the spirit wanted to divulge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c64e954-adfc-40a2-a3b2-85f1b4626976.jpg?1783927289"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Stonerise Spirit
+{
+    "name": "Stonerise Spirit",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Bird",
+    "oracleText": "Flying\n{4}, Exile a card from your graveyard: Target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Uriah Voth",
+        "flavorText": "The carved cliffs of Pillardrop thrum with the sounds of ancient spirits rising from the past.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/388f2e45-570f-4a35-b205-37e1345b5d06.jpg?1783927384"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Study Break
 {
     "name": "Study Break",
@@ -3075,6 +5595,74 @@
     ]
 }
 
+// Tangletrap
+{
+    "name": "Tangletrap",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Tangletrap deals 5 damage to target creature with flying.\n• Destroy target artifact.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:flying"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Tangletrap deals 5 damage to target creature with flying."
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Suzanne Helmigh",
+        "flavorText": "\"It's like that old saying: what goes up . . . feeds the arboretum.\"\n—Lisette, Witherbloom dean",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80fbf729-00c0-4237-8294-c857f96364d3.jpg?1783927337"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Teach by Example
 {
     "name": "Teach by Example",
@@ -3093,5 +5681,243 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Twinscroll Shaman
+{
+    "name": "Twinscroll Shaman",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dwarf Shaman",
+    "oracleText": "Double strike",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Chris Seaman",
+        "flavorText": "\"May your wretched name never grace the annals of history, you ignorant buffoon!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87193af5-4b6b-48d0-9b75-8171bb1d6e53.jpg?1783927350"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Umbral Juke
+{
+    "name": "Umbral Juke",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Target player sacrifices a creature or planeswalker of their choice.\n• Create a 2/1 white and black Inkling creature token with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature|planeswalker",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target player sacrifices a creature or planeswalker of their choice."
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 2,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE",
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Inkling"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ]
+                    },
+                    "description": "Create a 2/1 white and black Inkling creature token with flying."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "The sport of Mage Tower was conceived as a playful testing ground for young spellcasters.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3fbd0921-e953-492b-ad73-c8a8bfaa750b.jpg?1783927361"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Waterfall Aerialist
+{
+    "name": "Waterfall Aerialist",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Djinn Wizard",
+    "oracleText": "Flying\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Lie Setiawan",
+        "flavorText": "Form and function in perfect unity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7bc6966c-18d9-4675-9594-6f0b2d11c405.jpg?1783927372"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Witherbloom Campus
+{
+    "name": "Witherbloom Campus",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {G}.\n{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{4}, {T}: Scry 1."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "artist": "Alayna Danner",
+        "flavorText": "Mage-students fascinated by the energies of life and death choose Witherbloom, the college of essence studies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/7346fb2e-754e-47de-b33d-eb089b357ee4.jpg?1783927269"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Wormhole Serpent
+{
+    "name": "Wormhole Serpent",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Serpent",
+    "oracleText": "{3}{U}: Target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{3}{U}: Target creature can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "After drownings, devourings, and one highly unpleasant algae infestation, unsupervised portal use on campus was banned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d0fd73f-e161-4e42-b4f9-9246a9dba785.jpg?1783927371"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }


### PR DESCRIPTION
## Summary

Sweeps every ⚡ Assay-ready card in **STX** (`just assay-ready STX`: **58 → 0**).

**Four-way split**

| Bucket | Count | Work |
|---|---|---|
| original | 53 | canonical `card(...)` authored in `definitions/stx/cards/` |
| elsewhere | 0 | — |
| row-only | 0 | — |
| basic | 5 | 10 `basicLand(...)` vals (two illustrations per type, #366–375) + the set's `basicLands` override |
| unscaffolded | 0 | — |

**Reprint tail** (rows the new canonicals owe in other scaffolded sets, generated with `scripts/generate-reprints.py --since main`): J22 `Pillardrop Rescuer`, MSC `Rip Apart`.

Every canonical was authored to `oracle-assay compile`'s JSON rather than to the oracle text; metadata was taken from STX's own Scryfall payload and diffed back mechanically against every written file (0 mismatches).

## Verification

- **Differential** (fresh `installDist` binary, same for both runs): `6378 compared / 6324 confirmed / 54 divergent` → `6431 / 6377 / 54`. +53 compared, +53 confirmed, **zero new divergences**.
- `just assay-ready STX` on the branch: 0 Assay-ready (193 declined: 175 `LINE_DECLINED`, 15 `MULTI_FACE`, 3 `LINES_DO_NOT_FOLD`).
- `just check-card-printing` on all 53 canonicals: clean.
- `just rebless-cards`: only `snapshots/cards/STX.json` moved.
- `just build` over the committed batch (cards, basics, reprint rows, reblessed golden): **BUILD SUCCESSFUL**.

## Capability pre-flight

Every mechanic the batch touches is engine-live and already has corpus users: learn (`Patterns.Mechanic.learn()`), ward (`KeywordAbility.ward` / `wardLife` — read by `ManaContinuations` + `StaticAbilityHandler`), Lesson (a subtype only), choose-N modals, graveyard-leave batch triggers, self-cast cost gating. No new SDK vocabulary, so `card-sdk-language-reference.md` is unchanged. No scenario tests: no card here is a first-in-corpus mechanic.

Token art for the Summoning Lessons (Elemental 4/4, Inkling 2/1, Spirit 3/2) resolves from the synced STX sheet in `tokens.json`.

## Findings not fixed here

- **Magecraft has no SDK spelling** — zero corpus cards, no `Triggers.*` for "cast or copy an instant or sorcery". It is the reason most of STX's remaining 193 are declined; that is `add-feature` work, not a sweep.
- The brief generator produced `ProfessorSWarning` for *Professor's Warning* (apostrophe stripped into a word boundary). Renamed by hand to `ProfessorsWarning` (the `PoetsQuill` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1vhGvKqHiwVhAxaeNXhey

