### PR TITLE
Add three Ravnica cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1012,6 +1012,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   prevention clause are ignored (CR 615.6). The static, permanent-hosted equivalent is the
   `DamageCantBePrevented` replacement effect (Sunspine Lynx); use this effect when a spell/ability needs
   the shutoff without a permanent on the battlefield (Fear, Fire, Foes!).
+- `DamageCantBePrevented(appliesTo = EventPattern.DamageEvent(...))` — the static, permanent-hosted
+  replacement, **scoped by its `appliesTo` pattern**. Left at the default (`source` and `recipient` both
+  `Any`) it is the printed global "Damage can't be prevented" (Sunspine Lynx, Leyline of Punishment).
+  Narrow the pattern for a card that names one end of the damage instance: **Excruciator**'s "damage that
+  would be dealt by this creature can't be prevented" is
+  `DamageCantBePrevented(EventPattern.DamageEvent(source = SourceFilter.Self))`, which leaves every other
+  source's damage preventable. `DamageUtils.isDamagePreventionDisabled(state, recipientId, sourceId)`
+  matches the pattern against the concrete damage instance through the same `damageSourceMatches` /
+  `damageRecipientMatches` pair every other damage replacement uses, so a filter supported by one is
+  supported by all. Callers that don't know both ends of the instance get the *unscoped* answer only —
+  a scoped effect never blanks a shield it might not cover.
 - `DamageToTargetCantBePreventedThisTurnEffect(target)` — the **per-recipient** form: "Damage that
   would be dealt to that creature this turn can't be prevented **or dealt instead to another
   permanent or player**" (Whippoorwill). Stamps a turn-scoped marker on the recipient, cleared at
@@ -8024,6 +8035,10 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
 
 - `RevealTopOfLibrary` — *public reveal only*, no play permission: the controller's top card is
   shown to all players, but can only be played once drawn. (**Goblin Spy**)
+- `PlayersRevealTopOfLibrary` — the **symmetric** form: *every* player plays with the top card of their
+  library revealed to everyone, no matter who controls the permanent. Same visibility-only contract as
+  `RevealTopOfLibrary` (no play permission); the difference is which libraries are opened, which is why
+  it can't be spelled as the self-scoped variant. (**Wizened Snitches**)
 - `PlayFromTopOfLibrary` — public reveal **and** "play lands and cast spells from the top of your
   library" (all card types). (Future Sight)
 - `PlayFromTopWithAlternativeCost(withoutPayingManaCost = false, additionalCost = null, filter = null)`
@@ -8990,8 +9005,9 @@ composite abilities).
   next instance (a granted permanent has none of the printed replacement/static abilities to fall back on).
   `GrantCantBeCountered` gained an `includesAbilities` flag (default false) so "spells **and abilities** can't be
   countered" (Spider-Punk) also makes matching abilities uncounterable (e.g. Stifle fizzles); `DamageCantBePrevented`
