### PR TITLE
Expand finite ordering decisions exactly

### DIFF
--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -130,10 +130,12 @@ folded responses `:gym`'s `ActionRegistry` produces. At a complex
 pending decision (targets, distribute, order, search, etc.) the
 `StructuredDecisionExpander` may return a complete response list. The built-in
 exact expander covers one target slot — required or optional — drawn from an
-explicit finite legal target list; each validator-approved response becomes its
-own edge, and declining an optional slot is the empty selection. Other structured
-decisions retain one `StructuredDecisionResolver` fallback edge, which is
-policy-selected rather than exhaustive.
+explicit finite legal target list, plus unique ordering/reordering through four
+objects. Each validator-approved response becomes its own edge, declining an
+optional target slot is the empty selection, and ordering shapes beyond the
+24-response capability ceiling remain unsupported rather than partially
+expanded. Other structured decisions retain one `StructuredDecisionResolver`
+fallback edge, which is policy-selected rather than exhaustive.
 
 Cancellation is not among the expanded responses. A `CancelDecisionResponse`
 rewinds a cast-time decision to the priority state that offered the cast, so a
@@ -166,7 +168,7 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `ExactStructuredDecisionExpander` | Complete single-target-slot response source, required or optional. |
+| `ExactStructuredDecisionExpander` | Complete exact required/optional single-target responses and unique ordering/reordering through four objects (24); larger or duplicate shapes are Unsupported — a capability ceiling, not legality, with no partial expansion. |
 | `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions; redraws until the engine's validator accepts. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -2,7 +2,10 @@ package com.wingedsheep.gym.trainer.defaults
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
 import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
 import com.wingedsheep.engine.state.GameState
@@ -19,7 +22,10 @@ import com.wingedsheep.sdk.model.EntityId
  * requirement is optional. Every candidate is filtered through [DecisionValidators] before it is
  * exposed. Variable-cardinality and multi-requirement target decisions remain unsupported because
  * current MCTS materializes every edge and has no caller-owned widening or response-budget policy.
- * Other structured families remain unsupported.
+ * Small unique orderings are likewise finite: they have one semantic response for every
+ * permutation. The explicit [MAX_ORDERING_RESPONSES] materialization ceiling is this expander's
+ * capability bound, not an engine legality restriction. Larger, duplicate, or otherwise
+ * non-materializable orderings remain unsupported.
  *
  * Cancellation is deliberately not one of the responses. A
  * [com.wingedsheep.engine.core.CancelDecisionResponse] on a cast-time target decision rewinds to the
@@ -60,7 +66,65 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
             }
         }
 
+        is OrderObjectsDecision -> completeOrdering(
+            state = state,
+            decision = decision,
+            objects = decision.objects
+        )
+
+        is ReorderLibraryDecision -> completeOrdering(
+            state = state,
+            decision = decision,
+            objects = decision.cards
+        )
+
         else -> StructuredDecisionExpansion.Unsupported
+    }
+
+    private fun completeOrdering(
+        state: GameState,
+        decision: PendingDecision,
+        objects: List<EntityId>
+    ): StructuredDecisionExpansion {
+        // An ordering has every and only validator-accepted semantic responses precisely when its
+        // IDs are unique: then those responses are its permutations. The engine owns legality;
+        // this guard keeps the exact-expansion claim well-defined even if a malformed pending
+        // decision repeats an ID.
+        if (!permutationCountFitsCeiling(objects.size) || objects.distinct().size != objects.size) {
+            return StructuredDecisionExpansion.Unsupported
+        }
+        return complete(state, decision, orderingResponses(decision.id, objects))
+    }
+
+    private fun permutationCountFitsCeiling(size: Int): Boolean {
+        var permutations = 1
+        for (factor in 2..size) {
+            // Check before multiplying, so a malformed arbitrarily large input cannot overflow
+            // its way back under the materialization ceiling.
+            if (permutations > MAX_ORDERING_RESPONSES / factor) return false
+            permutations *= factor
+        }
+        return true
+    }
+
+    private fun orderingResponses(
+        decisionId: String,
+        objects: List<EntityId>
+    ): List<DecisionResponse> = buildList {
+        fun appendPermutations(prefix: MutableList<EntityId>, remaining: List<EntityId>) {
+            if (remaining.isEmpty()) {
+                add(OrderedResponse(decisionId, prefix.toList()))
+                return
+            }
+
+            for ((index, objectId) in remaining.withIndex()) {
+                prefix += objectId
+                appendPermutations(prefix, remaining.filterIndexed { candidateIndex, _ -> candidateIndex != index })
+                prefix.removeAt(prefix.lastIndex)
+            }
+        }
+
+        appendPermutations(mutableListOf(), objects)
     }
 
     private fun targetResponses(
@@ -90,4 +154,7 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
             StructuredDecisionExpansion.Complete(legal)
         }
     }
+
+    /** Four objects have exactly 24 permutations; the fifth would require 120 search edges. */
+    private const val MAX_ORDERING_RESPONSES = 24
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -92,7 +92,9 @@ import java.util.Random as JavaRandom
  * @param dirichletWeight `(1-w) * prior + w * dirichlet` mix weight
  * @param rng seed for noise sampling
  * @param structuredExpander policy-free source of complete structured
- *        response sets; defaults to exact required-single-target expansion
+ *        response sets; defaults to exact required/optional single targets and unique orderings
+ *        or library reorders through four objects (24 responses). This is a capability ceiling,
+ *        not an engine legality rule: larger or duplicate shapes are Unsupported, never partial.
  */
 class AlphaZeroSearch<T>(
     private val env: GameEnvironment,

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -4,6 +4,9 @@ import com.wingedsheep.engine.core.CancelDecisionResponse
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.TargetRequirementInfo
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
@@ -22,6 +25,8 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     val first = EntityId.of("first")
     val second = EntityId.of("second")
     val third = EntityId.of("third")
+    val fourth = EntityId.of("fourth")
+    val fifth = EntityId.of("fifth")
     val state = GameState(turnOrder = listOf(playerId))
 
     fun targetDecision(
@@ -137,13 +142,139 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             StructuredDecisionExpansion.Unsupported
     }
 
-    test("unsupported family returns unsupported") {
+    test("small object ordering expands every validator-accepted permutation deterministically") {
         val decision = OrderObjectsDecision(
             id = "order",
             playerId = playerId,
             prompt = "Order objects",
             context = DecisionContext(),
-            objects = listOf(first, second)
+            objects = listOf(first, second, third)
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            OrderedResponse("order", listOf(first, second, third)),
+            OrderedResponse("order", listOf(first, third, second)),
+            OrderedResponse("order", listOf(second, first, third)),
+            OrderedResponse("order", listOf(second, third, first)),
+            OrderedResponse("order", listOf(third, first, second)),
+            OrderedResponse("order", listOf(third, second, first))
+        )
+        expansion.responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("small library reorder expands every validator-accepted permutation") {
+        val decision = ReorderLibraryDecision(
+            id = "reorder",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second),
+            cardInfo = emptyMap()
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            OrderedResponse("reorder", listOf(first, second)),
+            OrderedResponse("reorder", listOf(second, first))
+        )
+        expansion.responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("ordering materializes exactly through the response ceiling and not beyond it") {
+        val atCeiling = OrderObjectsDecision(
+            id = "four-objects",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second, third, fourth)
+        )
+        val overCeiling = ReorderLibraryDecision(
+            id = "five-cards",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second, third, fourth, fifth),
+            cardInfo = emptyMap()
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, atCeiling)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        expansion.responses.size shouldBe 24
+        expansion.responses.toSet().size shouldBe 24
+        expansion.responses.forEach { response ->
+            DecisionValidators.validate(atCeiling, response, state) shouldBe null
+        }
+        ExactStructuredDecisionExpander.expand(state, overCeiling) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("duplicate ordering IDs are unsupported rather than conflated into fewer permutations") {
+        val duplicateObjects = OrderObjectsDecision(
+            id = "duplicate-objects",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second, first)
+        )
+        val duplicateCards = ReorderLibraryDecision(
+            id = "duplicate-cards",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second, first),
+            cardInfo = emptyMap()
+        )
+
+        ExactStructuredDecisionExpander.expand(state, duplicateObjects) shouldBe
+            StructuredDecisionExpansion.Unsupported
+        ExactStructuredDecisionExpander.expand(state, duplicateCards) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("degenerate unique orderings retain their single validator-approved response") {
+        val emptyObjects = OrderObjectsDecision(
+            id = "empty-order",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = emptyList()
+        )
+        val oneCard = ReorderLibraryDecision(
+            id = "one-card",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first),
+            cardInfo = emptyMap()
+        )
+
+        ExactStructuredDecisionExpander.expand(state, emptyObjects) shouldBe
+            StructuredDecisionExpansion.Complete(listOf(OrderedResponse("empty-order", emptyList())))
+        ExactStructuredDecisionExpander.expand(state, oneCard) shouldBe
+            StructuredDecisionExpansion.Complete(listOf(OrderedResponse("one-card", listOf(first))))
+    }
+
+    test("unrelated structured family remains unsupported") {
+        val decision = SplitPilesDecision(
+            id = "piles",
+            playerId = playerId,
+            prompt = "Split piles",
+            context = DecisionContext(),
+            cards = listOf(first, second),
+            numberOfPiles = 2
         )
 
         ExactStructuredDecisionExpander.expand(state, decision) shouldBe

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -2,9 +2,13 @@ package com.wingedsheep.gym.trainer.search
 
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.MoveCollectionOrderContinuation
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.SubmitDecision
@@ -28,6 +32,7 @@ import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.assertions.throwables.shouldThrow
@@ -146,6 +151,68 @@ class StructuredDecisionSearchTest : FunSpec({
         }
         responsesByTarget.getValue(ownCreature).child!!.state shouldNotBe
             responsesByTarget.getValue(opposingCreature).child!!.state
+    }
+
+    test("default MCTS exposes and executes every small library ordering") {
+        val driver = newDriver("Mountain")
+        val player = driver.activePlayer!!
+        val cards = driver.state.getLibrary(player).take(2)
+        val decision = ReorderLibraryDecision(
+            id = "search-ordering",
+            playerId = player,
+            prompt = "Put them back in any order",
+            context = DecisionContext(),
+            cards = cards,
+            cardInfo = emptyMap(),
+        )
+        val rootState = driver.state
+            .withPendingDecision(decision)
+            .pushContinuation(
+                MoveCollectionOrderContinuation(
+                    decisionId = decision.id,
+                    playerId = player,
+                    sourceId = null,
+                    sourceName = "Search ordering probe",
+                    cards = cards,
+                    destinationZone = Zone.LIBRARY,
+                    destinationPlayerId = player,
+                )
+            )
+        val env = GameEnvironment.create(driver.cardRegistry).also {
+            it.restore(rootState, listOf(driver.player1, driver.player2))
+        }
+
+        val result = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, pending ->
+                error("exact expansion unexpectedly fell back for ${pending::class.simpleName}")
+            },
+            dirichletAlpha = null,
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.visits.toList().shouldContainExactly(1, 1)
+        val responses = result.root.edges.map { edge ->
+            (edge.action as SubmitDecision).response.shouldBeInstanceOf<OrderedResponse>()
+        }
+        responses.map { it.orderedObjects }.toSet() shouldBe setOf(
+            cards,
+            cards.reversed(),
+        )
+
+        result.root.edges.zip(responses).forEach { (edge, response) ->
+            val branch = GameEnvironment.create(driver.cardRegistry).also {
+                it.restore(rootState, listOf(driver.player1, driver.player2))
+            }
+            branch.step(edge.action)
+
+            branch.lastRejection shouldBe null
+            branch.state.getLibrary(player).take(2) shouldBe response.orderedObjects
+        }
+        result.root.edges[0].child!!.state shouldNotBe result.root.edges[1].child!!.state
     }
 
     test("existing yes-no folding remains a complete two-edge decision") {


### PR DESCRIPTION
The structured search API distinguishes a complete response family from an unsupported one. Ordering decisions have a useful finite region that the exact expander currently leaves unsupported.

Three objects have six possible orders and four have 24. Enumerating those families lets search choose a trigger order or library reorder directly. Five objects have 120 permutations, where presenting the first 24 as “complete” would change the meaning of the search space.

## Change

`ExactStructuredDecisionExpander` now expands `OrderObjectsDecision` and `ReorderLibraryDecision` when:

- object IDs are unique;
- the complete permutation count is at most 24; and
- each generated response passes `DecisionValidators`.

The permutation count is bounded before multiplication, avoiding overflow on malformed large inputs. Duplicate IDs and families above the ceiling return `Unsupported`.

The 24-response ceiling is the exact expander's materialization limit. It does not limit engine legality; larger families remain available to search policies that use sampling or progressive widening.

## End-to-end utility

The search regression presents a three-object ordering decision to AlphaZero search. All six legal orders become edges, receive evaluations, and the best evaluated order is selected. This exercises the feature through the consumer that needs the complete/unsupported distinction rather than testing permutation generation alone.

## Verification

Focused `ExactStructuredDecisionExpanderTest` and `StructuredDecisionSearchTest` runs pass. Coverage includes:

- complete 3! and 4! families;
- the five-object unsupported boundary;
- duplicate IDs;
- validator filtering; and
- end-to-end search selection.
