### PR TITLE
Add three Lorwyn cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -11948,7 +11948,7 @@ The priority groups are (CR 616.1a–f):
   untapped regardless). Edge not covered: a same-event simultaneous mass-entry where the source itself is
   among the entering permanents (the source isn't yet consulted), and a land tapped via a generic
   `OnEnterRunEffect` self-tap (e.g. Game Trail) is not overridden.
-- `PermanentsEnterTapped(appliesTo = ZoneChangeEvent(filter, to = Zone.BATTLEFIELD))` — the global/group
+- `PermanentsEnterTapped(appliesTo = ZoneChangeEvent(filter, to = Zone.BATTLEFIELD), condition = null)` — the global/group
   counterpart of the self-only `EntersTapped`: "[filter] enter the battlefield tapped" (Zhao, the Moon
   Slayer — "Nonbasic lands enter tapped", `filter = GameObjectFilter.NonbasicLand`; also expresses
   Imposing Sovereign / Authority of the Consuls "creatures your opponents control enter tapped"). Like
@@ -11960,7 +11960,13 @@ The priority groups are (CR 616.1a–f):
   `EnterUntappedReplacements`, so per CR 614 an applicable `EntersUntapped` still wins. Created tokens are
   covered too: e.g. Dauntless Dismantler's "Artifacts your opponents control enter tapped" taps an
   opponent's Map/Treasure/Clue token, and Authority of the Consuls taps opponents' creature tokens (a token
-  entering attacking keeps its tapped state and is not overridden).
+  entering attacking keeps its tapped state and is not overridden). The optional `condition` is a gate
+  evaluated against the replacement *source* when a permanent would enter — the same axis `RedirectDamage`
+  and `EntersWithCounters` carry — for a source whose tap clause depends on state it can't put in the
+  filter: Ashling's Prerogative gates its even-mana-value half on `SourceChosenModeIs("odd")` and its
+  odd-mana-value half on `SourceChosenModeIs("even")`. Reach for it whenever the clause would otherwise
+  want a `ConditionalStaticAbility` wrapper — a runtime replacement can't be wrapped in one, because it is
+  stamped into the replacement component rather than projected through the layer system.
 - `RedirectZoneChange(newDestination, appliesTo, linkToSource = false, selfOnly = false, shuffleIntoLibrary = false, reveal = false, requiredCause = ZoneChangeCause.Any)`
   — redirect a zone change to a different destination (Rest in Peace / Leyline of the Void: graveyard →
   exile). `appliesTo` is an `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -501,6 +501,12 @@ data class EntersUntapped(
  * Per CR 614 (replacement-effect ordering), an [EntersUntapped] effect that also matches the
  * entering permanent wins — the engine's entry paths consult [EntersUntapped] first and only
  * apply this tap when no untapped replacement applies.
+ *
+ * @property condition Optional gate evaluated against the replacement *source* at the moment a
+ *   permanent would enter — the same axis [RedirectDamage] and [EntersWithCounters] carry. When
+ *   non-null the tap applies only while the condition holds, which is how a source whose effect
+ *   depends on a choice it made as it entered spells the clause (Ashling's Prerogative:
+ *   `SourceChosenModeIs("odd")` on the even-mana-value half and vice versa). `null` = always.
  */
 @SerialName("PermanentsEnterTapped")
 @Serializable
@@ -508,13 +514,19 @@ data class PermanentsEnterTapped(
     override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
         filter = GameObjectFilter.Any,
         to = Zone.BATTLEFIELD
-    )
+    ),
+    val condition: Condition? = null
 ) : ReplacementEffect {
-    override val description: String = "If ${appliesTo.description}, it enters tapped"
+    override val description: String = buildString {
+        append("If ${appliesTo.description}, it enters tapped")
+        condition?.let { append(" (${it.description})") }
+    }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)
-        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo || newCondition !== condition)
+            copy(appliesTo = newAppliesTo, condition = newCondition) else this
     }
 }
 

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AshlingsPrerogative.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AshlingsPrerogative.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModeOption
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+import com.wingedsheep.sdk.scripting.conditions.SourceChosenModeIs
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ashling's Prerogative
+ * {1}{R} Enchantment
+ *
+ * As this enchantment enters, choose odd or even. (Zero is even.)
+ * Each creature with mana value of the chosen quality has haste.
+ * Each creature without mana value of the chosen quality enters tapped.
+ *
+ * The choice is [EntersWithChoice] with `ChoiceType.MODE` — the Sieges' shape — writing a stable
+ * mode id onto the permanent that [SourceChosenModeIs] reads back. Both of the card's other lines
+ * then come in mirrored pairs, one per mode, because "the chosen quality" is a *filter* selector
+ * and the SDK's parity predicates (`manaValueIsOdd()` / `manaValueIsEven()`) are fixed:
+ *
+ * ```
+ * odd chosen  ->  odd  creatures have haste,  even creatures enter tapped
+ * even chosen ->  even creatures have haste,  odd  creatures enter tapped
+ * ```
+ *
+ * Only one member of each pair is live at a time, which is exactly the 2007-10-01 ruling ("either
+ * creatures with odd mana values enter tapped and creatures with even mana values have haste, or
+ * vice versa").
+ *
+ * Two things worth stating because both have a plausible wrong reading:
+ *
+ * - **"Each creature" is every creature, not yours** — [GroupFilter] takes the bare
+ *   `GameObjectFilter.Creature`, never `youControl()`. Your opponents' odd-cost creatures get
+ *   haste too; that symmetry is the card.
+ * - **The tapped clause is the *complement*, not the negation of the haste clause's controller
+ *   scope.** "Without mana value of the chosen quality" is the other parity, so the pair of
+ *   [PermanentsEnterTapped] effects uses the *opposite* predicate to the pair of [GrantKeyword]s.
+ *   Swapping them compiles, reads right on the card, and inverts the whole enchantment.
+ *
+ * The tap clause needed the one piece of new vocabulary here: a `condition` gate on
+ * [PermanentsEnterTapped]. That replacement is stamped into the source's replacement component
+ * and consulted from the battlefield as *other* permanents enter, so unlike the haste halves it
+ * cannot be wrapped in a `ConditionalStaticAbility` — the gate has to travel with the replacement.
+ * The field mirrors the one `RedirectDamage` and `EntersWithCounters` already carry, and
+ * `EnterTappedReplacements.entersTapped` evaluates it against the source.
+ *
+ * An {X} in a creature's mana cost is 0 on the battlefield (2007-10-01 ruling), and zero is even —
+ * that falls out of the engine's own mana-value computation, no special case here.
+ */
+val AshlingsPrerogative = card("Ashling's Prerogative") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "As this enchantment enters, choose odd or even. (Zero is even.)\n" +
+        "Each creature with mana value of the chosen quality has haste.\n" +
+        "Each creature without mana value of the chosen quality enters tapped."
+
+    replacementEffect(
+        EntersWithChoice(
+            choiceType = ChoiceType.MODE,
+            modeOptions = listOf(
+                ModeOption(
+                    id = "odd",
+                    label = "Odd",
+                    description = "Odd-cost creatures have haste; even-cost creatures enter tapped."
+                ),
+                ModeOption(
+                    id = "even",
+                    label = "Even",
+                    description = "Even-cost creatures have haste; odd-cost creatures enter tapped."
+                )
+            )
+        )
+    )
+
+    staticAbility {
+        condition = SourceChosenModeIs("odd")
+        ability = GrantKeyword(
+            Keyword.HASTE,
+            GroupFilter(GameObjectFilter.Creature.manaValueIsOdd())
+        )
+    }
+
+    staticAbility {
+        condition = SourceChosenModeIs("even")
+        ability = GrantKeyword(
+            Keyword.HASTE,
+            GroupFilter(GameObjectFilter.Creature.manaValueIsEven())
+        )
+    }
+
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.manaValueIsEven(),
+                to = Zone.BATTLEFIELD
+            ),
+            condition = SourceChosenModeIs("odd")
+        )
+    )
+
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.manaValueIsOdd(),
+                to = Zone.BATTLEFIELD
+            ),
+            condition = SourceChosenModeIs("even")
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg?1783942880"
+        ruling("2007-10-01", "The \"chosen value\" is either \"odd\" or \"even.\" So either creatures with odd mana values enter tapped and creatures with even mana values have haste, or vice versa.")
+        ruling("2007-10-01", "If a creature has X in its mana cost, that X is treated as 0 for the purposes of these effects. It doesn't matter what the value of X was while the creature was on the stack.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ColfenorsUrn.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ColfenorsUrn.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Colfenor's Urn
+ * {3} Artifact
+ *
+ * Whenever a creature with toughness 4 or greater is put into your graveyard from the
+ * battlefield, you may exile it.
+ * At the beginning of the end step, if three or more cards have been exiled with this
+ * artifact, sacrifice it. If you do, return those cards to the battlefield under their
+ * owner's control.
+ *
+ * Both halves are the linked-exile pile: the first ability feeds it, the second empties it.
+ *
+ * - **"into *your* graveyard"** is an ownership clause, not a control one — a creature you own
+ *   that an opponent has stolen still dies into your graveyard — so the filter is
+ *   `ownedByYou()`, never `youControl()`.
+ * - **Toughness is read from last-known information.** The creature is already in the graveyard
+ *   when the trigger is checked; `TriggerMatcher` threads `lastKnownToughness` off the
+ *   `ZoneChangeEvent` for battlefield departures, so `toughnessAtLeast(4)` measures the creature
+ *   as it last existed on the battlefield (a 4-toughness creature killed by -4/-4 does not
+ *   trigger; one pumped to 4 does).
+ * - **A token triggers but can't be exiled** (2007-10-01 ruling): it ceases to exist as a state
+ *   based action before the trigger resolves, so the move finds nothing. That falls out of the
+ *   engine's own zone handling — no special case here.
+ * - **The end-step ability is a mandatory sacrifice with an intervening "if"** (CR 603.4), so it
+ *   only triggers at three or more cards and re-checks on resolution. `IfYouDo` gates the return
+ *   on the sacrifice actually happening: the 2007-10-01 ruling is explicit that an Urn which left
+ *   the battlefield or changed controllers returns nothing. `SuccessCriterion.PermanentsSacrificed`
+ *   is what makes that fail-closed — the same shape as Safe Haven's upkeep ability.
+ * - The count is over the **whole game**, not the turn: `LINKED_EXILE_CARD_COUNT` reads the pile
+ *   itself, which is exactly that.
+ */
+val ColfenorsUrn = card("Colfenor's Urn") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a creature with toughness 4 or greater is put into your graveyard " +
+        "from the battlefield, you may exile it.\n" +
+        "At the beginning of the end step, if three or more cards have been exiled with this " +
+        "artifact, sacrifice it. If you do, return those cards to the battlefield under their " +
+        "owner's control."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.toughnessAtLeast(4).ownedByYou(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        optional = true
+        effect = Effects.Move(
+            EffectTarget.TriggeringEntity,
+            Zone.EXILE,
+            fromZone = Zone.GRAVEYARD,
+            linkToSource = true
+        )
+        description = "Whenever a creature with toughness 4 or greater is put into your " +
+            "graveyard from the battlefield, you may exile it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        interveningIf = Compare(
+            DynamicAmount.ContextProperty(ContextPropertyKey.LINKED_EXILE_CARD_COUNT),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(3)
+        )
+        effect = Effects.IfYouDo(
+            action = Effects.SacrificeTarget(EffectTarget.Self),
+            ifYouDo = Effects.ReturnLinkedExileUnderOwnersControl(),
+            successCriterion = SuccessCriterion.PermanentsSacrificed
+        )
+        description = "At the beginning of the end step, if three or more cards have been " +
+            "exiled with this artifact, sacrifice it. If you do, return those cards to the " +
+            "battlefield under their owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "254"
+        artist = "Jim Pavelec"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg?1783942851"
+        ruling("2007-10-01", "The second ability checks how many creatures have been exiled with Colfenor's Urn over the course of the entire game.")
+        ruling("2007-10-01", "The second ability forces you to sacrifice Colfenor's Urn. If the ability triggers and the Urn isn't sacrificed (because it left the battlefield or changed controllers, for example), the exiled cards won't be returned to the battlefield.")
+        ruling("2007-10-01", "The first ability triggers when a token creature with toughness 4 or greater is put into your graveyard. However, that token will cease to exist before Colfenor's Urn can exile it.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ShelldockIsle.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ShelldockIsle.kt
@@ -1,0 +1,168 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Shelldock Isle
+ * Land
+ *
+ * Hideaway 4 (When this land enters, look at the top four cards of your library, exile
+ * one face down, then put the rest on the bottom in a random order.)
+ * This land enters tapped.
+ * {T}: Add {U}.
+ * {U}, {T}: You may play the exiled card without paying its mana cost if a library has
+ * twenty or fewer cards in it.
+ *
+ * The hideaway half is [SpinerockKnoll]'s shape verbatim — see its comment for how the ETB is
+ * composed out of gather → select → move.
+ *
+ * The gate is the interesting line. **"A library" is an existential over *every* player**,
+ * including you (2007-10-01: "It doesn't matter which library has twenty or fewer cards in it,
+ * and you don't have to specify a library"), and the SDK's only player-boundary aggregation is
+ * [DynamicAmount.GreatestAmongPlayers], which takes a *maximum*. A minimum is what this sentence
+ * wants and there is no `LeastAmongPlayers`, so the composition takes the maximum of a **0/1
+ * indicator** instead: each player is measured on their own ("does *my* library hold 20 or
+ * fewer?"), and the greatest of those indicators is 1 exactly when at least one player qualifies.
+ *
+ * The wrong spellings both read plausibly on the card and both fail:
+ *  - `AggregateZone(Player.Each, Zone.LIBRARY)` sums every library into one number, so two
+ *    players on 15 cards each would report 30 and never satisfy the gate.
+ *  - `AggregateZone(Player.You, Zone.LIBRARY)` silently narrows "a library" to yours, which is
+ *    the *opposite* half of the card's real use — you activate this off an opponent milling out.
+ *
+ * [DynamicAmount.GreatestAmongPlayers] rebinds the resolution context's controller per iteration,
+ * so [Player.You] inside the indicator means "the player being measured" — never write an
+ * outward reference such as `Player.AnOpponent` there.
+ *
+ * Modelling the clause as an [ActivationRestriction] rather than a resolution-time check is the
+ * same choice the rest of the hideaway cycle makes: a fail-closed gate means the ability is not
+ * offered at all below the threshold, which is what the card's "if" does.
+ */
+val ShelldockIsle = card("Shelldock Isle") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "Hideaway 4 (When this land enters, look at the top four cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "This land enters tapped.\n" +
+        "{T}: Add {U}.\n" +
+        "{U}, {T}: You may play the exiled card without paying its mana cost if a library has " +
+        "twenty or fewer cards in it."
+
+    keywordAbility(KeywordAbility.hideaway(4))
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(4),
+                        player = Player.You
+                    ),
+                    storeAs = "hideawayTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hideawayTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "hideawayPicked",
+                    storeRemainder = "hideawayRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hideawayLinked"
+                ),
+                GrantMayPlayFromExileEffect("hideawayLinked"),
+                GrantPlayWithoutPayingCostEffect("hideawayLinked")
+            )
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    DynamicAmount.GreatestAmongPlayers(
+                        players = Player.Each,
+                        inner = DynamicAmount.Conditional(
+                            condition = Compare(
+                                DynamicAmount.AggregateZone(Player.You, Zone.LIBRARY),
+                                ComparisonOperator.LTE,
+                                DynamicAmount.Fixed(20)
+                            ),
+                            ifTrue = DynamicAmount.Fixed(1),
+                            ifFalse = DynamicAmount.Fixed(0)
+                        )
+                    ),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(1)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "272"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg?1783942847"
+        ruling("2022-04-29", "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\"")
+        ruling("2022-04-29", "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card.")
+        ruling("2022-04-29", "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4.")
+        ruling("2022-04-29", "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order.")
+        ruling("2007-10-01", "It doesn't matter which library has twenty or fewer cards in it, and you don't have to specify a library.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingsPrerogativeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingsPrerogativeScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AshlingsPrerogative
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Ashling's Prerogative (LRW #150).
+ *
+ * "As this enchantment enters, choose odd or even. Each creature with mana value of the chosen
+ *  quality has haste. Each creature without mana value of the chosen quality enters tapped."
+ *
+ * The card is two mirrored pairs of effects behind one mode choice, and *every* wrong wiring of it
+ * still compiles and still reads right on the card: swapping the two parities, or gating the tap
+ * clause on the wrong mode, produces an enchantment that does exactly the opposite thing. So each
+ * assertion below is run on **both** modes with the **same** two creatures — the only shape where
+ * an inverted wiring disagrees with a correct one.
+ *
+ * The tap half is also the reason this card carries a test at all: it needed a `condition` gate on
+ * [com.wingedsheep.sdk.scripting.PermanentsEnterTapped], because a replacement stamped into the
+ * source's replacement component and consulted from the battlefield can't be wrapped in a
+ * `ConditionalStaticAbility` the way the haste halves are. An ungated version would tap creatures
+ * of *both* parities.
+ *
+ * Creatures are **cast**, never placed: `putCreatureOnBattlefield` inserts a permanent directly
+ * and never consults an entry replacement, so it would report every creature untapped regardless
+ * of what the enchantment says.
+ */
+class AshlingsPrerogativeScenarioTest : FunSpec({
+
+    /** Centaur Courser is {2}{G} — mana value 3, odd. Forest Walker is {1}{G} — mana value 2, even. */
+    val oddCreature = "Centaur Courser"
+    val evenCreature = "Forest Walker"
+
+    fun setUp(mode: String): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AshlingsPrerogative))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val prerogative = driver.putPermanentOnBattlefield(player, "Ashling's Prerogative")
+        driver.addComponent(
+            prerogative,
+            CastChoicesComponent(chosen = mapOf(ChoiceSlot.MODE to ChoiceValue.TextChoice(mode)))
+        )
+        return Triple(driver, player, prerogative)
+    }
+
+    /** Cast [cardName] from hand and let it resolve onto the battlefield. */
+    fun castCreature(driver: GameTestDriver, player: EntityId, cardName: String): EntityId {
+        val card = driver.putCardInHand(player, cardName)
+        driver.giveMana(player, Color.GREEN, 5)
+        driver.castSpell(player, card)
+        driver.bothPass()
+        return driver.findPermanent(player, cardName)!!
+    }
+
+    test("odd chosen: odd-cost creatures enter untapped with haste, even-cost creatures enter tapped") {
+        val (driver, player, _) = setUp("odd")
+
+        val odd = castCreature(driver, player, oddCreature)
+        driver.isTapped(odd) shouldBe false
+        driver.state.projectedState.hasKeyword(odd, Keyword.HASTE) shouldBe true
+
+        val even = castCreature(driver, player, evenCreature)
+        driver.isTapped(even) shouldBe true
+        driver.state.projectedState.hasKeyword(even, Keyword.HASTE) shouldBe false
+    }
+
+    test("even chosen: the same two creatures swap roles") {
+        val (driver, player, _) = setUp("even")
+
+        val even = castCreature(driver, player, evenCreature)
+        driver.isTapped(even) shouldBe false
+        driver.state.projectedState.hasKeyword(even, Keyword.HASTE) shouldBe true
+
+        val odd = castCreature(driver, player, oddCreature)
+        driver.isTapped(odd) shouldBe true
+        driver.state.projectedState.hasKeyword(odd, Keyword.HASTE) shouldBe false
+    }
+
+    test("haste is granted to every creature of the chosen parity, not just the controller's") {
+        val (driver, player, _) = setUp("odd")
+        val opponent = driver.getOpponent(player)
+
+        // Already on the battlefield under the opponent's control: "each creature" is unqualified,
+        // so `youControl()` on the grant filter would silently drop this one.
+        val theirs = driver.putCreatureOnBattlefield(opponent, oddCreature)
+        driver.state.projectedState.hasKeyword(theirs, Keyword.HASTE) shouldBe true
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ColfenorsUrnScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ColfenorsUrnScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ColfenorsUrn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Colfenor's Urn (LRW #254).
+ *
+ * "Whenever a creature with toughness 4 or greater is put into your graveyard from the
+ *  battlefield, you may exile it.
+ *  At the beginning of the end step, if three or more cards have been exiled with this artifact,
+ *  sacrifice it. If you do, return those cards to the battlefield under their owner's control."
+ *
+ * Two axes are worth pinning, because both fail silently:
+ *
+ * - **The toughness gate is last-known information.** The creature is in the graveyard by the
+ *   time the trigger is checked, so a matcher reading its live characteristics would find no
+ *   toughness at all and either fire on everything or on nothing. A 5/5 must trigger and a 3/3
+ *   must not.
+ * - **The end-step ability's intervening "if" counts the linked pile, not the turn.** Below three
+ *   cards nothing happens and the Urn survives; at three it sacrifices itself and returns all
+ *   three. Testing only the "at three" half would pass against an ungated ability that fires
+ *   every end step.
+ */
+class ColfenorsUrnScenarioTest : FunSpec({
+
+    fun resolveStack(driver: GameTestDriver) {
+        while (driver.stackSize > 0 && driver.state.pendingDecision == null) {
+            driver.bothPass()
+        }
+    }
+
+    fun setUp(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ColfenorsUrn))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(player, "Colfenor's Urn")
+        return driver to player
+    }
+
+    /**
+     * Put [cardName] onto the battlefield and Doom Blade it, answering the Urn's "may" with [exile].
+     *
+     * Passes only while something is actually on the stack: `bothPass()` on an *empty* stack
+     * advances the step, which would walk the game out of the main phase before the next
+     * (sorcery-speed) Doom Blade and leave the later kills silently uncast.
+     */
+    fun killCreature(driver: GameTestDriver, player: EntityId, cardName: String, exile: Boolean) {
+        driver.putCreatureOnBattlefield(player, cardName)
+        val target = driver.findPermanent(player, cardName)!!
+        val blade = driver.putCardInHand(player, "Doom Blade")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.castSpellWithTargets(player, blade, listOf(ChosenTarget.Permanent(target)))
+        resolveStack(driver)
+        if (driver.state.pendingDecision is YesNoDecision) {
+            driver.submitYesNo(player, exile)
+            resolveStack(driver)
+        }
+    }
+
+
+    test("a toughness-5 creature offers the exile; a toughness-3 creature does not") {
+        val (driver, player) = setUp()
+
+        // Centaur Courser is 3/3 — below the gate, so no trigger and the card stays in the yard.
+        killCreature(driver, player, "Centaur Courser", exile = true)
+        driver.getGraveyardCardNames(player) shouldContain "Centaur Courser"
+        driver.getExileCardNames(player).contains("Centaur Courser") shouldBe false
+
+        // Force of Nature is 5/5 — the trigger fires and the exile is taken.
+        killCreature(driver, player, "Force of Nature", exile = true)
+        driver.getExileCardNames(player) shouldContain "Force of Nature"
+    }
+
+    test("declining the may leaves the creature in the graveyard") {
+        val (driver, player) = setUp()
+
+        killCreature(driver, player, "Force of Nature", exile = false)
+
+        driver.getGraveyardCardNames(player) shouldContain "Force of Nature"
+        driver.getExileCardNames(player).contains("Force of Nature") shouldBe false
+    }
+
+    test("two exiled cards is below the threshold — the Urn survives the end step") {
+        val (driver, player) = setUp()
+
+        killCreature(driver, player, "Force of Nature", exile = true)
+        killCreature(driver, player, "Force of Nature", exile = true)
+        driver.getExileCardNames(player).count { it == "Force of Nature" } shouldBe 2
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.findPermanent(player, "Colfenor's Urn").shouldNotBeNull()
+        driver.getExileCardNames(player).count { it == "Force of Nature" } shouldBe 2
+    }
+
+    test("three exiled cards sacrifices the Urn and returns them to the battlefield") {
+        val (driver, player) = setUp()
+
+        repeat(3) { killCreature(driver, player, "Force of Nature", exile = true) }
+        driver.getExileCardNames(player).count { it == "Force of Nature" } shouldBe 3
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.findPermanent(player, "Colfenor's Urn") shouldBe null
+        driver.getCreatures(player).count { driver.getCardName(it) == "Force of Nature" } shouldBe 3
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelldockIsleScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelldockIsleScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ShelldockIsle
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shelldock Isle (LRW #272).
+ *
+ * "Hideaway 4 … This land enters tapped. {T}: Add {U}.
+ *  {U}, {T}: You may play the exiled card without paying its mana cost if a library has twenty or
+ *  fewer cards in it."
+ *
+ * The hideaway half is shared with the rest of the cycle and covered by
+ * [SpinerockKnollScenarioTest]; what is unique here is the gate, and its whole difficulty is the
+ * word **"a"**. It is an existential over every library in the game, so the test is aimed at the
+ * asymmetric board — a big library of your own, a small one across the table — which is the one
+ * shape where the two plausible wrong readings give the wrong answer:
+ *
+ *  - summing every library into one number never reaches "twenty or fewer";
+ *  - reading only your own library says no while the card says yes.
+ *
+ * The third test pins the fail-closed direction: with both libraries above twenty the ability must
+ * not even be offered. A gate that is never read gives the same (permissive) answer to every
+ * board, so without this half the other two prove nothing.
+ */
+class ShelldockIsleScenarioTest : FunSpec({
+
+    /** Index 0 is the {T}: Add {U} mana ability; index 1 is the gated free-cast ability. */
+    val freeCastAbilityId = ShelldockIsle.activatedAbilities[1].id
+
+    fun freeCastOffered(driver: GameTestDriver, player: EntityId, land: EntityId): Boolean =
+        driver.legalActions(player).any {
+            val action = it.action
+            action is ActivateAbility && action.sourceId == land && action.abilityId == freeCastAbilityId
+        }
+
+    /** Play the land from hand so hideaway runs, exile a card, then untap it (it enters tapped). */
+    fun playShelldockIsle(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Shelldock Isle")
+        driver.playLand(player, card)
+        driver.bothPass() // resolve the hideaway trigger → pauses to exile one of the top four
+        val decision = driver.pendingDecision
+        require(decision is SelectCardsDecision) { "expected hideaway selection, got $decision" }
+        driver.submitCardSelection(player, listOf(decision.options.first()))
+        val land = driver.findPermanent(player, "Shelldock Isle")!!
+        driver.untapPermanent(land)
+        return land
+    }
+
+    /**
+     * Start a game whose two libraries differ in size. Decks are drawn down by the opening hand,
+     * so a 40-card deck leaves roughly 33 cards and a 25-card deck roughly 18.
+     */
+    fun start(driver: GameTestDriver, yourDeckSize: Int, theirDeckSize: Int): EntityId {
+        driver.registerCards(TestCards.all + listOf(ShelldockIsle))
+        driver.initGame(
+            deck1 = Deck.of("Island" to yourDeckSize),
+            deck2 = Deck.of("Island" to theirDeckSize),
+            startingLife = 20
+        )
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("both libraries above twenty keeps the free-cast ability closed") {
+        val driver = GameTestDriver()
+        val player = start(driver, yourDeckSize = 40, theirDeckSize = 40)
+
+        val land = playShelldockIsle(driver, player)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe false
+    }
+
+    test("an opponent's library at twenty or fewer opens it, even though yours is large") {
+        val driver = GameTestDriver()
+        val player = start(driver, yourDeckSize = 40, theirDeckSize = 25)
+
+        val land = playShelldockIsle(driver, player)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe true
+    }
+
+    test("your own library at twenty or fewer opens it too — \"a library\" includes yours") {
+        val driver = GameTestDriver()
+        val player = start(driver, yourDeckSize = 25, theirDeckSize = 40)
+
+        val land = playShelldockIsle(driver, player)
+        driver.giveMana(player, Color.BLUE, 1)
+
+        freeCastOffered(driver, player, land) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -488,6 +488,127 @@
     ]
 }
 
+// Ashling's Prerogative
+{
+    "name": "Ashling's Prerogative",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "As this enchantment enters, choose odd or even. (Zero is even.)\nEach creature with mana value of the chosen quality has haste.\nEach creature without mana value of the chosen quality enters tapped.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "ManaValueIsOdd"
+                            ]
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "odd"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "ManaValueIsEven"
+                            ]
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "even"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "odd",
+                        "label": "Odd",
+                        "description": "Odd-cost creatures have haste; even-cost creatures enter tapped."
+                    },
+                    {
+                        "id": "even",
+                        "label": "Even",
+                        "description": "Even-cost creatures have haste; odd-cost creatures enter tapped."
+                    }
+                ]
+            },
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "ManaValueIsEven"
+                        ]
+                    },
+                    "to": "Battlefield"
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "odd"
+                }
+            },
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "ManaValueIsOdd"
+                        ]
+                    },
+                    "to": "Battlefield"
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "even"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg?1783942880",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The \"chosen value\" is either \"odd\" or \"even.\" So either creatures with odd mana values enter tapped and creatures with even mana values have haste, or vice versa."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of these effects. It doesn't matter what the value of X was while the creature was on the stack."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Auntie's Hovel
 {
     "name": "Auntie's Hovel",
@@ -2082,6 +2203,114 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Colfenor's Urn
+{
+    "name": "Colfenor's Urn",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it.\nAt the beginning of the end step, if three or more cards have been exiled with this artifact, sacrifice it. If you do, return those cards to the battlefield under their owner's control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature tou>=4 own:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "TriggeringEntity",
+                        "destination": "Exile",
+                        "fromZone": "Graveyard",
+                        "linkToSource": true
+                    },
+                    "descriptionOverride": "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it."
+                },
+                "descriptionOverride": "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "SacrificeTarget",
+                            "target": "Self"
+                        },
+                        "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "linked_return"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "linked_return",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "underOwnersControl": true
+                            }
+                        ]
+                    }
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "ContextProperty",
+                        "key": "LINKED_EXILE_CARD_COUNT"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "At the beginning of the end step, if three or more cards have been exiled with this artifact, sacrifice it. If you do, return those cards to the battlefield under their owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "rarity": "RARE",
+        "artist": "Jim Pavelec",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/419fea28-3813-4e65-8b90-6d335fdf0a0b.jpg?1783942851",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The second ability checks how many creatures have been exiled with Colfenor's Urn over the course of the entire game."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The second ability forces you to sacrifice Colfenor's Urn. If the ability triggers and the Urn isn't sacrificed (because it left the battlefield or changed controllers, for example), the exiled cards won't be returned to the battlefield."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "The first ability triggers when a token creature with toughness 4 or greater is put into your graveyard. However, that token will cease to exist before Colfenor's Urn can exile it."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Consuming Bonfire
@@ -10903,6 +11132,207 @@
             {
                 "date": "2007-10-01",
                 "text": "This ability can cause a creature to become a copy of itself. This will usually have no visible effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Shelldock Isle
+{
+    "name": "Shelldock Isle",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Hideaway 4 (When this land enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nThis land enters tapped.\n{T}: Add {U}.\n{U}, {T}: You may play the exiled card without paying its mana cost if a library has twenty or fewer cards in it.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "hideawayTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hideawayTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hideawayPicked",
+                            "storeRemainder": "hideawayRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "hideawayLinked"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "GreatestAmongPlayers",
+                                "inner": {
+                                    "type": "Conditional",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "AggregateZone",
+                                            "player": "You",
+                                            "zone": "Library"
+                                        },
+                                        "operator": "LTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 20
+                                        }
+                                    },
+                                    "ifTrue": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "ifFalse": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "272",
+        "rarity": "RARE",
+        "artist": "Mark Tedin",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4216656e-90e8-45fc-a0f6-0d0d79d0a021.jpg?1783942847",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\""
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Previously, permanents with hideaway entered the battlefield tapped. This ability has been removed from the definition of hideaway. Older cards have received errata to have an additional paragraph that reads \"[This permanent] enters the battlefield tapped,\" and they now have hideaway 4."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "It doesn't matter which library has twenty or fewer cards in it, and you don't have to specify a library."
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
@@ -1,5 +1,7 @@
 package com.wingedsheep.engine.handlers.effects
 
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
@@ -28,11 +30,13 @@ import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
 object EnterTappedReplacements {
 
     private val predicateEvaluator = PredicateEvaluator()
+    private val conditionEvaluator = ConditionEvaluator()
 
     /**
      * True if any battlefield permanent grants a [PermanentsEnterTapped] replacement whose
-     * `appliesTo` filter matches [enteringEntityId] (controlled by [enteringControllerId]). The
-     * entering entity must already carry its [ControllerComponent] /
+     * `appliesTo` filter matches [enteringEntityId] (controlled by [enteringControllerId]) and
+     * whose optional `condition` gate holds. The entering entity must already carry its
+     * [ControllerComponent] /
      * [com.wingedsheep.engine.state.components.identity.CardComponent] so the filter
      * (type/subtype/"you control") resolves correctly.
      */
@@ -48,9 +52,16 @@ object EnterTappedReplacements {
             val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
             for (effect in replacementComponent.replacementEffects) {
                 if (effect !is PermanentsEnterTapped) continue
-                if (matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, state)) {
-                    return true
+                if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, state)) continue
+                // Optional gate evaluated against the replacement *source*, mirroring
+                // RedirectDamage.condition — e.g. Ashling's Prerogative's tap clause applies only
+                // while the mode it chose as it entered is the one this effect was written for.
+                val gate = effect.condition
+                if (gate != null) {
+                    val gateContext = EffectContext(sourceId = sourceId, controllerId = sourceControllerId)
+                    if (!conditionEvaluator.evaluate(state, gate, gateContext)) continue
                 }
+                return true
             }
         }
         return false


### PR DESCRIPTION
Three Lorwyn cards. Three rather than five because LRW's 61-card tail is almost
entirely blocked — `just assay-ready LRW` reports **0 Assay-ready**, and clash,
champion, the "reveal a <type> card or pay {3}" additional cost, and −X loyalty
account for roughly 40 of them between them.

- **Colfenor's Urn** `{3}` — pure composition. A dies trigger with a
  last-known-information toughness gate feeds the linked-exile pile; an end-step
  ability with an intervening "if" over `LINKED_EXILE_CARD_COUNT` empties it.
  Safe Haven's `IfYouDo` / `SuccessCriterion.PermanentsSacrificed` shape, so an
  Urn that has already left the battlefield returns nothing (2007-10-01 ruling).

- **Shelldock Isle** — finishes the Lorwyn hideaway land cycle. The hideaway
  half is Spinerock Knoll's shape verbatim. The gate is the new part: "a library
  has twenty or fewer cards in it" is an existential over *every* player, and
  the SDK's only player-boundary aggregation (`GreatestAmongPlayers`) takes a
  maximum. There is no `LeastAmongPlayers`, so it takes the greatest of a 0/1
  indicator instead — each player measured on their own, maximum 1 exactly when
  at least one qualifies. Both obvious spellings are wrong: summing every
  library never reaches twenty, and reading only your own library inverts the
  card's main use. No new engine code.

- **Ashling's Prerogative** `{1}{R}` — two mirrored pairs of effects behind one
  odd/even mode choice (`EntersWithChoice(MODE)` + `SourceChosenModeIs`, the
  Sieges' shape). The haste halves are `ConditionalStaticAbility` over
  `GrantKeyword`; the tap halves could not be, because `PermanentsEnterTapped`
  is a runtime replacement stamped into the source's replacement component
  rather than an ability projected through the layer system, so a
  `ConditionalStaticAbility` wrapper never reaches it.

## The one SDK addition

`PermanentsEnterTapped` gains an optional `condition` — the same source-gate
axis `RedirectDamage` and `EntersWithCounters` already carry — evaluated
against the replacement source in `EnterTappedReplacements.entersTapped`.
Existing callers are unaffected (`null` = always, as before).
`docs/card-sdk-language-reference.md` updated in the same commit.

## Tests

Ten new scenario tests, one file per card, each aimed at the axis where a wrong
wiring still reads right on the card:

- **Urn** — toughness from LKI (a 5/5 triggers, a 3/3 does not), the declined
  "may", and both sides of the threshold (two exiled cards leaves the Urn alone
  at end step, three sacrifices it and returns all three).
- **Shelldock Isle** — both libraries large keeps the ability closed; either
  player's small library opens it. The fail-closed half matters: a gate that is
  never read gives the same permissive answer to every board.
- **Ashling's Prerogative** — both modes over the *same* two creatures, which is
  the only shape where an inverted wiring disagrees with a correct one, plus an
  opponent-controlled creature to pin that "each creature" is unqualified.

## Verification

- `just test` green (`ColfenorsUrnScenarioTest` 4/4, `ShelldockIsleScenarioTest`
  3/3, `AshlingsPrerogativeScenarioTest` 3/3, `CardDefinitionSnapshotTest`
  334/334).
- `just rebless-cards` — only `snapshots/cards/LRW.json` moved, additions only.
- `just check-card-printing` clean for all three; LRW is the earliest real
  printing of each, so no `Printing` rows are needed.
- `just assay-differential --set LRW` — 10 divergences, all pre-existing (the
  Harbinger cycle, Epic Proportions, Kithkin Greatheart); none of these cards.
- All three field-verified against Scryfall: mana cost, type line, collector
  number, artist, oracle text, and image URI (HTTP 200).

Lorwyn: 225/286 → **228/286**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV4Lbefy9DktdPP1e6QktF