### PR TITLE
Add five Ravnica: City of Guilds radiance cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -10965,6 +10965,14 @@ Army just amassed by a sibling/action effect, or any cost-chosen entity. The plu
   by `PredicateContext.fromEffectContext`). `PredicateEvaluator.resolveEntityReference` resolves
   `EntityReference.AmassedArmy` / `FromCostStorage` from it (mirroring
   `TargetResolutionUtils.resolveEntityReference`), instead of returning null.
+- `PredicateContext` also carries the spell/ability's chosen `targets`, and
+  `resolveEntityReference` resolves `EntityReference.Target(i)` from them — so a **resolution-time
+  group filter** can be relative to a cast-time target. This is the Radiance shape: `Effects.X(target)
+  then Patterns.Group.xAll(GroupFilter(Creature.sharingColorWith(EntityReference.Target(0))).otherThanTarget())`
+  (Cleansing Beam, Surge of Zeal, Wojek Siren, Rally the Righteous, Leave No Trace). The target is
+  acted on directly rather than folded into the group because a colorless target shares a color with
+  nothing, not even itself. During target *enumeration* nothing has been chosen yet, so a target
+  filter that names `Target(i)` still sees null there.
 - `TargetFinder.findLegalTargets(..., pipelineContext = …)` accepts the resolving effect's
   `PredicateContext` and folds it into the per-candidate context, so **target enumeration** sees
   the pipeline. `ReflexiveTriggerEffectExecutor` passes it for deferred ("when you do, … target …")

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CleansingBeam.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/CleansingBeam.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Cleansing Beam
+ * {4}{R}
+ * Instant
+ *
+ * Radiance — Cleansing Beam deals 2 damage to target creature and each other creature that
+ * shares a color with it.
+ *
+ * Radiance is an ability word: one target, and a resolution-time group relative to it. The
+ * target is damaged directly; the group is every *other* creature sharing a color with the
+ * target — `sharingColorWith(EntityReference.Target(0))` for the colour test, `otherThanTarget()`
+ * so the target isn't hit twice. A colorless target shares a color with nothing (Scryfall ruling
+ * 2005-10-01), so only the target is damaged. The group is checked as the spell resolves, and if
+ * the target has become illegal the whole spell fizzles and no other creature is affected.
+ */
+val CleansingBeam = card("Cleansing Beam") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Radiance — Cleansing Beam deals 2 damage to target creature and each other " +
+        "creature that shares a color with it."
+
+    spell {
+        val victim = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(2, victim) then
+            Patterns.Group.dealDamageToAll(
+                2,
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "118"
+        artist = "Pat Lee"
+        flavorText = "\"Justice is toothless without punishment. Righteousness cannot succeed " +
+            "without the suffering of the guilty.\"\n—Razia"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg?1783943657"
+        ruling("2005-10-01", "All creatures that share a color are affected, even your own.")
+        ruling(
+            "2005-10-01",
+            "If it targets a colorless creature, it doesn't affect any other creatures. A colorless " +
+                "creature shares a color with nothing, not even other colorless creatures."
+        )
+        ruling("2005-10-01", "You check which creatures share a color with the target when the spell resolves.")
+        ruling(
+            "2005-10-01",
+            "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes " +
+                "an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LeaveNoTrace.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/LeaveNoTrace.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Leave No Trace
+ * {1}{W}
+ * Instant
+ *
+ * Radiance — Destroy target enchantment and each other enchantment that shares a color with it.
+ *
+ * Radiance over enchantments: the target is destroyed directly; every *other* enchantment
+ * sharing a color with it (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`)
+ * is found as the spell resolves and destroyed too. A colorless enchantment shares a color with
+ * nothing, so only it is destroyed.
+ */
+val LeaveNoTrace = card("Leave No Trace") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Radiance — Destroy target enchantment and each other enchantment that shares " +
+        "a color with it."
+
+    spell {
+        val radiant = target("target enchantment", Targets.Enchantment)
+        effect = Effects.Destroy(radiant) then
+            Patterns.Group.destroyAll(
+                GroupFilter(
+                    GameObjectFilter.Enchantment.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Pat Lee"
+        flavorText = "The magic of the Boros patrols the streets even when their soldiers do not."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg?1783943698"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RallyTheRighteous.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/RallyTheRighteous.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Rally the Righteous
+ * {1}{R}{W}
+ * Instant
+ *
+ * Radiance — Untap target creature and each other creature that shares a color with it. Those
+ * creatures get +2/+0 until end of turn.
+ *
+ * Radiance: the target is untapped and pumped directly; every *other* creature sharing a color
+ * with it (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`) is gathered once
+ * as the spell resolves and untapped-then-pumped in the same pass — "those creatures" is the
+ * group the first sentence named, so it isn't re-evaluated for the pump. A colorless target
+ * shares a color with nothing, so only it is affected.
+ */
+val RallyTheRighteous = card("Rally the Righteous") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Instant"
+    oracleText = "Radiance — Untap target creature and each other creature that shares a color " +
+        "with it. Those creatures get +2/+0 until end of turn."
+
+    spell {
+        val radiant = target("target creature", Targets.Creature)
+        effect = Effects.Untap(radiant) then
+            Effects.ModifyStats(2, 0, radiant) then
+            Effects.ForEachInGroup(
+                filter = GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget(),
+                effect = Effects.Untap(EffectTarget.Self) then
+                    Effects.ModifyStats(2, 0, EffectTarget.Self)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "222"
+        artist = "Dan Murayama Scott"
+        flavorText = "Yuri took up the ragged Boros banner, and his brethren, inspired by the act, " +
+            "followed him back into the fight."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg?1783943614"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SurgeOfZeal.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SurgeOfZeal.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Surge of Zeal
+ * {R}
+ * Instant
+ *
+ * Radiance — Target creature and each other creature that shares a color with it gain haste
+ * until end of turn.
+ *
+ * Radiance: the target gains haste directly; every *other* creature sharing a color with it
+ * (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`) is found as the spell
+ * resolves and gains haste too. A colorless target shares a color with nothing, so only it is
+ * affected.
+ */
+val SurgeOfZeal = card("Surge of Zeal") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Radiance — Target creature and each other creature that shares a color with it " +
+        "gain haste until end of turn."
+
+    spell {
+        val radiant = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.HASTE, radiant) then
+            Patterns.Group.grantKeywordToAll(
+                Keyword.HASTE,
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Justin Sweet"
+        flavorText = "\"If only my poxes were as infectious as their zealotry.\"\n—Savra"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg?1783943646"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekSiren.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekSiren.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Wojek Siren
+ * {W}
+ * Instant
+ *
+ * Radiance — Target creature and each other creature that shares a color with it get +1/+1
+ * until end of turn.
+ *
+ * Radiance: the target is pumped directly; every *other* creature sharing a color with it
+ * (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`) is found as the spell
+ * resolves and pumped too. A colorless target shares a color with nothing, so only it grows.
+ */
+val WojekSiren = card("Wojek Siren") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Radiance — Target creature and each other creature that shares a color with it " +
+        "get +1/+1 until end of turn."
+
+    spell {
+        val radiant = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(1, 1, radiant) then
+            Patterns.Group.modifyStatsForAll(
+                1,
+                1,
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "It is the call to arms, the call to fury, the call to blood."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg?1783943692"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CleansingBeamScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CleansingBeamScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.CleansingBeam
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cleansing Beam (RAV #118) — "Radiance — Cleansing Beam deals 2 damage to target creature and
+ * each other creature that shares a color with it."
+ *
+ * The radiance group is a resolution-time battlefield filter relative to the spell's own target
+ * (`sharingColorWith(EntityReference.Target(0))`), which is what these tests pin down: a
+ * multicolor target radiates to every creature sharing *any* of its colors, on both sides of
+ * the table; a colorless target radiates to nothing (ruling 2005-10-01); and the target itself
+ * is damaged exactly once.
+ */
+class CleansingBeamScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + CleansingBeam)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.damageOn(id: EntityId): Int = state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    fun GameTestDriver.beam(caster: EntityId, target: EntityId) {
+        giveMana(caster, Color.RED, 5)
+        val beam = putCardInHand(caster, "Cleansing Beam")
+        castSpellWithTargets(caster, beam, listOf(ChosenTarget.Permanent(target))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("a black-green target radiates 2 damage to every other black or green creature, on both sides") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val trampler = d.putCreatureOnBattlefield(opp, "Deathtouch Trampler")  // {1}{B}{G} 3/3
+        d.putCreatureOnBattlefield(opp, "Black Creature")                        // {1}{B} 2/2 — dies
+        val courser = d.putCreatureOnBattlefield(me, "Centaur Courser")          // {2}{G} 3/3 — mine, still hit
+        val lions = d.putCreatureOnBattlefield(opp, "Savannah Lions")            // {W} 2/1 — spared
+        val guide = d.putCreatureOnBattlefield(me, "Goblin Guide")               // {R} — spared
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")         // colorless — spared
+
+        d.beam(me, trampler)
+
+        withClue("the target took exactly 2 — not 2 from the target clause plus 2 from the group") {
+            d.damageOn(trampler) shouldBe 2
+        }
+        withClue("Black Creature shares black and died to the 2 damage") {
+            d.findPermanent(opp, "Black Creature").shouldBeNull()
+            d.getGraveyardCardNames(opp) shouldBe listOf("Black Creature")
+        }
+        withClue("my own Centaur Courser shares green and was hit too") {
+            d.damageOn(courser) shouldBe 2
+        }
+        withClue("white, red and colorless creatures share no color with the target and were spared") {
+            d.damageOn(lions) shouldBe 0
+            d.damageOn(guide) shouldBe 0
+            d.damageOn(golem) shouldBe 0
+            d.findPermanent(opp, "Savannah Lions").shouldNotBeNull()
+        }
+    }
+
+    test("a colorless target shares a color with nothing, so only it is damaged") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")         // 2/2 — dies
+        val myr = d.putCreatureOnBattlefield(opp, "Palladium Myr")               // another colorless 2/2
+        val courser = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        d.beam(me, golem)
+
+        withClue("the colorless target itself still took the 2 damage") {
+            d.findPermanent(opp, "Artifact Creature").shouldBeNull()
+            d.getGraveyardCardNames(opp) shouldBe listOf("Artifact Creature")
+        }
+        withClue("colorless creatures don't share a color even with each other") {
+            d.findPermanent(opp, "Palladium Myr").shouldNotBeNull()
+            d.damageOn(myr) shouldBe 0
+        }
+        d.damageOn(courser) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LeaveNoTraceScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LeaveNoTraceScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Blockbuster
+import com.wingedsheep.mtg.sets.definitions.rav.cards.DoublingSeason
+import com.wingedsheep.mtg.sets.definitions.rav.cards.GlareOfSubdual
+import com.wingedsheep.mtg.sets.definitions.rav.cards.HalcyonGlaze
+import com.wingedsheep.mtg.sets.definitions.rav.cards.LeaveNoTrace
+import com.wingedsheep.mtg.sets.definitions.rav.cards.LightOfSanction
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Leave No Trace (RAV #23) — "Radiance — Destroy target enchantment and each other enchantment
+ * that shares a color with it."
+ *
+ * Radiance over a non-creature target: a green-white enchantment radiates to the green and the
+ * white enchantments on either side of the table, and leaves the blue and red ones alone.
+ */
+class LeaveNoTraceScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(
+            TestCards.all + listOf(
+                LeaveNoTrace, GlareOfSubdual, DoublingSeason, LightOfSanction, HalcyonGlaze, Blockbuster
+            )
+        )
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.leaveNoTrace(caster: EntityId, target: EntityId) {
+        giveMana(caster, Color.WHITE, 2)
+        val spell = putCardInHand(caster, "Leave No Trace")
+        castSpellWithTargets(caster, spell, listOf(ChosenTarget.Permanent(target))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("a green-white target takes every other green or white enchantment with it, on both sides") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val glare = d.putPermanentOnBattlefield(opp, "Glare of Subdual")   // {2}{G}{W}
+        d.putPermanentOnBattlefield(opp, "Doubling Season")               // {4}{G}
+        d.putPermanentOnBattlefield(me, "Light of Sanction")              // {1}{W}{W} — mine, still destroyed
+        d.putPermanentOnBattlefield(opp, "Halcyon Glaze")                 // {2}{U} — spared
+        d.putPermanentOnBattlefield(me, "Blockbuster")                    // {3}{R}{R} — spared
+
+        d.leaveNoTrace(me, glare)
+
+        withClue("the target and every green or white enchantment were destroyed") {
+            d.findPermanent(opp, "Glare of Subdual").shouldBeNull()
+            d.findPermanent(opp, "Doubling Season").shouldBeNull()
+            d.findPermanent(me, "Light of Sanction").shouldBeNull()
+            d.getGraveyardCardNames(opp) shouldContainExactlyInAnyOrder listOf("Glare of Subdual", "Doubling Season")
+            d.getGraveyardCardNames(me) shouldContainExactlyInAnyOrder listOf("Light of Sanction", "Leave No Trace")
+        }
+        withClue("the blue and red enchantments share no color with the target") {
+            d.findPermanent(opp, "Halcyon Glaze").shouldNotBeNull()
+            d.findPermanent(me, "Blockbuster").shouldNotBeNull()
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/CleansingBeamReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/CleansingBeamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cleansing Beam reprint in CMD. Canonical CardDefinition lives in Ravnica: City of Guilds.
+ */
+val CleansingBeamReprint = Printing(
+    oracleId = "5c208258-f987-4d41-8eee-62e188d47ffb",
+    name = "Cleansing Beam",
+    setCode = "CMD",
+    collectorNumber = "116",
+    scryfallId = "e7a2e024-dcb4-4344-b98d-43dc6638932b",
+    artist = "Pat Lee",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7a2e024-dcb4-4344-b98d-43dc6638932b.jpg?1783941211",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1415,6 +1415,95 @@
     ]
 }
 
+// Cleansing Beam
+{
+    "name": "Cleansing Beam",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Cleansing Beam deals 2 damage to target creature and each other creature that shares a color with it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "UNCOMMON",
+        "artist": "Pat Lee",
+        "flavorText": "\"Justice is toothless without punishment. Righteousness cannot succeed without the suffering of the guilty.\"\n—Razia",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63cbaab6-db0d-40bb-bdf4-aee6543d9f27.jpg?1783943657",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "All creatures that share a color are affected, even your own."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "You check which creatures share a color with the target when the spell resolves."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Clinging Darkness
 {
     "name": "Clinging Darkness",
@@ -5851,6 +5940,72 @@
     ]
 }
 
+// Leave No Trace
+{
+    "name": "Leave No Trace",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Destroy target enchantment and each other enchantment that shares a color with it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsEnchantment",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "target enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Pat Lee",
+        "flavorText": "The magic of the Boros patrols the streets even when their soldiers do not.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58466d46-7225-42ff-8471-6d489be32cf3.jpg?1783943698"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Light of Sanction
 {
     "name": "Light of Sanction",
@@ -7727,6 +7882,103 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Rally the Righteous
+{
+    "name": "Rally the Righteous",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Untap target creature and each other creature that shares a color with it. Those creatures get +2/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            },
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Yuri took up the ragged Boros banner, and his brethren, inspired by the act, followed him back into the fight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9da51b6c-2e27-4b41-8fb0-bd9f6ad47b19.jpg?1783943614"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -9916,6 +10168,70 @@
     ]
 }
 
+// Surge of Zeal
+{
+    "name": "Surge of Zeal",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Target creature and each other creature that shares a color with it gain haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Justin Sweet",
+        "flavorText": "\"If only my poxes were as infectious as their zealotry.\"\n—Savra",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6c07fa6-b575-46f9-ab39-fb777d4b8acd.jpg?1783943646"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Surveilling Sprite
 {
     "name": "Surveilling Sprite",
@@ -11945,6 +12261,84 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Wojek Siren
+{
+    "name": "Wojek Siren",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Target creature and each other creature that shares a color with it get +1/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "It is the call to arms, the call to fury, the call to blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a55c0d7d-2325-4d7e-b449-c8fdcf988ec0.jpg?1783943692"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1289,7 +1289,17 @@ class PredicateEvaluator {
                 com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
                     .exiledCard(state, context?.sourceId, ref.index)
             is EntityReference.Triggering -> context?.triggeringEntityId
-            is EntityReference.Target -> null // Not available in predicate context
+            // The spell/ability's cast-time targets are threaded into [PredicateContext.targets]
+            // by `fromEffectContext`, so a resolution-time group filter can be relative to a
+            // chosen target — "each other creature that shares a color with it" (Radiance).
+            // Empty during target *enumeration* (nothing chosen yet), where this yields null.
+            is EntityReference.Target -> when (val chosen = context?.targets?.getOrNull(ref.index)) {
+                is ChosenTarget.Permanent -> chosen.entityId
+                is ChosenTarget.Card -> chosen.cardId
+                is ChosenTarget.Spell -> chosen.spellEntityId
+                is ChosenTarget.Player -> chosen.playerId
+                null -> null
+            }
             is EntityReference.Sacrificed -> null
             is EntityReference.TappedAsCost -> null
             is EntityReference.AffectedEntity -> context?.affectedEntityId


### PR DESCRIPTION
Five Ravnica: City of Guilds cards from the **Radiance** cycle, plus the one-line engine fix that lets the shape compose. RAV goes 218 → 223 / 291.

## The shape

Radiance is "target X and each other X that shares a color with it". Every card here is

```kotlin
Effects.X(target) then
    Patterns.Group.xAll(GroupFilter(Creature.sharingColorWith(EntityReference.Target(0))).otherThanTarget())
```

The target is acted on directly rather than folded into the group because a colorless target shares a color with nothing, not even itself (Scryfall ruling 2005-10-01) — the group is only the *others*.

## Engine fix (not new vocabulary)

`PredicateEvaluator.resolveEntityReference` returned `null` for `EntityReference.Target` ("not available in predicate context") even though `PredicateContext.targets` was already threaded in by `fromEffectContext`. It now resolves the chosen target by index, so a resolution-time group filter can be relative to a cast-time target. Target *enumeration* is unchanged — nothing is chosen yet there, so a target filter naming `Target(i)` still sees null (Spawnbroker stays blocked). Documented in the language reference under "Pipeline values inside target filters".

## Cards

- **Cleansing Beam** — `DealDamage(2, target)` + `Group.dealDamageToAll(2, …)`. Scenario test: a black-green target radiates to black and green creatures on both sides, spares white/red/colorless, is damaged exactly once; a colorless target radiates to nothing. Also adds the CMD `Printing` row.
- **Surge of Zeal** — `GrantKeyword(HASTE, target)` + `Group.grantKeywordToAll(HASTE, …)`.
- **Wojek Siren** — `ModifyStats(1, 1, target)` + `Group.modifyStatsForAll(1, 1, …)`.
- **Rally the Righteous** — untap + `+2/+0` on the target, then one `ForEachInGroup` pass doing both per creature (the group is named once; not re-evaluated for the pump).
- **Leave No Trace** — `Destroy(target)` + `Group.destroyAll(…)` over enchantments. Scenario test: a green-white target takes green and white enchantments on both sides, spares blue and red.

## Verification

- `just test` — BUILD SUCCESSFUL (14 722 passed, 0 failed)
- `just rebless-cards` — only `RAV.json` moved, additions only
- `just assay-differential --set RAV` — 0 DIVERGENT (all five decline, as expected for this grammar)
- `just check-card-printing` ok for all five

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WS9WqKjNVFMbYpznX38Qt
