### PR TITLE
Let a choose-N modal spell announce its X (Profane Command)

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProfaneCommand.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ProfaneCommand.kt
@@ -68,7 +68,10 @@ val ProfaneCommand = card("Profane Command") {
             }
             mode("Up to X target creatures gain fear until end of turn") {
                 target(
-                    "creatures to gain fear",
+                    // The id is the whole phrase after the "up to " the optional flag prints, so
+                    // the server-driven per-mode prompt reads "up to X target creatures" rather
+                    // than "up to creatures".
+                    "X target creatures",
                     TargetCreature(optional = true, dynamicMaxCount = DynamicAmount.XValue)
                 )
                 effect = ForEachTargetEffect(

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProfaneCommandScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProfaneCommandScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -185,6 +186,64 @@ class ProfaneCommandScenarioTest : FunSpec({
         val projected = projector.project(driver.state)
         projected.hasKeyword(bears, Keyword.FEAR) shouldBe true
         projected.hasKeyword(lions, Keyword.FEAR) shouldBe true
+    }
+
+    // The web client's choose-N modal panel submits the modes (and the announced X) and lets the
+    // server drive per-mode targeting on the battlefield — no flat `targets`, no
+    // `modeTargetsOrdered`. That path prices its own target prompts, so the X announced with the
+    // modes has to reach them too, or the same three spellings that the direct-cast tests above
+    // cover go back to reading an unbound X.
+    fun GameTestDriver.castCommandClientShaped(
+        caster: EntityId,
+        x: Int,
+        modes: List<Int>,
+    ): ExecutionResult {
+        giveMana(caster, Color.BLACK, x + 2)
+        val spell = putCardInHand(caster, "Profane Command")
+        return submit(CastSpell(playerId = caster, cardId = spell, chosenModes = modes, xValue = x))
+    }
+
+    test("server-driven mode targeting offers X creatures for the fear mode, not one") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        driver.castCommandClientShaped(me, x = 2, modes = listOf(grantFear, loseLife))
+            .error shouldBe null
+
+        val fearDecision = driver.pendingDecision as ChooseTargetsDecision
+        // "Up to X target creatures" — the static count on the requirement is the placeholder 1.
+        fearDecision.targetRequirements.single().maxTargets shouldBe 2
+        driver.submitTargetSelection(me, listOf(bears, lions))
+
+        val playerDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(me, listOf(opp))
+        playerDecision.targetRequirements.single().maxTargets shouldBe 1
+
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bears, Keyword.FEAR) shouldBe true
+        projected.hasKeyword(lions, Keyword.FEAR) shouldBe true
+        driver.getLifeTotal(opp) shouldBe 18
+    }
+
+    test("server-driven mode targeting hides a graveyard creature above the announced X") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        val courser = driver.putCardInGraveyard(me, "Centaur Courser") // mana value 3
+        val bears = driver.putCardInGraveyard(me, "Grizzly Bears") // mana value 2
+
+        driver.castCommandClientShaped(me, x = 2, modes = listOf(reanimate, loseLife))
+            .error shouldBe null
+
+        val reanimateDecision = driver.pendingDecision as ChooseTargetsDecision
+        reanimateDecision.legalTargets[0] shouldBe listOf(bears)
+        reanimateDecision.legalTargets[0]!!.contains(courser) shouldBe false
     }
 
     test("'up to X target creatures' refuses X + 1 of them") {

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -9589,7 +9589,7 @@
                             "filter": {
                                 "baseFilter": "creature"
                             },
-                            "id": "creatures to gain fear",
+                            "id": "X target creatures",
                             "dynamicMaxCount": "XValue"
                         }
                     ],

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -4576,6 +4576,39 @@ class CastSpellHandler(
         return base.copy(additionalCostPayment = merged)
     }
 
