### PR TITLE
Keep Gym observation zones complete and schema-stable

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -192,11 +192,11 @@ class ObservationBuilder(
         perspectivePlayerId: EntityId,
         revealAll: Boolean
     ): List<ZoneView> {
-        // Emit a view for every (player, zone) in turn order so trainers see a
-        // consistent shape regardless of whether a zone happens to be empty.
-        val perPlayerZones = listOf(
-            Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD
-        )
+        // Emit a view for every modeled (player, zone) in turn order so trainers see a
+        // consistent shape regardless of whether a zone happens to be empty. The stack has its
+        // own ordered representation above; every other Zone is stored under a ZoneKey and must
+        // not disappear merely because this allowlist predates it (COMMAND and SIDEBOARD both did).
+        val perPlayerZones = Zone.entries.filterNot { it == Zone.STACK }
         val views = mutableListOf<ZoneView>()
         for (playerId in state.turnOrder) {
             for (zone in perPlayerZones) {

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -59,6 +59,17 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
+/** Stable serialized order for the per-player zone views in [TrainingObservation]. */
+internal val TRAINING_OBSERVATION_ZONE_ORDER = listOf(
+    Zone.HAND,
+    Zone.LIBRARY,
+    Zone.GRAVEYARD,
+    Zone.EXILE,
+    Zone.BATTLEFIELD,
+    Zone.COMMAND,
+    Zone.SIDEBOARD,
+)
+
 /**
  * Converts `(GameState, perspectivePlayerId)` into a [TrainingObservation].
  *
@@ -192,14 +203,14 @@ class ObservationBuilder(
         perspectivePlayerId: EntityId,
         revealAll: Boolean
     ): List<ZoneView> {
-        // Emit a view for every modeled (player, zone) in turn order so trainers see a
-        // consistent shape regardless of whether a zone happens to be empty. The stack has its
-        // own ordered representation above; every other Zone is stored under a ZoneKey and must
-        // not disappear merely because this allowlist predates it (COMMAND and SIDEBOARD both did).
-        val perPlayerZones = Zone.entries.filterNot { it == Zone.STACK }
+        // Emit a view for every modeled (player, zone) in the contract's stable order so trainers
+        // see a consistent shape regardless of whether a zone happens to be empty. The stack has
+        // its own ordered representation above. Keep this order explicit: changing enum declaration
+        // order must not silently reorder model-facing inputs, and adding a zone must force an
+        // intentional schema decision through the completeness regression.
         val views = mutableListOf<ZoneView>()
         for (playerId in state.turnOrder) {
-            for (zone in perPlayerZones) {
+            for (zone in TRAINING_OBSERVATION_ZONE_ORDER) {
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
                 val wholeZoneVisible = revealAll ||

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
@@ -11,5 +11,5 @@ package com.wingedsheep.gym.contract
  * what matters.
  */
 object SchemaHash {
-    const val CURRENT: String = "argentum-gym-contract@v1.4-object-semantics"
+    const val CURRENT: String = "argentum-gym-contract@v1.5-complete-zones"
 }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -157,7 +157,8 @@ data class ZoneView(
  *
  * Not every field is populated for every zone:
  * - On the battlefield: all fields relevant to a permanent are set.
- * - In the library/hand/graveyard/exile: the card's static properties are set;
+ * - Outside the battlefield (library/hand/graveyard/exile/command/sideboard): the card's static
+ *   properties are set;
  *   dynamic properties (tapped, damage, counters) default to their "not present" values.
  */
 @Serializable

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
@@ -149,6 +149,37 @@ class ObservationVisibilityTest : ScenarioTestBase() {
             }
         }
 
+        test("every modeled player zone is represented with engine-owned visibility") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInCommandZone(2, "Mountain")
+                .withCardInSideboard(1, "Forest")
+                .withCardInSideboard(2, "Hill Giant")
+                .build()
+            val view = observe(game.state, game.player1Id)
+
+            game.state.turnOrder.forEach { playerId ->
+                view.zones
+                    .filter { it.ownerId == playerId }
+                    .map { it.zoneType }
+                    .toSet() shouldBe Zone.entries.filterNot { it == Zone.STACK }.toSet()
+            }
+
+            zone(view, game.player2Id, Zone.COMMAND).let {
+                it.hidden shouldBe false
+                it.cards.single().name shouldBe "Mountain"
+            }
+            zone(view, game.player1Id, Zone.SIDEBOARD).let {
+                it.hidden shouldBe false
+                it.cards.single().name shouldBe "Forest"
+            }
+            zone(view, game.player2Id, Zone.SIDEBOARD).let {
+                it.hidden shouldBe true
+                it.size shouldBe 1
+                it.cards shouldBe emptyList()
+            }
+        }
+
         test("a face-down object keeps its public characteristics and loses its identity") {
             val game = scenario()
                 .withPlayers()

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -74,8 +74,8 @@ class TrainingObservationTest : FunSpec({
         obs.stateDigest shouldMatch Regex("[0-9a-f]{64}")
         obs.legalActions.shouldNotBeEmpty()
 
-        // Hand + library + graveyard + exile + battlefield for each player.
-        obs.zones.size shouldBe 2 * 5
+        // Every player-keyed zone is present; stack has its own ordered field.
+        obs.zones.size shouldBe 2 * (Zone.entries.size - 1)
 
         val encoded = json.encodeToString(TrainingObservation.serializer(), obs)
         val decoded = json.decodeFromString(TrainingObservation.serializer(), encoded)

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -22,6 +22,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -80,6 +81,31 @@ class TrainingObservationTest : FunSpec({
         val encoded = json.encodeToString(TrainingObservation.serializer(), obs)
         val decoded = json.decodeFromString(TrainingObservation.serializer(), encoded)
         decoded shouldBe obs
+    }
+
+    test("per-player zones have an explicit complete schema order") {
+        TRAINING_OBSERVATION_ZONE_ORDER.shouldContainExactly(
+            Zone.HAND,
+            Zone.LIBRARY,
+            Zone.GRAVEYARD,
+            Zone.EXILE,
+            Zone.BATTLEFIELD,
+            Zone.COMMAND,
+            Zone.SIDEBOARD,
+        )
+        TRAINING_OBSERVATION_ZONE_ORDER.toSet() shouldBe
+            Zone.entries.filterNot { it == Zone.STACK }.toSet()
+
+        val env = newEnv()
+        val perspective = env.playerIds[0]
+        val observation = ObservationBuilder(env.cardRegistry)
+            .build(env.state, perspective, env.legalActions())
+            .observation as TrainingObservation
+
+        observation.zones
+            .filter { it.ownerId == perspective }
+            .map { it.zoneType }
+            .shouldContainExactly(TRAINING_OBSERVATION_ZONE_ORDER)
     }
 
     test("an actionId from the observation resolves to a steppable action") {


### PR DESCRIPTION
`ObservationBuilder` still hand-selects an older set of player zones. Cards in `COMMAND` and `SIDEBOARD` therefore disappear from Gym state, even though the engine models both zones and a commander in the command zone is public decision information.

The tempting fix is to iterate `Zone.entries`, but that would let a future engine zone silently change the serialized training schema and its ordering. Observation completeness and schema stability both need to be explicit.

## What changes

The Gym observation now has one named, ordered player-zone contract:

1. hand
2. library
3. graveyard
4. exile
5. battlefield
6. command
7. sideboard

`STACK` remains separate because it already has its own ordered representation.

`ObservationBuilder` emits every listed zone for every player, including empty zones, in this stable order. Visibility still determines how much of each card a viewer can see.

A coverage assertion compares the contract with the engine's `Zone` family minus `STACK`. Adding another engine zone now produces a focused failing test and an intentional schema decision instead of either silently omitting the zone or silently changing observation order.

The schema description and hash include the added entries, so schema-pinned consumers can detect the new shape.

## Verification

18 focused tests pass on `d39ace4f9e8a4cc25ed766090f031d077f2e9bdc`:

- `TrainingObservationTest`
- `ObservationVisibilityTest`

The new cases exercise populated and empty command/sideboard zones, the exact stable order, completeness against the current `Zone` enum, and viewer-specific identity masking.
