### PR TITLE
Add three Lorwyn cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3102,11 +3102,13 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 **Reveal patterns**
 
 - `revealUntilNonlandDealDamage(target)` — Bonecrusher Giant shape.
-- `revealUntilMatchToHand(filter, restDestination?, restOrder?)` — Spinner of Souls / Wirewood Herald
-  shape: reveal from the top of your library until you reveal a card matching `filter`; that card goes to
-  hand and the cards revealed before it go to `restDestination` (default: bottom of library) in `restOrder`
-  (default: random). If the library empties before a match, nothing goes to hand and every revealed card
-  goes to the rest destination.
+- `revealUntilMatchToHand(filter, restDestination?, restOrder?, count?)` — Spinner of Souls / Wirewood
+  Herald shape: reveal from the top of your library until you reveal `count` cards matching `filter`
+  (default 1); those cards go to hand and the cards revealed alongside them go to `restDestination`
+  (default: bottom of library) in `restOrder` (default: random). If the library empties before `count`
+  matches, every match found so far still goes to hand and the rest go to the rest destination.
+  **Fathom Trawl** is the `count = 3` case, with `restOrder = CardOrder.ControllerChooses` for its
+  "in any order".
 - `wheelEffect(players)` — each player shuffles hand into library, draws that many.
 - `factOrFiction(count = 5, keepZone, otherZone, ...)` — reveal/look at the top `count`, an
   opponent splits them into two piles, then you choose which pile goes to `keepZone` (hand) and

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4379,7 +4379,12 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `.manaValueAtMostDynamic(DynamicAmount.TurnTracking(Player.You, TurnTracker.LIFE_GAINED))`. The cap
   fails closed (matches nothing) when there is no controller context to resolve a player-scoped amount,
   and is `false` in the layer-projection / cost-calculation / cast-record paths (no resolution context),
