### PR TITLE
Add Breath of Fury, and fix a re-attached Aura being graveyarded by SBA

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BreathOfFury.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/BreathOfFury.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Breath of Fury
+ * {2}{R}{R}
+ * Enchantment — Aura
+ * Enchant creature you control
+ * When enchanted creature deals combat damage to a player, sacrifice it and attach this Aura to a
+ * creature you control. If you do, untap all creatures you control and after this phase, there is
+ * an additional combat phase.
+ *
+ * The re-attach is a resolution-time *choice*, not a target — so it is a gather over the creatures
+ * you control followed by a `chooseExactly(1)`, not a `target()` handle. Gathering *after* the
+ * sacrifice is what makes the sacrificed host ineligible without an explicit exclusion, and
+ * `ChooseExactly`'s clamp is the 2005-10-01 ruling: with no legal creature left the selection is
+ * empty, `ifNotEmpty` skips the payoff, and the now-unattached Aura is put into its owner's
+ * graveyard by the unattached-Auras state-based action (never mid-resolution, so the attach above
+ * still lands while the Aura is host-less).
+ */
+val BreathOfFury = card("Breath of Fury") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\n" +
+        "When enchanted creature deals combat damage to a player, sacrifice it and attach this " +
+        "Aura to a creature you control. If you do, untap all creatures you control and after " +
+        "this phase, there is an additional combat phase."
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = Effects.Pipeline {
+            run(Effects.SacrificeTarget(EffectTarget.EnchantedCreature))
+            val hosts = gather(CardSource.ControlledPermanents(filter = GameObjectFilter.Creature))
+            val newHost = chooseExactly(
+                1,
+                from = hosts,
+                prompt = "Choose a creature to attach Breath of Fury to",
+                useTargetingUI = true,
+            )
+            ifNotEmpty(newHost) {
+                run(Effects.AttachEquipment(EffectTarget.PipelineTarget(newHost.key)))
+                run(Patterns.Group.untapGroup(GroupFilter.AllCreaturesYouControl))
+                run(Effects.AddCombatPhase)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "116"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg?1783943657"
+        ruling(
+            "2005-10-01",
+            "If there isn't a legal creature to attach Breath of Fury to after the enchanted " +
+                "creature is sacrificed, you don't untap your creatures or get an additional " +
+                "combat phase, and Breath of Fury is put into its owner's graveyard as a " +
+                "state-based action."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreathOfFuryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BreathOfFuryScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.state.components.player.ExtraPhaseKind
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Breath of Fury (RAV #116, {2}{R}{R}, Enchantment — Aura).
+ *
+ *   Enchant creature you control
+ *   When enchanted creature deals combat damage to a player, sacrifice it and attach this Aura to
+ *   a creature you control. If you do, untap all creatures you control and after this phase, there
+ *   is an additional combat phase.
+ *
+ * Two things the card is easy to get wrong, and both are asserted here. The re-attach is a
+ * *choice*, not a target — so the prompt must offer every creature you control **except** the one
+ * just sacrificed, which is only true because the candidates are gathered after the sacrifice.
+ * And per the 2005-10-01 ruling, an empty candidate list is not a partial resolution: no untap, no
+ * extra combat, and the Aura falls off to the graveyard. A version that untapped first, or that
+ * gathered before sacrificing, passes the happy-path test and fails the second one.
+ */
+class BreathOfFuryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Breath of Fury") {
+
+            test("connecting sacrifices the host, moves the Aura, untaps the team, and adds a combat") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Breath of Fury", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant", tapped = true)
+                    .withCardOnBattlefield(1, "Craw Wurm", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aura = game.findPermanent("Breath of Fury")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Bob took the Bears' 2 damage, which is what fired the trigger") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+
+                // Two creatures remain, so the re-attach is a real choice rather than an auto-pick.
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("the sacrificed host is gone by the time the candidates are gathered") {
+                    decision.options.toSet() shouldBe setOf(giant, wurm)
+                }
+                game.selectCards(listOf(giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the enchanted creature was sacrificed") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("the Aura moved to the chosen creature rather than falling off") {
+                    game.isOnBattlefield("Breath of Fury") shouldBe true
+                    game.state.getEntity(aura)!!.get<AttachedToComponent>()!!.targetId shouldBe giant
+                }
+                withClue("all creatures you control untap — not just the new host") {
+                    game.state.getEntity(giant)!!.has<TappedComponent>() shouldBe false
+                    game.state.getEntity(wurm)!!.has<TappedComponent>() shouldBe false
+                }
+                withClue("one additional combat phase is queued for the attacking player") {
+                    val queued = game.state.getEntity(game.state.activePlayerId!!)
+                        ?.get<AdditionalPhasesComponent>()?.phases.orEmpty()
+                    queued.size shouldBe 1
+                    queued.single().kind shouldBe ExtraPhaseKind.COMBAT
+                }
+            }
+
+            test("with no other creature the Aura falls off and there is no untap or extra combat") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Breath of Fury", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() is CombatResolutionDecision) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.checkStateBasedActions()
+
+                withClue("nothing to attach to, so no prompt is raised") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("the host was still sacrificed — that half is not conditional") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("an unattached Aura is put into its owner's graveyard (CR 704.5m)") {
+                    game.isOnBattlefield("Breath of Fury") shouldBe false
+                    game.isInGraveyard(1, "Breath of Fury") shouldBe true
+                }
+                withClue("'if you do' failed, so no additional combat phase") {
+                    game.state.getEntity(game.state.activePlayerId!!)
+                        ?.get<AdditionalPhasesComponent>()?.phases.orEmpty() shouldBe emptyList()
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BreathOfFuryReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BreathOfFuryReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Breath of Fury reprint in C16. The canonical CardDefinition lives in
+ * Ravnica: City of Guilds (`rav`), the card's earliest real printing; this
+ * file contributes only per-printing presentation data.
+ */
+val BreathOfFuryReprint = Printing(
+    oracleId = "fdaa0faf-e7ee-48b3-9330-de0fc3792ad3",
+    name = "Breath of Fury",
+    setCode = "C16",
+    collectorNumber = "121",
+    scryfallId = "a1fce58d-d754-4532-b4d0-4bb3cf108090",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1fce58d-d754-4532-b4d0-4bb3cf108090.jpg?1783937066",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1068,6 +1068,110 @@
     ]
 }
 
+// Breath of Fury
+{
+    "name": "Breath of Fury",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nWhen enchanted creature deals combat damage to a player, sacrifice it and attach this Aura to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SacrificeTarget",
+                            "target": "EnchantedCreature"
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "ControlledPermanents",
+                                "filter": "creature"
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected2",
+                            "prompt": "Choose a creature to attach Breath of Fury to",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "selected2",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "AttachEquipment",
+                                        "target": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "selected2"
+                                        }
+                                    },
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "TapUntap",
+                                            "target": "Self",
+                                            "tap": false
+                                        }
+                                    },
+                                    "AddCombatPhase"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbef6f4a-f9a0-4a4c-b8a2-6c3a8fb7e14a.jpg?1783943657",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If there isn't a legal creature to attach Breath of Fury to after the enchanted creature is sacrificed, you don't untap your creatures or get an additional combat phase, and Breath of Fury is put into its owner's graveyard as a state-based action."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Caregiver
 {
     "name": "Caregiver",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -83,29 +83,36 @@ class UnattachedAurasCheck(
             val hostLeft = container.get<AttachmentHostLeftComponent>()
             if (hostLeft != null) {
                 newState = newState.updateEntity(entityId) { c -> c.without<AttachmentHostLeftComponent>() }
-                if (isAura) {
-                    val result = SbaZoneMovementHelper.putPermanentInGraveyard(
-                        newState, entityId, cardComponent,
-                        lastKnownAttachedTo = hostLeft.lastKnownHostId
-                    )
-                    newState = result.newState
-                    events.addAll(result.events)
-                } else {
-                    // CR 704.5n: an Equipment whose host left becomes unattached but stays on the
-                    // battlefield. Only force the unattach when it's still pointing at the host that
-                    // left (or is already unattached) — the marker exists for the blink case where the
-                    // host returns under the same EntityId. If an effect has *re-attached* it to a
-                    // different permanent in the meantime (e.g. Zack Fair attaches "an Equipment that
-                    // was attached to it" to another creature as it's sacrificed), leave that new
-                    // attachment in place; the legality checks below validate the new host instead.
-                    val current = container.get<AttachedToComponent>()
-                    if (current == null || current.targetId == hostLeft.lastKnownHostId) {
+                // Only act on the marker while the attachment is *still* pointing at the host that
+                // left (or is already unattached) — the marker exists for the blink case where the
+                // host returns under the same EntityId. If an effect has re-attached it to a
+                // different permanent in the meantime, both 704.5m and 704.5n are silent: the
+                // attachment is neither unattached nor (necessarily) illegally attached, so the
+                // ordinary legality checks below judge the *new* host instead. Two printed cards
+                // do exactly this inside one resolution — Zack Fair attaches "an Equipment that was
+                // attached to it" to another creature as it is sacrificed, and Breath of Fury
+                // sacrifices its own enchanted creature and attaches itself to another creature
+                // you control. Applying the marker blindly would put a legally-attached Aura into
+                // its owner's graveyard.
+                val current = container.get<AttachedToComponent>()
+                if (current == null || current.targetId == hostLeft.lastKnownHostId) {
+                    if (isAura) {
+                        // CR 704.5m: an Aura whose host left is put into its owner's graveyard.
+                        val result = SbaZoneMovementHelper.putPermanentInGraveyard(
+                            newState, entityId, cardComponent,
+                            lastKnownAttachedTo = hostLeft.lastKnownHostId
+                        )
+                        newState = result.newState
+                        events.addAll(result.events)
+                    } else {
+                        // CR 704.5n: an Equipment whose host left becomes unattached but stays on
+                        // the battlefield.
                         val (detached, unattachEvents) = unattachEmittingEvent(newState, entityId)
                         newState = detached
                         events.addAll(unattachEvents)
                     }
+                    continue
                 }
-                continue
             }
 
             val attachedTo = container.get<AttachedToComponent>()


### PR DESCRIPTION
## Cards

- **Breath of Fury** (RAV #116, `{2}{R}{R}` Enchantment — Aura) — "When enchanted creature deals combat damage to a player, sacrifice it and attach this Aura to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase."

  An ATTACHED-binding combat-damage trigger over an `Effects.Pipeline`: sacrifice the enchanted creature → gather the creatures you control → `chooseExactly(1)` with the battlefield targeting UI → `ifNotEmpty { AttachEquipment, Patterns.Group.untapGroup, Effects.AddCombatPhase }`. No new SDK vocabulary.

  Two details the shape buys for free. The candidates are gathered *after* the sacrifice, so the dead host is ineligible without an explicit exclusion. And `ChooseExactly`'s clamp *is* the 2005-10-01 ruling — with no creature left the selection is empty, the payoff is skipped, and the Aura falls off. The re-attach is a resolution-time choice, not a target, so it is a select-from-collection rather than a `target()` handle; the client already routes that decision to `BattlefieldSelectionUI`.

  C16 gets a `Printing` row (canonical stays in RAV, the earliest real printing). SLD is unscaffolded.

## Engine fix this needed

`UnattachedAurasCheck` (CR 704.5m/n) cleared the "host left the battlefield" marker and then, for an **Aura**, put it into its owner's graveyard unconditionally — even when an effect had already re-attached it to a legal new host during the same resolution. The **Equipment** leg of the same branch already guarded for exactly that case (Zack Fair attaching an Equipment elsewhere as its host is sacrificed), and its own comment said the legality checks below should judge the new host — but the `continue` meant they never ran.

The guard now covers both types: an attachment that has been re-pointed at a different permanent falls through to the ordinary host-legality checks instead of being removed. Neither 704.5m nor 704.5n fires for an attachment that is neither unattached nor illegally attached. This is a scope fix in an existing SBA, not new vocabulary.

Breath of Fury is the first Aura to hit it — it sacrifices its own host and re-attaches itself in one resolution — and its scenario test is the regression test.

## Cards considered and dropped

RAV stands at 230/291. Of the 61 missing, 55 were already triaged as blocked (12 on dredge, 13 on transmute — neither keyword exists in `mtg-sdk` — plus 30 individually blocked). I probed the 6 untriaged ones and confirmed 5 need `add-feature`, so this PR is one card rather than a handful:

- **Mindleech Mass** — `CastSpellHandler` rejects any cast whose card is not in *your* hand or one of the permitted non-hand zones; `CastFromZoneEnumerator` enumerates exile, not another player's hand. Casting from an opponent's hand needs a new branch in both.
- **Chorus of the Conclave** — no static that injects an optional additional cost into *other* spells (the existing `AdditionalCost` types are card-level, and the alternative-cost statics are a different shape).
- **Flickerform** — `PutOntoBattlefieldAttachedToChosen` takes a host *filter*, not an entity, so "return the other cards attached to **that** creature" cannot be spelled.
- **Eye of the Storm**, **Master Warcraft** — whole mechanics.

## Verification

- `just test-rules` — engine tests plus every card scenario: BUILD SUCCESSFUL. `BreathOfFuryScenarioTest` 2/2, `ZackFairScenarioTest` 3/3 (the Equipment side of the branch I touched).
- `just rebless-cards` — only `RAV.json` moved, only Breath of Fury in it.
- `just check-card-printing "Breath of Fury"` — clean.
- `just assay-differential --set RAV` — 103 compared, 0 divergent.
- CR 704.5m/n verified against the Comprehensive Rules text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgbC39NpHAg8wmccZ5kLsz