-  is a global replacement — while one is on the battlefield (or the "damage can't be prevented this turn" one-shot is
-  active) `DamageUtils.applyDamagePreventionShields` applies no prevention shields (CR 615.12).
+  is a battlefield replacement scoped by its own `appliesTo` pattern — while one is on the battlefield (or the "damage
+  can't be prevented this turn" one-shot is active) `DamageUtils.applyDamagePreventionShields` applies no prevention
+  shields to the damage instances that pattern names (CR 615.12).
 - `Exploit` — "Exploit (When this creature enters, you may sacrifice a creature.)" (CR 702.110, Dragons of Tarkir;
   reprinted MH1/MH2/VOW/PIP/MH3). Display-only keyword; wire the behavior with the `card { exploit(onExploit, onExploitTargets) }`
   builder helper. It adds the keyword plus one `EntersBattlefield` triggered ability whose effect is a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -558,6 +558,23 @@ data object RevealTopOfLibrary : StaticAbility {
 }
 
 /**
+ * **Every** player plays with the top card of their library revealed (to all players), without
+ * granting anyone permission to play it from there. Used for Wizened Snitches.
+ *
+ * The all-players sibling of [RevealTopOfLibrary]. The distinction is which libraries are opened,
+ * not who may look: both reveal publicly, but [RevealTopOfLibrary] opens only the ability's own
+ * controller's library, so it can't spell a symmetric "players play with …" — that wording is one
+ * effect covering every player's library regardless of who controls the permanent. Like its
+ * sibling it is visibility-only, and grants no play-from-top permission.
+ */
+@SerialName("PlayersRevealTopOfLibrary")
+@Serializable
+data object PlayersRevealTopOfLibrary : StaticAbility {
+    override val description: String =
+        "Players play with the top card of their libraries revealed."
+}
+
+/**
  * You may play lands and cast spells matching a filter from the top of your library.
  * Unlike PlayFromTopOfLibrary, this restricts which spells can be cast (but always allows lands).
  * Used for Glarb, Calamity's Augur (mana value 4 or greater).

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BatheInLight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BatheInLight.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bathe in Light
+ * {1}{W}
+ * Instant
+ *
+ * Radiance — Choose a color. Target creature and each other creature that shares a color with it
+ * gain protection from the chosen color until end of turn.
+ *
+ * Two independent ideas that only look entangled. The **colour choice** is
+ * [Effects.ChooseColorThen], which pauses for the decision and re-runs its body with the chosen
+ * colour on the effect context — every `GrantProtectionFromChosenColor` under it reads that one
+ * colour, so the whole radiance group is protected from the same colour (Scryfall ruling: the
+ * chosen colour has nothing to do with the colour the creatures share). The **radiance group** is
+ * the usual RAV shape: the target is granted directly, and every *other* creature sharing a colour
+ * with it (`sharingColorWith(EntityReference.Target(0))`, `otherThanTarget()`) is gathered once at
+ * resolution and granted via [Effects.ForEachInGroup] with `EffectTarget.Self` bound to each
+ * iterated creature — the documented `ChooseColorThen` + `ForEachInGroup` recipe.
+ *
+ * A colorless target shares a colour with nothing, not even other colorless creatures, so only it
+ * is protected; and because only one creature is targeted, an illegal target fizzles the whole
+ * spell and no other creature is affected.
+ */
+val BatheInLight = card("Bathe in Light") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Radiance — Choose a color. Target creature and each other creature that shares " +
+        "a color with it gain protection from the chosen color until end of turn."
+
+    spell {
+        val radiant = target("target creature", Targets.Creature)
+        effect = Effects.ChooseColorThen(
+            Effects.GrantProtectionFromChosenColor(radiant) then
+                Effects.ForEachInGroup(
+                    filter = GroupFilter(
+                        GameObjectFilter.Creature.sharingColorWith(EntityReference.Target(0))
+                    ).otherThanTarget(),
+                    effect = Effects.GrantProtectionFromChosenColor(EffectTarget.Self)
+                )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"Truth shines even in darkness. Those who march on the side of truth walk " +
+            "always in righteous light.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg?1783943708"
+        ruling(
+            "2005-10-01",
+            "The color you choose as the spell resolves has nothing to do with the color or colors " +
+                "shared by the affected creatures."
+        )
+        ruling("2005-10-01", "All creatures that share a color are affected, even your own.")
+        ruling(
+            "2005-10-01",
+            "If it targets a colorless creature, it doesn't affect any other creatures. A colorless " +
+                "creature shares a color with nothing, not even other colorless creatures."
+        )
+        ruling("2005-10-01", "You check which creatures share a color with the target when the spell resolves.")
+        ruling(
+            "2005-10-01",
+            "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes " +
+                "an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Excruciator.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Excruciator.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DamageCantBePrevented
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Excruciator
+ * {6}{R}{R}
+ * Creature — Avatar
+ * 7/7
+ *
+ * Damage that would be dealt by this creature can't be prevented.
+ *
+ * The same [DamageCantBePrevented] replacement as Leyline of Punishment, *scoped to its own
+ * source*: `EventPattern.DamageEvent(source = SourceFilter.Self)` is the "by this creature" half,
+ * so every other source's damage on the battlefield stays preventable. Protection prevents damage
+ * (CR 702.16e), which is why Excruciator can damage a creature with protection from red — while
+ * still being unable to *block* one, since protection's other three letters are untouched.
+ *
+ * Only effects that use the word "prevent" are switched off: redirection still applies, shield
+ * counters and prevention shields survive un-consumed, regeneration still works, and a replacement
+ * that swaps the damage for something else (Phytohydra) still replaces it.
+ */
+val Excruciator = card("Excruciator") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Avatar"
+    power = 7
+    toughness = 7
+    oracleText = "Damage that would be dealt by this creature can't be prevented."
+
+    replacementEffect(
+        DamageCantBePrevented(appliesTo = EventPattern.DamageEvent(source = SourceFilter.Self))
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Paolo Parente"
+        flavorText = "\"Though used as a piercing weapon, the tusk is more akin to a stinger, " +
+            "spreading pain instantly throughout the body of its victim. This specimen deserves " +
+            "further study.\"\n—Simic research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg?1783943655"
+        ruling("2005-10-01", "An effect may redirect Excruciator's damage.")
+        ruling(
+            "2005-10-01",
+            "Excruciator can deal damage to creatures with protection from red. (It can't block " +
+                "creatures with protection from red, though.)"
+        )
+        ruling(
+            "2005-10-01",
+            "Damage prevention shields that would prevent this damage aren't used up and they stick " +
+                "around for the next time something would deal damage."
+        )
+        ruling("2005-10-01", "A creature dealt lethal damage by Excruciator can be regenerated.")
+        ruling(
+            "2005-10-01",
+            "Replacement effects that don't use the word \"prevent\" can replace Excruciator's damage " +
+                "with something else. See Phytohydra and Szadek, Lord of Secrets, for example."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WizenedSnitches.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/WizenedSnitches.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.PlayersRevealTopOfLibrary
+
+/**
+ * Wizened Snitches
+ * {3}{U}
+ * Creature — Faerie Rogue
+ * 1/3
+ *
+ * Flying
+ * Players play with the top card of their libraries revealed.
+ *
+ * The symmetric form of Goblin Spy's [com.wingedsheep.sdk.scripting.RevealTopOfLibrary]:
+ * [PlayersRevealTopOfLibrary] opens *every* player's top card to *every* player, including the
+ * libraries of players who control no permanent with the ability. Like its sibling it grants no
+ * permission to play the revealed card — the top card is public information and nothing more, so
+ * it still can't be cycled, suspended, discarded, or have its activated abilities used from there.
+ */
+val WizenedSnitches = card("Wizened Snitches") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\nPlayers play with the top card of their libraries revealed."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = PlayersRevealTopOfLibrary
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Greg Staples"
+        flavorText = "\"Be careful what information you ask them to find, for it will likely be " +
+            "the subject of tale time at the alehouse.\"\n—Sirislav, Dimir spy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg?1783943675"
+        ruling(
+            "2013-04-15",
+            "The top card of your library isn't in your hand, so you can't suspend it, cycle it, " +
+                "discard it, or activate any of its activated abilities."
+        )
+        ruling(
+            "2013-04-15",
+            "If the top card of your library changes while you're casting a spell, playing a land, " +
+                "or activating an ability, the new top card won't be revealed until you finish doing so."
+        )
+        ruling(
+            "2013-04-15",
+            "When playing with the top card of your library revealed, if an effect tells you to draw " +
+                "several cards, reveal each one before you draw it."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BatheInLightScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BatheInLightScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rav.cards.BatheInLight
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bathe in Light (RAV #2) — "Radiance — Choose a color. Target creature and each other creature
+ * that shares a color with it gain protection from the chosen color until end of turn."
+ *
+ * Two things are being pinned. The **chosen colour** must reach every grant, not just the target's
+ * — the whole group is protected from one colour picked at resolution, and that colour has nothing
+ * to do with the colour the group shares (ruling 2005-10-01). The **radiance group** is the target
+ * plus every *other* creature sharing a colour with it, on both sides of the table; a colorless
+ * target shares a colour with nothing, so it radiates to no one.
+ */
+class BatheInLightScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BatheInLight)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.hasProtectionFromRed(id: EntityId): Boolean =
+        state.projectedState.hasKeyword(id, "PROTECTION_FROM_RED")
+
+    /** Casts Bathe in Light at [target] and answers the colour prompt with red. */
+    fun GameTestDriver.bathe(caster: EntityId, target: EntityId) {
+        giveMana(caster, Color.WHITE, 2)
+        val spell = putCardInHand(caster, "Bathe in Light")
+        castSpellWithTargets(caster, spell, listOf(ChosenTarget.Permanent(target))).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && pendingDecision == null && guard++ < 10) bothPass()
+        val decision = pendingDecision ?: error("Expected a colour-choice decision from Bathe in Light")
+        submitDecision(caster, ColorChosenResponse(decision.id, Color.RED))
+        guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    test("the target and every other creature sharing a colour with it gain protection from the chosen colour") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val lions = d.putCreatureOnBattlefield(me, "Savannah Lions")        // {W} 2/1 — the target
+        val otherWhite = d.putCreatureOnBattlefield(opp, "Savannah Lions")  // the opponent's, still hit
+        val bears = d.putCreatureOnBattlefield(opp, "Grizzly Bears")        // {1}{G} — shares nothing
+        val golem = d.putCreatureOnBattlefield(opp, "Artifact Creature")    // colorless — shares nothing
+
+        d.bathe(me, lions)
+
+        withClue("the target itself is protected from the chosen colour") {
+            d.hasProtectionFromRed(lions) shouldBe true
+        }
+        withClue("radiance reaches the opponent's white creature too") {
+            d.hasProtectionFromRed(otherWhite) shouldBe true
+        }
+        withClue("creatures sharing no colour with the target are untouched") {
+            d.hasProtectionFromRed(bears) shouldBe false
+            d.hasProtectionFromRed(golem) shouldBe false
+        }
+    }
+
+    test("a colorless target shares a colour with nothing, so only it is protected") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val golem = d.putCreatureOnBattlefield(me, "Artifact Creature")     // the target
+        val otherGolem = d.putCreatureOnBattlefield(opp, "Artifact Creature")
+        val lions = d.putCreatureOnBattlefield(opp, "Savannah Lions")
+
+        d.bathe(me, golem)
+
+        withClue("the colorless target is still protected") {
+            d.hasProtectionFromRed(golem) shouldBe true
+        }
+        withClue("colorless creatures don't share a colour even with each other") {
+            d.hasProtectionFromRed(otherGolem) shouldBe false
+        }
+        d.hasProtectionFromRed(lions) shouldBe false
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExcruciatorScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExcruciatorScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.p02.cards.GoblinPiker
+import com.wingedsheep.mtg.sets.definitions.rav.cards.Excruciator
+import com.wingedsheep.mtg.sets.definitions.usg.cards.DiscipleOfLaw
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Excruciator (RAV #121) — "Damage that would be dealt by this creature can't be prevented."
+ *
+ * Protection prevents damage (CR 702.16e), so Excruciator's combat damage kills a blocker with
+ * protection from red. The half that is easy to get wrong is the *scope*: the shutoff names its
+ * own source, so any other red creature in the same combat must still be walled off by the same
+ * protection. Both attackers swing into an identical blocker in one combat so the two answers are
+ * read from one board — a global shutoff would kill both Disciples, and a shutoff that never fired
+ * would kill neither.
+ */
+class ExcruciatorScenarioTest : FunSpec({
+
+    test("Excruciator's damage ignores protection from red, and only Excruciator's does") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + Excruciator + DiscipleOfLaw + GoblinPiker)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = d.player1
+        val defender = d.player2
+
+        val excruciator = d.putCreatureOnBattlefield(attacker, "Excruciator")   // 7/7 red
+        val piker = d.putCreatureOnBattlefield(attacker, "Goblin Piker")        // 2/1 red
+        d.removeSummoningSickness(excruciator)
+        d.removeSummoningSickness(piker)
+
+        // Two identical 1/2 blockers, each with protection from red.
+        val blockingExcruciator = d.putCreatureOnBattlefield(defender, "Disciple of Law")
+        val blockingPiker = d.putCreatureOnBattlefield(defender, "Disciple of Law")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(attacker, listOf(excruciator, piker), defender)
+        d.passPriority(attacker)
+
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(
+            defender,
+            mapOf(
+                blockingExcruciator to listOf(excruciator),
+                blockingPiker to listOf(piker)
+            )
+        )
+        // The defender may hold priority after blockers are declared.
+        if (d.state.priorityPlayerId != attacker) d.passPriority(defender)
+
+        d.passPriorityUntil(Step.END)
+
+        withClue("protection couldn't prevent Excruciator's 7 damage, so its blocker died") {
+            d.getGraveyardCardNames(defender) shouldBe listOf("Disciple of Law")
+            d.getCreatures(defender).contains(blockingExcruciator) shouldBe false
+        }
+        withClue("the Goblin Piker's damage was still prevented by the same protection") {
+            d.getCreatures(defender) shouldBe listOf(blockingPiker)
+        }
+        withClue("both blockers still dealt their damage back") {
+            // Excruciator (7/7) took 1 from its blocker, Goblin Piker (2/1) took 1 and died.
+            d.findPermanent(attacker, "Excruciator").shouldNotBeNull()
+            d.findPermanent(attacker, "Goblin Piker").shouldBeNull()
+        }
+        withClue("neither attacker got through — the defender took no damage") {
+            d.getLifeTotal(defender) shouldBe 20
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WizenedSnitchesScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WizenedSnitchesScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.inv.cards.GoblinSpy
+import com.wingedsheep.mtg.sets.definitions.rav.cards.WizenedSnitches
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Wizened Snitches (RAV #75) — "Players play with the top card of their libraries revealed."
+ *
+ * The symmetric sibling of Goblin Spy's self-scoped reveal, and the asymmetry is exactly what
+ * these tests pin: one Snitches opens *both* libraries to *both* players, including the library of
+ * the player who controls nothing. Goblin Spy is played alongside as the control — its reveal
+ * still opens only its own controller's library, so a regression that made every reveal symmetric
+ * would be caught here rather than in Goblin Spy's own test.
+ */
+class WizenedSnitchesScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + WizenedSnitches + GoblinSpy)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun transformer(d: GameTestDriver) = ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("one Snitches reveals both players' top cards to both players") {
+        val d = driver()
+        val controller = d.player1
+        val opponent = d.player2
+
+        d.putCreatureOnBattlefield(controller, "Wizened Snitches")
+        val myTop = d.putCardOnTopOfLibrary(controller, "Lightning Bolt")
+        val theirTop = d.putCardOnTopOfLibrary(opponent, "Giant Growth")
+
+        val opponentView = transformer(d).transform(d.state, viewingPlayerId = opponent)
+        opponentView.cards.keys shouldContain myTop
+        opponentView.cards.keys shouldContain theirTop
+
+        val controllerView = transformer(d).transform(d.state, viewingPlayerId = controller)
+        controllerView.cards.keys shouldContain myTop
+        controllerView.cards.keys shouldContain theirTop
+    }
+
+    test("Goblin Spy stays self-scoped: only its controller's top card is public") {
+        val d = driver()
+        val controller = d.player1
+        val opponent = d.player2
+
+        d.putCreatureOnBattlefield(controller, "Goblin Spy")
+        val myTop = d.putCardOnTopOfLibrary(controller, "Lightning Bolt")
+        val theirTop = d.putCardOnTopOfLibrary(opponent, "Giant Growth")
+
+        val controllerView = transformer(d).transform(d.state, viewingPlayerId = controller)
+        controllerView.cards.keys shouldContain myTop
+        controllerView.cards.keys shouldNotContain theirTop
+    }
+
+    test("with no reveal source, neither top card is public") {
+        val d = driver()
+        val controller = d.player1
+        val opponent = d.player2
+
+        val myTop = d.putCardOnTopOfLibrary(controller, "Lightning Bolt")
+        val theirTop = d.putCardOnTopOfLibrary(opponent, "Giant Growth")
+
+        val opponentView = transformer(d).transform(d.state, viewingPlayerId = opponent)
+        opponentView.cards.keys shouldNotContain myTop
+
+        val controllerView = transformer(d).transform(d.state, viewingPlayerId = controller)
+        controllerView.cards.keys shouldNotContain theirTop
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BatheInLightReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/BatheInLightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bathe in Light reprint in CMD. Canonical CardDefinition lives in its earliest set (RAV).
+ */
+val BatheInLightReprint = Printing(
+    oracleId = "8e862a8e-7954-43ad-9bc0-09ce7b9859f0",
+    name = "Bathe in Light",
+    setCode = "CMD",
+    collectorNumber = "9",
+    scryfallId = "0fbc21ac-a7bb-4810-a405-76ca95eb92c5",
+    artist = "Alex Horley-Orlandelli",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fbc21ac-a7bb-4810-a405-76ca95eb92c5.jpg?1783941255",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -162,6 +162,94 @@
     ]
 }
 
+// Bathe in Light
+{
+    "name": "Bathe in Light",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Radiance — Choose a color. Target creature and each other creature that shares a color with it gain protection from the chosen color until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ChooseColorThen",
+            "then": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "GrantProtectionFromChosenColor",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "SharesColorWith",
+                                            "entity": "Target"
+                                        }
+                                    ]
+                                },
+                                "excludeTarget": true
+                            }
+                        },
+                        "body": {
+                            "type": "GrantProtectionFromChosenColor",
+                            "target": "Self"
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"Truth shines even in darkness. Those who march on the side of truth walk always in righteous light.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7bd976e-56c7-482e-8d2f-073b0b589274.jpg?1783943708",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "The color you choose as the spell resolves has nothing to do with the color or colors shared by the affected creatures."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "All creatures that share a color are affected, even your own."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If it targets a colorless creature, it doesn't affect any other creatures. A colorless creature shares a color with nothing, not even other colorless creatures."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "You check which creatures share a color with the target when the spell resolves."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Only one creature is targeted. If that creature leaves the battlefield or otherwise becomes an illegal target, the entire spell doesn't resolve. No other creatures are affected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Benevolent Ancestor
 {
     "name": "Benevolent Ancestor",
@@ -3306,6 +3394,61 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Excruciator
+{
+    "name": "Excruciator",
+    "manaCost": "{6}{R}{R}",
+    "typeLine": "Creature — Avatar",
+    "oracleText": "Damage that would be dealt by this creature can't be prevented.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "DamageCantBePrevented",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "source": "SourceSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Paolo Parente",
+        "flavorText": "\"Though used as a piercing weapon, the tusk is more akin to a stinger, spreading pain instantly throughout the body of its victim. This specimen deserves further study.\"\n—Simic research notes",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg?1783943655",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "An effect may redirect Excruciator's damage."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Excruciator can deal damage to creatures with protection from red. (It can't block creatures with protection from red, though.)"
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Damage prevention shields that would prevent this damage aren't used up and they stick around for the next time something would deal damage."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "A creature dealt lethal damage by Excruciator can be regenerated."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Replacement effects that don't use the word \"prevent\" can replace Excruciator's damage with something else. See Phytohydra and Szadek, Lord of Secrets, for example."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -12370,6 +12513,50 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Wizened Snitches
+{
+    "name": "Wizened Snitches",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nPlayers play with the top card of their libraries revealed.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "PlayersRevealTopOfLibrary"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "\"Be careful what information you ask them to find, for it will likely be the subject of tale time at the alehouse.\"\n—Sirislav, Dimir spy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf35807a-a003-4a99-a883-03b8e097f1b2.jpg?1783943675",
+        "rulings": [
+            {
+                "date": "2013-04-15",
+                "text": "The top card of your library isn't in your hand, so you can't suspend it, cycle it, discard it, or activate any of its activated abilities."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "If the top card of your library changes while you're casting a spell, playing a land, or activating an ability, the new top card won't be revealed until you finish doing so."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "When playing with the top card of your library revealed, if an effect tells you to draw several cards, reveal each one before you draw it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -207,7 +207,7 @@ object DamageUtils {
 
         // Check for global "damage can't be prevented" effects (Sunspine Lynx, Leyline of Punishment)
         @Suppress("NAME_SHADOWING")
-        val cantBePrevented = cantBePrevented || isDamagePreventionDisabled(state, targetId)
+        val cantBePrevented = cantBePrevented || isDamagePreventionDisabled(state, targetId, sourceId)
 
         // Check for damage redirection (Glarecaster, Zealous Inquisitor). Whippoorwill's clause
         // shuts this half off too — "…or dealt instead to another permanent or player" — so a
@@ -1221,10 +1221,33 @@ object DamageUtils {
     }
 
     /**
-     * Check if damage prevention is globally disabled by any DamageCantBePrevented replacement effect
-     * on the battlefield (e.g., Sunspine Lynx, Leyline of Punishment).
+     * Whether damage prevention is switched off for the damage instance ([sourceId] → [recipientId]).
+     *
+     * Three shutoffs feed this, narrowest last:
+     *  - the turn-scoped one-shot (Fear, Fire, Foes!),
+     *  - the per-recipient marker (Whippoorwill),
+     *  - a [DamageCantBePrevented] replacement on the battlefield.
+     *
+     * The last one is **scoped by its own `appliesTo` pattern**, not global. An unscoped pattern
+     * (`DamageEvent()`, source and recipient both `Any` — Leyline of Punishment, Sunspine Lynx)
+     * still shuts prevention off for everyone; a scoped one only covers the damage instances its
+     * pattern names, so Excruciator's "damage that would be dealt by **this creature** can't be
+     * prevented" (`SourceFilter.Self`) leaves every other source's damage preventable. Reading
+     * `appliesTo` here is what keeps that promise — the scan used to answer `true` for any
+     * `DamageCantBePrevented` on the battlefield at all.
+     *
+     * A scoped effect needs the concrete damage instance to judge, so a caller that passes neither
+     * end gets the unscoped answer only. That is deliberately the safe direction: an unknown
+     * instance never blanks a prevention shield or a protection keyword it might not cover.
+     *
+     * @param recipientId the entity being damaged, when the caller knows it
+     * @param sourceId the source dealing the damage, when the caller knows it
      */
-    fun isDamagePreventionDisabled(state: GameState, recipientId: EntityId? = null): Boolean {
+    fun isDamagePreventionDisabled(
+        state: GameState,
+        recipientId: EntityId? = null,
+        sourceId: EntityId? = null
+    ): Boolean {
         // Turn-scoped "Damage can't be prevented this turn" (Fear, Fire, Foes!).
         if (state.damageCantBePreventedThisTurn) return true
         // Per-recipient: "damage that would be dealt to that creature this turn can't be prevented"
@@ -1235,12 +1258,37 @@ object DamageUtils {
         ) {
             return true
         }
+        val projected = state.projectedState
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
 
             for (effect in replacementComponent.replacementEffects) {
-                if (effect is DamageCantBePrevented) return true
+                if (effect !is DamageCantBePrevented) continue
+                val pattern = effect.appliesTo as? EventPattern.DamageEvent ?: continue
+                // Unscoped: the printed "damage can't be prevented" with no source or recipient
+                // clause. Answers for every instance, including the ones this call knows nothing about.
+                if (pattern.source is SourceFilter.Any && pattern.recipient is RecipientFilter.Any) {
+                    return true
+                }
+                val recipient = recipientId ?: continue
+                if (pattern.source !is SourceFilter.Any && sourceId == null) continue
+                val hostControllerId = replacementHostController(state, entityId) ?: continue
+                if (!damageSourceMatches(
+                        state, projected, pattern.source, sourceId,
+                        hostId = entityId, hostControllerId = hostControllerId, recipientId = recipient,
+                    )
+                ) {
+                    continue
+                }
+                if (!damageRecipientMatches(
+                        state, projected, pattern.recipient, recipient,
+                        hostId = entityId, hostControllerId = hostControllerId,
+                    )
+                ) {
+                    continue
+                }
+                return true
             }
         }
         return false
@@ -1267,7 +1315,7 @@ object DamageUtils {
         // CR 615.12 — when damage can't be prevented, prevention shields aren't reduced and prevent
         // nothing. When any battlefield "damage can't be prevented" (Spider-Punk) or the "this turn"
         // one-shot (Fear, Fire, Foes!) is active, no shield applies and the damage passes through in full.
-        if (isDamagePreventionDisabled(state, targetId)) return state to amount
+        if (isDamagePreventionDisabled(state, targetId, sourceId)) return state to amount
 
         var remainingDamage = amount
         val updatedEffects = state.floatingEffects.toMutableList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -928,8 +928,16 @@ internal class CombatDamageManager(
             val isPlayer = container.get<LifeTotalComponent>() != null && container.get<CardComponent>() == null
             if (isPlayer) continue
             // Per-recipient, so it is read inside the loop: a creature marked unpreventable
-            // (Whippoorwill) takes damage in full while its neighbours keep their shields.
-            val cantBePrevented = DamageUtils.isDamagePreventionDisabled(state, targetId)
+            // (Whippoorwill) takes damage in full while its neighbours keep their shields. The
+            // shutoff can also be scoped to the damage's *source* (Excruciator), and a shield
+            // counter covers the whole CR 510.2 batch — so it is enough that any one of the
+            // sources assigned to this creature is unpreventable.
+            val cantBePrevented = assignments
+                .filter { it.targetId == targetId }
+                .let { hits ->
+                    hits.isEmpty() && DamageUtils.isDamagePreventionDisabled(state, targetId) ||
+                        hits.any { DamageUtils.isDamagePreventionDisabled(state, targetId, it.sourceId) }
+                }
             val shielded = applyShieldCounterToDamage(newState, targetId, cantBePrevented)
             if (shielded != null) {
                 newState = shielded.state
@@ -1595,7 +1603,8 @@ internal class CombatDamageManager(
                         incomingDamage.getOrPut(targetId) { mutableMapOf() }
                             .merge(attackerId, amplified) { a, b -> a + b }
                     } else {
-                        val damageCantBePrevented = DamageUtils.isDamagePreventionDisabled(state, targetId)
+                        val damageCantBePrevented =
+                            DamageUtils.isDamagePreventionDisabled(state, targetId, attackerId)
                         val attackerColors = projected.getColors(attackerId)
                         val attackerSubtypes = projected.getSubtypes(attackerId)
                         val attackerTypes = projected.getTypes(attackerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamagePipeline.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamagePipeline.kt
@@ -100,7 +100,9 @@ internal class ProtectionModifier : CombatDamageModifier {
         // per-recipient (Whippoorwill) as well as global (Sunspine Lynx): one marked creature must
         // take its damage in full without blanking protection for everyone else in the combat.
         return assignments.filter { assignment ->
-            if (DamageUtils.isDamagePreventionDisabled(state, assignment.targetId)) return@filter true
+            if (DamageUtils.isDamagePreventionDisabled(state, assignment.targetId, assignment.sourceId)) {
+                return@filter true
+            }
             val sourceColors = projected.getColors(assignment.sourceId)
             val sourceSubtypes = projected.getSubtypes(assignment.sourceId)
             val sourceSupertypes = projected.getSupertypes(assignment.sourceId)
@@ -137,10 +139,13 @@ internal class ProtectionModifier : CombatDamageModifier {
  */
 internal class PlayerProtectionModifier : CombatDamageModifier {
     override fun modify(state: GameState, projected: ProjectedState, assignments: List<CombatDamageAssignment>): List<CombatDamageAssignment> {
-        // Left as a global early-out on purpose: every target here is a player, and the
-        // per-recipient shutoff (Whippoorwill) only ever marks a creature.
-        if (DamageUtils.isDamagePreventionDisabled(state)) return assignments
+        // Per assignment, not a global early-out: the shutoff can be scoped to the damage's
+        // *source* (Excruciator), so one attacker's damage may ignore player protection while
+        // another attacker's in the same combat does not.
         return assignments.filter { assignment ->
+            if (DamageUtils.isDamagePreventionDisabled(state, assignment.targetId, assignment.sourceId)) {
+                return@filter true
+            }
             !PlayerProtectionRules.isProtectedFromSource(
                 state,
                 playerId = assignment.targetId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1062,6 +1062,7 @@ class StaticAbilityHandler(
             is OpponentsPlayWithHandsRevealed,
             is RevealFirstDrawEachTurn,
             is RevealTopOfLibrary,
+            is com.wingedsheep.sdk.scripting.PlayersRevealTopOfLibrary,
 
             // Coin-flip replacements, queried by CoinFlipService via CoinFlipModifiers — the
             // result-dictating one (CR 705.3) and the flip-more-coins one (CR 614). Neither is a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlayersRevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
 import com.wingedsheep.sdk.scripting.StaticAbility
 
@@ -209,10 +210,20 @@ class Visibility(
     private fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) { it is LookAtFaceDownCreatures }
 
+    /**
+     * Whether the top card of [playerId]'s library is face up to everyone. Two shapes reach this:
+     * a self-scoped static that [playerId] themselves controls — [PlayFromTopOfLibrary] (Future
+     * Sight) or [RevealTopOfLibrary] (Goblin Spy) — or a symmetric
+     * [PlayersRevealTopOfLibrary] (Wizened Snitches) controlled by *any* player, which opens every
+     * library including the libraries of players who control nothing.
+     */
     private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) {
             it is PlayFromTopOfLibrary || it is RevealTopOfLibrary
-        }
+        } ||
+            state.turnOrder.any { controllerId ->
+                hasActiveStaticAbility(state, controllerId) { it is PlayersRevealTopOfLibrary }
+            }
 
     private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
         hasActiveStaticAbility(state, playerId) { it is LookAtTopOfLibrary }


### PR DESCRIPTION
Three more from Ravnica: City of Guilds, taking it from 227/291 to **230/291**.

| Card | What it does | How |
|---|---|---|
| **Bathe in Light** ({1}{W} Instant) | Radiance — choose a color; the target and each other creature sharing a color with it gain protection from the chosen color until end of turn | Pure composition: `Effects.ChooseColorThen` + the set's `sharingColorWith(EntityReference.Target(0))` / `otherThanTarget()` radiance group driven by `ForEachInGroup` with `EffectTarget.Self` — the documented ChooseColorThen + ForEachInGroup recipe |
| **Excruciator** ({6}{R}{R} 7/7) | Damage that would be dealt by this creature can't be prevented | `DamageCantBePrevented(EventPattern.DamageEvent(source = SourceFilter.Self))`, plus the engine fix that makes `appliesTo` load-bearing |
| **Wizened Snitches** ({3}{U} 1/3 flier) | Players play with the top card of their libraries revealed | New `PlayersRevealTopOfLibrary` static — the symmetric sibling of Goblin Spy's self-scoped `RevealTopOfLibrary` |

CMD (2011) reprints Bathe in Light, so that set gets a `Printing` row; all three canonicals stay in RAV, their earliest real expansion.

## The two engine changes

**`DamageCantBePrevented` was global regardless of its own `appliesTo`.** The type has carried an `EventPattern` since it was added, but `DamageUtils.isDamagePreventionDisabled` answered `true` for any such replacement anywhere on the battlefield — so Excruciator would have blanked every prevention effect in the game, Leyline of Punishment-style. The scan now matches the pattern against the concrete damage instance through the same `damageSourceMatches` / `damageRecipientMatches` pair every other damage replacement uses, so a filter supported by one is supported by all. An unscoped pattern (source and recipient both `Any`) still shuts prevention off globally — that is what Leyline of Punishment and Sunspine Lynx print, and their behaviour is unchanged.

Callers thread the damage source through: `dealDamageToTarget`, `applyDamagePreventionShields`, and the two combat sites. `PlayerProtectionModifier` stops early-outing globally and decides per assignment, because one attacker's damage may ignore player protection while another's in the same combat does not; the shield-counter path keeps its CR 510.2 batch scope by asking whether *any* source assigned to that creature is unpreventable. A caller that knows neither end of the instance still gets the unscoped answer only — a scoped effect never blanks a shield it might not cover.

**`RevealTopOfLibrary` is self-scoped** — `Visibility.revealsTopOfLibraryPublicly` only scans the library owner's own battlefield — so it cannot spell "*players* play with …", which opens every library regardless of who controls the permanent. `PlayersRevealTopOfLibrary` sits alongside it with the same visibility-only contract (no play-from-top permission), wired into the one visibility scan plus the `StaticAbilityHandler` passthrough that lists the other reveal statics as non-Rule-613 no-ops.

## Verification

- `just build` green (the whole gate, including `:mtg-sets:test` and every scenario suite).
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent.
- `just check-card-printing` clean for all three.
- RAV card golden re-blessed; only these three cards moved.
- Scenario tests, one per card. Excruciator's puts both attackers into a single combat against identical protection-from-red blockers, so the scoping is read off one board: Excruciator's blocker dies, the Goblin Piker's survives. Wizened Snitches' plays Goblin Spy alongside as the control, so a regression that made every reveal symmetric is caught there.

## Not in this PR

The rest of the RAV tail is genuinely blocked, and two cards were triaged out while picking this batch rather than approximated:

- **Brightflame** — "you gain life equal to the damage dealt this way" is the *total* across the radiance group, and the ruling is explicit that prevented damage doesn't count. There is no damage-dealt accumulator in the engine (`ExcessMarkedDamage` is the only post-damage read), so the only composable spelling gains life for damage that was prevented. That wants a small `add-feature`, not a card.
- **Warp World** — the five phases have to interleave across players (all artifacts/creatures/lands enter together, *then* all enchantments), and `ForEachPlayer` is per-player sequential with a fresh pipeline per iteration. Also `add-feature`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L12XRkwDxTN5eYVy7mDCzJ
