### PR TITLE
Add four Ravnica cards: three radiance abilities and Flash Conscription

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlashConscription.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FlashConscription.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Flash Conscription
+ * {5}{R}
+ * Instant
+ *
+ * Untap target creature and gain control of it until end of turn. That creature gains haste until
+ * end of turn. If {W} was spent to cast this spell, the creature gains "Whenever this creature
+ * deals combat damage, you gain that much life" until end of turn.
+ *
+ * One of Ravnica's "if {X} was spent" riders: the card is mono-red and the white mana is a
+ * *payment* question, not a colour requirement, so a Boros land or any-colour source turns it on.
+ * `Conditions.ManaSpentToCastIncludes` reads the payment recorded on the spell, so a copy of Flash
+ * Conscription — never cast, nothing spent for it — correctly misses the rider.
+ *
+ * The granted ability is the Vigorous Charge shape: a `GrantTriggeredAbilityEffect` carrying a
+ * combat-damage trigger whose amount is the event's own damage. The life goes to the ability's
+ * controller, i.e. whoever controls the creature when it connects — which is you for this turn,
+ * and its owner again once the control effect wears off (2005-10-01 ruling).
+ */
+val FlashConscription = card("Flash Conscription") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Untap target creature and gain control of it until end of turn. That creature " +
+        "gains haste until end of turn. If {W} was spent to cast this spell, the creature gains " +
+        "\"Whenever this creature deals combat damage, you gain that much life\" until end of turn."
+
+    spell {
+        val conscript = target("target creature", Targets.Creature)
+        effect = Effects.Untap(conscript)
+            .then(Effects.GainControl(conscript, Duration.EndOfTurn))
+            .then(Effects.GrantKeyword(Keyword.HASTE, conscript))
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ManaSpentToCastIncludes(requiredWhite = 1),
+                    effect = GrantTriggeredAbilityEffect(
+                        ability = TriggeredAbility.create(
+                            trigger = Triggers.dealsDamage(damageType = DamageType.Combat).event,
+                            binding = Triggers.dealsDamage(damageType = DamageType.Combat).binding,
+                            effect = Effects.GainLife(
+                                DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+                            ),
+                            descriptionOverride = "Whenever this creature deals combat damage, you gain that much life."
+                        ),
+                        target = conscript,
+                        duration = Duration.EndOfTurn
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Stephen Tappin"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg?1783943654"
+        ruling(
+            "2005-10-01",
+            "If white mana was paid, the player who controls the creature when it deals combat damage " +
+                "will be the one who gains life."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InciteHysteria.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/InciteHysteria.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Incite Hysteria
+ * {2}{R}
+ * Sorcery
+ *
+ * Radiance — Until end of turn, target creature and each other creature that shares a color with
+ * it gain "This creature can't block."
+ *
+ * Radiance: the target is restricted directly; every *other* creature sharing a color with it
+ * (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`) is found as the spell
+ * resolves and restricted too. The restriction is stamped on the creatures at resolution, so a
+ * creature that changes colour before blockers are declared still can't block (2005-11-01
+ * ruling), and one that becomes the target's colour afterwards is unaffected. A colorless target
+ * shares a color with nothing, so only it is restricted.
+ */
+val InciteHysteria = card("Incite Hysteria") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Radiance — Until end of turn, target creature and each other creature that " +
+        "shares a color with it gain \"This creature can't block.\""
+
+    spell {
+        val radiant = target("target creature", Targets.Creature)
+        effect = Effects.CantBlock(radiant) then
+            Effects.ForEachInGroup(
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget(),
+                Effects.CantBlock(EffectTarget.Self)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Paolo Parente"
+        flavorText = "\"The Boros say they want to bring order to Ravnica. Funny then, how well " +
+            "they use chaos.\"\n—Trigori, Azorius senator"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg?1783943651"
+        ruling(
+            "2005-11-01",
+            "The targeted creature and the creatures that share a color with it at the time Incite " +
+                "Hysteria resolves gain an ability that says they can't block this turn. It doesn't " +
+                "matter if those creatures change colors before blockers are declared."
+        )
+        ruling("2005-10-01", "All creatures that share a color are affected, even your own.")
+        ruling(
+            "2005-10-01",
+            "If it targets a colorless creature, it doesn't affect any other creatures. A colorless " +
+                "creature shares a color with nothing, not even other colorless creatures."
+        )
+        ruling("2005-10-01", "You check which creatures share a color with the target when the spell resolves.")
+        ruling(
+            "2005-10-01",
+            "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes " +
+                "an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekApothecary.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekApothecary.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Wojek Apothecary
+ * {2}{W}{W}
+ * Creature — Human Cleric
+ * 1/1
+ *
+ * Radiance — {T}: Prevent the next 1 damage that would be dealt to target creature and each other
+ * creature that shares a color with it this turn.
+ *
+ * Radiance with a prevention shield instead of damage: the target gets its own shield directly,
+ * and every *other* creature sharing a color with it (`sharingColorWith(EntityReference.Target(0))`,
+ * `otherThanTarget()`) is found as the ability resolves and gets a shield of its own. Each shield
+ * is per-creature — 1 damage prevented on each, not 1 across the group — which is why this is a
+ * `ForEachInGroup` around `PreventNextDamage` rather than a group-scoped prevention. A colorless
+ * target shares a color with nothing, so only it is shielded.
+ *
+ * Scryfall lists a `psal` (Salvat 2005) printing three weeks before Ravnica, but that is a regional
+ * box product rather than a real expansion, so the canonical printing stays RAV — the same call
+ * Selesnya Sanctuary and Seed Spark document.
+ */
+val WojekApothecary = card("Wojek Apothecary") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Radiance — {T}: Prevent the next 1 damage that would be dealt to target creature " +
+        "and each other creature that shares a color with it this turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        val patient = target("target creature", Targets.Creature)
+        effect = Effects.PreventNextDamage(1, patient) then
+            Effects.ForEachInGroup(
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget(),
+                Effects.PreventNextDamage(1, EffectTarget.Self)
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Keith Garletts"
+        flavorText = "\"A few arrows aren't enough to pierce your faith, soldier. You'll be back " +
+            "on the battlefield by sun's dawn.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg?1783943692"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekEmbermage.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WojekEmbermage.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Wojek Embermage
+ * {3}{R}
+ * Creature — Human Wizard
+ * 1/2
+ *
+ * Radiance — {T}: This creature deals 1 damage to target creature and each other creature that
+ * shares a color with it.
+ *
+ * The repeatable half of Cleansing Beam: one target, and a resolution-time group relative to it.
+ * The target is damaged directly; the group is every *other* creature sharing a color with the
+ * target — `sharingColorWith(EntityReference.Target(0))` for the colour test, `otherThanTarget()`
+ * so the target isn't hit twice. The Embermage itself is red, so a red target catches it too;
+ * "each other creature" is relative to the target, not to the source, and there is no
+ * `excludeSelf` here. A colorless target shares a color with nothing, so only it is damaged.
+ */
+val WojekEmbermage = card("Wojek Embermage") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "Radiance — {T}: This creature deals 1 damage to target creature and each other " +
+        "creature that shares a color with it."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        val victim = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(1, victim) then
+            Patterns.Group.dealDamageToAll(
+                1,
+                GroupFilter(
+                    GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                ).otherThanTarget()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Luca Zontini"
+        flavorText = "\"Your brother's crimes are your crimes. You stood by and lent support, so " +
+            "you too must face judgment.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg?1783943643"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlashConscriptionScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FlashConscriptionScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.FlashConscription
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Flash Conscription (RAV #124) — "Untap target creature and gain control of it until end of turn.
+ * That creature gains haste until end of turn. If {W} was spent to cast this spell, the creature
+ * gains 'Whenever this creature deals combat damage, you gain that much life' until end of turn."
+ *
+ * Two things are worth pinning. The threaten half must actually *untap* — a tapped blocker you
+ * steal is worthless if the control grant alone is applied — and the haste must let it attack the
+ * turn it changes hands. The white rider is a **payment** question, not a colour requirement: the
+ * card is mono-red, so the same spell resolves with and without the life-gain depending only on
+ * which mana paid for it. Both branches are cast here off the same board.
+ */
+class FlashConscriptionScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + FlashConscription)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * Cast Flash Conscription at [victim], paying its generic half with [white] white mana and the
+     * rest in red. {5}{R} is six mana; the {R} is a real colour requirement, the rest is generic.
+     */
+    fun GameTestDriver.conscript(victim: EntityId, white: Int) {
+        if (white > 0) giveMana(player1, Color.WHITE, white)
+        giveMana(player1, Color.RED, 6 - white)
+        val card = putCardInHand(player1, "Flash Conscription")
+        castSpellWithTargets(player1, card, listOf(ChosenTarget.Permanent(victim))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("the stolen creature is untapped, changes hands, and can attack the same turn") {
+        val d = driver()
+        val opp = d.player2
+        val guide = d.putCreatureOnBattlefield(opp, "Goblin Guide")   // 2/1, tapped and sick
+        d.tapPermanent(guide)
+
+        d.conscript(guide, white = 0)
+
+        withClue("'untap target creature' is a real half of the spell, not flavour on the control grant") {
+            d.isTapped(guide) shouldBe false
+        }
+        withClue("control change is a Layer-2 continuous effect — read it off projected state") {
+            d.state.projectedState.getController(guide) shouldBe d.player1
+        }
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        withClue("haste lets the freshly-stolen creature attack immediately") {
+            d.declareAttackers(d.player1, listOf(guide), opp).error shouldBe null
+        }
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareNoBlockers(opp).error shouldBe null
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        withClue("no white was spent, so no life came back off the 2 combat damage") {
+            d.getLifeTotal(d.player1) shouldBe 20
+            d.getLifeTotal(opp) shouldBe 18
+        }
+    }
+
+    test("white mana in the payment attaches the lifelink-style rider to the stolen creature") {
+        val d = driver()
+        val opp = d.player2
+        val guide = d.putCreatureOnBattlefield(opp, "Goblin Guide")   // 2/1
+
+        d.conscript(guide, white = 1)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(d.player1, listOf(guide), opp).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareNoBlockers(opp).error shouldBe null
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        withClue("the granted trigger pays its life to whoever controls the creature — me, this turn") {
+            d.getLifeTotal(d.player1) shouldBe 22
+            d.getLifeTotal(opp) shouldBe 18
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InciteHysteriaScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InciteHysteriaScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.InciteHysteria
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Incite Hysteria (RAV #132) — "Radiance — Until end of turn, target creature and each other
+ * creature that shares a color with it gain 'This creature can't block.'"
+ *
+ * The radiance group here carries a *restriction* rather than damage or a pump, so the proof has
+ * to run through the block declaration itself: every red creature on the far side must be refused
+ * as a blocker while a creature of another colour is still legal. The target is restricted by the
+ * direct half of the effect and the rest by the group half — a `CantBlock` that only reached the
+ * group would leave the named creature free to block, which is the failure this pins down.
+ */
+class InciteHysteriaScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + InciteHysteria)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.incite(victim: EntityId) {
+        giveMana(player1, Color.RED, 3)
+        val card = putCardInHand(player1, "Incite Hysteria")
+        castSpellWithTargets(player1, card, listOf(ChosenTarget.Permanent(victim))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("every red creature is locked out of blocking; a white one still blocks") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val attacker = d.putCreatureOnBattlefield(me, "Centaur Courser")
+        d.removeSummoningSickness(attacker)
+        val guide = d.putCreatureOnBattlefield(opp, "Goblin Guide")            // {R} — the target
+        val prospector = d.putCreatureOnBattlefield(opp, "Test Hasty Prospector") // {R} — radiated onto
+        val lions = d.putCreatureOnBattlefield(opp, "Savannah Lions")          // {W} — untouched
+
+        d.incite(guide)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(attacker), opp).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("the named target itself must be restricted, not only the radiance group") {
+            d.declareBlockers(opp, mapOf(guide to listOf(attacker))).error shouldNotBe null
+        }
+        withClue("the other red creature was caught by the radiance group") {
+            d.declareBlockers(opp, mapOf(prospector to listOf(attacker))).error shouldNotBe null
+        }
+        withClue("white shares no color with a red target, so it can still block") {
+            d.declareBlockers(opp, mapOf(lions to listOf(attacker))).error shouldBe null
+        }
+    }
+
+    test("a colorless target is restricted alone — colorless shares a color with nothing") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val attacker = d.putCreatureOnBattlefield(me, "Centaur Courser")
+        d.removeSummoningSickness(attacker)
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")   // colorless — the target
+        val myr = d.putCreatureOnBattlefield(opp, "Palladium Myr")         // another colorless
+
+        d.incite(golem)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(attacker), opp).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("the colorless target is still restricted by the direct half") {
+            d.declareBlockers(opp, mapOf(golem to listOf(attacker))).error shouldNotBe null
+        }
+        withClue("colorless creatures don't share a color even with each other") {
+            d.declareBlockers(opp, mapOf(myr to listOf(attacker))).error shouldBe null
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekApothecaryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekApothecaryScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.WojekApothecary
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wojek Apothecary (RAV #36) — "Radiance — {T}: Prevent the next 1 damage that would be dealt to
+ * target creature and each other creature that shares a color with it this turn."
+ *
+ * The radiance group carries a prevention shield, and each creature in it gets a shield **of its
+ * own**: 1 damage prevented on every white creature, not 1 damage prevented across the group. The
+ * two bolts below are there to catch a group-scoped shield that would spend itself on the first
+ * one and leave the second bare.
+ */
+class WojekApothecaryScenarioTest : FunSpec({
+
+    val apothecaryAbility = WojekApothecary.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + WojekApothecary)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.damageOn(id: EntityId): Int = state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    fun GameTestDriver.shield(source: EntityId, target: EntityId) {
+        submit(
+            ActivateAbility(player1, source, apothecaryAbility, targets = listOf(ChosenTarget.Permanent(target)))
+        ).isSuccess shouldBe true
+        // The activator keeps priority after putting the ability on the stack.
+        passPriority(player2)
+        bothPass()
+    }
+
+    fun GameTestDriver.bolt(victim: EntityId) {
+        giveMana(player1, Color.RED, 1)
+        val card = putCardInHand(player1, "Lightning Bolt")
+        castSpellWithTargets(player1, card, listOf(ChosenTarget.Permanent(victim))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("every white creature gets its own 1-damage shield; other colors get none") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+        val apothecary = d.putCreatureOnBattlefield(me, "Wojek Apothecary").also { d.removeSummoningSickness(it) }
+        val mine = d.putCreatureOnBattlefield(me, "Morph Test Creature")    // {2}{W} 2/3 — the target
+        val theirs = d.putCreatureOnBattlefield(opp, "Morph Test Creature") // {2}{W} 2/3 — radiated onto
+        val zombie = d.putCreatureOnBattlefield(opp, "Black Creature")      // {1}{B} 2/2 — unshielded
+
+        d.shield(apothecary, mine)
+
+        d.bolt(mine)
+        d.bolt(theirs)
+        d.bolt(zombie)
+
+        withClue("the target's own shield ate 1 of the 3") {
+            d.damageOn(mine) shouldBe 2
+        }
+        withClue("the second white creature had a shield of its own, not a share of one") {
+            d.damageOn(theirs) shouldBe 2
+        }
+        withClue("black shares no color with a white target, so all 3 landed and killed a 2/2") {
+            d.findPermanent(opp, "Black Creature").shouldBeNull()
+        }
+        withClue("the ability's tap cost was paid") {
+            d.isTapped(apothecary) shouldBe true
+        }
+    }
+
+    test("the shield is spent by the first damage and does not prevent a second point") {
+        val d = driver()
+        val me = d.player1
+        val apothecary = d.putCreatureOnBattlefield(me, "Wojek Apothecary").also { d.removeSummoningSickness(it) }
+        val cleric = d.putCreatureOnBattlefield(me, "Morph Test Creature")  // 2/3
+
+        d.shield(apothecary, cleric)
+
+        d.bolt(cleric)
+        withClue("3 damage, 1 prevented") {
+            d.damageOn(cleric) shouldBe 2
+        }
+        d.bolt(cleric)
+        withClue("'the next 1 damage' is one shot — the second bolt is unprevented and kills it") {
+            d.findPermanent(me, "Morph Test Creature").shouldBeNull()
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekEmbermageScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekEmbermageScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.WojekEmbermage
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wojek Embermage (RAV #152) — "Radiance — {T}: This creature deals 1 damage to target creature
+ * and each other creature that shares a color with it."
+ *
+ * The first *activated* radiance ability in the corpus: the previous five were all spells, so
+ * these tests pin the group down where the target list belongs to an ability rather than to a
+ * spell on the stack. The Embermage is itself red, and "each other creature" is relative to the
+ * **target**, not to the source — so a red target radiates back onto the Embermage that fired the
+ * ability. That self-hit is the assertion most likely to be lost to a stray `excludeSelf`.
+ */
+class WojekEmbermageScenarioTest : FunSpec({
+
+    val embermageAbility = WojekEmbermage.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + WojekEmbermage)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.damageOn(id: EntityId): Int = state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    /** An Embermage of player 1's, already past its summoning sickness. */
+    fun GameTestDriver.embermage(): EntityId =
+        putCreatureOnBattlefield(player1, "Wojek Embermage").also { removeSummoningSickness(it) }
+
+    fun GameTestDriver.fire(source: EntityId, target: EntityId) {
+        submit(
+            ActivateAbility(player1, source, embermageAbility, targets = listOf(ChosenTarget.Permanent(target)))
+        ).isSuccess shouldBe true
+        // The activator keeps priority after putting the ability on the stack.
+        passPriority(player2)
+        bothPass()
+    }
+
+    test("a red target radiates 1 damage onto every other red creature, the Embermage included") {
+        val d = driver()
+        val opp = d.player2
+        val firing = d.embermage()
+        val bystander = d.embermage()
+        val guide = d.putCreatureOnBattlefield(opp, "Goblin Guide")        // {R} 2/1 — the target, dies
+        val lions = d.putCreatureOnBattlefield(opp, "Savannah Lions")      // {W} 1/1 — spared
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")   // colorless 2/2 — spared
+
+        d.fire(firing, guide)
+
+        withClue("the target took its 1 damage and a 2/1 died to it") {
+            d.findPermanent(opp, "Goblin Guide").shouldBeNull()
+            d.getGraveyardCardNames(opp) shouldBe listOf("Goblin Guide")
+        }
+        withClue("'each other creature' is relative to the target, so the firing Embermage hits itself") {
+            d.damageOn(firing) shouldBe 1
+            d.damageOn(bystander) shouldBe 1
+        }
+        withClue("white and colorless creatures share no color with the target") {
+            d.damageOn(lions) shouldBe 0
+            d.damageOn(golem) shouldBe 0
+            d.findPermanent(opp, "Savannah Lions").shouldNotBeNull()
+        }
+        withClue("the ability's tap cost was paid") {
+            d.isTapped(firing) shouldBe true
+            d.isTapped(bystander) shouldBe false
+        }
+    }
+
+    test("a colorless target shares a color with nothing, so only it is damaged") {
+        val d = driver()
+        val opp = d.player2
+        val firing = d.embermage()
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")   // colorless 2/2 — the target
+        val myr = d.putCreatureOnBattlefield(opp, "Palladium Myr")         // another colorless 2/2
+
+        d.fire(firing, golem)
+
+        d.damageOn(golem) shouldBe 1
+        withClue("colorless creatures don't share a color even with each other") {
+            d.damageOn(myr) shouldBe 0
+        }
+        withClue("the red Embermage shares no color with a colorless target either") {
+            d.damageOn(firing) shouldBe 0
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -12443,6 +12443,87 @@
     ]
 }
 
+// Wojek Apothecary
+{
+    "name": "Wojek Apothecary",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Radiance — {T}: Prevent the next 1 damage that would be dealt to target creature and each other creature that shares a color with it this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "PreventDamageShield",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "SharesColorWith",
+                                                "entity": "Target"
+                                            }
+                                        ]
+                                    },
+                                    "excludeTarget": true
+                                }
+                            },
+                            "body": {
+                                "type": "PreventDamageShield",
+                                "target": "Self",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Keith Garletts",
+        "flavorText": "\"A few arrows aren't enough to pierce your faith, soldier. You'll be back on the battlefield by sun's dawn.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef74fea5-2345-4ffd-8951-f420e17259e6.jpg?1783943692"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Wojek Siren
 {
     "name": "Wojek Siren",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -3814,6 +3814,101 @@
     ]
 }
 
+// Flash Conscription
+{
+    "name": "Flash Conscription",
+    "manaCost": "{5}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Untap target creature and gain control of it until end of turn. That creature gains haste until end of turn. If {W} was spent to cast this spell, the creature gains \"Whenever this creature deals combat damage, you gain that much life\" until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "ManaSpentToCastIncludes",
+                            "requiredWhite": 1
+                        }
+                    },
+                    "then": {
+                        "type": "GrantTriggeredAbility",
+                        "ability": {
+                            "id": "ability_1",
+                            "trigger": {
+                                "type": "DealsDamageEvent",
+                                "damageType": "DamageCombat"
+                            },
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            "descriptionOverride": "Whenever this creature deals combat damage, you gain that much life."
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Tappin",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52361237-a653-4470-9ed5-c531c040c686.jpg?1783943654",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If white mana was paid, the player who controls the creature when it deals combat damage will be the one who gains life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flight of Fancy
 {
     "name": "Flight of Fancy",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -12524,6 +12524,87 @@
     ]
 }
 
+// Wojek Embermage
+{
+    "name": "Wojek Embermage",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Radiance — {T}: This creature deals 1 damage to target creature and each other creature that shares a color with it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "SharesColorWith",
+                                                "entity": "Target"
+                                            }
+                                        ]
+                                    },
+                                    "excludeTarget": true
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "UNCOMMON",
+        "artist": "Luca Zontini",
+        "flavorText": "\"Your brother's crimes are your crimes. You stood by and lent support, so you too must face judgment.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1614866-fb0b-47bd-ab26-5c20ff175d10.jpg?1783943643"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Wojek Siren
 {
     "name": "Wojek Siren",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -5601,6 +5601,90 @@
     ]
 }
 
+// Incite Hysteria
+{
+    "name": "Incite Hysteria",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Radiance — Until end of turn, target creature and each other creature that shares a color with it gain \"This creature can't block.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "SharesColorWith",
+                                        "entity": "Target"
+                                    }
+                                ]
+                            },
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Paolo Parente",
+        "flavorText": "\"The Boros say they want to bring order to Ravnica. Funny then, how well they use chaos.\"\n—Trigori, Azorius senator",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a31f5060-df9e-4665-bf60-a8e33da55c84.jpg?1783943651",
+        "rulings": [
+            {
+                "date": "2005-11-01",
+                "text": "The targeted creature and the creatures that share a color with it at the time Incite Hysteria resolves gain an ability that says they can't block this turn. It doesn't matter if those creatures change colors before blockers are declared."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "All creatures that share a color are affected, even your own."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "You check which creatures share a color with the target when the spell resolves."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Indentured Oaf
 {
     "name": "Indentured Oaf",


### PR DESCRIPTION
Four Ravnica: City of Guilds cards, all composing existing primitives — three of them radiance, which the engine gained recently.

| Card | # | Shape |
|---|---|---|
| **Wojek Embermage** | 152 | Radiance — `{T}`: 1 damage to the target, then `Patterns.Group.dealDamageToAll` over `sharingColorWith(Target(0)).otherThanTarget()`. The repeatable half of Cleansing Beam. |
| **Wojek Apothecary** | 36 | Radiance with a prevention shield — `ForEachInGroup` around `PreventNextDamage(1)` so each creature gets its *own* shield rather than one shared across the group. |
| **Incite Hysteria** | 132 | Radiance carrying a *restriction* — `CantBlock` on the target directly, then over the colour-sharing group. |
| **Flash Conscription** | 124 | Untap + `GainControl` + haste, with a `ManaSpentToCastIncludes(requiredWhite = 1)` rider granting a combat-damage lifegain trigger via `GrantTriggeredAbilityEffect`. |

No new SDK vocabulary — every effect, filter and condition already existed.

### Notes

- **Radiance is target-relative, not source-relative.** "Each other creature that shares a color with it" is `otherThanTarget()`, not `excludeSelf` — so a red target catches the firing Wojek Embermage itself. There's a test pinning exactly that.
- **A colorless target shares a color with nothing**, not even other colorless creatures (2005-10-01 ruling). Each radiance card has a test for the colorless case.
- **Flash Conscription's white is a payment question, not a colour requirement.** The card is mono-red; the same spell resolves with and without the lifegain depending only on which mana paid. Both branches are cast off the same board in the test. `colorIdentity = "R"` follows the convention of all seven sibling "if {X} was spent" cards already in RAV (Boros Fury-Shield, Seed Spark, Vigor Mortis, …), rather than Scryfall's `["R","W"]`.
- **Wojek Apothecary** has a `psal` (Salvat 2005) printing dated three weeks before Ravnica, but that's a regional box product rather than a real expansion, so the canonical stays RAV — the same call Selesnya Sanctuary and Seed Spark already document. `just check-card-printing` agrees.

### Verification

- `just test-class` over all four scenario tests — **8/8 passed**
- `CardDefinitionSnapshotTest`, `CardLintTest`, `FacadeBoundaryTest` — **passed**; the `RAV.json` golden diff is purely additive and contains exactly these four card trees, no unrelated card moved
- `just check-card-printing` on all four — **canonical correct, no reprint rows owed elsewhere**
- `just check-backlog` — in sync (RAV has no `backlog/sets/` entry, so nothing to tick)
- Oracle text, mana cost, type line, P/T, collector number, rarity and artist verified field-for-field against Scryfall for all four

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdyAaDr5x1XMm6CBcRUzhy
