### PR TITLE
Add two Lorwyn cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7420,6 +7420,12 @@ staticAbility {
 - `LegendRuleDoesNotApplyTo(filter)` — "The 'legend rule' doesn't apply to [filter] you control"
   (Spider-Verse — Spiders). Scan-based: `LegendRuleCheck` excludes permanents you control matching
   `filter` from the same-name duplicate grouping, so you may keep multiple copies (CR 704.5j).
+- `SkipDrawStep` — "Skip your draw step." Controller-scoped and standing: `DrawPhaseManager` scans the
+  projected battlefield (via `RoomFaceStatics`) as the draw step begins and takes no draw for a player
+  who controls one, every turn, without consuming anything. The one-shot counterparts are the
+  `SkipDrawStepComponent` marker and `Effects.SkipStepOrPhaseThisTurn`, both of which are spent by the
+  step they skip. Not unwrapped from a `ConditionalStaticAbility` — add that to
+  `DrawPhaseManager.skipsDrawStep` if an "as long as …" wording ever needs it. (Colfenor's Plans)
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4842,6 +4842,12 @@ work for abilities-on-stack (which carry no `CardComponent`).
 - `HasLeastManaValueAmong(candidates)` (filter builder `hasLeastManaValueAmong(candidates)`) — has the
   least mana value among battlefield permanents matching the supplied composable filter. Ties all
   qualify, and target legality is rechecked at resolution (Culling Scales).
+- `HasGreatestManaValueAmongAllCreatures` (filter builder `hasGreatestManaValueAmongAllCreatures()`) —
+  has the greatest mana value among **all** creatures on the battlefield, both players' (Favor of the
+  Mighty). Ties all qualify. Its candidate set is fixed rather than filter-supplied precisely so the
+  continuous-effect projection pass can evaluate it — `HasLeastManaValueAmong` above takes a filter and
+  is therefore a point-of-use (target / gather) predicate only, inert as a static's affected set. Mana
+  value is read off the printed cost, so X counts as 0 (CR 202.3b) and a face-down creature counts as 0.
 - `IsRingBearer` (filter builder `ringBearer()`) — the creature is its controller's Ring-bearer
   (CR 701.54: has `RingBearerComponent` and is controlled by its designating owner). Used for
   player-level Ring-bearer conditions via `Conditions.YouControl(Creature.ringBearer(), negate = …)`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -1048,6 +1048,26 @@ data class LegendRuleDoesNotApplyTo(
 }
 
 /**
+ * The controller skips their draw step — "Skip your draw step." (Colfenor's Plans, Necropotence).
+ *
+ * Like [NoMaximumHandSize] this is a turn-based read rather than a continuous-projection effect:
+ * [com.wingedsheep.engine.core.DrawPhaseManager] scans the battlefield for it as the draw step
+ * begins and, when the drawing player controls a permanent that has it, takes no draw. It is the
+ * standing counterpart of
+ * [com.wingedsheep.sdk.scripting.effects.SkipStepOrPhaseThisTurnEffect] / the one-shot
+ * "skip your next draw step" marker, which are consumed by the step they skip.
+ *
+ * The draw-step read matches the ability by type and does **not** unwrap a
+ * [ConditionalStaticAbility], so an "as long as …" wording needs that unwrapping added to
+ * `DrawPhaseManager.skipsDrawStep` first — every printed use of this line so far is unconditional.
+ */
+@SerialName("SkipDrawStep")
+@Serializable
+data object SkipDrawStep : StaticAbility {
+    override val description: String = "Skip your draw step"
+}
+
+/**
  * Removes the maximum hand size limit for the controller.
  * Used for cards like Thought Vessel and Reliquary Tower: "You have no maximum hand size."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -1258,6 +1258,14 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.HasLeastPowerAmongAllCreatures
     )
 
+    /**
+     * Must have the greatest mana value among *all* creatures on the battlefield (global, both
+     * players). On a tie every maximum-mana-value creature matches (Favor of the Mighty).
+     */
+    fun hasGreatestManaValueAmongAllCreatures() = copy(
+        statePredicates = statePredicates + StatePredicate.HasGreatestManaValueAmongAllCreatures
+    )
+
     /** Must have the least mana value among battlefield permanents matching [candidates]. */
     fun hasLeastManaValueAmong(candidates: GameObjectFilter) = copy(
         statePredicates = statePredicates + StatePredicate.HasLeastManaValueAmong(candidates)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -694,6 +694,25 @@ sealed interface StatePredicate {
     }
 
     /**
+     * Has the greatest mana value among *all* creatures on the battlefield (global scope, both
+     * players), not just the ones its controller controls. Ties match every creature sharing the
+     * maximum — "if there's a tie for highest mana value, all of those creatures" (Favor of the
+     * Mighty, 2007-10-01).
+     *
+     * Mana value is read off the printed mana cost, so an X in it counts as 0 (CR 202.3b) and a
+     * face-down creature — which has no mana cost — counts as 0. The mirror of
+     * [HasLeastPowerAmongAllCreatures] on the mana-value axis; unlike [HasLeastManaValueAmong] its
+     * candidate set is fixed rather than filter-supplied, which is what lets the continuous-effect
+     * projection pass evaluate it (a static ability's affected set is resolved without an
+     * ability-controller context).
+     */
+    @SerialName("HasGreatestManaValueAmongAllCreatures")
+    @Serializable
+    data object HasGreatestManaValueAmongAllCreatures : Entity {
+        override val description: String = "with the greatest mana value"
+    }
+
+    /**
      * Has the least mana value among battlefield permanents matching [candidates]. Ties match every
      * permanent sharing the minimum, allowing ordinary target selection to choose among them.
      */

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ColfenorsPlans.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ColfenorsPlans.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
+import com.wingedsheep.sdk.scripting.RestrictSpellsCastPerTurn
+import com.wingedsheep.sdk.scripting.SkipDrawStep
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Colfenor's Plans
+ * {2}{B}{B}
+ * Enchantment
+ *
+ * When this enchantment enters, exile the top seven cards of your library face down.
+ * You may look at the cards exiled with this enchantment, and you may play lands and cast
+ * spells from among those cards.
+ * Skip your draw step.
+ * You can't cast more than one spell each turn.
+ *
+ * Four printed lines, four pieces:
+ *
+ *  - **The ETB is a gather → move**, with `linkToSource = true` so the seven cards become *this*
+ *    enchantment's pile. That link is what the play permission below reads; without it the cards
+ *    would be ordinary face-down exile that nobody can ever see or use.
+ *  - **"You may look at" and "you may play" are two separate grants** —
+ *    `MoveCollectionEffect.lookableInExile` and [GrantMayCastFromLinkedExile]. Exile gives a
+ *    face-down card's own controller no baseline visibility (CR 708.5), so dropping the look grant
+ *    would leave you playing blind out of your own pile; and the look grant alone confers no
+ *    permission to play. See Jacob Hauken, Inspector for the pair in its original form.
+ *  - **`filter = Any` is what admits the lands.** A land is played, never cast (CR 305.1), and the
+ *    grant's land leg is the same permission as its cast leg — which is exactly the printed "play
+ *    lands **and** cast spells". `withoutPayingManaCost` stays off: this card's pile is played at
+ *    full price, unlike hideaway's.
+ *  - **[SkipDrawStep]** is the standing counterpart of the engine's one-shot skip marker, added
+ *    for this card. It is read as the draw step begins rather than projected, because a skipped
+ *    draw step is a turn-based action.
+ *
+ * The one-spell-per-turn clause is [RestrictSpellsCastPerTurn] scoped to the controller — Rule of
+ * Law's ability with `eachPlayer = false`, the Yawgmoth's Agenda shape. Note it binds *every*
+ * spell you cast, not just the ones out of the pile.
+ */
+val ColfenorsPlans = card("Colfenor's Plans") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, exile the top seven cards of your library face " +
+        "down.\n" +
+        "You may look at the cards exiled with this enchantment, and you may play lands and cast " +
+        "spells from among those cards.\n" +
+        "Skip your draw step.\n" +
+        "You can't cast more than one spell each turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7)),
+                storeAs = "colfenorsPlansExiled",
+            ),
+            MoveCollectionEffect(
+                from = "colfenorsPlansExiled",
+                destination = CardDestination.ToZone(Zone.EXILE),
+                faceDown = FaceDownMode.HIDDEN,
+                linkToSource = true,
+                lookableInExile = true,
+            ),
+        )
+        description = "When this enchantment enters, exile the top seven cards of your library " +
+            "face down."
+    }
+
+    staticAbility {
+        ability = GrantMayCastFromLinkedExile(filter = GameObjectFilter.Any)
+    }
+
+    staticAbility {
+        ability = SkipDrawStep
+    }
+
+    staticAbility {
+        ability = RestrictSpellsCastPerTurn(maxPerTurn = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "106"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg?1783942893"
+        ruling(
+            "2007-10-01",
+            "The turn you cast Colfenor's Plans, you have cast (at least) one spell that turn. " +
+                "After it enters and its last ability goes into effect, you can't cast any more " +
+                "spells that turn."
+        )
+        ruling(
+            "2007-10-01",
+            "Playing a card exiled with Colfenor's Plans follows all the normal rules for playing " +
+                "that card. You must pay its costs, and you must follow all timing restrictions, " +
+                "for example."
+        )
+        ruling("2007-10-01", "If an exiled card has morph, you may cast it face down.")
+        ruling(
+            "2013-04-15",
+            "If Colfenor's Plans leaves the battlefield, you can continue to look at cards exiled " +
+                "by it, but you can no longer play them."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FavorOfTheMighty.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/FavorOfTheMighty.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantProtection
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Favor of the Mighty
+ * {1}{W}
+ * Kindred Enchantment — Giant
+ *
+ * Each creature with the greatest mana value has protection from each color.
+ *
+ * Two things about the one sentence:
+ *
+ *  - **"Each creature" is every creature on the battlefield, not yours.** The group filter carries
+ *    no controller predicate on purpose — the enchantment shields an opponent's fatty just as
+ *    happily as your own, which is the whole reason it's a Giant card. Aim any test at an
+ *    opponent's creature: the implicit "you control" reading passes every same-side assertion.
+ *  - **"The greatest mana value" is a global maximum with ties, so it is a state predicate on the
+ *    affected set, not a condition on the ability.** The set is recomputed on every projection
+ *    pass, which is what the 2007-10-01 ruling ("this effect is checked continuously … if a new
+ *    creature enters with the highest mana value, it gains protection and the previous highest
+ *    loses it") asks for; a `ConditionalStaticAbility` gate would ask a yes/no question about the
+ *    enchantment instead of picking out creatures. `HasGreatestManaValueAmongAllCreatures` is the
+ *    mana-value mirror of `HasLeastPowerAmongAllCreatures`, added for this card: ties leave every
+ *    creature sharing the maximum in the set, and X in a mana cost counts as 0 (CR 202.3b), both
+ *    of which the rulings call out.
+ *
+ * Protection from each color is five [GrantProtection] statics, one per color — the same shape
+ * Mask of Law and Grace pairs for two colors, and the static counterpart of the five keyword
+ * grants Sygg, Wanderbrine Shield composes for the until-your-next-turn version. There is no
+ * "from each color" [com.wingedsheep.sdk.scripting.ProtectionScope]; `Colors(Color.entries)` would
+ * need one continuous effect to carry five qualities, and five independent effects is both the
+ * existing house shape and how the projection reads them back.
+ */
+private val greatestManaValueCreatures = GroupFilter(
+    GameObjectFilter.Creature.hasGreatestManaValueAmongAllCreatures()
+)
+
+val FavorOfTheMighty = card("Favor of the Mighty") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Kindred Enchantment — Giant"
+    oracleText = "Each creature with the greatest mana value has protection from each color."
+
+    Color.entries.forEach { color ->
+        staticAbility {
+            ability = GrantProtection(color, greatestManaValueCreatures)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "14"
+        artist = "Larry MacDougall"
+        flavorText = "\"What does a mountain fear of a fly? Giants are barely aware of us, let " +
+            "alone afraid.\"\n—Gaddock Teeg"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg?1783942915"
+        ruling(
+            "2007-10-01",
+            "If there's a tie for highest mana value, all of those creatures have protection " +
+                "from all colors."
+        )
+        ruling(
+            "2007-10-01",
+            "This effect is checked continuously. If a new creature enters with the highest mana " +
+                "value, it gains protection from all colors and the previous highest loses it."
+        )
+        ruling(
+            "2007-10-01",
+            "If a creature has X in its mana cost, that X is treated as 0 for the purposes of " +
+                "this effect. It doesn't matter what the value of X was while the creature was " +
+                "on the stack."
+        )
+        ruling(
+            "2024-06-07",
+            "This cards was originally printed with the \"tribal\" card type. That card type has " +
+                "been replaced with \"kindred\". This change does not affect the gameplay " +
+                "function of this card."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ColfenorsPlansScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ColfenorsPlansScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.ColfenorsPlans
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.withClue
+
+/**
+ * Scenario test for Colfenor's Plans (LRW #106).
+ *
+ * "When this enchantment enters, exile the top seven cards of your library face down.
+ *  You may look at the cards exiled with this enchantment, and you may play lands and cast spells
+ *  from among those cards.
+ *  Skip your draw step.
+ *  You can't cast more than one spell each turn."
+ *
+ * The new vocabulary here is the standing `SkipDrawStep` static, and the thing worth pinning about
+ * it is its **scope**: it is the controller's draw step, not everyone's. So the first test watches
+ * both players' draw steps in one game — the opponent's draw is the half that a player-agnostic
+ * read of the static would break, and it is invisible if you only assert on the controller.
+ *
+ * The second test covers the pile the enchantment builds: seven cards, face down, and playable
+ * from exile afterwards. "You may play lands" is the leg that needs `filter = Any` — a land is
+ * played, never cast (CR 305.1) — and a Swamp deck makes the pile all lands, so the land play is
+ * exactly what shows up in the legal actions. It is checked on a *later* turn on purpose: per the
+ * 2007-10-01 ruling, the turn you cast this you have already used up your one spell.
+ */
+class ColfenorsPlansScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ColfenorsPlans)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** The face-down cards in [player]'s exile that this enchantment's pile is made of. */
+    fun GameTestDriver.exiledCards(player: EntityId): List<EntityId> = getExile(player).toList()
+
+    test("the controller skips their draw step; the opponent still draws") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Colfenor's Plans")
+
+        val opponentHandBefore = d.getHandSize(d.player2)
+        val controllerHandBefore = d.getHandSize(d.player1)
+
+        // Player 2's draw step (turn 2) — the enchantment is not theirs.
+        d.passPriorityUntil(Step.DRAW)
+        withClue("\"Skip your draw step\" binds the controller only") {
+            d.getHandSize(d.player2) shouldBe opponentHandBefore + 1
+        }
+
+        // Player 1's draw step (turn 3) — the first one they actually get, since the starting
+        // player skips their own turn-1 draw by CR 103.8a.
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.DRAW)
+        withClue("the controller's draw step happened and drew nothing") {
+            d.getHandSize(d.player1) shouldBe controllerHandBefore
+        }
+
+        // And it is standing, not a one-shot marker: the next one is skipped too.
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.DRAW) // player 2 draws
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.DRAW) // player 1 again
+        withClue("a standing static skips every draw step, not just the next one") {
+            d.getHandSize(d.player1) shouldBe controllerHandBefore
+        }
+    }
+
+    test("entering exiles the top seven face down, and they can be played later") {
+        val d = driver()
+        val plans = d.putCardInHand(d.player1, "Colfenor's Plans")
+        d.giveMana(d.player1, Color.BLACK, 4)
+        d.castSpell(d.player1, plans).error shouldBe null
+        d.bothPass() // the enchantment resolves
+        d.bothPass() // its enters trigger resolves
+
+        val pile = d.exiledCards(d.player1)
+        withClue("the top seven cards of your library") {
+            pile.size shouldBe 7
+        }
+        withClue("face down") {
+            pile.all { d.state.getEntity(it)?.has<FaceDownComponent>() == true } shouldBe true
+        }
+
+        // Round to player 1's next main phase — the cast turn is spent (2007-10-01 ruling).
+        d.passPriorityUntil(Step.DRAW) // player 2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.DRAW) // player 1, skipped
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        withClue("\"you may play lands … from among those cards\" — a land in the pile is offered " +
+            "as a land play, which only a grant whose filter admits lands can do") {
+            d.legalActions(d.player1).any { legal ->
+                val action = legal.action
+                action is PlayLand && action.cardId in pile
+            } shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FavorOfTheMightyScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FavorOfTheMightyScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.FavorOfTheMighty
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Favor of the Mighty (LRW #14).
+ *
+ * "Each creature with the greatest mana value has protection from each color."
+ *
+ * Three readings of that sentence are plausible and only one is right, so each test is aimed at a
+ * board where the wrong ones disagree:
+ *
+ *  - **"Each creature" is not "each creature you control."** The first test puts the biggest
+ *    creature across the table; the implicit-controller reading passes every same-side assertion
+ *    and fails only here.
+ *  - **A tie protects all of them** (2007-10-01). The second test gives both players an equal
+ *    top-mana-value creature; a `maxOrNull`-then-pick-one reading would shield only one.
+ *  - **The set is recomputed continuously** (2007-10-01: "if a new creature enters with the
+ *    highest mana value, it gains protection … and the previous highest loses it"). The third
+ *    test moves the maximum after the enchantment has resolved, which a set locked in at
+ *    resolution time would not notice.
+ */
+class FavorOfTheMightyScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FavorOfTheMighty))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast and resolve Favor of the Mighty for [player]. */
+    fun castFavor(driver: GameTestDriver, player: EntityId) {
+        val card = driver.putCardInHand(player, "Favor of the Mighty")
+        driver.giveMana(player, Color.WHITE, 2)
+        driver.castSpell(player, card)
+        driver.bothPass()
+    }
+
+    /** Protection from every colour, as five separate projected keywords. */
+    fun hasProtectionFromEachColor(driver: GameTestDriver, entity: EntityId): Boolean {
+        val projected = projector.project(driver.state)
+        return Color.entries.all { projected.hasKeyword(entity, "PROTECTION_FROM_${it.name}") }
+    }
+
+    /** Protection from no colour at all — the "not in the affected set" assertion. */
+    fun hasProtectionFromNoColor(driver: GameTestDriver, entity: EntityId): Boolean {
+        val projected = projector.project(driver.state)
+        return Color.entries.none { projected.hasKeyword(entity, "PROTECTION_FROM_${it.name}") }
+    }
+
+    test("the opponent's greatest-mana-value creature is protected, your smaller one is not") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // {3}{G}{G} across the table, {W} on your side.
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Force of Nature")
+        val yours = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        castFavor(driver, you)
+
+        hasProtectionFromEachColor(driver, theirs) shouldBe true
+        hasProtectionFromNoColor(driver, yours) shouldBe true
+    }
+
+    test("a tie for the greatest mana value protects every creature sharing it") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Two {2}{G} creatures, one per side, and a {W} creature that misses the maximum.
+        val yourCourser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val theirCourser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        castFavor(driver, you)
+
+        hasProtectionFromEachColor(driver, yourCourser) shouldBe true
+        hasProtectionFromEachColor(driver, theirCourser) shouldBe true
+        hasProtectionFromNoColor(driver, lions) shouldBe true
+    }
+
+    test("a bigger creature entering later takes the protection off the previous maximum") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        castFavor(driver, you)
+
+        // The only creature in play is the maximum, so it is protected.
+        hasProtectionFromEachColor(driver, lions) shouldBe true
+
+        val forceOfNature = driver.putCreatureOnBattlefield(opponent, "Force of Nature")
+
+        hasProtectionFromEachColor(driver, forceOfNature) shouldBe true
+        hasProtectionFromNoColor(driver, lions) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -2205,6 +2205,88 @@
     ]
 }
 
