### PR TITLE
Add two Ravnica cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -11810,6 +11810,15 @@ The priority groups are (CR 616.1a–f):
   `RecipientFilter` the prevention and `ModifyDamageAmount` paths understand works here too —
   including `RecipientFilter.OpponentOrPermanentTheyControl` (Twinflame Tyrant). Each hosting
   permanent is its own replacement and applies once (CR 616.1): two Twinflame Tyrants quadruple.
+- `HalveDamage(restrictions?, appliesTo)` — the dividing mirror of `DoubleDamage`: matching damage is
+  halved, **rounded down**. Ghosts of the Innocent: `HalveDamage(appliesTo = DamageEvent(recipient =
+  RecipientFilter.Any))` — "a permanent or player" is the unscoped recipient, so combat and burn,
+  creatures and players, the host's own controller included, are all halved. Its own type rather than
+  a negative `ModifyDamageAmount` because the reduction is *multiplicative* and no `DynamicAmount` can
+  read the incoming amount. Half of 1 rounded down is 0, so a 1-damage source deals nothing; each
+  hosting permanent applies once (CR 616.1), so three copies take 14 to 7, 3, then 1. It runs after
+  the `DoubleDamage` pass and shares its `restrictions` / `damageType` / source / recipient handling.
+  It is **not** a prevention effect, so `DamageCantBePrevented` (Excruciator) does not switch it off.
   A player who is a legal recipient sees a "Damage Doubled" badge on their life orb — **except** when
   the source filter is attachment-scoped (`SourceFilter.EquippedCreature` / `EnchantedCreature`), which
   badges the attached creature's card instead, and only while it is attached. That case is a property

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7691,6 +7691,12 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   taxed by {2} becomes `{2}, {T}:` — and there is no `manaFloor`, since costs only grow. Skyseer's
   Chariot: "Activated abilities of sources with the chosen name cost {2} more to activate" →
   `IncreaseActivatedAbilityCost(GroupFilter(GameObjectFilter.Any.namedFromChosenComponent()), DynamicAmount.Fixed(2))`.
