### PR TITLE
Add 53 Assay-ready cards to Conflux

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/EtherswornAdjudicatorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/EtherswornAdjudicatorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ethersworn Adjudicator reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val EtherswornAdjudicatorReprint = Printing(
+    oracleId = "ca2a7669-4932-4a78-8a6c-8558b7c05ba5",
+    name = "Ethersworn Adjudicator",
+    setCode = "C16",
+    collectorNumber = "90",
+    scryfallId = "f84cedf6-2ad7-4b94-95b3-70deb03ef23b",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f84cedf6-2ad7-4b94-95b3-70deb03ef23b.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SphinxSummonerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SphinxSummonerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sphinx Summoner reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val SphinxSummonerReprint = Printing(
+    oracleId = "77ae7caa-e180-4efb-9348-ab389364b186",
+    name = "Sphinx Summoner",
+    setCode = "C16",
+    collectorNumber = "223",
+    scryfallId = "83226f26-8d8f-42f2-ab23-997e72e954f2",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/83226f26-8d8f-42f2-ab23-997e72e954f2.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AbsorbVis.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AbsorbVis.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Absorb Vis
+ * {6}{B}
+ * Sorcery
+ * Target player loses 4 life and you gain 4 life.
+ * Basic landcycling {1}{B}
+ *
+ * Two life clauses sharing one target slot: [Effects.LoseLife] aimed at the bound player and
+ * [Effects.GainLife] left on its default controller recipient, joined by [Effects.Composite].
+ * Only the loss is targeted — the gain names "you", so no second requirement is declared.
+ *
+ * "Basic landcycling" is [KeywordAbility.basicLandcycling], the typecycling machinery narrowed to
+ * *basic* land cards (not merely lands carrying a basic land type), which is the `IsBasicLand`
+ * search filter the printed reminder text spells out.
+ */
+val AbsorbVis = card("Absorb Vis") {
+    manaCost = "{6}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player loses 4 life and you gain 4 life.\n" +
+        "Basic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land " +
+        "card, reveal it, put it into your hand, then shuffle.)"
+
+    spell {
+        val t = target("target", TargetPlayer())
+        effect = Effects.Composite(
+            Effects.LoseLife(4, t),
+            Effects.GainLife(4)
+        )
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{B}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Brandon Kitkouski"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AncientZiggurat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AncientZiggurat.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Ancient Ziggurat
+ * Land
+ *
+ * {T}: Add one mana of any color. Spend this mana only to cast a creature spell.
+ *
+ * [Effects.AddManaOfChoice] already defaults to one mana from all five colours, so only the
+ * [ManaRestriction.CreatureSpellsOnly] rider needs naming — the restriction rides on the mana in
+ * the pool rather than on the ability. `manaAbility = true` plus [TimingRule.ManaAbility] keep it
+ * off the stack (CR 605.1a).
+ */
+val AncientZiggurat = card("Ancient Ziggurat") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "{T}: Add one mana of any color. Spend this mana only to cast a creature spell."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(restriction = ManaRestriction.CreatureSpellsOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "John Avon"
+        flavorText = "Built in honor of Alara's creatures, the ziggurat vanished long ago. When Progenitus awakened, the temple emerged again."
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AshasFavor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AshasFavor.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Asha's Favor
+ * {2}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature has flying, first strike, and vigilance.
+ *
+ * "Enchant creature" is the `auraTarget`, without which the Aura would have nothing to attach to
+ * and would never enter attached. The three granted keywords are three [GrantKeyword] statics,
+ * each left on its default `attachedCreature()` filter so it reads "enchanted creature" — the SDK
+ * models one grant per keyword rather than a combined set.
+ */
+val AshasFavor = card("Asha's Favor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has flying, first strike, and vigilance."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Donato Giancola"
+        flavorText = "As his new wings lifted him high above Bant, Taric felt his earthly aspirations transform into heavenly resolve."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AvenTrailblazer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AvenTrailblazer.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aven Trailblazer
+ * {2}{W}
+ * Creature — Bird Soldier
+ * 2 / *
+ * Flying
+ * Domain — Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.
+ *
+ * Domain is an ability word (CR 207.2c) with no rules meaning of its own; the count is
+ * [DynamicAmounts.domain] — the distinct basic land subtypes among the lands you control, capped
+ * at five by there being only five. Only the toughness is characteristic-defining here, so power
+ * stays a printed literal and the toughness goes through [dynamicToughness] rather than
+ * `dynamicStats`.
+ */
+val AvenTrailblazer = card("Aven Trailblazer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    oracleText = "Flying\n" +
+        "Domain — Aven Trailblazer's toughness is equal to the number of basic land types among lands you control."
+
+    power = 2
+    dynamicToughness(DynamicAmounts.domain())
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Chris Rahn"
+        flavorText = "\"The bird wore the form of a man, bereft of filigree. Why do the Texts not speak of it?\" —Belator of Esper"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/BeaconBehemoth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/BeaconBehemoth.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Beacon Behemoth
+ * {3}{G}{G}
+ * Creature — Beast
+ * 5 / 3
+ * {1}: Target creature with power 5 or greater gains vigilance until end of turn.
+ *
+ * The power threshold is a restriction on the *target*, not a condition on the effect —
+ * `TargetFilter.Creature.powerAtLeast(5)`, so it is checked on announcement and rechecked against
+ * projected state on resolution. The Behemoth is itself a 5/3, so it is a legal target for its own
+ * ability. The grant is [Effects.GrantKeyword] with its default `Duration.EndOfTurn`, which is
+ * exactly the printed "until end of turn". Same shape as Bloodthorn Taunter, with a mana cost in
+ * place of the tap.
+ */
+val BeaconBehemoth = card("Beacon Behemoth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 3
+    oracleText = "{1}: Target creature with power 5 or greater gains vigilance until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(5)))
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Jesper Ejsing"
+        flavorText = "When its smoky plumes light Naya's sky, every creature from the smallest pip fawn to the largest rannet heeds the warning."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/BoneSaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/BoneSaw.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Bone Saw
+ * {0}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+0.
+ * Equip {1}
+ *
+ * The plainest Equipment shape there is: a [ModifyStats] static for the printed buff, and
+ * [equipAbility] for the printed "Equip {1}" line. The equip half is deliberately *not*
+ * hand-rolled as `activatedAbility { isEquipAbility = true }` — an unflagged equip ability is
+ * invisible to every engine rule keyed off `ActivatedAbility.isEquipAbility` (Leonin Shikari's
+ * instant-speed permission, Forge Anew's free first equip). The facade also supplies the sorcery
+ * timing and the "creature you control" target requirement that Assay's model shows.
+ */
+val BoneSaw = card("Bone Saw") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Pete Venters"
+        flavorText = "In a world where death is always violent, cruel weapons are as common as rocks."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ChildOfAlara.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ChildOfAlara.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Child of Alara
+ * {W}{U}{B}{R}{G}
+ * Legendary Creature — Avatar
+ * 6 / 6
+ * Trample
+ * When Child of Alara dies, destroy all nonland permanents. They can't be regenerated.
+ *
+ * The wrath is [Patterns.Group.destroyAllPipeline], not a per-permanent iteration: the group is
+ * gathered once from the battlefield and moved as one collection, so every permanent leaves
+ * simultaneously and none of them sees the others go. `noRegenerate = true` is the printed "they
+ * can't be regenerated" — the flag rides on the collection move rather than needing its own
+ * `CantBeRegenerated` shield per permanent. [Triggers.Dies] is the plain battlefield → graveyard
+ * self-trigger; the sweep reads nothing off the dying Child, so no last-known information is
+ * involved.
+ */
+val ChildOfAlara = card("Child of Alara") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Creature — Avatar"
+    power = 6
+    toughness = 6
+    oracleText = "Trample\n" +
+        "When Child of Alara dies, destroy all nonland permanents. They can't be regenerated."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Group.destroyAllPipeline(
+            filter = GameObjectFilter.NonlandPermanent,
+            noRegenerate = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "101"
+        artist = "Steve Argyle"
+        flavorText = "The progeny of the Maelstrom shows no allegiance—and no mercy—to any of the five shards."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/CliffrunnerBehemoth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/CliffrunnerBehemoth.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Cliffrunner Behemoth — Conflux #79
+ * {3}{G} · Creature — Rhino Beast · 5 / 3
+ *
+ * This creature has haste as long as you control a red permanent.
+ * This creature has lifelink as long as you control a white permanent.
+ *
+ * Two printed sentences, two independent [ConditionalStaticAbility] rows — each a [GrantKeyword]
+ * over [Filters.Self] (the source permanent) gated on its own condition, so the haste and the
+ * lifelink switch on and off separately as the board changes. Each condition is
+ * `Conditions.YouControl(GameObjectFilter.Permanent.withColor(...))`, an `Exists` over your
+ * battlefield: a bare *permanent* filter, so a red land or artifact counts just as much as a red
+ * creature. Compare [ToxicIguanar], which uses the same shape for a single grant.
+ */
+val CliffrunnerBehemoth = card("Cliffrunner Behemoth") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino Beast"
+    power = 5
+    toughness = 3
+    oracleText = "This creature has haste as long as you control a red permanent.\n" +
+        "This creature has lifelink as long as you control a white permanent."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.RED))
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.LIFELINK, Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.WHITE))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "79"
+        artist = "Wayne Reynolds"
+        flavorText = "It's revered for its power, celebrated for its grace, and feared for the avalanches triggered by its thunderous feet."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ConstrictingTendrils.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ConstrictingTendrils.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Constricting Tendrils
+ * {U}
+ * Instant
+ * Target creature gets -3/-0 until end of turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * One [Effects.ModifyStats] over a named target; the facade's default duration is already
+ * `Duration.EndOfTurn`, so the printed "until end of turn" needs no argument. The -0 toughness
+ * half is still written explicitly — it is the printed modifier, not an omission. Cycling is
+ * [KeywordAbility.cycling], which carries its own cost and lowers to the discard-and-draw
+ * activated ability.
+ */
+val ConstrictingTendrils = card("Constricting Tendrils") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-0 until end of turn.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-3, 0, t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "David Palumbo"
+        flavorText = "Priests of Bant protect their temples with traps more elaborate than any mosaic floor."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/DarklitGargoyle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/DarklitGargoyle.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Darklit Gargoyle
+ * {1}{W}
+ * Artifact Creature — Gargoyle
+ * 1 / 2
+ * Flying
+ * {B}: This creature gets +2/-1 until end of turn.
+ *
+ * A bare [Costs.Mana] activation — no tap, no target — whose [Effects.ModifyStats] points at
+ * [EffectTarget.Self]. The default duration is already `Duration.EndOfTurn`, so the printed
+ * "until end of turn" adds no argument.
+ */
+val DarklitGargoyle = card("Darklit Gargoyle") {
+    manaCost = "{1}{W}"
+    colorIdentity = "BW"
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{B}: This creature gets +2/-1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(2, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Howard Lyon"
+        flavorText = "It shines in the darkness of its master's ambitions."
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Dreadwing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Dreadwing.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dreadwing
+ * {B}
+ * Creature — Zombie
+ * 1 / 1
+ * {1}{U}{R}: This creature gets +3/+0 and gains flying until end of turn.
+ *
+ * The two printed halves are one [Effects.Composite] — the pump and the keyword grant both point at
+ * [EffectTarget.Self] and both take the facade default `Duration.EndOfTurn`, so "until end of turn"
+ * needs no argument. The off-colour activation cost is why the colour identity runs wider than the
+ * `{B}` mana cost. Same shape as Hyalopterous Lemure.
+ */
+val Dreadwing = card("Dreadwing") {
+    manaCost = "{B}"
+    colorIdentity = "UBR"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{U}{R}: This creature gets +3/+0 and gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}{R}")
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Mark Hyzer"
+        flavorText = "Dreadwings spring from lofty perches to surprise kathari in midflight. They smother their prey and then consume it as they glide gently toward the ground."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EmberWeaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EmberWeaver.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Ember Weaver
+ * {2}{G}
+ * Creature — Spider
+ * 2/3
+ * Reach (This creature can block creatures with flying.)
+ * As long as you control a red permanent, this creature gets +1/+0 and has first strike.
+ *
+ * Reach is a printed [Keyword]. The domain-lord line is two [ConditionalStaticAbility] statics
+ * sharing one condition — [ModifyStats] for the +1/+0 and [GrantKeyword] for first strike — over
+ * [Filters.Self], which is `GroupFilter.source()`: the static reads *projected* battlefield state,
+ * never the card's own type line.
+ *
+ * "A red **permanent**", not a red creature: the condition is
+ * [Conditions.YouControl] over `GameObjectFilter.Permanent.withColor(RED)`, the same shape
+ * Shadowmoor's Horde of Boggarts counts with.
+ */
+val EmberWeaver = card("Ember Weaver") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 2
+    toughness = 3
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "As long as you control a red permanent, this creature gets +1/+0 and has first strike."
+
+    keywords(Keyword.REACH)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 0, filter = Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.RED))
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.RED))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Steve Prescott"
+        flavorText = "\"Each night, the sun unravels and blows away. Each day, the spiders set a new one in the sky.\" —Sunseeder myth"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EsperCormorants.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EsperCormorants.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Esper Cormorants
+ * {2}{W}{U}
+ * Artifact Creature — Bird
+ * 3/3
+ * Flying
+ *
+ * A printed [Keyword.FLYING] and nothing else — the artifact half of the type line is parsed
+ * type-line data, not a script.
+ */
+val EsperCormorants = card("Esper Cormorants") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Artifact Creature — Bird"
+    power = 3
+    toughness = 3
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Warren Mahy"
+        flavorText = "\"The smiths of this land must be mad to reach so far and so high for another creature to decorate.\" —Cagen Vargan, Jhessian sea scout"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EtherswornAdjudicator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/EtherswornAdjudicator.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ethersworn Adjudicator
+ * {4}{U}
+ * Artifact Creature — Vedalken Knight
+ * 4 / 4
+ * Flying
+ * {1}{W}{B}, {T}: Destroy target creature or enchantment.
+ * {2}{U}: Untap this creature.
+ *
+ * The removal is [Effects.Destroy] over [Targets.CreatureOrEnchantment] — one requirement whose
+ * filter is the printed disjunction, not two abilities. The untap is the untapped half of the
+ * same tap/untap atom, [Effects.Untap] on [EffectTarget.Self], and it deliberately carries no
+ * tap in its own cost: paying {2}{U} is what lets the Adjudicator destroy again.
+ */
+val EtherswornAdjudicator = card("Ethersworn Adjudicator") {
+    manaCost = "{4}{U}"
+    colorIdentity = "BUW"
+    typeLine = "Artifact Creature — Vedalken Knight"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "{1}{W}{B}, {T}: Destroy target creature or enchantment.\n" +
+        "{2}{U}: Untap this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}{B}"), Costs.Tap)
+        val victim = target("target", Targets.CreatureOrEnchantment)
+        effect = Effects.Destroy(victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "26"
+        artist = "Dan Murayama Scott"
+        flavorText = "Esper mages devised their weapons to be so devastating that war seemed unnecessary."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FaerieMechanist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FaerieMechanist.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Faerie Mechanist
+ * {3}{U}
+ * Artifact Creature — Faerie Artificer
+ * 2 / 2
+ * Flying
+ * When this creature enters, look at the top three cards of your library. You may reveal an
+ * artifact card from among them and put it into your hand. Put the rest on the bottom of your
+ * library in any order.
+ *
+ * The dig is the shared [Patterns.Library.lookAtTopRevealMatchingToHand] recipe — Glint-Nest
+ * Crane with a three-card pile. The pattern already supplies the optional single pick, the
+ * artifact filter as an unselectable-but-visible mask over all three cards, the reveal as the
+ * kept card moves to hand, and the bottom-of-library destination for the remainder; "in any
+ * order" is the non-default [CardOrder.ControllerChooses].
+ */
+val FaerieMechanist = card("Faerie Mechanist") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Faerie Artificer"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(3),
+            filter = GameObjectFilter.Artifact,
+            prompt = "You may reveal an artifact card from among them and put it into your hand",
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FieryFall.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FieryFall.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Fiery Fall
+ * {5}{R}
+ * Instant
+ * Fiery Fall deals 5 damage to target creature.
+ * Basic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card,
+ * reveal it, put it into your hand, then shuffle.)
+ *
+ * The spell half is a plain [Effects.DealDamage] over one named target ([Targets.Creature]).
+ * Basic landcycling is [KeywordAbility.basicLandcycling], which is the shared cycling machinery
+ * with its search narrowed to *basic* land cards and its reminder text prefixed "Basic
+ * landcycling" — it carries its own cost, so no `keywords(...)` entry belongs alongside it.
+ */
+val FieryFall = card("Fiery Fall") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Fiery Fall deals 5 damage to target creature.\n" +
+        "Basic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land " +
+        "card, reveal it, put it into your hand, then shuffle.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(5, t)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Daarken"
+        flavorText = "Jund feasts on the unprepared."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Fleshformer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Fleshformer.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fleshformer
+ * {2}{B}
+ * Creature — Human Wizard
+ * 2 / 2
+ * {W}{U}{B}{R}{G}: This creature gets +2/+2 and gains fear until end of turn. Target creature
+ * gets -2/-2 until end of turn. Activate only during your turn.
+ *
+ * One activated ability, not two: the whole printed block is a single {W}{U}{B}{R}{G} activation.
+ * The effect keeps the printed sentence structure — the first sentence's two clauses ("gets +2/+2
+ * *and* gains fear") are chained together and then composed with the second sentence's -2/-2, so
+ * the self-pump and the target's shrink stay one atomic resolution. "This creature" is
+ * [EffectTarget.Self]; only the -2/-2 half takes a target. "Activate only during your turn" is
+ * [ActivationRestriction.OnlyDuringYourTurn], which the activation-legality check reads — it is
+ * not expressible as a timing rule.
+ */
+val Fleshformer = card("Fleshformer") {
+    manaCost = "{2}{B}"
+    colorIdentity = "BGRUW"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{W}{U}{B}{R}{G}: This creature gets +2/+2 and gains fear until end of turn. " +
+        "Target creature gets -2/-2 until end of turn. Activate only during your turn. " +
+        "(A creature with fear can't be blocked except by artifact creatures and/or black creatures.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{U}{B}{R}{G}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, EffectTarget.Self)
+                .then(Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self)),
+            Effects.ModifyStats(-2, -2, t)
+        )
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Dave Kendall"
+        flavorText = "Necromancers who discovered the new sources of mana were quick to dream up new nightmares with them."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/GluttonousSlime.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/GluttonousSlime.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Gluttonous Slime
+ * {2}{G}
+ * Creature — Ooze
+ * 2 / 2
+ * Flash
+ * Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)
+ *
+ * Devour is three declarations, not one. [Keyword.DEVOUR] plus [KeywordAbility.devour] render the
+ * printed line and give the rest of the engine the keyword to read, but both halves are
+ * display-only on their own — the [EntersWithDevour] replacement effect is what actually offers the
+ * sacrifice and stamps the +1/+1 counters as the Slime enters. Its defaults (the plain creature
+ * filter, the unnamed variant) are exactly the printed "devour 1". Same idiom as Caldera Hellion.
+ * Flash is a plain printed keyword and needs nothing else.
+ */
+val GluttonousSlime = card("Gluttonous Slime") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ooze"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\n" +
+        "Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)"
+
+    keywords(Keyword.FLASH, Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(1))
+
+    replacementEffect(EntersWithDevour(multiplier = 1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Trevor Claxton"
+        flavorText = "On Jund, everything eventually ends up in something else's stomach."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/GoblinOutlander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/GoblinOutlander.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Goblin Outlander — Conflux #109
+ * {B}{R} · Creature — Goblin Scout · 2/2
+ *
+ * Protection from white
+ *
+ * One of the five "Outlander" commons, each an enemy-coloured 2/2 Scout with protection from the
+ * colour its two colours are allied against. The whole card is the printed protection keyword:
+ * [KeywordAbility.Protection] with a [ProtectionScope.Color] scope, which the engine projects as a
+ * protection keyword read by targeting, blocking, combat and non-combat damage, and aura fall-off
+ * alike — no per-card wiring.
+ */
+val GoblinOutlander = card("Goblin Outlander") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Goblin Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from white"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Trevor Claxton"
+        flavorText = "Egbol stared in wonder at Naya's landscape. So much to eat. So much to steal."
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/IgniteDisorder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/IgniteDisorder.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ignite Disorder
+ * {1}{R}
+ * Instant
+ * Ignite Disorder deals 3 damage divided as you choose among one, two, or three target white
+ * and/or blue creatures.
+ *
+ * The Arc Lightning shape: **one** target requirement with `count = 3, minCount = 1` plus a
+ * [DividedDamageEffect], not three separate targets — the engine reads the requirement's range to
+ * ask for a damage distribution at cast time and validates that every chosen target gets at least
+ * one damage. "White and/or blue" is a single noun phrase, so it is one filter:
+ * [GameObjectFilter.withAnyColor] unions the two colours into a single `Or` predicate rather than
+ * two independent clauses.
+ */
+val IgniteDisorder = card("Ignite Disorder") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Ignite Disorder deals 3 damage divided as you choose among one, two, or three " +
+        "target white and/or blue creatures."
+
+    spell {
+        target(
+            "target",
+            TargetCreature(
+                count = 3,
+                minCount = 1,
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withAnyColor(Color.WHITE, Color.BLUE)
+                )
+            )
+        )
+        effect = DividedDamageEffect(
+            totalDamage = 3,
+            minTargets = 1,
+            maxTargets = 3
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "\"Bant is a world imprisoned by polished stone and tyrannical rule. It yearns to strike back against those who restrain it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/InkwellLeviathan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/InkwellLeviathan.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inkwell Leviathan
+ * {7}{U}{U}
+ * Artifact Creature — Leviathan
+ * 7 / 11
+ * Trample
+ * Islandwalk
+ * Shroud
+ *
+ * Three printed keywords and nothing else — every one of them is a live [Keyword] the engine
+ * reads (trample in combat damage assignment, islandwalk as an evasion check against the
+ * defending player's lands, shroud in target legality), so the card is exactly its keyword list.
+ */
+val InkwellLeviathan = card("Inkwell Leviathan") {
+    manaCost = "{7}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Leviathan"
+    power = 7
+    toughness = 11
+    oracleText = "Trample\n" +
+        "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n" +
+        "Shroud (This creature can't be the target of spells or abilities.)"
+
+    keywords(Keyword.TRAMPLE, Keyword.ISLANDWALK, Keyword.SHROUD)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "30"
+        artist = "Anthony Francisco"
+        flavorText = "\"Into its maw went the seventh sea, never to be seen again while the world remains.\" —Esper fable"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/JhessianBalmgiver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/JhessianBalmgiver.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Jhessian Balmgiver
+ * {1}{W}{U}
+ * Creature — Human Cleric
+ * 1 / 1
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ * {T}: Target creature can't be blocked this turn.
+ *
+ * Two separate {T} abilities, so only one can be used per untap. The first is
+ * [Effects.PreventNextDamage] with a fixed amount over an [AnyTarget] — the shield's other
+ * knobs (scope, direction, source filter, "this turn" duration) all stay on their defaults.
+ * "Can't be blocked" is an [AbilityFlag], not a [com.wingedsheep.sdk.core.Keyword]: the blocking
+ * rules read the flag, so granting it through [Effects.GrantKeyword]'s flag overload is what
+ * actually makes the creature unblockable rather than merely printing a word on it.
+ */
+val JhessianBalmgiver = card("Jhessian Balmgiver") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Prevent the next 1 damage that would be dealt to any target this turn.\n" +
+        "{T}: Target creature can't be blocked this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", AnyTarget())
+        effect = Effects.PreventNextDamage(1, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "David Palumbo"
+        flavorText = "\"You have two choices: heed my advice now or need my healing later.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Kranioceros.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Kranioceros.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kranioceros
+ * {4}{R}
+ * Creature — Beast
+ * 5/2
+ * {1}{W}: This creature gets +0/+3 until end of turn.
+ *
+ * A self-pump with an off-colour activation cost: [Effects.ModifyStats] over
+ * [EffectTarget.Self], whose default duration is already `Duration.EndOfTurn`, so the printed
+ * "until end of turn" needs no argument. The `{W}` in the cost is why the card's colour identity
+ * is RW while its mana cost is mono-red.
+ */
+val Kranioceros = card("Kranioceros") {
+    manaCost = "{4}{R}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 2
+    oracleText = "{1}{W}: This creature gets +0/+3 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.ModifyStats(0, 3, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Steve Argyle"
+        flavorText = "\"A surly beast, the kranioceros will raise its defenses at the smallest threat. Stay out of sight and downwind, or you'll disrupt its natural migrations.\" —Ebrel, godtoucher mentor"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/MatcaRioters.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/MatcaRioters.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Matca Rioters
+ * {2}{G}
+ * Creature — Human Warrior
+ * * / *
+ * Domain — Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.
+ *
+ * Domain is an ability word (CR 207.2c) with no rules meaning of its own; the count is
+ * [DynamicAmounts.domain] — the distinct basic land subtypes among the lands you control. Both
+ * halves read the same source, which is exactly what [dynamicStats] composes, so no literal
+ * `power` / `toughness` line is emitted.
+ */
+val MatcaRioters = card("Matca Rioters") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior"
+    oracleText = "Domain — Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control."
+
+    dynamicStats(DynamicAmounts.domain())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Steve Argyle"
+        flavorText = "When outsiders interrupted the matca championship, things got ugly."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/MoltenFrame.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/MoltenFrame.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Molten Frame
+ * {1}{R}
+ * Instant
+ * Destroy target artifact creature.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Artifact creature" is one noun phrase and so one filter — the shared
+ * [GameObjectFilter.ArtifactCreature] (both predicates required, an `And`), never an `Or` union.
+ * [Effects.Destroy] is the `byDestruction` move to the graveyard, so indestructible and
+ * regeneration still apply. Cycling is [KeywordAbility.cycling], which carries its own cost.
+ */
+val MoltenFrame = card("Molten Frame") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact creature.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature)))
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Izzy"
+        flavorText = "The metal filigree in his body glowed red-hot, and his flesh soon followed."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/NacatlOutlander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/NacatlOutlander.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Nacatl Outlander — Conflux #119
+ * {R}{G} · Creature — Cat Scout · 2/2
+ *
+ * Protection from blue
+ *
+ * The Naya member of the "Outlander" cycle — see [GoblinOutlander]. Its only printed line is the
+ * protection keyword, spelled as [KeywordAbility.Protection] over a [ProtectionScope.Color] scope;
+ * the engine projects that keyword and every protection rule (targeting, blocking, damage, aura
+ * fall-off) reads it directly.
+ */
+val NacatlOutlander = card("Nacatl Outlander") {
+    manaCost = "{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Cat Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from blue"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLUE)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Survival in the wilds of Naya left Tiyan well equipped to win the civilized battles of Bant."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/NacatlSavage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/NacatlSavage.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Nacatl Savage — Conflux #86
+ * {1}{G} · Creature — Cat Warrior · 2/1
+ *
+ * Protection from artifacts
+ *
+ * Naya's answer to Esper, and the card-type sibling of the colour-scoped Outlander cycle
+ * ([GoblinOutlander] and friends). "Protection from artifacts" is the same
+ * [KeywordAbility.Protection] keyword with a [ProtectionScope.CardType] scope instead of a colour
+ * one — projected as a protection keyword that targeting, blocking, damage prevention and aura
+ * fall-off all read, so an artifact creature can't block it and an artifact source deals it no
+ * damage without any per-card wiring.
+ */
+val NacatlSavage = card("Nacatl Savage") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Protection from artifacts"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Artifact")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Paolo Parente"
+        flavorText = "\"Blades dull and armor dents. Marisi taught us that instinct is the only thing a true warrior needs.\" —Ajani"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ObeliskOfAlara.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ObeliskOfAlara.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obelisk of Alara
+ * {6}
+ * Artifact
+ * {1}{W}, {T}: You gain 5 life.
+ * {1}{U}, {T}: Draw a card, then discard a card.
+ * {1}{B}, {T}: Target creature gets -2/-2 until end of turn.
+ * {1}{R}, {T}: This artifact deals 3 damage to target player or planeswalker.
+ * {1}{G}, {T}: Target creature gets +4/+4 until end of turn.
+ *
+ * Five independent activated abilities, one per colour, each a mana-plus-tap [Costs.Composite].
+ * They are five abilities rather than one modal effect because each has its own cost — a mode is
+ * chosen after a single cost is paid, and nothing here shares one; the tap is separately paid and
+ * so only one can be activated per untap step anyway.
+ *
+ * "Draw a card, then discard a card" is the corpus's standing composition: [Effects.DrawCards]
+ * followed by the [Patterns.Hand.discardCards] pipeline (gather hand → choose one → move to
+ * graveyard as a discard), both defaulting to the ability's controller.
+ *
+ * The pump and the shrink are the same [Effects.ModifyStats] with opposite signs; its default
+ * duration is already `Duration.EndOfTurn`, so the printed "until end of turn" needs no argument.
+ */
+val ObeliskOfAlara = card("Obelisk of Alara") {
+    manaCost = "{6}"
+    colorIdentity = "BGRUW"
+    typeLine = "Artifact"
+    oracleText = "{1}{W}, {T}: You gain 5 life.\n" +
+        "{1}{U}, {T}: Draw a card, then discard a card.\n" +
+        "{1}{B}, {T}: Target creature gets -2/-2 until end of turn.\n" +
+        "{1}{R}, {T}: This artifact deals 3 damage to target player or planeswalker.\n" +
+        "{1}{G}, {T}: Target creature gets +4/+4 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        effect = Effects.GainLife(5)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Tap)
+        val victim = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-2, -2, victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.Tap)
+        val victim = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(3, victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap)
+        val beneficiary = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(4, 4, beneficiary)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "140"
+        artist = "Jeremy Jarvis"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Paleoloth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Paleoloth.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Paleoloth
+ * {4}{G}{G}
+ * Creature — Beast
+ * 5 / 5
+ * Whenever another creature you control with power 5 or greater enters, you may return target creature card from your graveyard to your hand.
+ *
+ * The printed "another" is [TriggerBinding.OTHER] on a [Triggers.entersBattlefield] whose filter
+ * carries the whole restriction — creature, power 5 or greater, controlled by you — so the power
+ * test is read off projected state when the permanent enters rather than baked into a condition.
+ * Paleoloth is itself a 5/5, which is exactly why the binding matters: under `SELF`/`ANY` it would
+ * recur a card off its own arrival. The printed "you may" is `optional = true`
+ * (a `Gate.MayDecide` around the recursion), and the target is the prebuilt
+ * [Targets.CreatureCardInYourGraveyard] — owned by you, in the graveyard zone.
+ */
+val Paleoloth = card("Paleoloth") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Whenever another creature you control with power 5 or greater enters, you may return target creature card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.powerAtLeast(5).youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        optional = true
+        val recurred = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.ReturnToHand(recurred)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "88"
+        artist = "Christopher Moeller"
+        flavorText = "\"Gods do not sleep soundly in the earth's embrace.\" —Mayael the Anima"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ParasiticStrix.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ParasiticStrix.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Parasitic Strix
+ * {2}{U}
+ * Artifact Creature — Bird
+ * 2 / 2
+ * Flying
+ * When this creature enters, if you control a black permanent, target player loses 2 life and you gain 2 life.
+ *
+ * Conflux's "domain of a colour" clause is an ordinary intervening-"if" (CR 603.4), so it is
+ * checked both when the Strix enters and again on resolution — losing the last black permanent in
+ * response fizzles the drain. [Conditions.YouControl] over `Permanent.withColor(BLACK)` is the
+ * existential the JSON names `Exists(You, Battlefield, …)`; the bare noun "permanent" is
+ * deliberately not narrowed to creatures. The drain is one [Effects.Composite] of a targeted
+ * [Effects.LoseLife] and an untargeted [Effects.GainLife], whose controller default is already you.
+ */
+val ParasiticStrix = card("Parasitic Strix") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, if you control a black permanent, target player loses 2 life and you gain 2 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.BLACK))
+        val victim = target("target", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(2, victim),
+            Effects.GainLife(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Steven Belledin"
+        flavorText = "After finding no sustenance on the edges of Grixis, it turned to the skies of Bant."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/PestilentKathari.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/PestilentKathari.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pestilent Kathari
+ * {2}{B}
+ * Creature — Bird Warrior
+ * 1/1
+ * Flying
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ * {2}{R}: This creature gains first strike until end of turn.
+ *
+ * Two printed [Keyword]s plus one self-pump-shaped grant: [Effects.GrantKeyword] onto
+ * [EffectTarget.Self]. The facade's default duration is already `Duration.EndOfTurn`, so the
+ * printed "until end of turn" needs no argument of its own.
+ */
+val PestilentKathari = card("Pestilent Kathari") {
+    manaCost = "{2}{B}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Bird Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n" +
+        "{2}{R}: This creature gains first strike until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RakkaMar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RakkaMar.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakka Mar
+ * {2}{R}{R}
+ * Legendary Creature — Human Shaman
+ * 2/2
+ * Haste
+ * {R}, {T}: Create a 3/1 red Elemental creature token with haste.
+ *
+ * Haste is a printed [Keyword]. The activation is one [Effects.CreateToken] behind a
+ * [Costs.Composite] of mana plus [Costs.Tap] — the token's own haste rides on the effect's
+ * `keywords` set, which is what makes it able to attack the turn it is minted.
+ */
+val RakkaMar = card("Rakka Mar") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "{R}, {T}: Create a 3/1 red Elemental creature token with haste."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Elemental"),
+            keywords = setOf(Keyword.HASTE)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Jason Chan"
+        flavorText = "\"The finest pawns are those with pawns of their own.\" —Nicol Bolas"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RhoxMeditant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RhoxMeditant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Rhox Meditant
+ * {3}{W}
+ * Creature — Rhino Monk
+ * 2/4
+ * When this creature enters, if you control a green permanent, draw a card.
+ *
+ * The "if" is an intervening-if clause (CR 603.4), not a condition on the effect: it is checked
+ * both when the trigger would go on the stack and again on resolution, which is what
+ * `interveningIf` means here rather than folding the check into the effect. The check itself is
+ * [Conditions.YouControl] over `GameObjectFilter.Permanent.withColor(GREEN)` — a bare "permanent"
+ * noun, so no creature narrowing.
+ */
+val RhoxMeditant = card("Rhox Meditant") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rhino Monk"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, if you control a green permanent, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.GREEN))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Donato Giancola"
+        flavorText = "The weight of her conviction balances on the harmony of her soul."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SacellumArchers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SacellumArchers.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sacellum Archers
+ * {2}{G}
+ * Creature — Elf Archer
+ * 2/3
+ * {R}{W}, {T}: This creature deals 2 damage to target attacking or blocking creature.
+ *
+ * A single activated ability: [Costs.Composite] of mana plus [Costs.Tap], one [TargetObject]
+ * narrowed by `GameObjectFilter.Creature.attackingOrBlocking()` — which is exactly the
+ * `StatePredicate.Or(IsAttacking, IsBlocking)` the printed line means — and [Effects.DealDamage]
+ * pointed at that binding.
+ */
+val SacellumArchers = card("Sacellum Archers") {
+    manaCost = "{2}{G}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Elf Archer"
+    power = 2
+    toughness = 3
+    oracleText = "{R}{W}, {T}: This creature deals 2 damage to target attacking or blocking creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}{W}"), Costs.Tap)
+        val creature = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.attackingOrBlocking()))
+        )
+        effect = Effects.DealDamage(2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Kev Walker"
+        flavorText = "\"Our arrows are aimed not at the sacred behemoths but at those who dare to dream of such a trophy.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScattershotArcher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScattershotArcher.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scattershot Archer — Conflux #90
+ * {G} · Creature — Elf Archer · 1/2
+ *
+ * {T}: This creature deals 1 damage to each creature with flying.
+ *
+ * "Each creature with flying" is untargeted, so it is [Effects.ForEachInGroup] over
+ * `Filters.Group.allCreatures.withKeyword(Keyword.FLYING)` rather than a target requirement —
+ * `IterationSpace.Group` binds each flier in turn as the body's [EffectTarget.Self], so a single
+ * one-damage facade applies once per flier. The group is snapshotted before the first iteration,
+ * and each flier takes damage from this creature independently (so lifelink, deathtouch, and
+ * protection from green all read the archer as the source).
+ */
+val ScattershotArcher = card("Scattershot Archer") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Archer"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: This creature deals 1 damage to each creature with flying."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.ForEachInGroup(
+            filter = Filters.Group.allCreatures.withKeyword(Keyword.FLYING),
+            effect = Effects.DealDamage(1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "90"
+        artist = "Steve Argyle"
+        flavorText = "To train her elves for war, Mayael would drop a sackful of acorns from the tree canopy. Each archer tried to split as many as possible before the acorns hit the forest floor below."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfDominance.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfDominance.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scepter of Dominance
+ * {1}{W}{W}
+ * Artifact
+ * {W}, {T}: Tap target permanent.
+ *
+ * One activated ability: a mana-plus-tap [Costs.Composite] and [Effects.Tap] over the widest
+ * target the SDK ships, [Targets.Permanent] — the printed noun is "permanent", not "creature",
+ * so the requirement carries `GameObjectFilter.Permanent` and nothing narrower.
+ */
+val ScepterOfDominance = card("Scepter of Dominance") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{W}, {T}: Tap target permanent."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val victim = target("target", Targets.Permanent)
+        effect = Effects.Tap(victim)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Howard Lyon"
+        flavorText = "\"Whether or not you will bow to me is not open to debate. The question is, will I ever let you rise?\" —Fridius, telemin master"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfFugue.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfFugue.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Scepter of Fugue
+ * {B}{B}
+ * Artifact
+ * {1}{B}, {T}: Target player discards a card. Activate only during your turn.
+ *
+ * The discard is the shared [Patterns.Hand.discardCards] recipe (gather the target's hand →
+ * they choose one → move it to their graveyard as a discard). Pointing it at the bound target
+ * is the whole of "target player discards": the pattern derives both the hand it gathers and
+ * the player who chooses from that one argument.
+ *
+ * "Activate only during your turn" is [ActivationRestriction.OnlyDuringYourTurn].
+ */
+val ScepterOfFugue = card("Scepter of Fugue") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{1}{B}, {T}: Target player discards a card. Activate only during your turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Tap)
+        val victim = target("target", Targets.Player)
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+        effect = Patterns.Hand.discardCards(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "53"
+        artist = "Franz Vohwinkel"
+        flavorText = "One goes to Tidehollow either to forget or to be forgotten. Either way, the scullers will oblige."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfInsight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScepterOfInsight.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scepter of Insight
+ * {1}{U}{U}
+ * Artifact
+ * {3}{U}, {T}: Draw a card.
+ *
+ * A mana-plus-tap [Costs.Composite] over [Effects.DrawCards]; the draw's default target is the
+ * ability's controller, which is exactly what the printed line means and what Assay's model
+ * leaves unwritten.
+ */
+val ScepterOfInsight = card("Scepter of Insight") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{3}{U}, {T}: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.Tap)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Steven Belledin"
+        flavorText = "\"The road to truth has many branches, and so must the cane with which I walk it.\" —Voln the Elder"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScornfulAetherLich.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScornfulAetherLich.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scornful Aether-Lich
+ * {3}{U}
+ * Artifact Creature — Zombie Wizard
+ * 2/4
+ * {W}{B}: This creature gains fear and vigilance until end of turn. (Attacking doesn't cause it to
+ * tap, and it can't be blocked except by artifact creatures and/or black creatures.)
+ *
+ * One activation granting two keywords: [Effects.Composite] over two [Effects.GrantKeyword] calls
+ * onto [EffectTarget.Self], each defaulting to `Duration.EndOfTurn`. Two grants rather than one
+ * because a grant carries a single keyword — the same shape Gravelgill Duo uses for its fear.
+ */
+val ScornfulAetherLich = card("Scornful Aether-Lich") {
+    manaCost = "{3}{U}"
+    colorIdentity = "BUW"
+    typeLine = "Artifact Creature — Zombie Wizard"
+    power = 2
+    toughness = 4
+    oracleText = "{W}{B}: This creature gains fear and vigilance until end of turn. " +
+        "(Attacking doesn't cause it to tap, and it can't be blocked except by artifact creatures and/or black creatures.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{B}")
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Steven Belledin"
+        flavorText = "\"With no flesh, there is no pain, no hesitation, no emotion of any kind. He is crafted perfection.\" —Tezzeret"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SedraxisAlchemist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SedraxisAlchemist.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sedraxis Alchemist
+ * {2}{B}
+ * Creature — Zombie Wizard
+ * 2 / 2
+ * When this creature enters, if you control a blue permanent, return target nonland permanent to its owner's hand.
+ *
+ * Conflux's "if you control a <colour> permanent" clause is an ordinary intervening-"if"
+ * (CR 603.4): checked when the Alchemist enters and rechecked on resolution, so losing the last
+ * blue permanent in response fizzles the bounce. [Conditions.YouControl] over
+ * `Permanent.withColor(BLUE)` is the existential — the bare noun "permanent" is not narrowed to
+ * creatures. The bounce is [Effects.ReturnToHand], which routes to the card's *owner's* hand on its
+ * own, over the prebuilt [Targets.NonlandPermanent].
+ */
+val SedraxisAlchemist = card("Sedraxis Alchemist") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, if you control a blue permanent, return target nonland permanent to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.BLUE))
+        val bounced = target("target", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(bounced)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Karl Kopinski"
+        flavorText = "The problem with a liquid that can dissolve anything is finding something to carry it in."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SphinxSummoner.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SphinxSummoner.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Sphinx Summoner
+ * {3}{U}{B}
+ * Artifact Creature — Sphinx
+ * 3 / 3
+ * Flying
+ * When this creature enters, you may search your library for an artifact creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * The whole printed search is one [Patterns.Library.searchLibrary]: gather the library, choose up
+ * to one match, move it to hand revealed, shuffle, then emit the "a player searched their library"
+ * event (CR 701.23) that the pattern already appends. The printed "you may" is `optional = true`,
+ * which lowers to a `Gate.MayDecide` around the composite — the search itself asks nothing, so
+ * there is exactly one prompt. [GameObjectFilter.ArtifactCreature] is the prebuilt
+ * artifact-and-creature conjunction.
+ */
+val SphinxSummoner = card("Sphinx Summoner") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Artifact Creature — Sphinx"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, you may search your library for an artifact creature card, reveal it, put it into your hand, then shuffle."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.ArtifactCreature,
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Jaime Jones"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SylvanBounty.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SylvanBounty.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Sylvan Bounty
+ * {5}{G}
+ * Instant
+ * Target player gains 8 life.
+ * Basic landcycling {1}{G}
+ *
+ * A single [Effects.GainLife] pointed at the bound player rather than at the default controller —
+ * the printed line says "target player", so the recipient is the target slot, not "you".
+ *
+ * "Basic landcycling" is [KeywordAbility.basicLandcycling], the typecycling machinery narrowed to
+ * *basic* land cards, matching the `IsBasicLand` search filter in the reminder text.
+ */
+val SylvanBounty = card("Sylvan Bounty") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target player gains 8 life.\n" +
+        "Basic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land " +
+        "card, reveal it, put it into your hand, then shuffle.)"
+
+    spell {
+        val t = target("target", TargetPlayer())
+        effect = Effects.GainLife(8, t)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Chris Rahn"
+        flavorText = "Some who scouted new lands chose to stay."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Thornling.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Thornling.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thornling
+ * {3}{G}{G}
+ * Creature — Elemental Shapeshifter
+ * 4 / 4
+ * {G}: This creature gains haste until end of turn.
+ * {G}: This creature gains trample until end of turn.
+ * {G}: This creature gains indestructible until end of turn.
+ * {1}: This creature gets +1/-1 until end of turn.
+ * {1}: This creature gets -1/+1 until end of turn.
+ *
+ * The Morphling shape: five independent, repeatable activated abilities, each with only a mana
+ * cost (no {T}, so each can be activated any number of times). Every effect points at
+ * [EffectTarget.Self] — "this creature" is the source, not a target, so none of them declares a
+ * target requirement. The keyword grants and the stat swings both default to
+ * `Duration.EndOfTurn`, which is exactly the printed "until end of turn".
+ */
+val Thornling = card("Thornling") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Shapeshifter"
+    power = 4
+    toughness = 4
+    oracleText = "{G}: This creature gains haste until end of turn.\n" +
+        "{G}: This creature gains trample until end of turn.\n" +
+        "{G}: This creature gains indestructible until end of turn.\n" +
+        "{1}: This creature gets +1/-1 until end of turn.\n" +
+        "{1}: This creature gets -1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(-1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "95"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ToxicIguanar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ToxicIguanar.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Toxic Iguanar — Conflux #72
+ * {R} · Creature — Lizard · 1/1
+ *
+ * This creature has deathtouch as long as you control a green permanent.
+ *
+ * A Conflux "domain-lite" common: the grant is a [ConditionalStaticAbility] wrapping a
+ * [GrantKeyword] over [Filters.Self] (the source permanent), gated on
+ * `Conditions.YouControl(GameObjectFilter.Permanent.withColor(...))` — an `Exists` over your
+ * battlefield, which is the SDK spelling of "as long as you control a green permanent". A bare
+ * "permanent" filter, not a creature one: any green permanent turns the deathtouch on.
+ */
+val ToxicIguanar = card("Toxic Iguanar") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 1
+    toughness = 1
+    oracleText = "This creature has deathtouch as long as you control a green permanent. " +
+        "(Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.DEATHTOUCH, Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withColor(Color.GREEN))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Brandon Kitkouski"
+        flavorText = "There are no \"weak\" creatures on Jund. Even the smallest can strike a deadly blow."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/TraumaticVisions.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/TraumaticVisions.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Traumatic Visions
+ * {3}{U}{U}
+ * Instant
+ * Counter target spell.
+ * Basic landcycling {1}{U}
+ *
+ * A plain [Effects.CounterSpell] over [Targets.Spell] — an unfiltered `TargetObject` scoped to the
+ * stack, which is what "target spell" (no type restriction) means.
+ *
+ * "Basic landcycling" is [KeywordAbility.basicLandcycling], the typecycling machinery narrowed to
+ * *basic* land cards, matching the `IsBasicLand` search filter in the reminder text.
+ */
+val TraumaticVisions = card("Traumatic Visions") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\n" +
+        "Basic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land " +
+        "card, reveal it, put it into your hand, then shuffle.)"
+
+    spell {
+        target("target", Targets.Spell)
+        effect = Effects.CounterSpell()
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Cyril Van Der Haegen"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/TukatongueThallid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/TukatongueThallid.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tukatongue Thallid
+ * {G}
+ * Creature — Fungus
+ * 1 / 1
+ * When this creature dies, create a 1/1 green Saproling creature token.
+ *
+ * A plain [Triggers.Dies] self-trigger over [Effects.CreateToken]. The token's characteristics are
+ * printed literally, so nothing is read off the dying Fungus — no last-known information is needed
+ * here — and the token's controller defaults to the ability's controller.
+ */
+val TukatongueThallid = card("Tukatongue Thallid") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, create a 1/1 green Saproling creature token."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Vance Kovacs"
+        flavorText = "Jund's thallids tried to disguise their deliciousness by covering themselves in spines harvested from the tukatongue tree."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VagrantPlowbeasts.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VagrantPlowbeasts.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Vagrant Plowbeasts
+ * {5}{G}{W}
+ * Creature — Beast
+ * 6/6
+ * {1}: Regenerate target creature with power 5 or greater.
+ *
+ * [RegenerateEffect] is the shipped spelling — there is no `Effects.Regenerate` facade. The
+ * "power 5 or greater" clause is `GameObjectFilter.Creature.powerAtLeast(5)`, a card predicate the
+ * targeting check re-reads off projected state, so a creature pumped into range is a legal target.
+ */
+val VagrantPlowbeasts = card("Vagrant Plowbeasts") {
+    manaCost = "{5}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Beast"
+    power = 6
+    toughness = 6
+    oracleText = "{1}: Regenerate target creature with power 5 or greater."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val creature = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(5)))
+        )
+        effect = RegenerateEffect(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Plowbeasts of Naya escaped their harnesses in droves, content to snack on the conveniently cultivated fields of Eos and Valeron."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ValeronOutlander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ValeronOutlander.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Valeron Outlander — Conflux #130
+ * {G}{W} · Creature — Human Scout · 2/2
+ *
+ * Protection from black
+ *
+ * The Bant member of the "Outlander" cycle — see [GoblinOutlander]. The card is nothing but the
+ * printed protection keyword: [KeywordAbility.Protection] with a [ProtectionScope.Color] scope,
+ * which the engine projects for targeting, blocking, damage and aura fall-off.
+ */
+val ValeronOutlander = card("Valeron Outlander") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from black"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Matt Stewart"
+        flavorText = "After years of honing her philosophy in debate with stubborn rhoxes, Niella was ready to convert any heathen."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VedalkenOutlander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VedalkenOutlander.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Vedalken Outlander — Conflux #132
+ * {W}{U} · Artifact Creature — Vedalken Scout · 2/2
+ *
+ * Protection from red
+ *
+ * The Esper member of the "Outlander" cycle — see [GoblinOutlander] — and the only one printed as
+ * an artifact creature, which is carried entirely by the type line. The rules text is the printed
+ * protection keyword: [KeywordAbility.Protection] over a [ProtectionScope.Color] scope, projected
+ * by the engine for targeting, blocking, damage and aura fall-off.
+ */
+val VedalkenOutlander = card("Vedalken Outlander") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Artifact Creature — Vedalken Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from red"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Izzy"
+        flavorText = "The Seekers of Carmot searched across the unknown lands for the mystical red stone that could reforge Esper in ethereal perfection."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ViashinoSlaughtermaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ViashinoSlaughtermaster.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viashino Slaughtermaster
+ * {1}{R}
+ * Creature — Lizard Warrior
+ * 1/1
+ * Double strike
+ * {B}{G}: This creature gets +1/+1 until end of turn. Activate only once each turn.
+ *
+ * Double strike is a printed [Keyword]. The pump is [Effects.ModifyStats] onto
+ * [EffectTarget.Self] — its default duration is already `Duration.EndOfTurn` — and the printed
+ * "only once each turn" is [ActivationRestriction.OncePerTurn] on the ability itself, not a
+ * condition on the effect.
+ */
+val ViashinoSlaughtermaster = card("Viashino Slaughtermaster") {
+    manaCost = "{1}{R}"
+    colorIdentity = "BGR"
+    typeLine = "Creature — Lizard Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Double strike\n" +
+        "{B}{G}: This creature gets +1/+1 until end of turn. Activate only once each turn."
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{G}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Raymond Swanland"
+        flavorText = "\"I'll fight two at once, and then lick their guts from my blades.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ViewFromAbove.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ViewFromAbove.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * View from Above
+ * {1}{U}
+ * Instant
+ * Target creature gains flying until end of turn. If you control a white permanent, return
+ * View from Above to its owner's hand.
+ *
+ * Two sentences chained with `then`. The rider is a [Gate.WhenCondition] — a state check taken
+ * when View from Above *resolves*, not an intervening-if, so a white permanent that arrives after
+ * the spell was cast still counts. The condition is the general
+ * [Exists] over your battlefield with a bare "white permanent" filter (`IsPermanent` +
+ * `HasColor(WHITE)`), and the return moves [EffectTarget.Self] — the spell itself, which is still
+ * on the stack — to [Zone.HAND] rather than the targeted creature.
+ */
+val ViewFromAbove = card("View from Above") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gains flying until end of turn. If you control a white permanent, " +
+        "return View from Above to its owner's hand."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+            .then(
+                GatedEffect(
+                    gate = Gate.WhenCondition(
+                        Exists(
+                            Player.You,
+                            Zone.BATTLEFIELD,
+                            GameObjectFilter.Permanent.withColor(Color.WHITE)
+                        )
+                    ),
+                    then = Effects.ReturnToHand(EffectTarget.Self)
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Howard Lyon"
+        flavorText = "\"This air feels so heavy and thick. There are no winds to speak of. I fear the knowledge that comes from a place like this.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/WildLeotau.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/WildLeotau.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Wild Leotau
+ * {2}{G}{G}
+ * Creature — Cat
+ * 5/4
+ * At the beginning of your upkeep, sacrifice this creature unless you pay {G}.
+ *
+ * [Triggers.YourUpkeep] is `StepEvent(UPKEEP, You)` bound `ANY`. The "unless" is a **cost paid on
+ * resolution**, not a may-gate: [PayOrSufferEffect] pairs [Costs.pay.Mana] with
+ * [SacrificeSelfEffect], so declining — or being unable to pay — sacrifices the creature.
+ */
+val WildLeotau = card("Wild Leotau") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    power = 5
+    toughness = 4
+    oracleText = "At the beginning of your upkeep, sacrifice this creature unless you pay {G}."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{G}"), suffer = SacrificeSelfEffect)
+        description = "At the beginning of your upkeep, sacrifice this creature unless you pay {G}."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Michael Komarck"
+        flavorText = "\"Leotau that were born wild make the best mounts. It's like riding a thunderstorm.\" —Rafiq of the Many"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ZombieOutlander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ZombieOutlander.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Zombie Outlander — Conflux #133
+ * {U}{B} · Creature — Zombie Scout · 2/2
+ *
+ * Protection from green
+ *
+ * The Grixis member of the "Outlander" cycle — see [GoblinOutlander]. Its whole script is the
+ * printed protection keyword, spelled [KeywordAbility.Protection] with a [ProtectionScope.Color]
+ * scope; the engine projects it and reads it for targeting, blocking, damage and aura fall-off.
+ */
+val ZombieOutlander = card("Zombie Outlander") {
+    manaCost = "{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Zombie Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from green"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.GREEN)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Nils Hamm"
+        flavorText = "The ripe smell of life drifted into Grixis. The dead caught the scent and with reckless hunger followed it back into Jund."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/FaerieMechanistReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/FaerieMechanistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddf.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Mechanist reprint in DDF. Canonical CardDefinition lives in its earliest set.
+ */
+val FaerieMechanistReprint = Printing(
+    oracleId = "fcbe14c4-1b0d-486f-bb9c-0fed452668cb",
+    name = "Faerie Mechanist",
+    setCode = "DDF",
+    collectorNumber = "54",
+    scryfallId = "3dc5a5af-6599-4a29-8c4e-1fdf7e920046",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3dc5a5af-6599-4a29-8c4e-1fdf7e920046.jpg",
+    releaseDate = "2010-09-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/IgniteDisorderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/IgniteDisorderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ignite Disorder reprint in M10. Canonical CardDefinition lives in its earliest set.
+ */
+val IgniteDisorderReprint = Printing(
+    oracleId = "8f66317c-06fe-4320-9d98-eaedaef67c85",
+    name = "Ignite Disorder",
+    setCode = "M10",
+    collectorNumber = "141",
+    scryfallId = "c425d61c-f224-4ba6-a32e-44e3a3954c1b",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c425d61c-f224-4ba6-a32e-44e3a3954c1b.jpg",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/BoneSawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/BoneSawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Saw reprint in OGW. Canonical CardDefinition lives in its earliest set.
+ */
+val BoneSawReprint = Printing(
+    oracleId = "16e555f2-5aa8-4100-a036-eed48db0e84a",
+    name = "Bone Saw",
+    setCode = "OGW",
+    collectorNumber = "161",
+    scryfallId = "dc3d19ff-b618-4b07-99a8-ea6e7ee72459",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc3d19ff-b618-4b07-99a8-ea6e7ee72459.jpg",
+    releaseDate = "2016-01-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/FieryFallReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/FieryFallReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiery Fall reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val FieryFallReprint = Printing(
+    oracleId = "f014b1a1-20ef-475c-bf83-f1a82e68ab97",
+    name = "Fiery Fall",
+    setCode = "PC2",
+    collectorNumber = "43",
+    scryfallId = "d971d77b-3ff9-4454-8971-8b7493af9010",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d971d77b-3ff9-4454-8971-8b7493af9010.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GluttonousSlimeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GluttonousSlimeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gluttonous Slime reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val GluttonousSlimeReprint = Printing(
+    oracleId = "5797684a-a022-45d2-aa2e-4d375b33017e",
+    name = "Gluttonous Slime",
+    setCode = "PC2",
+    collectorNumber = "65",
+    scryfallId = "9ba0ace8-dcc0-4ecb-bc5a-156577a52684",
+    artist = "Trevor Claxton",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9ba0ace8-dcc0-4ecb-bc5a-156577a52684.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/TukatongueThallidReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/TukatongueThallidReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tukatongue Thallid reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val TukatongueThallidReprint = Printing(
+    oracleId = "c7dbd008-e941-497e-8305-80c53b1dffe2",
+    name = "Tukatongue Thallid",
+    setCode = "PC2",
+    collectorNumber = "79",
+    scryfallId = "8e7e2570-f473-473d-9c67-dd753aafb6ae",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e7e2570-f473-473d-9c67-dd753aafb6ae.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -1,3 +1,62 @@
+// Absorb Vis
+{
+    "name": "Absorb Vis",
+    "manaCost": "{6}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player loses 4 life and you gain 4 life.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{B}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Brandon Kitkouski",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/5528886e-3198-48b1-a3b0-6d41ba87bfd6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Aerie Mystics
 {
     "name": "Aerie Mystics",
@@ -51,6 +110,36 @@
         "BLUE",
         "GREEN"
     ]
+}
+
+// Ancient Ziggurat
+{
+    "name": "Ancient Ziggurat",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add one mana of any color. Spend this mana only to cast a creature spell.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": "CreatureSpellsOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "flavorText": "Built in honor of Alara's creatures, the ziggurat vanished long ago. When Progenitus awakened, the temple emerged again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0348247d-0a70-4961-8590-9de41386c69b.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Armillary Sphere
@@ -126,6 +215,184 @@
     "colorIdentityOverride": []
 }
 
+// Asha's Favor
+{
+    "name": "Asha's Favor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has flying, first strike, and vigilance.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Donato Giancola",
+        "flavorText": "As his new wings lifted him high above Bant, Taric felt his earthly aspirations transform into heavenly resolve.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28b817f7-ae05-4d31-8a2c-29d8082b4132.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Aven Trailblazer
+{
+    "name": "Aven Trailblazer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying\nDomain — Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land",
+                "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+            }
+        }
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Chris Rahn",
+        "flavorText": "\"The bird wore the form of a man, bereft of filigree. Why do the Texts not speak of it?\" —Belator of Esper",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb032cd3-96a4-4cef-bb89-0843f2ed8189.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Beacon Behemoth
+{
+    "name": "Beacon Behemoth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{1}: Target creature with power 5 or greater gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Jesper Ejsing",
+        "flavorText": "When its smoky plumes light Naya's sky, every creature from the smallest pip fawn to the largest rannet heeds the warning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cc42e33-7489-4a32-bb30-adc80ec13521.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Bone Saw
+{
+    "name": "Bone Saw",
+    "manaCost": "{0}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Pete Venters",
+        "flavorText": "In a world where death is always violent, cruel weapons are as common as rocks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3bf79d6-4b4a-4fdd-a831-36eff2523661.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Canyon Minotaur
 {
     "name": "Canyon Minotaur",
@@ -143,6 +410,458 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Child of Alara
+{
+    "name": "Child of Alara",
+    "manaCost": "{W}{U}{B}{R}{G}",
+    "typeLine": "Legendary Creature — Avatar",
+    "oracleText": "Trample\nWhen Child of Alara dies, destroy all nonland permanents. They can't be regenerated.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "nonland permanent"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy",
+                            "noRegenerate": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "MYTHIC",
+        "artist": "Steve Argyle",
+        "flavorText": "The progeny of the Maelstrom shows no allegiance—and no mercy—to any of the five shards.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/863f701f-fba2-48db-95ef-0926986cdac9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Cliffrunner Behemoth
+{
+    "name": "Cliffrunner Behemoth",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Rhino Beast",
+    "oracleText": "This creature has haste as long as you control a red permanent.\nThis creature has lifelink as long as you control a white permanent.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent red"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent white"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "flavorText": "It's revered for its power, celebrated for its grace, and feared for the avalanches triggered by its thunderous feet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Constricting Tendrils
+{
+    "name": "Constricting Tendrils",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -3/-0 until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 0
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "David Palumbo",
+        "flavorText": "Priests of Bant protect their temples with traps more elaborate than any mosaic floor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a110be3-93ec-40ef-94a6-e4c43f1ce211.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Darklit Gargoyle
+{
+    "name": "Darklit Gargoyle",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "Flying\n{B}: This creature gets +2/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Howard Lyon",
+        "flavorText": "It shines in the darkness of its master's ambitions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e7162e5-8c56-457e-91eb-b8ae4d1b6adb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Dreadwing
+{
+    "name": "Dreadwing",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{1}{U}{R}: This creature gets +3/+0 and gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Hyzer",
+        "flavorText": "Dreadwings spring from lofty perches to surprise kathari in midflight. They smother their prey and then consume it as they glide gently toward the ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afb997b6-d872-438f-bf8a-db976bc27a2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Ember Weaver
+{
+    "name": "Ember Weaver",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nAs long as you control a red permanent, this creature gets +1/+0 and has first strike.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent red"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent red"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Each night, the sun unravels and blows away. Each day, the spiders set a new one in the sky.\" —Sunseeder myth",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10effbe2-fd8e-44b6-a08c-3984a92254d9.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Esper Cormorants
+{
+    "name": "Esper Cormorants",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Warren Mahy",
+        "flavorText": "\"The smiths of this land must be mad to reach so far and so high for another creature to decorate.\" —Cagen Vargan, Jhessian sea scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c5068ed-8477-4d8d-9e37-c72474208e2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ethersworn Adjudicator
+{
+    "name": "Ethersworn Adjudicator",
+    "manaCost": "{4}{U}",
+    "typeLine": "Artifact Creature — Vedalken Knight",
+    "oracleText": "Flying\n{1}{W}{B}, {T}: Destroy target creature or enchantment.\n{2}{U}: Untap this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "MYTHIC",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Esper mages devised their weapons to be so devastating that war seemed unnecessary.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a35a056c-1e38-416b-bf01-2a1762b08020.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
     ]
 }
 
@@ -179,6 +898,236 @@
     "colorIdentityOverride": []
 }
 
+// Faerie Mechanist
+{
+    "name": "Faerie Mechanist",
+    "manaCost": "{3}{U}",
+    "typeLine": "Artifact Creature — Faerie Artificer",
+    "oracleText": "Flying\nWhen this creature enters, look at the top three cards of your library. You may reveal an artifact card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "artifact",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal an artifact card from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d350ebd7-afcf-4d67-8173-b07cad3fa9bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fiery Fall
+{
+    "name": "Fiery Fall",
+    "manaCost": "{5}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Fiery Fall deals 5 damage to target creature.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{R}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Daarken",
+        "flavorText": "Jund feasts on the unprepared.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/687bb467-b447-4901-8a65-cd91fd3aa15d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fleshformer
+{
+    "name": "Fleshformer",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{W}{U}{B}{R}{G}: This creature gets +2/+2 and gains fear until end of turn. Target creature gets -2/-2 until end of turn. Activate only during your turn. (A creature with fear can't be blocked except by artifact creatures and/or black creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{U}{B}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "FEAR",
+                                    "target": "Self"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "Necromancers who discovered the new sources of mana were quick to dream up new nightmares with them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00c57090-c1fe-4100-a03c-95607074280e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Fusion Elemental
 {
     "name": "Fusion Elemental",
@@ -201,6 +1150,112 @@
         "BLACK",
         "RED",
         "GREEN"
+    ]
+}
+
+// Gluttonous Slime
+{
+    "name": "Gluttonous Slime",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "Flash\nDevour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 1
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Trevor Claxton",
+        "flavorText": "On Jund, everything eventually ends up in something else's stomach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/258c7201-02b0-4e16-9fa6-0a79631e7724.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Goblin Outlander
+{
+    "name": "Goblin Outlander",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Goblin Scout",
+    "oracleText": "Protection from white",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "WHITE"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Trevor Claxton",
+        "flavorText": "Egbol stared in wonder at Naya's landscape. So much to eat. So much to steal.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e33683b-8bda-4bb9-beb4-fc0cd5ed79ae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Ignite Disorder
+{
+    "name": "Ignite Disorder",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Ignite Disorder deals 3 damage divided as you choose among one, two, or three target white and/or blue creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "DividedDamage",
+            "totalDamage": 3
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature white|blue"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "\"Bant is a world imprisoned by polished stone and tyrannical rule. It yearns to strike back against those who restrain it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e38419d9-e321-4642-aad4-99c5489f8fa8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -241,6 +1296,682 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Inkwell Leviathan
+{
+    "name": "Inkwell Leviathan",
+    "manaCost": "{7}{U}{U}",
+    "typeLine": "Artifact Creature — Leviathan",
+    "oracleText": "Trample\nIslandwalk (This creature can't be blocked as long as defending player controls an Island.)\nShroud (This creature can't be the target of spells or abilities.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 11
+    },
+    "keywords": [
+        "TRAMPLE",
+        "ISLANDWALK",
+        "SHROUD"
+    ],
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "RARE",
+        "artist": "Anthony Francisco",
+        "flavorText": "\"Into its maw went the seventh sea, never to be seen again while the world remains.\" —Esper fable",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb380a5a-a3f9-42fb-ac5c-f54afa3c1079.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Jhessian Balmgiver
+{
+    "name": "Jhessian Balmgiver",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Prevent the next 1 damage that would be dealt to any target this turn.\n{T}: Target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "David Palumbo",
+        "flavorText": "\"You have two choices: heed my advice now or need my healing later.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e638e38-15b9-4081-8340-985d4646e3d7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Kranioceros
+{
+    "name": "Kranioceros",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{1}{W}: This creature gets +0/+3 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Steve Argyle",
+        "flavorText": "\"A surly beast, the kranioceros will raise its defenses at the smallest threat. Stay out of sight and downwind, or you'll disrupt its natural migrations.\" —Ebrel, godtoucher mentor",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52aece74-cc1f-4f32-ad1f-00733eb79007.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Matca Rioters
+{
+    "name": "Matca Rioters",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Domain — Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land",
+                "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land",
+                "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Steve Argyle",
+        "flavorText": "When outsiders interrupted the matca championship, things got ugly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b32dcf7d-ac19-45c5-8c3a-1155bf25b216.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Molten Frame
+{
+    "name": "Molten Frame",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Izzy",
+        "flavorText": "The metal filigree in his body glowed red-hot, and his flesh soon followed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58356504-e28e-456c-b1d3-e6232f4d78a6.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Nacatl Outlander
+{
+    "name": "Nacatl Outlander",
+    "manaCost": "{R}{G}",
+    "typeLine": "Creature — Cat Scout",
+    "oracleText": "Protection from blue",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLUE"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Survival in the wilds of Naya left Tiyan well equipped to win the civilized battles of Bant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12b5b694-46c8-4cb0-ab6b-4bc67c04cc7f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Nacatl Savage
+{
+    "name": "Nacatl Savage",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Protection from artifacts",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Artifact"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Paolo Parente",
+        "flavorText": "\"Blades dull and armor dents. Marisi taught us that instinct is the only thing a true warrior needs.\" —Ajani",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad602fba-6a73-4fd0-aff5-802c3be3100e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Obelisk of Alara
+{
+    "name": "Obelisk of Alara",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{W}, {T}: You gain 5 life.\n{1}{U}, {T}: Draw a card, then discard a card.\n{1}{B}, {T}: Target creature gets -2/-2 until end of turn.\n{1}{R}, {T}: This artifact deals 3 damage to target player or planeswalker.\n{1}{G}, {T}: Target creature gets +4/+4 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_5",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "RARE",
+        "artist": "Jeremy Jarvis",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cc12ebe-54d8-4b91-8c68-3cde5690e26a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Paleoloth
+{
+    "name": "Paleoloth",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Whenever another creature you control with power 5 or greater enters, you may return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow>=5 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "RARE",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Gods do not sleep soundly in the earth's embrace.\" —Mayael the Anima",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Parasitic Strix
+{
+    "name": "Parasitic Strix",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, if you control a black permanent, target player loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent black"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Steven Belledin",
+        "flavorText": "After finding no sustenance on the edges of Grixis, it turned to the skies of Bant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a36cd0c3-1955-41b1-9a9c-b30b31a2f094.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Pestilent Kathari
+{
+    "name": "Pestilent Kathari",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Bird Warrior",
+    "oracleText": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n{2}{R}: This creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dba00df7-2c8d-435a-86d1-6bd7b7413585.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -301,6 +2032,65 @@
     ]
 }
 
+// Rakka Mar
+{
+    "name": "Rakka Mar",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Legendary Creature — Human Shaman",
+    "oracleText": "Haste\n{R}, {T}: Create a 3/1 red Elemental creature token with haste.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ],
+                    "keywords": [
+                        "HASTE"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Jason Chan",
+        "flavorText": "\"The finest pawns are those with pawns of their own.\" —Nicol Bolas",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Reliquary Tower
 {
     "name": "Reliquary Tower",
@@ -335,6 +2125,51 @@
         "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5c0c1a5-dce7-4c7d-8a5b-0bf93ba68ace.jpg?1562803667"
     },
     "colorIdentityOverride": []
+}
+
+// Rhox Meditant
+{
+    "name": "Rhox Meditant",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Rhino Monk",
+    "oracleText": "When this creature enters, if you control a green permanent, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent green"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Donato Giancola",
+        "flavorText": "The weight of her conviction balances on the harmony of her soul.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b74f4f8d-2191-4743-aac6-cdcb4a68379c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Rupture Spire
@@ -385,6 +2220,83 @@
     "colorIdentityOverride": []
 }
 
+// Sacellum Archers
+{
+    "name": "Sacellum Archers",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "{R}{W}, {T}: This creature deals 2 damage to target attacking or blocking creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"Our arrows are aimed not at the sacred behemoths but at those who dare to dream of such a trophy.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/160335df-8377-4f72-9d3f-4b1492bd23ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Scarland Thrinax
 {
     "name": "Scarland Thrinax",
@@ -426,6 +2338,348 @@
         "BLACK",
         "RED",
         "GREEN"
+    ]
+}
+
+// Scattershot Archer
+{
+    "name": "Scattershot Archer",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "{T}: This creature deals 1 damage to each creature with flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature kw:flying"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "artist": "Steve Argyle",
+        "flavorText": "To train her elves for war, Mayael would drop a sackful of acorns from the tree canopy. Each archer tried to split as many as possible before the acorns hit the forest floor below.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d74d6cdb-a087-4b3d-bf25-509200ed6d93.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Scepter of Dominance
+{
+    "name": "Scepter of Dominance",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "{W}, {T}: Tap target permanent.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Whether or not you will bow to me is not open to debate. The question is, will I ever let you rise?\" —Fridius, telemin master",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Scepter of Fugue
+{
+    "name": "Scepter of Fugue",
+    "manaCost": "{B}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{B}, {T}: Target player discards a card. Activate only during your turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "One goes to Tidehollow either to forget or to be forgotten. Either way, the scullers will oblige.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Scepter of Insight
+{
+    "name": "Scepter of Insight",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}{U}, {T}: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "RARE",
+        "artist": "Steven Belledin",
+        "flavorText": "\"The road to truth has many branches, and so must the cane with which I walk it.\" —Voln the Elder",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Scornful Aether-Lich
+{
+    "name": "Scornful Aether-Lich",
+    "manaCost": "{3}{U}",
+    "typeLine": "Artifact Creature — Zombie Wizard",
+    "oracleText": "{W}{B}: This creature gains fear and vigilance until end of turn. (Attacking doesn't cause it to tap, and it can't be blocked except by artifact creatures and/or black creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FEAR",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "\"With no flesh, there is no pain, no hesitation, no emotion of any kind. He is crafted perfection.\" —Tezzeret",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75cdb2ff-6e30-4766-9166-9036a0bdb809.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Sedraxis Alchemist
+{
+    "name": "Sedraxis Alchemist",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Wizard",
+    "oracleText": "When this creature enters, if you control a blue permanent, return target nonland permanent to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent"
+                    },
+                    "id": "target"
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent blue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Karl Kopinski",
+        "flavorText": "The problem with a liquid that can dissolve anything is finding something to carry it in.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fbbc5d7-86d0-4e09-b37c-e40eb88f3f33.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -488,6 +2742,456 @@
     ]
 }
 
+// Sphinx Summoner
+{
+    "name": "Sphinx Summoner",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Artifact Creature — Sphinx",
+    "oracleText": "Flying\nWhen this creature enters, you may search your library for an artifact creature card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "artifact creature"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Jaime Jones",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/006b5000-2a8f-4020-9dbf-7170da13b54e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Sylvan Bounty
+{
+    "name": "Sylvan Bounty",
+    "manaCost": "{5}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target player gains 8 life.\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{G}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 8
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Chris Rahn",
+        "flavorText": "Some who scouted new lands chose to stay.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f717c573-e448-400e-a228-d438491f1754.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thornling
+{
+    "name": "Thornling",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Elemental Shapeshifter",
+    "oracleText": "{G}: This creature gains haste until end of turn.\n{G}: This creature gains trample until end of turn.\n{G}: This creature gains indestructible until end of turn.\n{1}: This creature gets +1/-1 until end of turn.\n{1}: This creature gets -1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_5",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "MYTHIC",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Toxic Iguanar
+{
+    "name": "Toxic Iguanar",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "This creature has deathtouch as long as you control a green permanent. (Any amount of damage a creature with deathtouch deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent green"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Brandon Kitkouski",
+        "flavorText": "There are no \"weak\" creatures on Jund. Even the smallest can strike a deadly blow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28fd2dce-b91f-441f-a3ea-af87cc925713.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Traumatic Visions
+{
+    "name": "Traumatic Visions",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{U}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Cyril Van Der Haegen",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1e8b03d-9265-4699-b626-5efa73292d43.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Tukatongue Thallid
+{
+    "name": "Tukatongue Thallid",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Fungus",
+    "oracleText": "When this creature dies, create a 1/1 green Saproling creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Vance Kovacs",
+        "flavorText": "Jund's thallids tried to disguise their deliciousness by covering themselves in spines harvested from the tukatongue tree.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a84666a8-4ce5-46e7-9a39-f64a392515e7.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vagrant Plowbeasts
+{
+    "name": "Vagrant Plowbeasts",
+    "manaCost": "{5}{G}{W}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{1}: Regenerate target creature with power 5 or greater.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Plowbeasts of Naya escaped their harnesses in droves, content to snack on the conveniently cultivated fields of Eos and Valeron.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/546b0a74-ebef-4596-b730-2190e20b2e66.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Valeron Outlander
+{
+    "name": "Valeron Outlander",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Protection from black",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Matt Stewart",
+        "flavorText": "After years of honing her philosophy in debate with stubborn rhoxes, Niella was ready to convert any heathen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e73cd46-0dec-441b-bb91-ec6defb3355e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Valiant Guard
 {
     "name": "Valiant Guard",
@@ -505,6 +3209,152 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Vedalken Outlander
+{
+    "name": "Vedalken Outlander",
+    "manaCost": "{W}{U}",
+    "typeLine": "Artifact Creature — Vedalken Scout",
+    "oracleText": "Protection from red",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Izzy",
+        "flavorText": "The Seekers of Carmot searched across the unknown lands for the mystical red stone that could reforge Esper in ethereal perfection.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d75a7314-39f2-4e32-a5b0-ac1761b6d238.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Viashino Slaughtermaster
+{
+    "name": "Viashino Slaughtermaster",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "Double strike\n{B}{G}: This creature gets +1/+1 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"I'll fight two at once, and then lick their guts from my blades.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e60c30ee-616b-4b7d-97f9-cab1d6218e3a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// View from Above
+{
+    "name": "View from Above",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains flying until end of turn. If you control a white permanent, return View from Above to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "permanent white"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Howard Lyon",
+        "flavorText": "\"This air feels so heavy and thick. There are no winds to speak of. I fear the knowledge that comes from a place like this.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dc73034-4886-4855-b6de-392fa053fe9e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -563,5 +3413,81 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Wild Leotau
+{
+    "name": "Wild Leotau",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "At the beginning of your upkeep, sacrifice this creature unless you pay {G}.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{G}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, sacrifice this creature unless you pay {G}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Michael Komarck",
+        "flavorText": "\"Leotau that were born wild make the best mounts. It's like riding a thunderstorm.\" —Rafiq of the Many",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a47bc387-ac1a-42b4-9427-fc944094b3a1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zombie Outlander
+{
+    "name": "Zombie Outlander",
+    "manaCost": "{U}{B}",
+    "typeLine": "Creature — Zombie Scout",
+    "oracleText": "Protection from green",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "GREEN"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Nils Hamm",
+        "flavorText": "The ripe smell of life drifted into Grixis. The dead caught the scent and with reckless hunger followed it back into Jund.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f27c2690-5121-452b-b82a-72acb8be6878.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
     ]
 }


### PR DESCRIPTION
Sweeps Conflux's ⚡ Assay-ready bucket — every card Argentum Assay reads whole that the set had not authored yet.

## The four-way split

Computed with `just assay-ready CON --names --tail`:

| Bucket | Count | Work |
|---|---|---|
| `original` | 53 | authored here — Conflux is the earliest real printing for all of them |
| `elsewhere` | 0 | — |
| `row-only` | 0 | — |
| `basic` | 0 | Conflux falls back to Portal for basics (`basicLandsFallback`) |
| `unscaffolded` | 0 | — |

Every one of the 53 was verified against Scryfall with `missing-reprints.expected_canonical`: the
canonical for each belongs in CON, so nothing had to be authored in an earlier set. No set-object
edit was needed — `ConfluxSet` discovers both `cards` and `printings` through `CardDiscovery`.

## The tail

Authoring the 53 canonicals is what lets `check-card-printing` see that their *other* scaffolded
printings owe rows. `scripts/generate-reprints.py --cards-from <the 53>` emitted **8 rows across 5
sets** (printing caches refreshed first, so nothing was silently skipped on a stale TTL):

- PC2 3 — Fiery Fall, Gluttonous Slime, Tukatongue Thallid
- C16 2 — Ethersworn Adjudicator, Sphinx Summoner
- DDF 1 — Faerie Mechanist
- M10 1 — Ignite Disorder
- OGW 1 — Bone Saw

## Gates

- `just build` — **green** (the first run failed only on the `CON_.json` golden; `just rebless-cards`
  moved that one file and nothing else).
- `just assay-differential --set CON_` — **62 compared / 62 confirmed / 0 divergent**, 100.0%.
  Corpus-wide the run reads 6483 compared / 6429 confirmed / **54 divergent**, and none of the 54 is
  a Conflux card — the whole delta of this PR is confirmed.
- `just check-card-printing "<Card>"` — run over all 53; every one reports *canonical is in the
  card's earliest real printing and all scaffolded reprints have rows*.
- `just assay-ready CON` on the branch — **0 Assay-ready** (from 53), not inferred. The 75 cards
  Conflux still misses are all `LINE_DECLINED`: grammar work, not authoring work.

## Notes

- No SDK change, so `docs/card-sdk-language-reference.md` needed no edit — the diff is 53 card
  definitions, 8 `Printing(...)` rows and the CON golden, nothing else.
- The 54 corpus-wide differential divergences are pre-existing and live in other sets; this branch
  neither adds to nor fixes them. A clean pre-change baseline was not takeable here — the sweep was
  resumed from an already-dirty worktree — so the CON-scoped run is the A/B, and it covers 100% of
  the cards this PR adds.
- Conflux's tail is a grammar problem, not an authoring one: all 75 remaining missing cards decline
  at the line level, which is `add-feature`/Assay-grammar territory rather than another sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdyAaDr5x1XMm6CBcRUzhy