### PR TITLE
Add exactly-one environment transitions

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/ExactOneSubmissionResult.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/ExactOneSubmissionResult.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.gym
+
+import com.wingedsheep.engine.core.GameAction
+
+/**
+ * The outcome of submitting exactly one action to [GameEnvironment.stepExactlyOne].
+ *
+ * Rejection is deliberately separate from [StepResult]: it is control flow from the
+ * authoritative [com.wingedsheep.engine.core.ActionProcessor] boundary, not a game transition
+ * with a reward or terminal outcome.
+ */
+sealed interface ExactOneSubmissionResult {
+    /** The submitted action was accepted and its direct engine result was installed. */
+    data class Applied(val step: StepResult) : ExactOneSubmissionResult
+
+    /** The submitted [action] was rejected atomically by the action processor. */
+    data class Rejected(
+        val action: GameAction,
+        val reason: String
+    ) : ExactOneSubmissionResult
+}

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -198,6 +198,36 @@ class GameEnvironment private constructor(
     }
 
     /**
+     * Submit exactly one [action] through [ActionProcessor] and install its direct result.
+     *
+     * Unlike [step], this does not run simulator-driven automatic resolution: it never
+     * synthesizes an additional [GameAction], decision response, or priority pass. The submitted
+     * action may itself legitimately resolve the stack or advance the game (for example,
+     * [PassPriority]). [ActionProcessor] remains the authoritative action boundary: it performs
+     * the submitted action atomically and any resulting [PendingDecision] remains for the caller.
+     * A rejected action is returned as [ExactOneSubmissionResult.Rejected], rather than being
+     * represented as a game reward or outcome.
+     */
+    fun stepExactlyOne(action: GameAction): ExactOneSubmissionResult {
+        check(playerIds.isNotEmpty()) { "Call reset() before stepExactlyOne()" }
+
+        val result = processor.process(state, action).result
+        stepCount++
+        val rejection = result.error
+        if (rejection != null) {
+            lastStepEvents = result.events
+            lastRejection = rejection
+            return ExactOneSubmissionResult.Rejected(action, rejection)
+        }
+
+        state = result.state
+        events = events + result.events
+        lastStepEvents = result.events
+        lastRejection = null
+        return ExactOneSubmissionResult.Applied(buildStepResult(result.events))
+    }
+
+    /**
      * Enumerate all legal actions for the player who needs to act.
      *
      * Uses [EnumerationMode.ACTIONS_ONLY] to skip expensive auto-tap preview

--- a/gym/src/test/kotlin/com/wingedsheep/gym/GameEnvironmentExactOneSubmissionTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/GameEnvironmentExactOneSubmissionTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.gym
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.Concede
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.ChooseOptionEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.OptionType
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class GameEnvironmentExactOneSubmissionTest : ScenarioTestBase() {
+
+    private val twoChoices = CardDefinition.sorcery(
+        name = "Two Choices",
+        manaCost = ManaCost.parse("{B}"),
+        oracleText = "Choose a color. Choose a color.",
+        script = CardScript.spell(
+            effect = CompositeEffect(
+                listOf(
+                    ChooseOptionEffect(OptionType.COLOR, storeAs = "firstColor"),
+                    ChooseOptionEffect(OptionType.COLOR, storeAs = "secondColor")
+                )
+            )
+        )
+    )
+
+    init {
+        cardRegistry.register(twoChoices)
+
+        test("exactly one cast leaves the spell on the stack with priority unresolved") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Two Choices")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .build()
+            val environment = GameEnvironment.create(cardRegistry)
+            environment.restore(game.state, listOf(game.player1Id, game.player2Id))
+            val spell = game.state.getHand(game.player1Id).single()
+
+            val result = environment.stepExactlyOne(CastSpell(game.player1Id, spell))
+
+            result.shouldBeInstanceOf<ExactOneSubmissionResult.Applied>()
+            environment.state.stack shouldBe listOf(spell)
+            environment.state.priorityPlayerId shouldBe game.player1Id
+            environment.pendingDecision.shouldBeNull()
+        }
+
+        test("exactly one decision response leaves the following genuine decision unresolved") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Two Choices")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .build()
+            game.castSpell(1, "Two Choices")
+            game.resolveStack()
+            val firstDecision = game.getPendingDecision().shouldBeInstanceOf<ChooseOptionDecision>()
+
+            val environment = GameEnvironment.create(cardRegistry)
+            environment.restore(game.state, listOf(game.player1Id, game.player2Id))
+
+            val result = environment.stepExactlyOne(
+                SubmitDecision(firstDecision.playerId, OptionChosenResponse(firstDecision.id, 0))
+            )
+
+            val applied = result.shouldBeInstanceOf<ExactOneSubmissionResult.Applied>()
+            val secondDecision = applied.step.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            (secondDecision.id == firstDecision.id) shouldBe false
+        }
+
+        test("rejection is explicit and state-atomic") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Two Choices")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .build()
+            val environment = GameEnvironment.create(cardRegistry)
+            environment.restore(game.state, listOf(game.player1Id, game.player2Id))
+            val spell = game.state.getHand(game.player1Id).single()
+            val rejectedAction = CastSpell(game.player2Id, spell)
+            val stateBefore = environment.state
+
+            val result = environment.stepExactlyOne(rejectedAction)
+
+            val rejected = result.shouldBeInstanceOf<ExactOneSubmissionResult.Rejected>()
+            rejected.action shouldBe rejectedAction
+            rejected.reason.shouldNotBeBlank()
+            environment.state shouldBe stateBefore
+            environment.events.shouldBeEmpty()
+            environment.lastStepEvents.shouldBeEmpty()
+            environment.lastRejection shouldBe rejected.reason
+            environment.stepCount shouldBe 1
+        }
+
+        test("an accepted terminal action keeps ordinary terminal rewards") {
+            val game = scenario().withPlayers().build()
+            val environment = GameEnvironment.create(cardRegistry)
+            environment.restore(game.state, listOf(game.player1Id, game.player2Id))
+
+            val result = environment.stepExactlyOne(Concede(game.player1Id))
+
+            val applied = result.shouldBeInstanceOf<ExactOneSubmissionResult.Applied>()
+            applied.step.terminated shouldBe true
+            applied.step.reward[game.player1Id] shouldBe -1.0
+            applied.step.reward[game.player2Id] shouldBe 1.0
+        }
+    }
+}


### PR DESCRIPTION
`GameEnvironment.step` submits an action and then advances through forced work until it reaches the next Gym-facing state. That is useful for ordinary Gym clients, but it cannot represent callers that stop at every genuine player choice.

For example, casting a spell can open a target, ordering, or response decision. A search adapter needs to submit the spell and return at that decision so its own policy can choose the response. If the environment answers it automatically, the resulting trace contains a choice the caller never made.

## Change

`GameEnvironment.stepExactlyOne` submits one `GameAction` to `ActionProcessor`, installs that direct result, and returns immediately.

The result is typed:

- `Applied(StepResult)` means the submitted action was accepted and its immediate result became the environment state.
- `Rejected(action, reason)` means the action was rejected without changing strategic state.

The method does not consume a follow-on decision, priority pass, target choice, ordering, or mulligan response. `GameEnvironment.step` keeps its existing automatic-progression behavior.

Putting this operation on `GameEnvironment` keeps state installation, events, and rejection metadata synchronized in the same place as other environment transitions.

## Verification

`GameEnvironmentExactOneSubmissionTest` passes 4 focused tests covering:

- one ordinary accepted action;
- a new genuine decision left pending;
- the direct event/result surface; and
- atomic rejection with unchanged strategic state.
