### PR TITLE
Add three Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AshlingThePilgrim.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AshlingThePilgrim.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.IncrementAbilityResolutionCountEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ashling the Pilgrim — Lorwyn #149
+ * {1}{R} · Legendary Creature — Elemental Shaman · 1/1
+ *
+ * {1}{R}: Put a +1/+1 counter on Ashling. If this is the third time this ability has resolved
+ * this turn, remove all +1/+1 counters from Ashling, and it deals that much damage to each
+ * creature and each player.
+ *
+ * The per-turn tally is Lorwyn's own [IncrementAbilityResolutionCountEffect] /
+ * [Conditions.SourceAbilityResolvedNTimes] pair, shared with [SoulbrightFlamekin] and
+ * [InnerFlameIgniter]. The equality (not a threshold) is what makes the ruling "you won't get
+ * the bonus the fourth, fifth, sixth …" fall out for free, and counting *resolutions* rather
+ * than activations is the executor's own contract — a countered activation never reaches it.
+ *
+ * **"That much" has to be read before the counters are gone**, so the count is captured with
+ * [Effects.StoreNumber] and the damage reads it back through
+ * [DynamicAmount.VariableReference] (Lightning Coils' shape). Reading
+ * `countersOnSelf` directly in the damage step would evaluate *after* the removal and deal 0.
+ * The order on the card is load-bearing for a second reason: Ashling is a 1/1 again by the time
+ * the damage lands, so three counters kill it — the ruling's "it's likely that the damage will
+ * kill Ashling".
+ *
+ * The counter is put on *first* and the tally bumped after it, so the third activation's counter
+ * is included in "that much": three activations mean three counters and three damage.
+ *
+ * Damage to "each creature and each player" is the Earthquake shape — a
+ * [Effects.ForEachInGroup] over [GroupFilter.AllCreatures] (Ashling itself included) followed by
+ * [Effects.ForEachPlayer] over [Player.Each]. The stored number survives the player loop: only
+ * stored *collections* are reset per iteration, not stored numbers.
+ */
+val AshlingThePilgrim = card("Ashling the Pilgrim") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Elemental Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{R}: Put a +1/+1 counter on Ashling. If this is the third time this ability " +
+        "has resolved this turn, remove all +1/+1 counters from Ashling, and it deals that much " +
+        "damage to each creature and each player."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(IncrementAbilityResolutionCountEffect)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(3),
+                    effect = Effects.Composite(
+                        listOf(
+                            Effects.StoreNumber(
+                                "ashlingRemovedCounters",
+                                DynamicAmounts.countersOnSelf(
+                                    CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE)
+                                ),
+                            ),
+                            Effects.RemoveAllCountersOfType(
+                                Counters.PLUS_ONE_PLUS_ONE,
+                                EffectTarget.Self,
+                            ),
+                            Effects.ForEachInGroup(
+                                GroupFilter.AllCreatures,
+                                DealDamageEffect(
+                                    DynamicAmount.VariableReference("ashlingRemovedCounters"),
+                                    EffectTarget.Self,
+                                ),
+                            ),
+                            Effects.ForEachPlayer(
+                                Player.Each,
+                                listOf(
+                                    Effects.DealDamage(
+                                        DynamicAmount.VariableReference("ashlingRemovedCounters"),
+                                        EffectTarget.Controller,
+                                    )
+                                ),
+                            ),
+                        )
+                    )
+                )
+            )
+        description = "Put a +1/+1 counter on Ashling. If this is the third time this ability has " +
+            "resolved this turn, remove all +1/+1 counters from Ashling, and it deals that much " +
+            "damage to each creature and each player."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "149"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg?1783942881"
+        ruling("2023-07-28", "\"That much damage\" refers to the number of +1/+1 counters removed from Ashling the Pilgrim. Since the counters are removed, it's likely that the damage will kill Ashling.")
+        ruling("2023-07-28", "Ashling the Pilgrim's ability counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total.")
+        ruling("2023-07-28", "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered.")
+        ruling("2023-07-28", "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LammastideWeave.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LammastideWeave.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lammastide Weave — Lorwyn #226
+ * {1}{G} · Instant
+ *
+ * Choose a card name, then target player mills a card. If a card with the chosen name was milled
+ * this way, you gain life equal to its mana value.
+ * Draw a card.
+ *
+ * The Aberrant Researcher / Loafing Giant idiom: `Patterns.Library.mill(1, …)` publishes the
+ * milled card to the standard `"milled"` collection, and [Conditions.CollectionContainsMatch]
+ * reads it back — here against [GameObjectFilter.namedFromVariable], the name the controller just
+ * chose with [Effects.ChooseCardName]. Because the check is against the *gathered card* rather
+ * than against the graveyard, a replacement effect that sends the milled card elsewhere still
+ * pays off, which is the same reason that idiom was chosen there.
+ *
+ * The life gained is [DynamicAmount.ManaValueSumOfCollection] over that one-card collection.
+ * A sum is exact here precisely because the mill count is one: "its mana value" has a single
+ * referent, and an empty library mills nothing, matches nothing, and gains nothing.
+ *
+ * The name is chosen *before* the mill (printed "choose a card name, **then**"), so the chooser
+ * cannot see the card first. The draw is a separate sentence and happens either way.
+ */
+val LammastideWeave = card("Lammastide Weave") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose a card name, then target player mills a card. If a card with the chosen " +
+        "name was milled this way, you gain life equal to its mana value.\n" +
+        "Draw a card."
+
+    spell {
+        target("target player", Targets.Player)
+        effect = Effects.Composite(
+            listOf(
+                Effects.ChooseCardName(
+                    storeAs = "weaveChosenName",
+                    prompt = "Choose a card name",
+                ),
+                Patterns.Library.mill(1, EffectTarget.ContextTarget(0)),
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch(
+                        "milled",
+                        GameObjectFilter.Any.namedFromVariable("weaveChosenName"),
+                    ),
+                    effect = Effects.GainLife(DynamicAmount.ManaValueSumOfCollection("milled")),
+                ),
+                Effects.DrawCards(1),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Howard Lyon"
+        flavorText = "\"A ribbon torn will ward away dark dreams.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg?1783942861"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Shapesharer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/Shapesharer.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Shapesharer — Lorwyn #85
+ * {1}{U} · Creature — Shapeshifter · 1/1
+ *
+ * Changeling (This card is every creature type.)
+ * {2}{U}: Target Shapeshifter becomes a copy of target creature until your next turn.
+ *
+ * Two target requirements in printed order: the Shapeshifter that changes (index 0) and the
+ * creature it copies (index 1). [Effects.EachPermanentBecomesCopyOfTarget] carries both — the
+ * `affected` parameter names the permanent that becomes the copy, `target` the copy source —
+ * which is Fleeting Reflection's shape with a longer duration.
+ *
+ * **"Target Shapeshifter" is a bare tribal noun, so it reads *permanent*, not creature.** Lorwyn
+ * prints no noncreature Shapeshifter permanent, but the reading is the one the rules give and the
+ * one the corpus standardised on; a `Creature.withSubtype` spelling would silently narrow it the
+ * day a Kindred artifact with changeling shows up. Changeling itself makes every changeling card a
+ * Shapeshifter, so the ability can retarget any of them.
+ *
+ * [Duration.UntilYourNextTurn] is the printed "until your next turn" exactly: the copy is reverted
+ * after the untap step of this ability's controller's next turn, which is the ruling's "doesn't
+ * wear off until just before your next untap step (even if an effect will cause that untap step to
+ * be skipped)".
+ *
+ * The rest of the rulings are Rule 707 falling out of the shared copy machinery rather than
+ * anything this card spells: copiable values only (so counters, tapped state, attachments and
+ * pump effects on the source are not copied, and effects already applied to the *affected*
+ * Shapeshifter keep applying on top), copies-of-copies resolve to what the source is copying, and
+ * a Shapesharer that copies something else loses changeling and this very ability along with the
+ * rest of its printed card. Either target becoming illegal makes the whole ability do nothing.
+ */
+val Shapesharer = card("Shapesharer") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "{2}{U}: Target Shapeshifter becomes a copy of target creature until your next turn."
+
+    keywords(Keyword.CHANGELING)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        target(
+            "target Shapeshifter",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Permanent.withSubtype("Shapeshifter"))
+            )
+        )
+        target("target creature", Targets.Creature)
+        effect = Effects.EachPermanentBecomesCopyOfTarget(
+            target = EffectTarget.ContextTarget(1),
+            duration = Duration.UntilYourNextTurn,
+            affected = EffectTarget.ContextTarget(0),
+        )
+        description = "Target Shapeshifter becomes a copy of target creature until your next turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Alan Pollack"
+        flavorText = "One good mimic deserves another."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg?1783942897"
+        ruling("2017-09-29", "If either target becomes an illegal target, the ability will resolve but have no effect.")
+        ruling("2007-10-01", "If the targeted Shapeshifter copies a creature that's copying a creature, it will become whatever the chosen creature is copying.")
+        ruling("2007-10-01", "The copy effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped).")
+        ruling("2007-10-01", "If Shapesharer itself becomes a copy of another creature, it loses both changeling and its activated ability (unless it's copying another creature with changeling and/or another Shapesharer, of course).")
+        ruling("2007-10-01", "The targeted Shapeshifter copies the printed values of the targeted creature, plus any copy effects that have been applied to it. It won't copy counters on that creature. It won't copy effects that have changed the creature's power, toughness, types, color, and so on.")
+        ruling("2007-10-01", "If the targeted Shapeshifter becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face down and thus can't be turned face up.")
+        ruling("2007-10-01", "Effects that have already applied to the targeted Shapeshifter will continue to apply to it. For example, if Giant Growth had given it +3/+3 earlier in the turn, then this ability makes it a copy of Grizzly Bears, it will be a 5/5 Grizzly Bears.")
+        ruling("2007-10-01", "This ability can cause a creature to become a copy of itself. This will usually have no visible effect.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingThePilgrimScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingThePilgrimScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AshlingThePilgrim
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ashling the Pilgrim (LRW #149) — "{1}{R}: Put a +1/+1 counter on Ashling. If this is the third
+ * time this ability has resolved this turn, remove all +1/+1 counters from Ashling, and it deals
+ * that much damage to each creature and each player."
+ *
+ * Two claims that a card built from existing primitives can still get wrong, and neither is
+ * visible in the snapshot golden:
+ *
+ *  - **"That much" is the count *before* the removal.** The damage reads a
+ *    `StoreNumber` captured ahead of `RemoveAllCountersOfType`; wiring it to read the counters
+ *    directly would evaluate after the removal and deal 0 to everything. Three damage vs. zero is
+ *    the whole assertion.
+ *  - **The stored number has to survive the per-player loop.** `ForEachPlayerEffect` resets stored
+ *    *collections* per iteration; if it reset stored *numbers* too, creatures would take 3 and
+ *    players 0. Asserting both halves of "each creature and each player" is what separates them.
+ *
+ * The first test also pins the equality on the *second* resolution: a `>= 3` mis-wiring reads
+ * identically on the card and only shows up there.
+ */
+class AshlingThePilgrimScenarioTest : FunSpec({
+
+    val flareAbility = AshlingThePilgrim.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(AshlingThePilgrim))
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Priority does not reliably revert to the activator after a resolution; normalise. */
+    fun handPriorityTo(d: GameTestDriver, player: EntityId) {
+        d.priorityPlayer?.takeIf { it != player }?.let { d.passPriority(it) }
+    }
+
+    fun flare(d: GameTestDriver, me: EntityId, ashling: EntityId) {
+        handPriorityTo(d, me)
+        d.submit(ActivateAbility(me, ashling, flareAbility)).isSuccess shouldBe true
+        d.bothPass()
+        handPriorityTo(d, me)
+    }
+
+    test("counters accumulate, and the third resolution converts all of them into damage") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+        val ashling = d.putCreatureOnBattlefield(me, "Ashling the Pilgrim")
+        val courser = d.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val forceOfNature = d.putCreatureOnBattlefield(opponent, "Force of Nature")
+        d.giveMana(me, Color.RED, 12)
+
+        flare(d, me, ashling)
+        withClue("first resolution: a counter, nothing else") {
+            d.state.projectedState.getPower(ashling) shouldBe 2
+            d.getLifeTotal(me) shouldBe 20
+            d.getLifeTotal(opponent) shouldBe 20
+        }
+
+        flare(d, me, ashling)
+        withClue("second resolution: the payoff is an equality, so still no damage") {
+            d.state.projectedState.getPower(ashling) shouldBe 3
+            d.state.projectedState.getToughness(ashling) shouldBe 3
+            d.getLifeTotal(me) shouldBe 20
+            d.getLifeTotal(opponent) shouldBe 20
+            d.getGraveyardCardNames(opponent) shouldNotContain "Centaur Courser"
+        }
+
+        flare(d, me, ashling)
+        withClue("third resolution: three counters removed, three damage everywhere") {
+            d.getLifeTotal(me) shouldBe 17
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+        withClue("the 3/3 dies to it and the 5/5 does not — the damage really is 3, not lethal-to-all") {
+            d.getGraveyardCardNames(opponent) shouldContain "Centaur Courser"
+            d.state.projectedState.getToughness(forceOfNature) shouldBe 5
+            d.getGraveyardCardNames(opponent) shouldNotContain "Force of Nature"
+        }
+        withClue("Ashling is a 1/1 again when the damage lands, so it kills itself (2023-07-28 ruling)") {
+            d.getGraveyardCardNames(me) shouldContain "Ashling the Pilgrim"
+        }
+    }
+
+    test("the tally is per-entity, so a second Ashling starts from zero") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+        val ashling = d.putCreatureOnBattlefield(me, "Ashling the Pilgrim")
+        d.giveMana(me, Color.RED, 12)
+
+        repeat(3) { flare(d, me, ashling) }
+        d.getLifeTotal(opponent) shouldBe 17
+        d.getGraveyardCardNames(me) shouldContain "Ashling the Pilgrim"
+
+        // "Abilities from other creatures with the same name don't count towards the total."
+        val second = d.putCreatureOnBattlefield(me, "Ashling the Pilgrim")
+        flare(d, me, second)
+        withClue("a fresh Ashling is on its own first resolution — one counter, no damage") {
+            d.state.projectedState.getPower(second) shouldBe 2
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LammastideWeaveScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LammastideWeaveScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.LammastideWeave
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lammastide Weave (LRW #226) — "Choose a card name, then target player mills a card. If a card
+ * with the chosen name was milled this way, you gain life equal to its mana value. Draw a card."
+ *
+ * The gamble is the whole card, so the test runs it both ways off the *same* board: the same
+ * milled card, once with the name guessed right and once with it guessed wrong. That pairing is
+ * what separates a working name check from one that fails open (always pays) or fails closed
+ * (never pays) — either mis-wiring is invisible against a single run.
+ *
+ * "Equal to its mana value" is read off the milled card, not off Lammastide Weave, so the milled
+ * card deliberately has a mana value ({3}{G}{G} = 5) that no other number on the board could be
+ * confused for.
+ *
+ * The draw is a separate sentence and happens either way, which is the third assertion in both
+ * directions. It is asserted as "the hand is the size it was before casting": one card left for
+ * the spell, one came back from the draw.
+ */
+class LammastideWeaveScenarioTest : FunSpec({
+
+    /** The board, the caster, and the caster's hand size with the Weave still in it. */
+    data class Run(val driver: GameTestDriver, val caster: EntityId, val handBeforeCast: Int)
+
+    /** Cast the Weave at the opponent over a stacked library, naming [nameToGuess]. */
+    fun runWeave(nameToGuess: String, milledCard: String = "Force of Nature"): Run {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(LammastideWeave))
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+        d.putCardOnTopOfLibrary(opponent, milledCard)
+        val weave = d.putCardInHand(me, "Lammastide Weave")
+        d.giveMana(me, Color.GREEN, 2)
+        val handBeforeCast = d.getHandSize(me)
+
+        d.castSpell(me, weave, listOf(opponent)).isSuccess shouldBe true
+        d.bothPass()
+
+        val decision = d.pendingDecision
+        withClue("resolving the Weave asks for a card name") {
+            (decision is ChooseOptionDecision) shouldBe true
+        }
+        decision as ChooseOptionDecision
+        val index = decision.options.indexOf(nameToGuess)
+        withClue("\"$nameToGuess\" should be offered among the nameable cards") {
+            (index >= 0) shouldBe true
+        }
+        d.submitDecision(me, OptionChosenResponse(decision.id, index))
+
+        // Settle whatever is left of the resolution without over-passing into another step.
+        var guard = 0
+        while (guard++ < 8 && (d.state.stack.isNotEmpty() || d.pendingDecision != null)) {
+            if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass()
+        }
+        return Run(d, me, handBeforeCast)
+    }
+
+    test("guessing the milled card's name gains life equal to its mana value") {
+        val (d, me, handBeforeCast) = runWeave(nameToGuess = "Force of Nature")
+        val opponent = d.getOpponent(me)
+
+        withClue("the target player milled the card") {
+            d.getGraveyardCardNames(opponent) shouldContain "Force of Nature"
+        }
+        withClue("{3}{G}{G} is mana value 5, and the life goes to the Weave's controller") {
+            d.getLifeTotal(me) shouldBe 25
+            d.getLifeTotal(opponent) shouldBe 20
+        }
+        withClue("the draw is a separate sentence — one card out, one card in") {
+            d.getHandSize(me) shouldBe handBeforeCast
+        }
+    }
+
+    test("guessing wrong mills and draws all the same, but gains nothing") {
+        val (d, me, handBeforeCast) = runWeave(nameToGuess = "Centaur Courser")
+        val opponent = d.getOpponent(me)
+
+        withClue("the mill is unconditional") {
+            d.getGraveyardCardNames(opponent) shouldContain "Force of Nature"
+        }
+        withClue("no card with the chosen name was milled, so no life") {
+            d.getLifeTotal(me) shouldBe 20
+        }
+        withClue("and the draw still happens") {
+            d.getHandSize(me) shouldBe handBeforeCast
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShapesharerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShapesharerScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Shapesharer (LRW #85) — "{2}{U}: Target Shapeshifter becomes a copy of target creature until
+ * your next turn."
+ *
+ * The card is pure composition over `EachPermanentBecomesCopyOfTarget`, so what is worth proving is
+ * the two things composition can silently get wrong:
+ *
+ *  - **Which target is which.** `affected` (index 0, the Shapeshifter) and `target` (index 1, the
+ *    copy source) are both `ContextTarget`s of the same shape; swapping them still compiles, still
+ *    reads right on the card, and turns "the Shapeshifter becomes a Giant" into "the Giant becomes
+ *    a Shapeshifter". The test aims the two at *different* permanents controlled by *different*
+ *    players, which is the only board where the swap is visible.
+ *  - **The duration.** "Until your next turn" is a strictly longer window than the end-of-turn
+ *    cleanup that most copy effects use, so the copy has to survive the whole of the opponent's
+ *    turn and wear off only after the untap step of the controller's next one.
+ */
+class ShapesharerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Shapesharer") {
+
+            // The duration case runs three turns, so both libraries need cards — a draw from an
+            // empty library ends the game (CR 704.5b) and silently stalls the turn advance.
+            fun board(): ScenarioTestBase.TestGame {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Shapesharer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Fire-Belly Changeling", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) {
+                    builder = builder.withCardInLibrary(1, "Island").withCardInLibrary(2, "Island")
+                }
+                return builder.build()
+            }
+
+            fun ScenarioTestBase.TestGame.reshape(shapeshifter: EntityId, source: EntityId) {
+                val abilityId = cardRegistry.getCard("Shapesharer")!!.script.activatedAbilities[0].id
+                val result = execute(
+                    ActivateAbility(
+                        playerId = player1Id,
+                        sourceId = findPermanent("Shapesharer")!!,
+                        abilityId = abilityId,
+                        targets = listOf(
+                            entityIdToChosenTarget(state, shapeshifter),
+                            entityIdToChosenTarget(state, source),
+                        )
+                    )
+                )
+                withClue("activating Shapesharer should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+            }
+
+            /**
+             * Advance to the next player's upkeep. Routed through the end step on purpose:
+             * `passUntilPhase` returns immediately when the game is already at the requested
+             * phase/step, so two upkeep hops in a row would silently be a single hop.
+             */
+            fun ScenarioTestBase.TestGame.advanceToNextUpkeep() {
+                passUntilPhase(Phase.ENDING, Step.END)
+                passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            }
+
+            test("the targeted Shapeshifter becomes the other creature, and the copy source is untouched") {
+                val game = board()
+                val changeling = game.findPermanent("Fire-Belly Changeling")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.reshape(shapeshifter = changeling, source = giant)
+
+                withClue("index 0 is the Shapeshifter that changes") {
+                    game.state.getEntity(changeling)!!.get<CardComponent>()!!.name shouldBe "Hill Giant"
+                    game.state.projectedState.getPower(changeling) shouldBe 3
+                    game.state.projectedState.getToughness(changeling) shouldBe 3
+                }
+                withClue("index 1 is only the copy source — the opponent's Giant is unchanged") {
+                    game.state.getEntity(giant)!!.get<CardComponent>()!!.name shouldBe "Hill Giant"
+                }
+                withClue("Shapesharer itself was not the affected permanent") {
+                    val shapesharer = game.findPermanent("Shapesharer")!!
+                    game.state.getEntity(shapesharer)!!.get<CardComponent>()!!.name shouldBe "Shapesharer"
+                }
+            }
+
+            test("the copy survives the opponent's whole turn and wears off on your next one") {
+                val game = board()
+                val changeling = game.findPermanent("Fire-Belly Changeling")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.reshape(shapeshifter = changeling, source = giant)
+
+                game.advanceToNextUpkeep()
+                withClue("still a Hill Giant during the opponent's turn — this is not end-of-turn") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                    game.state.getEntity(changeling)!!.get<CardComponent>()!!.name shouldBe "Hill Giant"
+                }
+
+                game.advanceToNextUpkeep()
+                withClue("reverted after the untap step of the controller's next turn") {
+                    game.state.activePlayerId shouldBe game.player1Id
+                    game.state.getEntity(changeling)!!
+                        .get<CardComponent>()!!.name shouldBe "Fire-Belly Changeling"
+                    game.state.projectedState.getPower(changeling) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -7677,6 +7677,108 @@
     ]
 }
 
+// Lammastide Weave
+{
+    "name": "Lammastide Weave",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose a card name, then target player mills a card. If a card with the chosen name was milled this way, you gain life equal to its mana value.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ChooseOption",
+                    "optionType": "CARD_NAME",
+                    "storeAs": "weaveChosenName",
+                    "prompt": "Choose a card name"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CollectionContainsMatch",
+                            "collection": "milled",
+                            "filter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "NameEqualsChosen",
+                                        "variableName": "weaveChosenName"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "ManaValueSumOfCollection",
+                            "collectionName": "milled"
+                        }
+                    }
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "UNCOMMON",
+        "artist": "Howard Lyon",
+        "flavorText": "\"A ribbon torn will ward away dark dreams.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/667fd7ab-de75-48e7-8d4b-a96130ae4666.jpg?1783942861"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Leaf Gilder
 {
     "name": "Leaf Gilder",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -355,6 +355,139 @@
     ]
 }
 
+// Ashling the Pilgrim
+{
+    "name": "Ashling the Pilgrim",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Elemental Shaman",
+    "oracleText": "{1}{R}: Put a +1/+1 counter on Ashling. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling, and it deals that much damage to each creature and each player.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 3
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "StoreNumber",
+                                        "name": "ashlingRemovedCounters",
+                                        "amount": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "+1/+1"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "RemoveAllCountersOfType",
+                                        "counterType": "+1/+1",
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "VariableReference",
+                                                "variableName": "ashlingRemovedCounters"
+                                            },
+                                            "target": "Self"
+                                        }
+                                    },
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Players",
+                                            "players": "Each"
+                                        },
+                                        "body": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "VariableReference",
+                                                "variableName": "ashlingRemovedCounters"
+                                            },
+                                            "target": "Controller"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Put a +1/+1 counter on Ashling. If this is the third time this ability has resolved this turn, remove all +1/+1 counters from Ashling, and it deals that much damage to each creature and each player."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63056eb9-4257-4530-8ff4-6909a2cedf47.jpg?1783942881",
+        "rulings": [
+            {
+                "date": "2023-07-28",
+                "text": "\"That much damage\" refers to the number of +1/+1 counters removed from Ashling the Pilgrim. Since the counters are removed, it's likely that the damage will kill Ashling."
+            },
+            {
+                "date": "2023-07-28",
+                "text": "Ashling the Pilgrim's ability counts resolutions, not activations. Any such abilities that are still on the stack won't count toward the total."
+            },
+            {
+                "date": "2023-07-28",
+                "text": "When the ability resolves, it counts the number of times that same ability from that this creature has already resolved that turn. It doesn't matter who controlled the creature or the previous abilities when they resolved. A copy of this ability (created by Rings of Brighthearth, for example) will count toward the total. Abilities from other creatures with the same name don't count towards the total. Neither does an ability that's been countered."
+            },
+            {
+                "date": "2023-07-28",
+                "text": "You get the bonus only the third time the ability resolves. You won't get the bonus the fourth, fifth, sixth, or any subsequent times."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Auntie's Hovel
 {
     "name": "Auntie's Hovel",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -10707,6 +10707,108 @@
     ]
 }
 
+// Shapesharer
+{
+    "name": "Shapesharer",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\n{2}{U}: Target Shapeshifter becomes a copy of target creature until your next turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "EachPermanentBecomesCopyOfTarget",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 1
+                    },
+                    "duration": "UntilYourNextTurn",
+                    "affected": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Shapeshifter"
+                        },
+                        "id": "target Shapeshifter"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Target Shapeshifter becomes a copy of target creature until your next turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Alan Pollack",
+        "flavorText": "One good mimic deserves another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg?1783942897",
+        "rulings": [
+            {
+                "date": "2017-09-29",
+                "text": "If either target becomes an illegal target, the ability will resolve but have no effect."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If the targeted Shapeshifter copies a creature that's copying a creature, it will become whatever the chosen creature is copying."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The copy effect doesn't wear off until just before your next untap step (even if an effect will cause that untap step to be skipped)."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If Shapesharer itself becomes a copy of another creature, it loses both changeling and its activated ability (unless it's copying another creature with changeling and/or another Shapesharer, of course)."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The targeted Shapeshifter copies the printed values of the targeted creature, plus any copy effects that have been applied to it. It won't copy counters on that creature. It won't copy effects that have changed the creature's power, toughness, types, color, and so on."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If the targeted Shapeshifter becomes a copy of a face-down creature, it will become a 2/2 creature with no name, creature type, abilities, mana cost, or color. It will not become face down and thus can't be turned face up."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Effects that have already applied to the targeted Shapeshifter will continue to apply to it. For example, if Giant Growth had given it +3/+3 earlier in the turn, then this ability makes it a copy of Grizzly Bears, it will be a 5/5 Grizzly Bears."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "This ability can cause a creature to become a copy of itself. This will usually have no visible effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shields of Velis Vel
 {
     "name": "Shields of Velis Vel",


### PR DESCRIPTION
Three more Lorwyn cards, all pure composition over existing primitives. Lorwyn goes 222/286 → 225/286.

- **Ashling the Pilgrim** — `{1}{R}`: a `+1/+1` counter, and on the third resolution this turn, remove them all and deal that much to each creature and each player. Reuses the `IncrementAbilityResolutionCount` / `SourceAbilityResolvedNTimes` pair that Soulbright Flamekin and Inner-Flame Igniter already share; "that much" is captured with `StoreNumber` *before* `RemoveAllCountersOfType` and read back through `VariableReference` (Lightning Coils' shape), because reading the counters in the damage step would evaluate after the removal and deal 0. Mass damage is Earthquake's `ForEachInGroup` + `ForEachPlayer`.
- **Shapesharer** — `{2}{U}`: target Shapeshifter becomes a copy of target creature until your next turn. `EachPermanentBecomesCopyOfTarget` with Fleeting Reflection's `affected` / `target` pair and `Duration.UntilYourNextTurn`. "Target Shapeshifter" is a bare tribal noun, so the filter is `Permanent.withSubtype`, not `Creature.withSubtype`.
- **Lammastide Weave** — `{1}{G}` instant: name a card, target player mills one, gain life equal to its mana value if it matched, draw. `ChooseCardName` + `Patterns.Library.mill` + `CollectionContainsMatch` over `namedFromVariable` (the Aberrant Researcher / Loafing Giant idiom), with `ManaValueSumOfCollection` for the life — exact because the mill count is one.

No SDK changes, so the language reference is unchanged.

### Dropped from the batch

**Wild Ricochet** was picked and then dropped: "you may choose new targets for target instant or sorcery spell" needs an *all*-targets retarget aimed at a `ContextTarget`. `ChangeTriggeringObjectTargetsEffect` does exactly that but only off `triggeringEntityId`, and `ChangeTargetEffect` only handles spells with a *single* target — using it would silently no-op on every multi-target spell. That is new SDK vocabulary, so it belongs in its own `add-feature` PR rather than an approximation here.

### Tests

A scenario test per card, each aimed at the axis where a plausible mis-wiring reads identically on the card:

- `AshlingThePilgrimScenarioTest` — the count is taken before the removal (3 damage, not 0), the second resolution pays nothing (equality, not threshold), and the stored number survives the per-player loop (players take damage too). Plus a second Ashling starting its own tally.
- `ShapesharerScenarioTest` — the two targets are aimed at permanents controlled by different players, the one board where swapping `affected` and `target` is visible; and three turns of advancement separate "until your next turn" from end of turn.
- `LammastideWeaveScenarioTest` — the same board run twice, name guessed right and wrong, which is what separates a working name check from one that fails open or closed.

### Verification

- `just build` green.
- `just check-card-printing` ok for all three (each card's earliest real printing is LRW; no scaffolded reprint sets to add rows for).
- `just assay-differential --set LRW` — 10 divergences, all pre-existing (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). None of the three new cards diverge.
- Snapshot golden re-blessed; only these three cards move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyZ7RDDRbmsTQAop7F4gTC