+// Colfenor's Plans
+{
+    "name": "Colfenor's Plans",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, exile the top seven cards of your library face down.\nYou may look at the cards exiled with this enchantment, and you may play lands and cast spells from among those cards.\nSkip your draw step.\nYou can't cast more than one spell each turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 7
+                                }
+                            },
+                            "storeAs": "colfenorsPlansExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "colfenorsPlansExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN",
+                            "lookableInExile": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this enchantment enters, exile the top seven cards of your library face down."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantMayCastFromLinkedExile",
+                "filter": {}
+            },
+            "SkipDrawStep",
+            "RestrictSpellsCastPerTurn"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "RARE",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg?1783942893",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "The turn you cast Colfenor's Plans, you have cast (at least) one spell that turn. After it enters and its last ability goes into effect, you can't cast any more spells that turn."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "Playing a card exiled with Colfenor's Plans follows all the normal rules for playing that card. You must pay its costs, and you must follow all timing restrictions, for example."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If an exiled card has morph, you may cast it face down."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "If Colfenor's Plans leaves the battlefield, you can continue to look at cards exiled by it, but you can no longer play them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Colfenor's Urn
 {
     "name": "Colfenor's Urn",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -4155,6 +4155,116 @@
     ]
 }
 
+// Favor of the Mighty
+{
+    "name": "Favor of the Mighty",
+    "manaCost": "{1}{W}",
+    "typeLine": "Kindred Enchantment — Giant",
+    "oracleText": "Each creature with the greatest mana value has protection from each color.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantProtection",
+                "color": "WHITE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasGreatestManaValueAmongAllCreatures"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "GrantProtection",
+                "color": "BLUE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasGreatestManaValueAmongAllCreatures"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "GrantProtection",
+                "color": "BLACK",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasGreatestManaValueAmongAllCreatures"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "GrantProtection",
+                "color": "RED",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasGreatestManaValueAmongAllCreatures"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "GrantProtection",
+                "color": "GREEN",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasGreatestManaValueAmongAllCreatures"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "RARE",
+        "artist": "Larry MacDougall",
+        "flavorText": "\"What does a mountain fear of a fly? Giants are barely aware of us, let alone afraid.\"\n—Gaddock Teeg",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg?1783942915",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "If there's a tie for highest mana value, all of those creatures have protection from all colors."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "This effect is checked continuously. If a new creature enters with the highest mana value, it gains protection from all colors and the previous highest loses it."
+            },
+            {
+                "date": "2007-10-01",
+                "text": "If a creature has X in its mana cost, that X is treated as 0 for the purposes of this effect. It doesn't matter what the value of X was while the creature was on the stack."
+            },
+            {
+                "date": "2024-06-07",
+                "text": "This cards was originally printed with the \"tribal\" card type. That card type has been replaced with \"kindred\". This change does not affect the gameplay function of this card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Final Revels
 {
     "name": "Final Revels",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -582,6 +582,7 @@ class BeginningPhaseManager(
         StatePredicate.HasAnyCounter,
         StatePredicate.HasGreatestPower,
         StatePredicate.HasLeastPowerAmongAllCreatures,
+        StatePredicate.HasGreatestManaValueAmongAllCreatures,
         StatePredicate.HasLeastPower,
         StatePredicate.IsEquipped,
         StatePredicate.IsEnchanted,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DrawPhaseManager.kt
@@ -12,8 +12,11 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.engine.state.components.player.SkipDrawStepComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceStatics
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.SkipDrawStep
 import com.wingedsheep.sdk.scripting.effects.Effect
 
 /**
@@ -100,6 +103,7 @@ class DrawPhaseManager(
                 s = s.updateEntity(teammate) { it.without<SkipDrawStepComponent>() }
                 continue
             }
+            if (skipsDrawStep(s, teammate)) continue
             val r = drawCards(s, teammate, 1)
             if (r.isPaused) {
                 return ExecutionResult.paused(r.newState, r.pendingDecision!!, teammateEvents + r.events)
@@ -118,6 +122,15 @@ class DrawPhaseManager(
             )
         }
 
+        // A standing "Skip your draw step" static (Colfenor's Plans) — unlike the marker above it
+        // is not consumed, so it applies every turn for as long as the permanent is around.
+        if (skipsDrawStep(s, activePlayer)) {
+            return ExecutionResult.success(
+                s.withPriority(activePlayer),
+                teammateEvents + StepChangedEvent(Step.DRAW)
+            )
+        }
+
         val drawResult = drawCards(s, activePlayer, 1)
         if (!drawResult.isSuccess) {
             return drawResult
@@ -125,6 +138,27 @@ class DrawPhaseManager(
 
         val newState = drawResult.newState.withPriority(activePlayer)
         return ExecutionResult.success(newState, teammateEvents + drawResult.events + StepChangedEvent(Step.DRAW))
+    }
+
+    /**
+     * Whether [playerId] controls a permanent with the [SkipDrawStep] static ability.
+     *
+     * Read the same way maximum hand size is ([com.wingedsheep.engine.core.MaximumHandSize]): a
+     * turn-based scan of the projected battlefield rather than a continuous-projection value,
+     * because a skipped draw step is a turn-based action, not a characteristic. Routed through
+     * [RoomFaceStatics] so a Room face's static counts only while its door is unlocked (CR 709.5).
+     */
+    private fun skipsDrawStep(state: GameState, playerId: EntityId): Boolean {
+        val projected = state.projectedState
+        for (permanentId in projected.getBattlefieldControlledBy(playerId)) {
+            val container = state.getEntity(permanentId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (RoomFaceStatics.activeStaticAbilities(container, cardDef).any { it is SkipDrawStep }) {
+                return true
+            }
+        }
+        return false
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -2331,6 +2331,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsRingBearer,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasGreatestPower,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPowerAmongAllCreatures,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasGreatestManaValueAmongAllCreatures,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPower,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1929,6 +1929,27 @@ class PredicateEvaluator {
                 entityPower <= minPower
             }
 
+            // Global greatest mana value among every creature on the battlefield. Mana value is
+            // a printed characteristic (no projection entry), so it is read off CardComponent; a
+            // face-down creature has no mana cost and counts as 0, mirroring the least-mana-value
+            // reading below. Ties leave every maximum-mana-value creature matching.
+            StatePredicate.HasGreatestManaValueAmongAllCreatures -> {
+                if (!projected.isCreature(entityId)) return false
+                val entityManaValue = if (projected.getProjectedValues(entityId)?.isFaceDown == true) 0
+                else container.get<CardComponent>()?.manaValue ?: return false
+                val maxManaValue = state.getBattlefield()
+                    .asSequence()
+                    .filter { projected.isCreature(it) }
+                    .mapNotNull { candidateId ->
+                        val candidate = state.getEntity(candidateId) ?: return@mapNotNull null
+                        if (projected.getProjectedValues(candidateId)?.isFaceDown == true) 0
+                        else candidate.get<CardComponent>()?.manaValue
+                    }
+                    .maxOrNull()
+                    ?: return false
+                entityManaValue >= maxManaValue
+            }
+
             is StatePredicate.HasLeastManaValueAmong -> {
                 val predicateContext = context ?: return false
                 val entityManaValue = if (projected.getProjectedValues(entityId)?.isFaceDown == true) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -696,6 +696,8 @@ internal class AffectsFilterResolver {
         // and gathering), where PredicateEvaluator has the full ability context. It is not a
         // continuous-effect applicability predicate.
         is StatePredicate.HasLeastManaValueAmong -> false
+        StatePredicate.HasGreatestManaValueAmongAllCreatures ->
+            hasGreatestManaValueAmongAllCreaturesInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasLeastPower -> hasLeastPowerInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasAnyCounter -> {
             val counters = container.get<CountersComponent>()
@@ -741,6 +743,36 @@ internal class AffectsFilterResolver {
             }
             ?: return false
         return entityPower >= maxPower
+    }
+
+    /**
+     * Global greatest mana value across every creature on the battlefield — the projection-pass
+     * reading of [StatePredicate.HasGreatestManaValueAmongAllCreatures] (Favor of the Mighty).
+     *
+     * Creature-ness is read from the projection (so a permanent that only *became* a creature this
+     * pass counts), while mana value is a printed characteristic no layer modifies and is read off
+     * [CardComponent]. A face-down creature has no mana cost, so it counts as 0. Ties match every
+     * maximum-mana-value creature, which is what the card's 2007-10-01 ruling asks for.
+     */
+    private fun hasGreatestManaValueAmongAllCreaturesInProjection(
+        state: GameState,
+        entityId: EntityId,
+        container: ComponentContainer,
+        projectedValues: Map<EntityId, MutableProjectedValues>
+    ): Boolean {
+        if (!isCreatureInProjection(state, entityId, projectedValues)) return false
+        val entityManaValue = if (projectedValues[entityId]?.isFaceDown == true) 0
+        else container.get<CardComponent>()?.manaValue ?: return false
+        val maxManaValue = state.getBattlefield()
+            .asSequence()
+            .filter { isCreatureInProjection(state, it, projectedValues) }
+            .mapNotNull { candidateId ->
+                if (projectedValues[candidateId]?.isFaceDown == true) 0
+                else state.getEntity(candidateId)?.get<CardComponent>()?.manaValue
+            }
+            .maxOrNull()
+            ?: return false
+        return entityManaValue >= maxManaValue
     }
 
     private fun hasLeastPowerAmongAllCreaturesInProjection(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1046,6 +1046,7 @@ class StaticAbilityHandler(
             // Turn-based actions (BeginningPhaseManager / CleanupPhaseManager):
             is DamagePersistsThroughCleanup,
             is NoMaximumHandSize,
+            is com.wingedsheep.sdk.scripting.SkipDrawStep,
             is SetMaximumHandSize,
             is PreventManaPoolEmptying,
             is ConvertEmptyingManaToRed,


### PR DESCRIPTION
Lorwyn 228/286 → **230/286**. Two cards, one commit each — each carries one small piece of new
SDK vocabulary, so both are noted below rather than presented as pure composition.

### Favor of the Mighty (LRW #14)
"Each creature with the greatest mana value has protection from each color." Five `GrantProtection`
statics over one group filter — the static counterpart of the five keyword grants Sygg, Wanderbrine
Shield composes, and the shape Mask of Law and Grace pairs for two colors.

The affected set is the new part: `StatePredicate.HasGreatestManaValueAmongAllCreatures`, the
mana-value mirror of `HasLeastPowerAmongAllCreatures`. A global maximum over every creature on the
battlefield, ties all matching, mana value read off the printed cost so X counts as 0 (CR 202.3b)
and a face-down creature counts as 0 — both of which the card's rulings call out.

Its candidate set is fixed rather than filter-supplied on purpose: the existing
`HasLeastManaValueAmong(candidates)` takes a filter and so is a point-of-use predicate only
(`AffectsFilterResolver` answers `false` for it, since a static's affected set is resolved with no
ability-controller context). A fixed scope is what lets the projection pass read this one, which a
static ability needs.

### Colfenor's Plans (LRW #106)
Enters exiling the top seven face down linked to itself (`lookableInExile` + `linkToSource`, Jacob
Hauken's shape — seeing and playing are separate grants), `GrantMayCastFromLinkedExile(filter =
Any)` for "play lands and cast spells from among those cards" at full price, and
`RestrictSpellsCastPerTurn(maxPerTurn = 1)` for the last line.

"Skip your draw step" had no standing spelling — only the one-shot `SkipDrawStepComponent` marker
and `Effects.SkipStepOrPhaseThisTurn`, both consumed by the step they skip. `StaticAbility.SkipDrawStep`
is that standing form, read the way maximum hand size is: a turn-based scan of the projected
battlefield in `DrawPhaseManager` (via `RoomFaceStatics`) rather than a Rule 613 projection, because
a skipped draw is a turn-based action, not a characteristic. Not unwrapped from
`ConditionalStaticAbility` — noted in the KDoc rather than promised, since every printed use of the
line is unconditional.

### Cards triaged out
The rest of Lorwyn's 58-card tail is `add-feature` work, not authoring work — `just assay-ready LRW`
reports 0 Assay-ready. Of the five previously untriaged cards, four are blocked:

- **Cairn Wanderer** — "it gains any landwalk abilities and any protection abilities" of creature
  cards in graveyards is a dynamic keyword copy, and protection is modelled as a static rather than
  a printed keyword, so a `CardPredicate.HasKeyword` scan can't see it at all.
- **Guile** — "if a spell or ability you control would counter a spell, instead …" has no
  counter-replacement vocabulary, and "put into a graveyard from anywhere" needs `triggerZones` over
  hand/library/stack, which `TriggerDetector` has no precedent for scanning.
- **Rings of Brighthearth** — copying an activated ability on the stack (the Lithoform Engine family)
  has no effect; only the continuations exist.
- **Nettlevine Blight** — the granted ability *chooses* its new host rather than targeting it, and
  moving an already-attached Aura to a chosen permanent has no primitive
  (`PutOntoBattlefieldAttachedToChosen` is for a card coming from another zone).
- **Twinning Glass** — needs same-name-cast-this-turn tracking plus a free cast from hand.

### Verification
- `just test` — full suite green.
- `just build` — green.
- `just rebless-cards` — only these two cards moved in `LRW.json`.
- `just check-card-printing` — both canonical in LRW, their only printing.
- `just assay-differential --set LRW` — 101 confirmed, 10 divergent, all ten pre-existing (the
  Harbinger cycle, Epic Proportions, Boggart Sprite-Chaser, Kithkin Greatheart); neither new card is
  Assay-readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV4Lbefy9DktdPP1e6QktF