+    /**
+     * How many targets a mode's requirement may take, for the cast-time per-mode decision.
+     *
+     * A [TargetObject.dynamicMaxCount] is authoritative when present — the static `count` is only
+     * the placeholder the author writes when the real cap isn't knowable until cast time. Mirrors
+     * [TargetValidator]'s `effectiveMaxCount`, so the count the player is *offered* and the count
+     * the cast is *validated* against are the same number; otherwise "up to X target creatures"
+     * offers one target at X = 3, or offers unbounded picks the validator then rejects.
+     */
+    private fun resolveModeTargetMaxCount(
+        state: GameState,
+        requirement: TargetRequirement,
+        casterId: EntityId,
+        cardId: EntityId,
+        xValue: Int?
+    ): Int {
+        val unboundedFallback = if (requirement.unlimited) Int.MAX_VALUE else requirement.count
+        if (requirement !is com.wingedsheep.sdk.scripting.targets.TargetObject) return unboundedFallback
+        val dyn = requirement.dynamicMaxCount ?: return unboundedFallback
+        if (dyn == com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue) {
+            return xValue ?: unboundedFallback
+        }
+        return try {
+            DynamicAmountEvaluator().evaluate(
+                state,
+                dyn,
+                EffectContext(sourceId = cardId, controllerId = casterId, xValue = xValue)
+            ).coerceAtLeast(0)
+        } catch (_: Exception) {
+            unboundedFallback
+        }
+    }
+
     internal fun presentCastModalTargetDecision(
         state: GameState,
         cardId: EntityId,
@@ -4601,22 +4634,44 @@ class CastSpellHandler(
 
             // Find legal targets per requirement. If any required slot has no legal
             // targets (and is mandatory), this mode can't resolve — surface an error.
+            //
+            // X was announced with the modes (CR 601.2b), so it is known here and every mode
+            // that reads it must see it: as a filter bound ("creature card with mana value X or
+            // less" — unbound, `ManaValueAtMostX` matches permissively and would offer targets
+            // the cast then rejects) and as a target count ("up to X target creatures", a
+            // `dynamicMaxCount` the static `count` placeholder would clamp to one).
+            val xContext = PredicateContext(
+                controllerId = casterId,
+                sourceId = cardId,
+                xValue = baseCastAction.xValue
+            )
             val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
+            mode.targetRequirements.forEachIndexed { index, req ->
+                legalTargetsMap[index] = targetFinder.findLegalTargets(
+                    state, req, casterId, cardId, pipelineContext = xContext
+                )
+            }
+            val allSatisfied = mode.targetRequirements.withIndex().all { (index, req) ->
+                legalTargetsMap[index]?.isNotEmpty() == true || req.effectiveMinCount == 0
+            }
+            if (!allSatisfied) {
+                return ExecutionResult.error(state, "No legal targets for mode: ${mode.description}")
+            }
             val requirementInfos = mode.targetRequirements.mapIndexed { index, req ->
-                val legal = targetFinder.findLegalTargets(state, req, casterId, cardId)
-                legalTargetsMap[index] = legal
+                // Targets are distinct objects, so no requirement can take more than there are
+                // legal ones — which also keeps an unbounded "any number of target …" mode from
+                // handing the client Int.MAX_VALUE as its cap. The floor stays the requirement's
+                // own minimum: a mandatory "two target creatures" with one legal creature is an
+                // unsatisfiable mode, and shrinking its cap would quietly let it through with one.
+                val legalCount = legalTargetsMap[index]?.size ?: 0
+                val maxTargets = resolveModeTargetMaxCount(state, req, casterId, cardId, baseCastAction.xValue)
+                    .coerceAtMost(maxOf(legalCount, req.effectiveMinCount))
                 com.wingedsheep.engine.core.TargetRequirementInfo(
                     index = index,
                     description = req.description,
                     minTargets = req.effectiveMinCount,
-                    maxTargets = req.count
+                    maxTargets = maxTargets
                 )
-            }
-            val allSatisfied = requirementInfos.all { info ->
-                (legalTargetsMap[info.index]?.isNotEmpty() == true) || info.minTargets == 0
-            }
-            if (!allSatisfied) {
-                return ExecutionResult.error(state, "No legal targets for mode: ${mode.description}")
             }
 
             val decisionId = java.util.UUID.randomUUID().toString()

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -48,6 +48,23 @@ describe('computePhases — choose-N modal', () => {
     })
     expect(computePhases(info)).toEqual([{ type: 'modalModes' }, { type: 'costPayment' }])
   })
