### PR TITLE
Clear stale rejection metadata when restoring environments

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -267,6 +267,7 @@ class GameEnvironment private constructor(
         this.playerIds = playerIds
         this.events = emptyList()
         this.lastStepEvents = emptyList()
+        this.lastRejection = null
         this.stepCount = stepCount
     }
 

--- a/gym/src/test/kotlin/com/wingedsheep/gym/GameEnvironmentTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/GameEnvironmentTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -99,6 +100,35 @@ class GameEnvironmentTest : FunSpec({
 
         env.stepCount shouldBe initialStep + 1
         result.state.shouldNotBeNull()
+    }
+
+    test("restore clears a rejection from an abandoned transition") {
+        val env = GameEnvironment.create(createRegistry())
+        env.reset(
+            GameConfig(
+                players = listOf(
+                    PlayerConfig("Alice", simpleDeck()),
+                    PlayerConfig("Bob", simpleDeck())
+                ),
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        val savedState = env.state
+        val savedPlayerIds = env.playerIds
+        val savedStepCount = env.stepCount
+        val priorityPlayer = env.agentToAct.shouldNotBeNull()
+        val nonPriorityPlayer = env.playerIds.first { it != priorityPlayer }
+
+        env.step(PassPriority(nonPriorityPlayer))
+        env.lastRejection.shouldNotBeNull()
+
+        env.restore(savedState, savedPlayerIds, savedStepCount)
+
+        env.lastRejection.shouldBeNull()
+        env.state shouldBe savedState
+        env.playerIds shouldBe savedPlayerIds
+        env.stepCount shouldBe savedStepCount
     }
 
     test("fork creates an independent copy") {


### PR DESCRIPTION
`GameEnvironment.restore` rewinds strategic state, events, and the step counter, but it currently leaves `lastRejection` from the abandoned branch in place.

A searcher can save root R, try an illegal action and receive rejection E, then restore R before exploring another action. At that point the environment describes R while `lastRejection` still describes E. Diagnostics can attribute the old rejection to the restored root or to the next transition.

## Change

Restoring a snapshot now clears `lastRejection` together with `events` and `lastStepEvents`.

Rejection is transient output from a transition attempt, so its lifetime follows the branch that produced it. `GameEnvironment` already owns snapshot installation and this metadata, making restore the single place to re-establish a coherent environment state.

## Verification

The focused `GameEnvironmentTest` regression:

1. saves a legal root;
2. produces a non-priority-player rejection;
3. restores the root; and
4. verifies that `lastRejection` is empty while state, player IDs, and step count match the snapshot.