+  `excludeManaAbilities = true` leaves mana abilities (CR 605) untaxed — the flag reads the ability's
+  own `isManaAbility`, the mirror of `PreventActivatedAbilities(nonManaAbilitiesOnly = true)`. It is
+  what makes a *board-wide* tax playable at all: Suppression Field, "Activated abilities cost {2}
+  more to activate unless they're mana abilities" →
+  `IncreaseActivatedAbilityCost(GroupFilter(GameObjectFilter.Any), DynamicAmount.Fixed(2), excludeManaAbilities = true)`.
+  Without it, every land's `{T}: Add …` would be taxed too.
 - `MayCastFromGraveyard(filter, lifeCost = 0, duringYourTurnOnly = false, entersWithCounter = null, addedSubtypeOnEntry = null, oncePerTurn = false, exileInsteadOfGraveyard = false)`
   — cast spells matching `filter` from your graveyard following normal timing, optionally paying
   `lifeCost` life. Free for Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -1143,12 +1143,18 @@ data class ReduceActivatedAbilityCost(
  *   [com.wingedsheep.sdk.scripting.filters.unified.GroupFilter.source] for "this permanent's
  *   abilities" or a battlefield filter for a group).
  * @property amount Dynamic generic-mana increase applied to each matching ability's cost.
+ * @property excludeManaAbilities Leave mana abilities (CR 605) untaxed — Suppression Field's
+ *   "unless they're mana abilities". A board-wide tax without this would price every land's
+ *   `{T}: Add …` at {2} more, which is the opposite of what the card says. The flag is the mirror of
+ *   [PreventActivatedAbilities]'s `nonManaAbilitiesOnly`; the ability's own `isManaAbility` flag
+ *   (CR 605.1a, enforced by `CardLinter`) is what the engine reads.
  */
 @SerialName("IncreaseActivatedAbilityCost")
 @Serializable
 data class IncreaseActivatedAbilityCost(
     val filter: GroupFilter,
-    val amount: DynamicAmount
+    val amount: DynamicAmount,
+    val excludeManaAbilities: Boolean = false
 ) : StaticAbility {
     override val description: String = buildString {
         append(filter.description.replaceFirstChar { it.uppercase() })
@@ -1156,6 +1162,7 @@ data class IncreaseActivatedAbilityCost(
             is DynamicAmount.Fixed -> append("'s activated abilities cost {${amount.amount}} more to activate")
             else -> append("'s activated abilities cost {X} more to activate, where X is ${amount.description}")
         }
+        if (excludeManaAbilities) append(" unless they're mana abilities")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -840,6 +840,54 @@ data class DoubleDamage(
 }
 
 /**
+ * Halve damage dealt, **rounded down** — the dividing mirror of [DoubleDamage].
+ *
+ * Ghosts of the Innocent: *"If a source would deal damage to a permanent or player, it deals half
+ * that damage, rounded down, to that permanent or player instead."* →
+ * `HalveDamage(appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.AnyPermanentOrPlayer))`.
+ *
+ * Modelled as its own type rather than a [ModifyDamageAmount] with a negative modifier because the
+ * reduction is *multiplicative*: it scales with the incoming amount, which no `DynamicAmount` can
+ * read. Its rulings follow from that:
+ *
+ * - Half of 1 rounded down is 0, so a 1-damage source deals no damage at all.
+ * - Each applicable `HalveDamage` applies once (CR 616.1) and they compound: three of them turn
+ *   14 into 7, then 3, then 1.
+ * - It is **not** a prevention effect, so [DamageCantBePrevented] (Excruciator) does not switch it
+ *   off, and prevention shields are not consumed by it.
+ *
+ * [restrictions] gates the halving on further conditions, mirroring [PreventDamage.restrictions] /
+ * [DoubleDamage.restrictions]; each entry is evaluated against the **replacement source's
+ * controller**, as everywhere else in the damage family.
+ */
+@SerialName("HalveDamage")
+@Serializable
+data class HalveDamage(
+    override val restrictions: List<Condition> = emptyList(),
+    override val appliesTo: EventPattern
+) : ReplacementEffect {
+    override val description: String = buildString {
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", it deals half that damage, rounded down, instead")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
+    }
+}
+
+/**
  * Modify damage dealt by an additive amount — either a fixed [modifier] or, when
  * [dynamicModifier] is supplied, an amount computed at damage time against the
  * replacement's *source* permanent.

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GhostsOfTheInnocent.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/GhostsOfTheInnocent.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.HalveDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Ghosts of the Innocent
+ * {5}{W}{W}
+ * Creature — Spirit
+ * 4/5
+ *
+ * If a source would deal damage to a permanent or player, it deals half that damage, rounded
+ * down, to that permanent or player instead.
+ *
+ * The dividing mirror of Furnace of Rath, and the reason it needs its own [HalveDamage]
+ * replacement rather than a `ModifyDamageAmount`: the reduction is *multiplicative*, scaling with
+ * the incoming amount, which no `DynamicAmount` can read. Everything else falls out of that —
+ * half of 1 rounded down is 0 (a 1-damage source deals nothing), and three copies compound
+ * 14 → 7 → 3 → 1, because each applicable replacement applies once (CR 616.1).
+ *
+ * `RecipientFilter.Any` is the "a permanent **or** player" half: unlike most of the damage family
+ * this card scopes neither by recipient nor by source, so every damage event in the game is
+ * halved — including damage dealt to the Ghosts themselves and to their controller.
+ *
+ * It is emphatically **not** a prevention effect, which is what makes it the one thing on the
+ * battlefield that still shrinks Excruciator's damage (also in this set).
+ */
+val GhostsOfTheInnocent = card("Ghosts of the Innocent") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 4
+    toughness = 5
+    oracleText = "If a source would deal damage to a permanent or player, it deals half that " +
+        "damage, rounded down, to that permanent or player instead."
+
+    replacementEffect(
+        HalveDamage(appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.Any))
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Kev Walker"
+        flavorText = "\"Ma said we should offer up blini-cakes and salt to the good ones, but I " +
+            "get that chill up my spine and just shut the door.\"\n—Otak, Tin Street shopkeep"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg?1783943699"
+        ruling(
+            "2005-10-01",
+            "If a damage prevention effect and Ghosts of the Innocent's effect would apply to the " +
+                "same damage, the player or the controller of the creature being dealt damage may " +
+                "apply the effects in either order (most likely applying the halving effect first)."
+        )
+        ruling(
+            "2005-10-01",
+            "Half of 1 rounded down is 0. A source that would deal 1 damage won't deal damage at all."
+        )
+        ruling(
+            "2005-10-01",
+            "Multiple Ghosts of the Innocent effects are cumulative, and each will halve the " +
+                "damage, rounded down. For example, with three on the battlefield, 14 damage " +
+                "becomes 7, then 3, then finally 1, and only 1 damage would actually be dealt."
+        )
+        ruling(
+            "2005-10-01",
+            "This isn't a damage prevention effect. If Excruciator (\"Damage that would be dealt " +
+                "by Excruciator can't be prevented\") would deal 7 damage to a permanent or " +
+                "player, it deals 3 damage instead."
+        )
+        ruling("2005-10-01", "If damage is redirected, it's only halved once.")
+        ruling(
+            "2005-10-01",
+            "If both Ghosts of the Innocent and Furnace of Rath (which doubles damage) are on the " +
+                "battlefield, the controller of the permanent being dealt damage or the player " +
+                "being dealt damage can apply the effects in either order. This can matter if the " +
+                "original amount of damage is odd."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SuppressionField.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/SuppressionField.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Suppression Field
+ * {1}{W}
+ * Enchantment
+ *
+ * Activated abilities cost {2} more to activate unless they're mana abilities.
+ *
+ * The board-wide form of Skyseer's Chariot's tax: the same [IncreaseActivatedAbilityCost], with
+ * `GameObjectFilter.Any` in place of the chosen-name predicate so it reaches every source, its
+ * controller's included. `excludeManaAbilities` is the "unless they're mana abilities" half — the
+ * engine reads the ability's own `isManaAbility` flag (CR 605.1a), so a land's `{T}: Add …` and a
+ * Signet's `{1}, {T}: Add …` stay at their printed cost while everything else pays {2} more.
+ *
+ * A tax, unlike a reduction, applies even to an ability with no mana in its cost: an equip, a
+ * loyalty ability, or a bare `{T}:` becomes `{2}, {T}:`. Static and triggered abilities are
+ * untouched — only abilities written "[cost]: [effect]" are activated abilities at all.
+ */
+val SuppressionField = card("Suppression Field") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Activated abilities cost {2} more to activate unless they're mana abilities."
+
+    staticAbility {
+        ability = IncreaseActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Any),
+            amount = DynamicAmount.Fixed(2),
+            excludeManaAbilities = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "John Avon"
+        flavorText = "The most feared of Azorius punishments is to be freed—sent back out into " +
+            "the world, stripped of all magical defenses."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg?1783943694"
+        ruling(
+            "2016-06-08",
+            "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" " +
+                "Some keywords are activated abilities and will have colons in their reminder text."
+        )
+        ruling(
+            "2005-10-01",
+            "Suppression Field's ability doesn't affect static abilities, triggered abilities, or " +
+                "mana abilities. (A \"mana ability\" is an ability that produces mana, not an " +
+                "ability that costs mana.)"
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostsOfTheInnocentScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostsOfTheInnocentScenarioTest.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ghosts of the Innocent (RAV #20) — {5}{W}{W} Creature — Spirit, 4/5.
+ *
+ *   If a source would deal damage to a permanent or player, it deals half that damage, rounded
+ *   down, to that permanent or player instead.
+ *
+ * The new [com.wingedsheep.sdk.scripting.HalveDamage] replacement, and the four things its 2005
+ * rulings actually pin down: the halving is *multiplicative* (so it cannot be a `ModifyDamageAmount`
+ * with a negative modifier), it rounds down hard enough that a 1-damage source deals nothing at
+ * all, it scopes to neither a source nor a recipient — combat and burn, creatures and players, its
+ * own controller included — and two copies compound rather than overlapping, because each
+ * applicable replacement applies once (CR 616.1).
+ */
+class GhostsOfTheInnocentScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.markedDamage(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<DamageComponent>()?.amount ?: 0
+
+    private fun TestGame.attackWith(creature: String) {
+        advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+        declareAttackers(mapOf(creature to 2)).error shouldBe null
+        passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+        resolveStack()
+        if (getPendingDecision() is CombatResolutionDecision) {
+            submitDefaultCombatDamage()
+            resolveStack()
+        }
+    }
+
+    init {
+        context("Ghosts of the Innocent") {
+
+            test("burn dealt to a player is halved, rounded down") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("3 damage halved and rounded down is 1") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+
+            test("a 1-damage source deals no damage at all") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardOnBattlefield(1, "Mons's Goblin Raiders")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.attackWith("Mons's Goblin Raiders")
+
+                withClue("half of 1, rounded down, is 0 — the 1/1 connects for nothing") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("halving is scoped to neither controller — it shrinks damage dealt to its own side too") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the card names no source and no recipient, so its controller is halved too") {
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+
+            test("damage dealt to a creature is halved, so a 3-damage burn spell spares a 2/2") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Lightning Bolt", bears).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("a permanent is a legal recipient for the halving, not just a player") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.markedDamage(bears) shouldBe 1
+                }
+            }
+
+            test("combat damage is halved as well") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.attackWith("Craw Wurm")
+
+                withClue("the Wurm's 6 power lands as 3") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+
+            test("two copies compound — 6 damage becomes 3, then 1") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardOnBattlefield(1, "Ghosts of the Innocent")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.attackWith("Craw Wurm")
+
+                withClue("each replacement applies once (CR 616.1): 6 → 3 → 1, not 6 → 3") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SuppressionFieldScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SuppressionFieldScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Suppression Field (RAV #31) — {1}{W} Enchantment.
+ *
+ *   Activated abilities cost {2} more to activate unless they're mana abilities.
+ *
+ * Two halves, and the second is what the card lives or dies on. The tax is the board-wide form of
+ * Skyseer's Chariot's `IncreaseActivatedAbilityCost`, and — as there — it applies even to an
+ * ability with no mana in its cost, so a bare `{T}:` becomes `{2}, {T}:`. The exemption is the new
+ * `excludeManaAbilities` flag: without it a global tax would price every land's and every Signet's
+ * mana ability at {2} more, which is the opposite of what the card says and would lock a player out
+ * of their own mana.
+ */
+class SuppressionFieldScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.actionFor(sourceId: EntityId) =
+        getLegalActions(1).first { (it.action as? ActivateAbility)?.sourceId == sourceId }
+
+    private fun TestGame.canActivate(sourceId: EntityId): Boolean =
+        getLegalActions(1).any { (it.action as? ActivateAbility)?.sourceId == sourceId && it.isAffordable }
+
+    private fun TestGame.manaPool(playerNumber: Int): ManaPoolComponent? =
+        state.getEntity(if (playerNumber == 1) player1Id else player2Id)?.get<ManaPoolComponent>()
+
+    init {
+        context("Suppression Field — the {2} tax") {
+
+            test("a bare {T} ability is taxed to {2}, {T} and priced out of reach") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                withClue("with no Suppression Field out, the free ping is activatable") {
+                    game.canActivate(tim) shouldBe true
+                }
+
+                val taxed = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withCardOnBattlefield(1, "Suppression Field")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val taxedTim = taxed.findPermanent("Prodigal Sorcerer")!!
+                withClue("a tax applies even where a reduction could not: {T} gains a mana part") {
+                    taxed.actionFor(taxedTim).description shouldBe "{2}, {T}: Deal 1 damage to target"
+                }
+                withClue("with no mana available the taxed ability is unaffordable") {
+                    taxed.canActivate(taxedTim) shouldBe false
+                }
+            }
+
+            test("the tax is exactly {2} — two untapped lands buy the ability back") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withCardOnBattlefield(1, "Suppression Field")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                game.canActivate(tim) shouldBe true
+            }
+
+            test("the tax reaches an opponent's abilities too — it names no controller") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Suppression Field")
+                    .withCardOnBattlefield(2, "Prodigal Sorcerer")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                val action = game.getLegalActions(2)
+                    .first { (it.action as? ActivateAbility)?.sourceId == tim }
+                withClue("Suppression Field is symmetric — the opponent's ping is taxed identically") {
+                    action.description shouldBe "{2}, {T}: Deal 1 damage to target"
+                    action.isAffordable shouldBe false
+                }
+            }
+        }
+
+        context("Suppression Field — mana abilities are exempt") {
+
+            test("a Signet's {1}, {T} mana ability keeps its printed cost") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Suppression Field")
+                    .withCardOnBattlefield(1, "Boros Signet")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val signet = game.findPermanent("Boros Signet")!!
+                withClue("two Plains cover the printed {1}; a {3} tax would put it out of reach") {
+                    game.canActivate(signet) shouldBe true
+                }
+
+                game.execute(game.actionFor(signet).action).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val pool = game.manaPool(1)
+                withClue("the ability resolved and added {R}{W}") {
+                    pool?.red shouldBe 1
+                    pool?.white shouldBe 1
+                }
+            }
+
+            test("a land's mana ability is untaxed, so a lone land still produces mana") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Suppression Field")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                withClue("a taxed {T}: Add {G} would need {2} the player does not have") {
+                    game.canActivate(forest) shouldBe true
+                }
+
+                game.execute(game.actionFor(forest).action).error shouldBe null
+                game.resolveStack()
+
+                withClue("the land still adds its {G} at the printed cost") {
+                    game.manaPool(1)?.green shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -4478,6 +4478,62 @@
     ]
 }
 
+// Ghosts of the Innocent
+{
+    "name": "Ghosts of the Innocent",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "If a source would deal damage to a permanent or player, it deals half that damage, rounded down, to that permanent or player instead.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "HalveDamage",
+                "appliesTo": "DamageEvent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "\"Ma said we should offer up blini-cakes and salt to the good ones, but I get that chill up my spine and just shut the door.\"\n—Otak, Tin Street shopkeep",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg?1783943699",
+        "rulings": [
+            {
+                "date": "2005-10-01",
+                "text": "If a damage prevention effect and Ghosts of the Innocent's effect would apply to the same damage, the player or the controller of the creature being dealt damage may apply the effects in either order (most likely applying the halving effect first)."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Half of 1 rounded down is 0. A source that would deal 1 damage won't deal damage at all."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Multiple Ghosts of the Innocent effects are cumulative, and each will halve the damage, rounded down. For example, with three on the battlefield, 14 damage becomes 7, then 3, then finally 1, and only 1 damage would actually be dealt."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "This isn't a damage prevention effect. If Excruciator (\"Damage that would be dealt by Excruciator can't be prevented\") would deal 7 damage to a permanent or player, it deals 3 damage instead."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If damage is redirected, it's only halved once."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "If both Ghosts of the Innocent and Furnace of Rath (which doubles damage) are on the battlefield, the controller of the permanent being dealt damage or the player being dealt damage can apply the effects in either order. This can matter if the original amount of damage is odd."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Glare of Subdual
 {
     "name": "Glare of Subdual",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -10650,6 +10650,49 @@
     ]
 }
 
+// Suppression Field
+{
+    "name": "Suppression Field",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Activated abilities cost {2} more to activate unless they're mana abilities.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "IncreaseActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": {}
+                },
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "excludeManaAbilities": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "flavorText": "The most feared of Azorius punishments is to be freed—sent back out into the world, stripped of all magical defenses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0df7883b-f744-4410-a682-7391bd697afb.jpg?1783943694",
+        "rulings": [
+            {
+                "date": "2016-06-08",
+                "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
+            },
+            {
+                "date": "2005-10-01",
+                "text": "Suppression Field's ability doesn't affect static abilities, triggered abilities, or mana abilities. (A \"mana ability\" is an ability that produces mana, not an ability that costs mana.)"
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Surge of Zeal
 {
     "name": "Surge of Zeal",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -308,7 +308,8 @@ class ActivateAbilityHandler(
             costWithDefinedX, ability, state, action.sourceId, action.playerId, action.targets
         )
         val costAfterAbilityReduction = castPermissionUtils.applyActivatedAbilityCostReduction(
-            costAfterGenericReduction, state, action.sourceId, ability.isExhaust, ability.isPowerUp
+            costAfterGenericReduction, state, action.sourceId, ability.isExhaust, ability.isPowerUp,
+            ability.isManaAbility
         )
         val costAfterEquipReduction = castPermissionUtils.applyEquipCostReduction(
             costAfterAbilityReduction, ability, state, action.playerId, equipTargetIdForCost,
@@ -701,7 +702,7 @@ class ActivateAbilityHandler(
                 castPermissionUtils.applyEquipCostReduction(
                     castPermissionUtils.applyActivatedAbilityCostReduction(
                         applyGenericCostReduction(costWithDefinedX, ability, state, action.sourceId, action.playerId, action.targets),
-                        state, action.sourceId, ability.isExhaust, ability.isPowerUp
+                        state, action.sourceId, ability.isExhaust, ability.isPowerUp, ability.isManaAbility
                     ),
                     ability, state, action.playerId, equipTargetIdForCost,
                     abilitySourceId = action.sourceId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -2105,8 +2105,8 @@ object DamageUtils {
      * Apply static damage amplification from permanents on the battlefield.
      *
      * Scans all battlefield entities for ReplacementEffectSourceComponent containing
-     * DoubleDamage effects, and doubles damage if the source and recipient match.
-     * Per MTG rules, damage amplification applies before prevention.
+     * DoubleDamage, HalveDamage and ModifyDamageAmount effects, and scales damage if the source and
+     * recipient match. Per MTG rules, damage amplification applies before prevention.
      *
      * @param state The current game state
      * @param targetId The entity receiving damage
@@ -2173,6 +2173,53 @@ object DamageUtils {
                 // Each DoubleDamage source is its own replacement effect and applies once
                 // (CR 616.1), so two Twinflame Tyrants quadruple rather than double.
                 amplifiedAmount *= 2
+            }
+        }
+
+        // Halving (Ghosts of the Innocent) — the dividing mirror of the loop above, run after it so
+        // an odd amount is doubled before it is halved. CR 616.1 lets the affected player order the
+        // two, and this fixed order is the one their rulings call out as the usual choice; each
+        // HalveDamage applies once, so three of them turn 14 into 1. Integer division is the
+        // "rounded down" half of the wording, and it is what takes a 1-damage source to 0.
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is com.wingedsheep.sdk.scripting.HalveDamage) continue
+
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is com.wingedsheep.sdk.scripting.EventPattern.DamageEvent) continue
+
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+
+                if (effect.restrictions.isNotEmpty()) {
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = sourceControllerId,
+                    )
+                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                }
+
+                val sourceMatches = damageSourceMatches(
+                    state, projected, damageEvent.source, sourceId,
+                    hostId = entityId, hostControllerId = sourceControllerId, recipientId = targetId,
+                )
+                if (!sourceMatches) continue
+
+                val recipientMatches = damageRecipientMatches(
+                    state, projected, damageEvent.recipient, targetId,
+                    hostId = entityId, hostControllerId = sourceControllerId,
+                )
+                if (!recipientMatches) continue
+
+                amplifiedAmount /= 2
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -177,7 +177,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         context.castPermissionUtils.applyEquipCostReduction(
                             context.castPermissionUtils.applyActivatedAbilityCostReduction(
                                 AbilityCostReduction.apply(costWithDefinedX, ability, state, entityId, playerId, context.targetUtils),
-                                state, entityId, ability.isExhaust, ability.isPowerUp
+                                state, entityId, ability.isExhaust, ability.isPowerUp, ability.isManaAbility
                             ),
                             ability, state, playerId, abilitySourceId = entityId
                         ),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -807,13 +807,14 @@ class CastPermissionUtils(
         state: GameState,
         sourceId: EntityId?,
         isExhaustAbility: Boolean = false,
-        isPowerUpAbility: Boolean = false
+        isPowerUpAbility: Boolean = false,
+        isManaAbility: Boolean = false
     ): AbilityCost {
         if (sourceId == null) return cost
         val reduced =
             if (isPowerUpAbility) applyPowerUpSelfReduction(cost, state, sourceId) else cost
         val (net, manaFloor) =
-            sumActivatedAbilityCostModifications(state, sourceId, isExhaustAbility, isPowerUpAbility)
+            sumActivatedAbilityCostModifications(state, sourceId, isExhaustAbility, isPowerUpAbility, isManaAbility)
         if (net == 0) return reduced
         // net > 0 reduces (floored), net < 0 taxes. A reduction can only shrink mana that is
         // already there; a tax applies to *every* activated ability, so a cost with no mana part
@@ -905,13 +906,15 @@ class CastPermissionUtils(
      * projected state.
      *
      * An `exhaustOnly` reduction contributes nothing unless [isExhaustAbility] is set, and likewise
-     * a `powerUpOnly` one unless [isPowerUpAbility] is set.
+     * a `powerUpOnly` one unless [isPowerUpAbility] is set. An `excludeManaAbilities` *increase*
+     * contributes nothing when [isManaAbility] is set (Suppression Field).
      */
     private fun sumActivatedAbilityCostModifications(
         state: GameState,
         sourceId: EntityId,
         isExhaustAbility: Boolean,
-        isPowerUpAbility: Boolean
+        isPowerUpAbility: Boolean,
+        isManaAbility: Boolean
     ): Pair<Int, Int> {
         var net = 0
         var floor = 0
@@ -935,6 +938,10 @@ class CastPermissionUtils(
                         floor = maxOf(floor, ability.manaFloor)
                     }
                     is com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost -> {
+                        // Suppression Field taxes "activated abilities … unless they're mana
+                        // abilities" (CR 605): a board-wide tax that skipped this would price every
+                        // land's `{T}: Add …` at {2} more.
+                        if (ability.excludeManaAbilities && isManaAbility) continue
                         if (!activatedAbilityReductionApplies(state, entityId, ability.filter, sourceId)) continue
                         val owner = controllerId ?: continue
                         net -= evaluator.evaluate(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1152,6 +1152,7 @@ class StaticAbilityHandler(
             is PreventDamage,
             is com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter,
             is DoubleDamage,
+            is com.wingedsheep.sdk.scripting.HalveDamage,
             is ModifyDamageAmount,
             is com.wingedsheep.sdk.scripting.CapDamage,
             is com.wingedsheep.sdk.scripting.SetMinimumDamage,


### PR DESCRIPTION
Two white cards from Ravnica: City of Guilds, taking the set from 231/291 to 233/291. Both needed a small addition to an existing SDK type — the set's tail has no purely-composable cards left, so this is deliberately a pair rather than a handful.

- **Ghosts of the Innocent** ({5}{W}{W}, 4/5) — "If a source would deal damage to a permanent or player, it deals half that damage, rounded down, instead." New `HalveDamage` replacement, the dividing mirror of `DoubleDamage`. It can't be a `ModifyDamageAmount` with a negative modifier because the reduction is *multiplicative* — it scales with the incoming amount, which no `DynamicAmount` can read. One loop in `DamageUtils.applyStaticDamageAmplification`, run after the `DoubleDamage` pass and sharing its restrictions / damage-type / source / recipient handling, plus the runtime classification in `StaticAbilityHandler`.
- **Suppression Field** ({1}{W}) — "Activated abilities cost {2} more to activate unless they're mana abilities." The board-wide form of Skyseer's Chariot's tax (`IncreaseActivatedAbilityCost` with `GameObjectFilter.Any`). The missing piece was the exemption: the type had no mana-ability escape and `ActivateAbilityHandler` applied it unconditionally, so a global tax would have priced every land's `{T}: Add …` at {2} more. Adds `excludeManaAbilities`, the mirror of `PreventActivatedAbilities(nonManaAbilitiesOnly = true)`, threaded as `isManaAbility` through `applyActivatedAbilityCostReduction` and its three call sites so the enumerator's offered cost and both payment paths keep agreeing.

### Rulings the tests pin down

Ghosts: half of 1 rounded down is 0 (a 1/1 connects for nothing); two copies compound 6 → 3 → 1, because each replacement applies once (CR 616.1); the card scopes neither source nor recipient, so combat and burn, creatures and players, and its own controller are all halved. Suppression Field: the tax applies to an ability with no mana in its cost (`{T}:` becomes `{2}, {T}:`), it is symmetric across players, and a Signet's `{1}, {T}` and a lone Forest both keep their printed cost.

### Verification

- `just test` — green (full suite, twice: once per commit's engine change).
- `GhostsOfTheInnocentScenarioTest` (6) and `SuppressionFieldScenarioTest` (5) — all pass.
- `just rebless-cards` — only `snapshots/cards/RAV.json` moved, for these two cards.
- `just assay-differential --set RAV` — 103/103 confirmed, 0 divergent.
- `just check-card-printing` — both canonical in RAV, their only real printing.
- `docs/card-sdk-language-reference.md` updated for both additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgbC39NpHAg8wmccZ5kLsz