+
+  it('a choose-N modal with an {X} cost (Profane Command) still announces X', () => {
+    // CR 601.2b announces the modes first and the value of X second. Dropping the xSelection
+    // phase cast the spell at X = 0 — every chosen mode read that 0 and did nothing.
+    const info = castAction({
+      manaCostString: '{X}{B}{B}',
+      hasXCost: true,
+      maxAffordableX: 4,
+      modalEnumeration: {
+        chooseCount: 2,
+        minChooseCount: 2,
+        allowRepeat: false,
+        modes: [],
+      },
+    })
+    expect(computePhases(info)).toEqual([{ type: 'modalModes' }, { type: 'xSelection' }])
+  })
 })
 
 describe('computePhases — emerge sacrifice', () => {

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -105,6 +105,14 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
     if (modalCostType === 'Blight' || modalCostType === 'TapForTotalPower') {
       modalPhases.push({ type: 'costPayment' })
     }
+    //    An {X} in the cost still has to be announced, and the early return above would drop the
+    //    prompt entirely — Profane Command ({X}{B}{B}, "choose two") then cast at X = 0 with every
+    //    chosen mode reading that 0, so the card silently did nothing. X comes *after* the modes,
+    //    per CR 601.2b's announcement order (mode choice, then the value of each variable), and
+    //    before the server-driven per-mode targeting that prices its "up to X targets" against it.
+    if (actionInfo.hasXCost) {
+      modalPhases.push({ type: 'xSelection' })
+    }
     return modalPhases
   }
 


### PR DESCRIPTION
## The bug

Profane Command ({X}{B}{B}, *Choose two*) can't be cast for any X in the web client.

`computePhases` has an early return for a choose-N modal cast — show the mode panel, submit
`chosenModes`, let the server drive per-mode targeting and payment. That return dropped the
`xSelection` phase, so the action went to the server with no X. Every chosen mode then read 0: no
life lost, nothing reanimated, −0/−0, no fear.

Threading X back in exposed two more places it never reached, both in the server-driven per-mode
target prompt that only this cast shape uses.

## The fix

**Client** — push `xSelection` after `modalModes` when the cast has an X cost. CR 601.2b announces
the mode choice first and the value of each variable second, which is also the order the
server-driven target prompts need.

**Engine** — `presentCastModalTargetDecision` now threads the announced X into its prompts:

- it found legal targets with no predicate context, and `ManaValueAtMostX` matches *permissively*
  when X is unbound, so "creature card with mana value X or less" offered graveyard cards the cast
  would then reject;
- it took `maxTargets` off the requirement's static `count`, so "up to X target creatures" offered
  exactly one creature at any X. The cap now resolves `dynamicMaxCount` the way `TargetValidator`
  already does, bounded by how many legal targets exist — so the count offered and the count
  validated are the same number.

Both are general to the path, not Profane Command specific: any choose-N modal mode with an
X-derived filter or target count went through them.

**Card** — the fear mode's target id was `"creatures to gain fear"`, which the optional quantifier
rendered as *"up to creatures to gain fear"* in that same prompt. Now *"up to X target creatures"*
(the snapshot golden moves with it).

## Verification

- `just test-class ProfaneCommandScenarioTest` — 8/8, including two new tests that cast the *client's*
  shape (modes + X, no targets, server-driven prompts): the fear mode offers X creatures rather than
  one, and the reanimation prompt hides a graveyard creature above the announced X.
- `just test-rules` + every era of `just test-scenarios` + `:mtg-sets:test` (the snapshot suite
  `test-rules` doesn't cover) — green. Three era modules crashed with a JVM `exit value 13` when the
  suite ran five test executors at once; each passes on its own, and no test failure was ever
  recorded.
- `npm run typecheck` and the client vitest suite for `pipelinePhases`.

Not covered here: the mode panel still previews the cost as `{X}{B}{B}` while X is unannounced, and a
manual-tap player still relies on the server auto-paying a modal cast (both pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011i7DMdAbGPd5nZHopi4pVg