-  matching the other entity-relative caps.
+  matching the other entity-relative caps. Available on `TargetFilter` too (mirroring
+  `.manaValueAtMostX()`), which is how a *targeting* restriction carries the cap rather than a
+  resolution-time check — **Spellstutter Sprite**'s "counter target spell with mana value X or less,
+  where X is the number of Faeries you control" is
+  `TargetFilter.SpellOnStack.manaValueAtMostDynamic(AggregateBattlefield(You, Permanent.withSubtype(FAERIE)))`,
+  so the CR 608.2b re-check on resolution gets the ruling's "determine X again" for free.
 - `.manaValueEqualsDynamic(amount)` — the fluent builder for `ManaValueEqualsDynamic` below, and
   `.manaValueAtMostDynamic`'s equality sibling. Oracle marks the difference by where it puts the
   comparison relative to the clause: "mana value **equal to** the number of harmony counters on this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -670,27 +670,30 @@ object LibraryPatterns {
     )
 
     /**
-     * "Reveal cards from the top of your library until you reveal a card matching [filter].
-     * Put that card into your hand and the rest [restDestination] (defaults to the bottom of
-     * your library) [restOrder] (defaults to a random order)." — Spinner of Souls / Wirewood
-     * Herald shape.
+     * "Reveal cards from the top of your library until you reveal [count] card(s) matching
+     * [filter]. Put those cards into your hand and the rest [restDestination] (defaults to the
+     * bottom of your library) [restOrder] (defaults to a random order)." — Spinner of Souls /
+     * Wirewood Herald at the default `count = 1`, Fathom Trawl at three.
      *
-     * The [filter] partition is reused twice: [GatherUntilMatchEffect] stops the reveal at the
-     * first match, then a [FilterCollectionEffect] over every revealed card splits the single
-     * match (→ hand) from the cards revealed before it (→ [restDestination]). If the library
-     * empties before a match is found, nothing goes to hand and every revealed card goes to the
-     * rest destination.
+     * The [filter] partition is reused twice: [GatherUntilMatchEffect] stops the reveal once
+     * [count] matches have been revealed, then a [FilterCollectionEffect] over every revealed
+     * card splits the matches (→ hand) from the cards revealed alongside them
+     * (→ [restDestination]). If the library empties before [count] matches are found, every
+     * match found so far still goes to hand and the rest go to the rest destination — Fathom
+     * Trawl's 2007-10-01 ruling.
      */
     fun revealUntilMatchToHand(
         filter: GameObjectFilter,
         restDestination: CardDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
-        restOrder: CardOrder = CardOrder.Random
+        restOrder: CardOrder = CardOrder.Random,
+        count: DynamicAmount = DynamicAmount.Fixed(1)
     ): CompositeEffect = CompositeEffect(
         listOf(
             GatherUntilMatchEffect(
                 filter = filter,
                 storeMatch = "ignored",
-                storeRevealed = "revealed"
+                storeRevealed = "revealed",
+                count = count
             ),
             RevealCollectionEffect(from = "revealed"),
             FilterCollectionEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.Serializable
 
 /**
@@ -403,6 +404,15 @@ data class TargetFilter(
 
     /** Mana value at most the X chosen for the source spell/ability */
     fun manaValueAtMostX() = copy(baseFilter = baseFilter.manaValueAtMostX())
+
+    /**
+     * Mana value at most a resolved [DynamicAmount] — "target spell with mana value X or less,
+     * where X is the number of Faeries you control" (Spellstutter Sprite). The pass-through of
+     * [ObjectFilter.manaValueAtMostDynamic] onto the *target* side, where the cap is re-read both
+     * when targets are chosen and again on resolution (CR 608.2b).
+     */
+    fun manaValueAtMostDynamic(amount: DynamicAmount) =
+        copy(baseFilter = baseFilter.manaValueAtMostDynamic(amount))
 
     /** Mana value exactly equal to the X chosen for the source spell/ability (Repeal, Spell Blast). */
     fun manaValueEqualsX() = copy(baseFilter = baseFilter.manaValueEqualsX())

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BurrentonForgeTender.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/BurrentonForgeTender.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Burrenton Forge-Tender
+ * {W}
+ * Creature — Kithkin Wizard
+ * 1/1
+ * Protection from red
+ * Sacrifice this creature: Prevent all damage a red source of your choice would deal this turn.
+ *
+ * Modelling notes:
+ * - The prevention has **no recipient clause** — it stops the chosen source's damage to anything,
+ *   not just to its controller. That is what `PreventAllDamageFromChosenSourceMatching` expresses
+ *   (`direction = FromTarget`), the same shield Mourner's Shield installs.
+ * - **The ability doesn't target** (2017-11-17 ruling): the source is chosen as the ability
+ *   resolves, and the ability can be activated with no red source on the board at all. A
+ *   `ChosenSourceMatching` eligibility filter is a choice restriction, not a target requirement, so
+ *   that falls out for free.
+ * - `nextInstanceOnly` stays false — this is an all-damage-for-the-turn shield, not a Circle of
+ *   Protection's single instance.
+ */
+val BurrentonForgeTender = card("Burrenton Forge-Tender") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Protection from red\n" +
+        "Sacrifice this creature: Prevent all damage a red source of your choice would deal this turn."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.PreventAllDamageFromChosenSourceMatching(
+            GameObjectFilter.Any.withColor(Color.RED)
+        )
+        description = "Sacrifice this creature: Prevent all damage a red source of your choice " +
+            "would deal this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Chuck Lukacs"
+        flavorText = "\"We are a clachan of smiths. The forge is as comfortable to us as a small " +
+            "fire during a cool winter's evening.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg?1783942917"
+        ruling(
+            "2017-11-17",
+            "If the red source you chose changes colors before it deals damage, the " +
+                "damage-prevention effect doesn't apply."
+        )
+        ruling(
+            "2017-11-17",
+            "The last ability of Burrenton Forge-Tender doesn't target anything. You choose a " +
+                "source of damage as the ability resolves, if able. You can activate it even if " +
+                "there is no source to choose."
+        )
+        ruling(
+            "2017-11-17",
+            "If a permanent spell is chosen as the source of damage, Burrenton Forge-Tender's " +
+                "prevention effect continues to apply for the rest of the turn to the permanent " +
+                "that spell becomes once it has entered the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FathomTrawl.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FathomTrawl.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fathom Trawl
+ * {3}{U}{U}
+ * Sorcery
+ * Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland
+ * cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of
+ * your library in any order.
+ *
+ * `Patterns.Library.revealUntilMatchToHand` at `count = 3`: the gather stops once three nonland
+ * cards have been revealed, then the same nonland partition splits the revealed pile — matches to
+ * hand, the lands revealed alongside them to the bottom. "In any order" is
+ * [CardOrder.ControllerChooses], not the pattern's default random order.
+ *
+ * The 2007-10-01 ruling — fewer than three nonland cards in the library reveals the whole library,
+ * takes every nonland card, and bottoms the rest — is the gather's own empty-library behaviour, not
+ * a separate branch.
+ */
+val FathomTrawl = card("Fathom Trawl") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Reveal cards from the top of your library until you reveal three nonland cards. " +
+        "Put the nonland cards revealed this way into your hand, then put the rest of the revealed " +
+        "cards on the bottom of your library in any order."
+
+    spell {
+        effect = Patterns.Library.revealUntilMatchToHand(
+            filter = GameObjectFilter.Nonland,
+            restOrder = CardOrder.ControllerChooses,
+            count = DynamicAmount.Fixed(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "65"
+        artist = "Paul Chadwick"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg?1783942903"
+        ruling(
+            "2007-10-01",
+            "If there are fewer than three nonland cards in your library, you will reveal your " +
+                "entire library, put all nonland cards into your hand, and put the rest back in any order."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SpellstutterSprite.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SpellstutterSprite.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Spellstutter Sprite
+ * {1}{U}
+ * Creature — Faerie Wizard
+ * 1/1
+ * Flash
+ * Flying
+ * When this creature enters, counter target spell with mana value X or less, where X is the number
+ * of Faeries you control.
+ *
+ * Modelling notes:
+ * - **The cap is a targeting restriction, not a resolution check.** It rides on the target filter as
+ *   `manaValueAtMostDynamic`, so the count is read when the trigger picks a target *and* again when
+ *   it resolves — exactly the 2007-10-01 ruling: if the Faerie count has dropped enough in between,
+ *   the ability is countered on resolution for having no legal target and the spell resolves.
+ * - **"The number of Faeries you control" is a bare tribal noun**, so it counts Faerie *permanents*,
+ *   not just Faerie creatures. Lorwyn prints Kindred noncreature Faeries, and the Sprite itself is
+ *   already on the battlefield when its own enters trigger resolves, so it always counts itself.
+ */
+val SpellstutterSprite = card("Spellstutter Sprite") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Flash\nFlying\nWhen this creature enters, counter target spell with mana value X " +
+        "or less, where X is the number of Faeries you control."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetSpell(
+            filter = TargetFilter.SpellOnStack.manaValueAtMostDynamic(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Permanent.withSubtype(Subtype.FAERIE),
+                )
+            )
+        )
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg?1783942897"
+        ruling(
+            "2007-10-01",
+            "The value of X needs to be determined both when the ability triggers (so you can " +
+                "choose a target) and again when the ability resolves (to check if that target is " +
+                "still legal). If the number of Faeries you control has decreased enough in that " +
+                "time to make the target illegal, Spellstutter Sprite's ability won't resolve (and " +
+                "the targeted spell will resolve as normal)."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurrentonForgeTenderScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurrentonForgeTenderScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.BurrentonForgeTender
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Burrenton Forge-Tender (LRW #7) — "Protection from red. Sacrifice this creature: Prevent all
+ * damage a red source of your choice would deal this turn."
+ *
+ * Player 1 attacks with two creatures — a red Goblin Guide (2/1) and a white Savannah Lions (1/1) —
+ * and player 2 sacrifices the Forge-Tender in the declare-blockers step. Two creatures rather than
+ * one is the point: a shield that ignored its `ChosenSourceMatching` colour filter would stop all
+ * three damage, so the Lions' 1 still landing is the assertion that the filter is doing work.
+ *
+ * The 2017-11-17 ruling that the ability doesn't target — the source is chosen *as it resolves*, and
+ * it can be activated with nothing to choose — falls out of modelling the colour clause as an
+ * eligibility filter on a resolution-time choice rather than as a target requirement. The first
+ * test reads that choice's option list directly.
+ */
+class BurrentonForgeTenderScenarioTest : FunSpec({
+
+    val sacAbility = BurrentonForgeTender.activatedAbilities.single().id
+
+    /**
+     * Player 1 attacks with a red Goblin Guide (2/1) and a white Savannah Lions (1/1);
+     * player 2 takes no blocks and holds priority in the declare-blockers step with an untapped
+     * Forge-Tender. Returns the Forge-Tender, the Goblin, and the Lions.
+     */
+    fun attackingBoard(): Triple<GameTestDriver, EntityId, Pair<EntityId, EntityId>> {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BurrentonForgeTender)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+
+        val goblin = d.putCreatureOnBattlefield(d.player1, "Goblin Guide")
+        val lions = d.putCreatureOnBattlefield(d.player1, "Savannah Lions")
+        d.removeSummoningSickness(goblin)
+        d.removeSummoningSickness(lions)
+        val tender = d.putCreatureOnBattlefield(d.player2, "Burrenton Forge-Tender")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(goblin, lions), d.player2).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareNoBlockers(d.player2).error shouldBe null
+
+        return Triple(d, tender, goblin to lions)
+    }
+
+    /** Sacrifice the Forge-Tender and pause on the source choice. */
+    fun GameTestDriver.sacrificeForgeTender(tender: EntityId) {
+        submit(ActivateAbility(player2, tender, sacAbility)).error shouldBe null
+        var guard = 0
+        while (guard++ < 10 && state.pendingDecision == null && state.stack.isNotEmpty()) bothPass()
+    }
+
+    test("only red sources are offered as the choice — and the ability never targeted") {
+        val (d, tender, creatures) = attackingBoard()
+        val (goblin, lions) = creatures
+
+        d.sacrificeForgeTender(tender)
+
+        val decision = d.state.pendingDecision
+        withClue("the ability pauses on resolution to choose a source: $decision") {
+            (decision is SelectCardsDecision) shouldBe true
+        }
+        val options = (decision as SelectCardsDecision).options
+        withClue("the red Goblin Guide qualifies") {
+            (goblin in options) shouldBe true
+        }
+        withClue("the white Savannah Lions is not a red source, so it is never offered") {
+            (lions in options) shouldBe false
+        }
+    }
+
+    test("the chosen red source deals no combat damage; the white attacker still connects") {
+        val (d, tender, creatures) = attackingBoard()
+        val (goblin, _) = creatures
+
+        d.sacrificeForgeTender(tender)
+        d.submitCardSelection(d.player2, listOf(goblin)).error shouldBe null
+
+        d.passPriorityUntil(Step.END_COMBAT)
+
+        withClue("the Goblin's 2 is prevented; the Lions' 1 is not") {
+            d.getLifeTotal(d.player2) shouldBe 19
+        }
+    }
+
+    test("without the sacrifice, all three damage lands") {
+        val (d, _, _) = attackingBoard()
+
+        d.passPriorityUntil(Step.END_COMBAT)
+
+        withClue("the control case — nothing is preventing anything") {
+            d.getLifeTotal(d.player2) shouldBe 17
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FathomTrawlScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FathomTrawlScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fathom Trawl (LRW #65, {3}{U}{U} Sorcery).
+ *
+ *   Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland
+ *   cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of
+ *   your library in any order.
+ *
+ * Three is the whole card, so the count is what these tests aim at. `revealUntilMatchToHand`
+ * defaulted to a single match before this card; a `count` that silently stayed at 1 would leave a
+ * card that reads right, draws one nonland, and bottoms the other two — the failure the first test
+ * catches. The second covers the 2007-10-01 ruling: fewer than three nonland cards in the library
+ * takes every one there is rather than fizzling.
+ */
+class FathomTrawlScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Library is seeded top-down in call order, so the interleaving here is deliberate: the third
+     * nonland card sits under two lands, and a fourth nonland sits under *it*. A correct reveal
+     * stops on "Hill Giant" and never touches "Gray Ogre".
+     */
+    private fun trawl(vararg library: String) = scenario()
+        .withPlayers("Alice", "Bob")
+        .withCardInHand(1, "Fathom Trawl")
+        .withLandsOnBattlefield(1, "Island", 5)
+        .apply { library.forEach { withCardInLibrary(1, it) } }
+        .withCardInLibrary(2, "Swamp")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Fathom Trawl") {
+
+            test("takes three nonland cards and bottoms the lands revealed alongside them") {
+                val game = trawl(
+                    "Grizzly Bears", // nonland 1
+                    "Forest",
+                    "Bog Imp", // nonland 2
+                    "Mountain",
+                    "Plains",
+                    "Hill Giant", // nonland 3 — the reveal stops here
+                    "Gray Ogre", // never revealed
+                )
+                val libraryBefore = game.librarySize(1)
+
+                game.castSpell(1, "Fathom Trawl").error shouldBe null
+                game.resolveStack()
+                // "In any order" is a controller decision; keeping the revealed order is a legal answer.
+                if (game.hasPendingDecision()) game.keepLibraryOrder()
+
+                withClue("all three nonland cards revealed this way go to hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInHand(1, "Bog Imp") shouldBe true
+                    game.isInHand(1, "Hill Giant") shouldBe true
+                }
+                withClue("the reveal stops at the third nonland card — the fourth is untouched") {
+                    game.isInHand(1, "Gray Ogre") shouldBe false
+                }
+                withClue("the lands revealed alongside them go to the bottom, not to hand") {
+                    game.isInHand(1, "Forest") shouldBe false
+                    game.isInHand(1, "Mountain") shouldBe false
+                    game.isInHand(1, "Plains") shouldBe false
+                }
+                withClue("only the three nonland cards left the library") {
+                    game.librarySize(1) shouldBe libraryBefore - 3
+                }
+                game.isInGraveyard(1, "Fathom Trawl") shouldBe true
+            }
+
+            test("with fewer than three nonland cards, it takes every one there is") {
+                val game = trawl("Forest", "Grizzly Bears", "Mountain", "Bog Imp", "Plains")
+
+                game.castSpell(1, "Fathom Trawl").error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.keepLibraryOrder()
+
+                withClue("the 2007-10-01 ruling: reveal the whole library, take every nonland card") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInHand(1, "Bog Imp") shouldBe true
+                }
+                withClue("the rest go back to the bottom rather than being lost") {
+                    game.librarySize(1) shouldBe 3
+                    game.isInGraveyard(1, "Forest") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellstutterSpriteScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpellstutterSpriteScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spellstutter Sprite (LRW #89, {1}{U} Creature — Faerie Wizard 1/1).
+ *
+ *   Flash, flying.
+ *   When this creature enters, counter target spell with mana value X or less, where X is the
+ *   number of Faeries you control.
+ *
+ * The whole card is the cap, and the cap has exactly one shape that reads right while being wrong:
+ * a filter that ignores the dynamic amount and lets the Sprite counter anything. The two tests are
+ * the same board on either side of the threshold — three Faeries against a mana value 2 spell, and
+ * one Faerie against the same spell — so a cap that isn't read gives the *same* answer in both and
+ * fails the second.
+ *
+ * The 2007-10-01 ruling's re-check on resolution is the engine's generic target-legality pass, which
+ * this card gets for free by carrying the cap on the target filter rather than checking it as the
+ * ability resolves.
+ */
+class SpellstutterSpriteScenarioTest : ScenarioTestBase() {
+
+    /** [otherFaeries] extra Faeries Alice controls *before* the Sprite itself enters. */
+    private fun sprite(otherFaeries: Int) = scenario()
+        .withPlayers("Alice", "Bob")
+        .withCardInHand(1, "Spellstutter Sprite")
+        .withLandsOnBattlefield(1, "Island", 3)
+        .apply { repeat(otherFaeries) { withCardOnBattlefield(1, "Nightshade Stinger") } }
+        .withCardInHand(2, "Grizzly Bears") // {1}{G}, mana value 2
+        .withLandsOnBattlefield(2, "Forest", 3)
+        .withCardInLibrary(1, "Island")
+        .withCardInLibrary(2, "Forest")
+        .withActivePlayer(2)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    private fun TestGame.stackSpell(name: String): EntityId? =
+        state.stack.find { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    init {
+        context("Spellstutter Sprite") {
+
+            test("three Faeries counter a mana value 2 spell") {
+                val game = sprite(otherFaeries = 2)
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                game.castSpell(1, "Spellstutter Sprite").error shouldBe null
+
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val bears = game.stackSpell("Grizzly Bears")
+                    if (bears != null) game.selectTargets(listOf(bears))
+                    game.resolveStack()
+                }
+
+                withClue("two Stingers plus the Sprite itself is X = 3, so mana value 2 is in range") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                game.isOnBattlefield("Spellstutter Sprite") shouldBe true
+            }
+
+            test("the Sprite alone can't reach a mana value 2 spell") {
+                val game = sprite(otherFaeries = 0)
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                game.castSpell(1, "Spellstutter Sprite").error shouldBe null
+
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    val bears = game.stackSpell("Grizzly Bears")
+                    if (bears != null) game.selectTargets(listOf(bears)) else game.skipTargets()
+                    game.resolveStack()
+                }
+
+                withClue("X = 1 with only the Sprite, so a mana value 2 spell is never a legal target") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+                withClue("the Sprite still resolves — a trigger with no legal target is simply removed") {
+                    game.isOnBattlefield("Spellstutter Sprite") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpellstutterSpriteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpellstutterSpriteReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spellstutter Sprite reprint in J22. Canonical CardDefinition lives in Lorwyn (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.lrw.cards.SpellstutterSprite`.
+ */
+val SpellstutterSpriteReprint = Printing(
+    oracleId = "32e60fb4-e841-4f82-9c83-5e63766e8e6f",
+    name = "Spellstutter Sprite",
+    setCode = "J22",
+    collectorNumber = "65",
+    scryfallId = "a0e262a3-0e69-4d61-8143-b9d137c31496",
+    artist = "Sila",
+    imageUri = "https://cards.scryfall.io/normal/front/a/0/a0e262a3-0e69-4d61-8143-b9d137c31496.jpg?1783919169",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1477,6 +1477,68 @@
     ]
 }
 
+// Burrenton Forge-Tender
+{
+    "name": "Burrenton Forge-Tender",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Kithkin Wizard",
+    "oracleText": "Protection from red\nSacrifice this creature: Prevent all damage a red source of your choice would deal this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "direction": "FromTarget",
+                    "sourceFilter": {
+                        "type": "ChosenSourceMatching",
+                        "filter": "red"
+                    }
+                },
+                "descriptionOverride": "Sacrifice this creature: Prevent all damage a red source of your choice would deal this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Chuck Lukacs",
+        "flavorText": "\"We are a clachan of smiths. The forge is as comfortable to us as a small fire during a cool winter's evening.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c000c3e4-d71a-43c8-8ded-f3da54bc088d.jpg?1783942917",
+        "rulings": [
+            {
+                "date": "2017-11-17",
+                "text": "If the red source you chose changes colors before it deals damage, the damage-prevention effect doesn't apply."
+            },
+            {
+                "date": "2017-11-17",
+                "text": "The last ability of Burrenton Forge-Tender doesn't target anything. You choose a source of damage as the ability resolves, if able. You can activate it even if there is no source to choose."
+            },
+            {
+                "date": "2017-11-17",
+                "text": "If a permanent spell is chosen as the source of damage, Burrenton Forge-Tender's prevention effect continues to apply for the rest of the turn to the permanent that spell becomes once it has entered the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Caterwauling Boggart
 {
     "name": "Caterwauling Boggart",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -10485,6 +10485,66 @@
     ]
 }
 
+// Spellstutter Sprite
+{
+    "name": "Spellstutter Sprite",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flash\nFlying\nWhen this creature enters, counter target spell with mana value X or less, where X is the number of Faeries you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "Counter",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "ManaValueAtMostDynamic",
+                                    "amount": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "permanent Faerie"
+                                    }
+                                }
+                            ]
+                        },
+                        "zone": "Stack"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Rebecca Guay",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e5ba4a9-a282-4d4b-b25a-179e05e458f4.jpg?1783942897",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The value of X needs to be determined both when the ability triggers (so you can choose a target) and again when the ability resolves (to check if that target is still legal). If the number of Faeries you control has decreased enough in that time to make the target illegal, Spellstutter Sprite's ability won't resolve (and the targeted spell will resolve as normal)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Spiderwig Boggart
 {
     "name": "Spiderwig Boggart",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -3465,6 +3465,79 @@
     ]
 }
 
+// Fathom Trawl
+{
+    "name": "Fathom Trawl",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherUntilMatch",
+                    "filter": "nonland",
+                    "storeMatch": "ignored",
+                    "storeRevealed": "revealed",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "revealed"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "revealed",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "nonland"
+                    },
+                    "storeMatching": "matchedToHand",
+                    "storeNonMatching": "rest"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "matchedToHand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "RARE",
+        "artist": "Paul Chadwick",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg?1783942903",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "If there are fewer than three nonland cards in your library, you will reveal your entire library, put all nonland cards into your hand, and put the rest back in any order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Faultgrinder
 {
     "name": "Faultgrinder",


### PR DESCRIPTION
Three Lorwyn cards, each with its own scenario test.

- **Burrenton Forge-Tender** ({W} 1/1 Kithkin Wizard) — protection from red plus "Sacrifice this creature: Prevent all damage a red source of your choice would deal this turn." Pure composition: `KeywordAbility.Protection(ProtectionScope.Color(RED))` and `Effects.PreventAllDamageFromChosenSourceMatching(Any.withColor(RED))`, the Mourner's Shield shape. The colour clause is an eligibility filter on a resolution-time choice, not a target requirement — which is the 2017-11-17 ruling that the ability doesn't target and can be activated with nothing to choose.
- **Fathom Trawl** ({3}{U}{U} sorcery) — `Patterns.Library.revealUntilMatchToHand` at three matches. The pattern already had the shape but was hard-wired to one; this threads `GatherUntilMatchEffect`'s existing `count` through as a defaulted parameter. "In any order" is `CardOrder.ControllerChooses`.
- **Spellstutter Sprite** ({1}{U} 1/1 Faerie Wizard, flash + flying) — the mana-value cap rides on the *target filter* (`TargetFilter.manaValueAtMostDynamic`, a new pass-through of the existing `ObjectFilter` predicate), so the count is read when the trigger picks a target and again by the CR 608.2b re-check on resolution. That is exactly the 2007-10-01 ruling. Also adds the J22 `Printing` row.

### Not batched — these need `add-feature`, not `add-card`

Evaluated and dropped while picking the handful, each blocked on missing engine vocabulary rather than on effort:

- **Lairwatch Giant** — `CanBlockAdditionalForCreatureGroup` exists, but "whenever this creature blocks two or more creatures" does not: `BlockEvent` fires once per blocked attacker with no `oncePerCombat` / minimum-count field.
- **Horde of Notions** — "play target Elemental card from your graveyard without paying its mana cost" has an exile-side primitive (`GrantFreeCastTargetFromExileEffect`) with no graveyard sibling.
- **Purity / Vigor / Hostility** — the Incarnations' prevention riders ("gain life equal to the damage prevented this way", "put that many +1/+1 counters") need a rider on the printed `PreventDamage` replacement, which only `PreventDamageEffect`'s durational shield has.
- **Aquitect's Will** — `AddLandTypeByCounter` is the right static, but a sorcery has no permanent to carry it and `GrantStaticAbility` is documented as inert for anything the layer projector reads.
- **Dread** — "when this is put into a graveyard from anywhere" needs trigger zones (hand, library, stack) that `TriggerDetector` has no precedent for scanning.

### Verification

- `just build` — green.
- `just test-class` for all three scenario tests — 7 tests, green.
- `just check-card-printing` — clean for all three (the J22 row was the one gap).
- `just assay-differential --set LRW` — 101 confirmed, 10 divergent, all ten pre-existing (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). None of these three cards diverge.
- `CardDefinitionSnapshotTest` re-blessed; only `LRW.json` moved, and only by adding these three cards.

LRW goes 210/286 → 213/286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vMQoG8Q3SfJQyEv2XnJgq
