### PR TITLE
Add 51 Assay-ready cards to Rise of the Eldrazi

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Vendetta.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Vendetta.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Vendetta
+ * {B}
+ * Instant
+ *
+ * Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.
+ *
+ * Modeling notes:
+ *  - "nonblack" is a restriction on what may be chosen, so it belongs on the target requirement,
+ *    not on a condition: `TargetFilter.Creature.notColor(Color.BLACK)` — the same spelling Notorious
+ *    Assassin uses in this set, and what Assay compiles (`IsCreature` + `NotColor BLACK`).
+ *  - "It can't be regenerated" is a marker placed on the creature *before* the destroy, matching
+ *    Assay's ordering (`CantBeRegenerated`, then the `byDestruction` move to the graveyard). It is
+ *    written out rather than folded into `Effects.Destroy(noRegenerate = true)` only so the life
+ *    loss can be slotted between the two — see the next note.
+ *  - "You lose life equal to that creature's toughness" reads last-known information: by the time
+ *    the sentence resolves the creature is gone. The engine's `DynamicAmount.EntityProperty` has no
+ *    last-known fallback for a *spell's* target (only for the triggering entity and the source), so
+ *    evaluated after the move it would read the creature's printed toughness and miss counters,
+ *    Auras and lords. Reading it while the creature is still on the battlefield — the life loss
+ *    ordered before the destroy — yields the rules-correct last-known value in every case,
+ *    indestructible creatures included. Agonizing Demise lowers its power-reading rider the same way
+ *    and for the same reason.
+ *  - The life loss is not targeted; it hits the spell's controller, so `EffectTarget.Controller` is
+ *    passed explicitly — [Effects.LoseLife] defaults to the *target opponent*, so here the default
+ *    is the wrong player and has to be overridden.
+ */
+val Vendetta = card("Vendetta") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness."
+
+    spell {
+        val creature = target(
+            "target nonblack creature",
+            TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK))
+        )
+        effect = Effects.CantBeRegenerated(creature)
+            .then(Effects.LoseLife(DynamicAmounts.targetToughness(0), EffectTarget.Controller))
+            .then(Effects.Destroy(creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Dan Frazier"
+        flavorText = "Starke knew the voice was Takara's, but the venom was Volrath's."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg?1783945943"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/NomadsAssemblyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/NomadsAssemblyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nomads' Assembly reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val NomadsAssemblyReprint = Printing(
+    oracleId = "a9a0088a-3c86-4baf-9754-79006f733ce1",
+    name = "Nomads' Assembly",
+    setCode = "C14",
+    collectorNumber = "82",
+    scryfallId = "00afdd58-a6e3-490c-8ff5-3d761fcd3885",
+    artist = "Erica Yang",
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00afdd58-a6e3-490c-8ff5-3d761fcd3885.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PestilenceDemonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PestilenceDemonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pestilence Demon reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val PestilenceDemonReprint = Printing(
+    oracleId = "2572add6-c0b1-44bd-8713-1e94e3fe69d6",
+    name = "Pestilence Demon",
+    setCode = "C14",
+    collectorNumber = "153",
+    scryfallId = "63b5db50-219f-4a87-a208-2d45a4a76a2d",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/6/3/63b5db50-219f-4a87-a208-2d45a4a76a2d.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SphinxOfMagosiReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SphinxOfMagosiReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sphinx of Magosi reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val SphinxOfMagosiReprint = Printing(
+    oracleId = "1c9cf20c-51e4-4a87-b9f8-231b6baf5d6b",
+    name = "Sphinx of Magosi",
+    setCode = "C14",
+    collectorNumber = "127",
+    scryfallId = "1b92959c-0995-4bcc-b937-fc272c4540e9",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b92959c-0995-4bcc-b937-fc272c4540e9.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/WallOfOmensReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/WallOfOmensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Omens reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val WallOfOmensReprint = Printing(
+    oracleId = "5f601f48-d24b-4883-9fde-b3f620e7c9ea",
+    name = "Wall of Omens",
+    setCode = "CMD",
+    collectorNumber = "37",
+    scryfallId = "4b64798d-e400-4e17-8b88-842a7a3e1bd1",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b64798d-e400-4e17-8b88-842a7a3e1bd1.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/BloodriteInvokerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/BloodriteInvokerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodrite Invoker reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodriteInvokerReprint = Printing(
+    oracleId = "2dd3a6f7-65a9-4157-9ad9-13a885ebe927",
+    name = "Bloodrite Invoker",
+    setCode = "DDP",
+    collectorNumber = "45",
+    scryfallId = "94ebd19f-c3ec-41de-bde0-3118b34b76a4",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94ebd19f-c3ec-41de-bde0-3118b34b76a4.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/MagmawReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/MagmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magmaw reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val MagmawReprint = Printing(
+    oracleId = "bc891258-2f22-4248-9972-4f41905744c6",
+    name = "Magmaw",
+    setCode = "DDP",
+    collectorNumber = "62",
+    scryfallId = "3f170d96-5070-41ed-abf3-e3bddceb9d0e",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3f170d96-5070-41ed-abf3-e3bddceb9d0e.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/MakindiGriffinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/MakindiGriffinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Makindi Griffin reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val MakindiGriffinReprint = Printing(
+    oracleId = "af2a951f-7630-48fe-bb37-273b66901eb6",
+    name = "Makindi Griffin",
+    setCode = "DDP",
+    collectorNumber = "6",
+    scryfallId = "05c4a9c4-20d5-457d-9127-c27b8768255a",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05c4a9c4-20d5-457d-9127-c27b8768255a.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TotemGuideHartebeestReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TotemGuideHartebeestReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Totem-Guide Hartebeest reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val TotemGuideHartebeestReprint = Printing(
+    oracleId = "c3a1bb65-556a-4016-a06a-3894710cb190",
+    name = "Totem-Guide Hartebeest",
+    setCode = "ORI",
+    collectorNumber = "37",
+    scryfallId = "589346d3-b32b-40f2-8513-741ceb88bf7b",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/589346d3-b32b-40f2-8513-741ceb88bf7b.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/RiseOfTheEldraziSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/RiseOfTheEldraziSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.roe
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -24,11 +23,14 @@ object RiseOfTheEldraziSet : MtgSet {
     override val displayName = "Rise of the Eldrazi"
     override val releaseDate = "2010-04-23"
     override val block = "Zendikar"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/AkoumBoulderfoot.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/AkoumBoulderfoot.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akoum Boulderfoot
+ * {4}{R}{R}
+ * Creature — Giant Warrior
+ * 4 / 5
+ *
+ * When this creature enters, it deals 1 damage to any target.
+ *
+ * Modeling notes:
+ *  - "**When** this creature enters" is a one-shot [Triggers.EntersBattlefield] on the card itself,
+ *    not a `whenever another … enters` watcher — the printed word is "when", and the trigger binds
+ *    to the source.
+ *  - "Any target" is [Targets.Any] (creature, player, or planeswalker), matching Assay's
+ *    `AnyTarget` requirement. The target is chosen as the ability goes on the stack, so it is a
+ *    `target(...)` handle on the triggered ability rather than a resolution-time choice.
+ *  - "**It** deals" — the damage source is the Boulderfoot, which is [Effects.DealDamage]'s default
+ *    when no `damageSource` is passed, so the argument is omitted rather than restated.
+ */
+val AkoumBoulderfoot = card("Akoum Boulderfoot") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 4
+    toughness = 5
+    oracleText = "When this creature enters, it deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+        description = "When this creature enters, it deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"If you're in Akoum and you glimpse a shadow overhead, the worst thing you can do is duck.\"\n—Chadir the Navigator"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg?1783941978"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BalaGedScorpion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BalaGedScorpion.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bala Ged Scorpion
+ * {3}{B}
+ * Creature — Scorpion
+ * 2 / 3
+ *
+ * When this creature enters, you may destroy target creature with power 1 or less.
+ *
+ * Modeling notes:
+ *  - Both halves of "you may destroy **target**" have to be present, and they happen at different
+ *    times: the target is chosen when the trigger goes on the stack (so it is a `target(...)`
+ *    handle on the ability, and CR 608.2b re-checks "power 1 or less" on resolution — pumping the
+ *    creature in response fizzles the ability), while the "may" is a decline offered *on*
+ *    resolution. `optional = true` is the authoring shorthand that lowers the effect into a
+ *    `Gate.MayDecide`, which is exactly the `Gated` wrapper Assay compiles from this line.
+ *  - "Creature with power 1 or less" is any creature on the battlefield — no "you control" is
+ *    printed — so it is the unscoped [Targets.CreatureWithPowerAtMost] facade.
+ *  - Plain [Effects.Destroy] (regeneration still allowed): the card says "destroy", not "destroy …
+ *    it can't be regenerated".
+ */
+val BalaGedScorpion = card("Bala Ged Scorpion") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Scorpion"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, you may destroy target creature with power 1 or less."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val creature = target("target creature with power 1 or less", Targets.CreatureWithPowerAtMost(1))
+        effect = Effects.Destroy(creature)
+        description = "When this creature enters, you may destroy target creature with power 1 or less."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Daarken"
+        flavorText = "Fast and lethal, with a penchant for the weak and infirm."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg?1783941989"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BloodriteInvoker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BloodriteInvoker.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Bloodrite Invoker
+ * {2}{B}
+ * Creature — Vampire Shaman
+ * 3 / 1
+ *
+ * {8}: Target player loses 3 life and you gain 3 life.
+ *
+ * Modeling notes:
+ *  - The level-up-less "invoker" cycle is a plain [activatedAbility] with a `{8}` mana cost and no
+ *    tap symbol, so it can be activated repeatedly and at instant speed — [Costs.Mana] alone, no
+ *    [Costs.Tap] and no timing restriction.
+ *  - Two life clauses sharing one target slot, exactly as Absorb Vis: [Effects.LoseLife] aimed at
+ *    the bound player, [Effects.GainLife] left on its default controller recipient. Only the loss
+ *    is targeted — the gain says "you" — so a single [TargetPlayer] requirement is declared.
+ *  - It is **target player**, not target opponent: the printed word allows you to point it at
+ *    yourself, so [TargetPlayer] rather than `TargetOpponent`.
+ *  - The two amounts are independent fixed 3s, not a linked drain: you gain 3 even if the target
+ *    had less than 3 life to lose.
+ */
+val BloodriteInvoker = card("Bloodrite Invoker") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Shaman"
+    power = 3
+    toughness = 1
+    oracleText = "{8}: Target player loses 3 life and you gain 3 life."
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        val victim = target("target player", TargetPlayer())
+        effect = Effects.Composite(
+            Effects.LoseLife(3, victim),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Svetlin Velinov"
+        flavorText = "\"The brood lineages unfolded across the world, each patterned after one of three progenitors, each a study in mindless consumption.\"\n—*The Invokers' Tales*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg?1783941988"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Bramblesnap.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Bramblesnap.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bramblesnap
+ * {1}{G}
+ * Creature — Elemental
+ * 1 / 1
+ *
+ * Trample
+ * Tap an untapped creature you control: This creature gets +1/+1 until end of turn.
+ *
+ * Modeling notes:
+ *  - Trample is a live keyword the combat code reads, so the printed line is just
+ *    `keywords(Keyword.TRAMPLE)`.
+ *  - The cost taps *another permanent*, it is not the `{T}` symbol: [Costs.TapPermanents] with
+ *    `count = 1`. Two consequences follow from that distinction — summoning sickness does not gate
+ *    the tapped creature (CR 302.6 applies only to `{T}`/`{Q}` in the cost of the source's own
+ *    ability, and the cost atom taps a *chosen* permanent, CR 701.26a), and Bramblesnap itself need
+ *    not be untapped to activate.
+ *  - The printed text does **not** say "another", so `excludeSelf` stays at its `false` default:
+ *    an untapped Bramblesnap is a legal choice for its own cost, taking itself out of combat to buy
+ *    +1/+1. Contrast `Costs.TapAnotherPermanent`, which is the wording this card avoids.
+ *  - **Divergence from Assay's compiled JSON, deliberately.** Assay renders the cost filter as bare
+ *    `IsCreature`, dropping the printed "you control". The tap-cost atom's candidate domain is
+ *    already `controlledUntapped(...)` — payer-scoped and untapped-only — so the two spellings are
+ *    behaviourally identical and Assay is merely under-specifying rather than saying something
+ *    different. The printed restriction is written out anyway as `GameObjectFilter.Creature
+ *    .youControl()`, matching Honeymoon Hearse and Dragonbrood's Relic, so that the card reads the
+ *    way it is printed and stays correct if the atom's domain is ever widened.
+ *  - "gets +1/+1 until end of turn" is [Effects.ModifyStats] on [EffectTarget.Self]; its `duration`
+ *    already defaults to `EndOfTurn`, so no explicit duration is written.
+ */
+val Bramblesnap = card("Bramblesnap") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 1
+    toughness = 1
+    oracleText = "Trample\n" +
+            "Tap an untapped creature you control: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature.youControl())
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Tap an untapped creature you control: This creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "James Ryman"
+        flavorText = "A bramblesnap is formed by grafting together thirteen different plants that already hunger for meat."
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg?1783941966"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DeathCultist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DeathCultist.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Death Cultist
+ * {B}
+ * Creature — Human Wizard
+ * 1 / 1
+ *
+ * Sacrifice this creature: Target player loses 1 life and you gain 1 life.
+ *
+ * Modeling notes:
+ *  - The sacrifice is a **cost**, not an effect: the whole ability is `Sacrifice this creature:`
+ *    before the colon, so it uses [Costs.SacrificeSelf] (the corpus's `CostSacrificeSelf` atom,
+ *    which is exactly what Assay compiles this line to) rather than an `Effects.Sacrifice` in the
+ *    resolution. The Cultist is therefore already in the graveyard when the drain resolves, and the
+ *    ability still resolves if it is somehow removed in response.
+ *  - "Target player" is the full player target, not "target opponent": [Targets.Player] binds a
+ *    handle that [Effects.LoseLife] consumes. Passing the bound handle matters — `Effects.LoseLife`
+ *    defaults to `Player.TargetOpponent`, which would silently narrow the printed wording.
+ *  - "loses 1 life **and** you gain 1 life" is one resolution with two ordered halves, so it is an
+ *    [Effects.Composite] of a targeted `LoseLife` and an untargeted `GainLife` (whose default
+ *    controller recipient is already correct — no explicit `EffectTarget.Controller`). This is not
+ *    lifelink-style linked drain: the gain happens even if the loss is replaced or prevented.
+ */
+val DeathCultist = card("Death Cultist") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: Target player loses 1 life and you gain 1 life."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, player),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Igor Kieryluk"
+        flavorText = "Death inevitably seduces all who study it."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg?1783941987"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DeathlessAngel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DeathlessAngel.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deathless Angel
+ * {4}{W}{W}
+ * Creature — Angel
+ * 5 / 7
+ *
+ * Flying
+ * {W}{W}: Target creature gains indestructible until end of turn.
+ *
+ * Modeling notes:
+ *  - `Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, target)` with the facade's default
+ *    `Duration.EndOfTurn`, matching the printed "until end of turn". A keyword grant, not a
+ *    damage-prevention shield: the creature shrugs off lethal damage and "destroy" but still dies
+ *    to 0 toughness or to sacrifice.
+ *  - `Targets.Creature` — the printed line says "target creature", with no "you control"
+ *    restriction, so an opponent's creature is a legal target too.
+ *  - The ability has no tap symbol and no other cost, so it is `Costs.Mana("{W}{W}")` alone and can
+ *    be activated repeatedly, including the turn this enters.
+ */
+val DeathlessAngel = card("Deathless Angel") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 5
+    toughness = 7
+    oracleText = "Flying\n" +
+            "{W}{W}: Target creature gains indestructible until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{W}")
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Johann Bodin"
+        flavorText = "\"I should have died that day, but I suffered not a scratch. I awoke in a lake of blood, none of it apparently my own.\"\n—*The War Diaries*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg?1783942009"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DemonicAppetite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DemonicAppetite.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Demonic Appetite
+ * {B}
+ * Enchantment — Aura
+ *
+ * Enchant creature you control
+ * Enchanted creature gets +3/+3.
+ * At the beginning of your upkeep, sacrifice a creature.
+ *
+ * Modeling notes:
+ *  - The enchant clause reads "creature **you control**", not "creature", so `auraTarget` is
+ *    `Targets.CreatureYouControl` rather than `Targets.Creature`. That is a real restriction, not
+ *    flavour: it is why this can't be handed to an opponent's creature as a drawback.
+ *  - The pump is one `staticAbility { ModifyStats(3, 3, Filters.EnchantedCreature) }` — the
+ *    attached-creature group filter, the Aura counterpart of the Equipment scope.
+ *  - The upkeep trigger is `Triggers.YourUpkeep` (`StepEvent(UPKEEP, Player.You)`), the printed
+ *    "your upkeep" and not "each upkeep".
+ *  - Its effect is `Effects.SacrificeOwn(GameObjectFilter.Creature)`, deliberately three things at
+ *    once. It is **not targeted**: "sacrifice a creature" names no target, so nothing is chosen on
+ *    announcement and nothing can be made illegal in response. It is **not scoped to the enchanted
+ *    creature**: the Aura's controller picks any creature they control, which is the whole tension
+ *    of the card — you may feed it something other than the buffed creature, or you may have to
+ *    feed it the buffed creature itself. And it names **no player**, so it is `SacrificeOwn` and
+ *    not `Effects.Sacrifice`, whose `target` parameter defaults to `Player.TargetOpponent` and
+ *    would make the opponent sacrifice instead.
+ */
+val DemonicAppetite = card("Demonic Appetite") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\n" +
+            "Enchanted creature gets +3/+3.\n" +
+            "At the beginning of your upkeep, sacrifice a creature."
+
+    auraTarget = Targets.CreatureYouControl
+
+    staticAbility {
+        ability = ModifyStats(3, 3, Filters.EnchantedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Igor Kieryluk"
+        flavorText = "\"Morality is just shorthand for the constraints of being powerless.\"\n—Ob Nixilis"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg?1783941986"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Deprive.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Deprive.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Deprive
+ * {U}{U}
+ * Instant
+ *
+ * As an additional cost to cast this spell, return a land you control to its owner's hand.
+ * Counter target spell.
+ *
+ * Modeling notes:
+ *  - The bounce is an **additional cost** (CR 601.2f), not an effect: it is paid as the spell is
+ *    cast, so a controller with no land on the battlefield cannot cast Deprive at all, and the land
+ *    still returns if the counter later fizzles because its target left the stack. That is
+ *    `Costs.additional.ReturnToHand`, matching Assay's `AdditionalAtom` → `AtomReturnToHand`.
+ *    The Disappearing Act / Familiar's Ruse shape, narrowed from a permanent to a land.
+ *  - The filter is the bare [GameObjectFilter.Land]. `CostAtom.ReturnToHand` already scopes its
+ *    candidates to permanents *you control*, which is exactly the printed "a land you control" —
+ *    so no `.youControl()` is written here, the same as Disappearing Act. Assay's JSON likewise
+ *    carries only the `IsLand` predicate.
+ *  - "Counter target spell" is the plain [Effects.CounterSpell] over a [Targets.Spell] requirement
+ *    — Assay's `TargetObject` with `zone: Stack` and no further predicates. `CounterEffect` reads
+ *    the spell's single declared target itself, so the facade takes no handle.
+ */
+val Deprive = card("Deprive") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, return a land you control to its owner's hand.\n" +
+            "Counter target spell."
+
+    additionalCost(Costs.additional.ReturnToHand(GameObjectFilter.Land))
+
+    spell {
+        target("target spell", Targets.Spell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Izzy"
+        flavorText = "\"That would have brought shame to you as a mage. Tell you what—I'll keep your secret.\"\n—Noyan Dar, Tazeem lullmage"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg?1783941998"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/EnatuGolem.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/EnatuGolem.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enatu Golem
+ * {6}
+ * Artifact Creature — Golem
+ * 3 / 5
+ *
+ * When this creature dies, you gain 4 life.
+ *
+ * Modeling notes:
+ *  - [Triggers.Dies] is precisely the battlefield → graveyard zone change Assay compiles this line
+ *    to (`ZoneChangeEvent` from Battlefield to Graveyard) with the default `SELF` binding, so no
+ *    filter and no binding override are needed.
+ *  - No `triggerZone` override: on a dies trigger, setting `triggerZone = GRAVEYARD` *replaces* the
+ *    default `{BATTLEFIELD}` active-zone set rather than adding to it, which stops the ability
+ *    seeing the death at all. The rest of the corpus's dies-triggers (Guardian Automaton, Polluted
+ *    Dead, Maalfeld Twins) all leave it alone, and so does this one.
+ *  - "you gain 4 life" is the untargeted [Effects.GainLife], whose default recipient is already the
+ *    ability's controller — writing `EffectTarget.Controller` here would restate a default.
+ */
+val EnatuGolem = card("Enatu Golem") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 5
+    oracleText = "When this creature dies, you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Daniel Ljunggren"
+        flavorText = "Golems conjured from the debris of Enatu Temple provided a sturdy but expendable first line of defense against the Eldrazi."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg?1783941957"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FlameSlash.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FlameSlash.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flame Slash
+ * {R}
+ * Sorcery
+ *
+ * Flame Slash deals 4 damage to target creature.
+ *
+ * Modeling notes:
+ *  - The plainest burn shape there is: one cast-time creature target, one fixed-amount
+ *    [Effects.DealDamage] pointed at it. Assay compiles exactly this — a `DealDamage` with a
+ *    `Fixed` amount of 4 over a single `TargetObject` whose only predicate is `IsCreature` — so
+ *    `Targets.Creature` is the filter, with no "you control" or other scoping the card doesn't print.
+ *  - The damage source is left implicit (the spell itself), which is what the printed
+ *    "Flame Slash deals" means; no `damageSource` override is needed.
+ */
+val FlameSlash = card("Flame Slash") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Flame Slash deals 4 damage to target creature."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(4, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Raymond Swanland"
+        flavorText = "After millennia asleep, the Eldrazi had forgotten about Zendikar's fiery temper and dislike of strangers."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg?1783941976"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FrostwindInvoker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FrostwindInvoker.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frostwind Invoker
+ * {4}{U}
+ * Creature — Merfolk Wizard
+ * 3 / 3
+ *
+ * Flying
+ * {8}: Creatures you control gain flying until end of turn.
+ *
+ * Modeling notes:
+ *  - The invoker ability is a plain [activatedAbility] with a `{8}` mana cost — no tap symbol, no
+ *    timing restriction — so it is repeatable and usable at instant speed.
+ *  - "Creatures you control" is a **group**, not a target: [Effects.ForEachInGroup] over
+ *    [GroupFilter.AllCreaturesYouControl] grants the keyword once per member, with
+ *    [EffectTarget.Self] naming the current iteration entity. That matches Assay's `ForEach` over
+ *    an `IterationSpace.Group` whose filter is `IsCreature` + `ControlledByYou`.
+ *  - The group is evaluated on resolution, so creatures that arrive later this turn do not gain
+ *    flying — which is what "creatures you control gain flying until end of turn" says (a one-shot
+ *    grant, not a continuous "have flying" static).
+ *  - [Effects.GrantKeyword] already defaults to an end-of-turn duration, so no explicit `duration`
+ *    is written.
+ */
+val FrostwindInvoker = card("Frostwind Invoker") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{8}: Creatures you control gain flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Svetlin Velinov"
+        flavorText = "\"We thought Zendikar's rage was kindled by its explorers and plunderers. But the world had sensed the stirrings of the Eldrazi.\"\n—*The Invokers' Tales*"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg?1783941996"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Gloomhunter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Gloomhunter.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gloomhunter
+ * {2}{B}
+ * Creature — Bat
+ * 2 / 1
+ *
+ * Flying
+ *
+ * Modeling notes:
+ *  - Vanilla flyer; a single `keywords(Keyword.FLYING)` declaration covers the printed line.
+ */
+val Gloomhunter = card("Gloomhunter") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    power = 2
+    toughness = 1
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Lars Grant-West"
+        flavorText = "Scavengers both mundane and magical follow in its wake, feeding on the scraps of flesh and spirit it leaves behind."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg?1783941985"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/GravitationalShift.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/GravitationalShift.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gravitational Shift
+ * {3}{U}{U}
+ * Enchantment
+ *
+ * Creatures with flying get +2/+0.
+ * Creatures without flying get -2/-0.
+ *
+ * Modeling notes:
+ *  - Two printed sentences, two `staticAbility { }` blocks. One `ModifyStats` carries one
+ *    (bonus, filter) pair, so the +2/+0 half and the -2/-0 half cannot share a block.
+ *  - The two halves partition all creatures by the FLYING keyword:
+ *    `GameObjectFilter.Creature.withKeyword(FLYING)` and `.withoutKeyword(FLYING)`. Both read
+ *    projected keywords, so a creature that gains or loses flying mid-turn moves between the two
+ *    groups on its own — which is what makes this one enchantment rather than two snapshots.
+ *  - Neither sentence says "you control", so neither filter gets a `youControl()`: this is a
+ *    symmetric global effect that shrinks the opponent's ground creatures too (the whole point
+ *    of the card in a blue flyers deck). Contrast Favorable Winds, whose printed "you control"
+ *    does scope its filter.
+ *  - The negative half is `powerBonus = -2, toughnessBonus = 0` — "-2/-0" touches power only.
+ */
+val GravitationalShift = card("Gravitational Shift") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Creatures with flying get +2/+0.\n" +
+            "Creatures without flying get -2/-0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = -2,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "69"
+        artist = "Svetlin Velinov"
+        flavorText = "As they awakened, the Eldrazi reasserted their mastery over all of Zendikar's natural forces."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg?1783941996"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/GuardDuty.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/GuardDuty.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Guard Duty
+ * {W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has defender.
+ *
+ * Modeling notes:
+ *  - "Enchant creature" is the Aura's attachment requirement, authored as
+ *    `auraTarget = Targets.Creature` — an Aura with no `auraTarget` never attaches to anything.
+ *  - The grant is a *static* ability (`GrantKeyword`), which projects in Layer 6 onto the
+ *    attached creature. Its default scope is the enchanted creature, so no explicit filter is
+ *    needed — the same shape as Zephyr Net, which grants defender and flying this way.
+ *  - Nothing about the grant is conditional or timed, so no `Duration` and no condition: it lasts
+ *    exactly as long as the Aura stays attached.
+ */
+val GuardDuty = card("Guard Duty") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+            "Enchanted creature has defender."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEFENDER)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Karl Kopinski"
+        flavorText = "\"I was told these were standard issue. Do I look standard to you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg?1783942008"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/HarmlessAssault.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/HarmlessAssault.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Harmless Assault
+ * {2}{W}{W}
+ * Instant
+ *
+ * Prevent all combat damage that would be dealt this turn by attacking creatures.
+ *
+ * Modeling notes:
+ *  - A *source-side* shield, not a Fog: the printed line names no recipient, so the damage is
+ *    silenced wherever it would land — attackers hitting the defending player, attackers trading
+ *    with blockers, attackers hitting a planeswalker. That is `Effects.PreventCombatDamageFrom`,
+ *    which is the unified `PreventDamageEffect` with `PreventionDirection.FromTarget` (no recipient
+ *    clause) and a `PreventionSourceFilter.FromGroup` naming the eligible sources — exactly the
+ *    shape Assay compiles this text to.
+ *  - `PreventionScope.CombatOnly` is baked into that facade and is load-bearing here: the card says
+ *    "combat damage", so an attacking creature's activated damage ability still resolves normally.
+ *  - `GroupFilter.AttackingCreatures` is the pre-built "creatures that are attacking" group. The
+ *    group is re-evaluated at the moment each damage instance would be dealt, so a creature that
+ *    stops attacking (or one put onto the battlefield attacking after this resolves) is judged as
+ *    it is when combat damage happens, which is what "attacking creatures" means.
+ */
+val HarmlessAssault = card("Harmless Assault") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn by attacking creatures."
+
+    spell {
+        effect = Effects.PreventCombatDamageFrom(GroupFilter.AttackingCreatures)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Chippy"
+        flavorText = "After encasing it in a paralyzing beam of light, the angel studied the Eldrazi as a child would study a bug, curiously and without fear."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg?1783942008"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/KorLineSlinger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/KorLineSlinger.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kor Line-Slinger
+ * {1}{W}
+ * Creature — Kor Scout
+ * 0 / 1
+ *
+ * {T}: Tap target creature with power 3 or less.
+ *
+ * Modeling notes:
+ *  - The whole cost is the tap symbol — [Costs.Tap], Assay's bare `CostTap` — so the ability is
+ *    once per turn and subject to summoning sickness (CR 302.6), with no mana component.
+ *  - "Target creature with power 3 or less" is [Targets.CreatureWithPowerAtMost], which builds the
+ *    `Creature.powerAtMost(3)` filter — Assay's `IsCreature` + `PowerAtMost(max: 3)` pair. Power is
+ *    read off *projected* state, so a creature pumped past 3 in response stops being a legal target
+ *    and the ability fizzles.
+ *  - The tap is [Effects.Tap] on the declared target; targeting an already-tapped creature is legal
+ *    and simply does nothing, so no untapped restriction is written into the filter.
+ */
+val KorLineSlinger = card("Kor Line-Slinger") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Scout"
+    power = 0
+    toughness = 1
+    oracleText = "{T}: Tap target creature with power 3 or less."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature with power 3 or less", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Steve Prescott"
+        flavorText = "\"I tried to tell her to stay behind, that this fight was too dangerous. I spent the next hour tied to the rafters.\"\n—Zahr Gada, Halimar expedition leader"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg?1783942006"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LastKiss.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LastKiss.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Last Kiss
+ * {2}{B}
+ * Instant
+ *
+ * Last Kiss deals 2 damage to target creature and you gain 2 life.
+ *
+ * Modeling notes:
+ *  - Assay compiles the sentence as a `Composite` of `DealDamage` then `GainLife`, which is the
+ *    `.then(...)` chain below. The order matters: both halves happen on resolution, and the damage
+ *    is dealt first, so the life gain is unconditional even if the damage is prevented or the
+ *    creature survives.
+ *  - The life gain has no target of its own — Assay emits a bare `GainLife`, and
+ *    `EffectTarget.Controller` is already [Effects.GainLife]'s default, so it is left unwritten
+ *    rather than restated.
+ */
+val LastKiss = card("Last Kiss") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Last Kiss deals 2 damage to target creature and you gain 2 life."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(2, creature)
+            .then(Effects.GainLife(2))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Vance Kovacs"
+        flavorText = "\"Romanticize it, glamorize it, call it what you will. To me, it will always be carnal, bloody murder.\"\n—Ayli, Kamsa cleric"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg?1783941983"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LavafumeInvoker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LavafumeInvoker.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lavafume Invoker
+ * {2}{R}
+ * Creature — Goblin Shaman
+ * 2 / 2
+ *
+ * {8}: Creatures you control get +3/+0 until end of turn.
+ *
+ * Modeling notes:
+ *  - The invoker ability is a plain [activatedAbility] with a `{8}` mana cost — no tap symbol, no
+ *    timing restriction — so it is repeatable and usable at instant speed.
+ *  - "Creatures you control" is a **group**, not a target: [Effects.ForEachInGroup] over
+ *    [GroupFilter.AllCreaturesYouControl] applies the pump once per member, with
+ *    [EffectTarget.Self] naming the current iteration entity. That is Assay's `ForEach` over an
+ *    `IterationSpace.Group` filtered on `IsCreature` + `ControlledByYou`.
+ *  - The toughness modifier is written as an explicit `0` because the printed line is `+3/+0`, and
+ *    the group is snapshotted on resolution — creatures that arrive later this turn are not pumped.
+ *  - [Effects.ModifyStats] already defaults to an end-of-turn duration, so no `duration` is written.
+ */
+val LavafumeInvoker = card("Lavafume Invoker") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{8}: Creatures you control get +3/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.ModifyStats(3, 0, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Dave Kendall"
+        flavorText = "\"Then the ancient masters themselves, towers of rapacity, rose and began their calamitous feast.\"\n—*The Invokers' Tales*"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg?1783941974"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LeafArrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LeafArrow.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaf Arrow
+ * {G}
+ * Instant
+ *
+ * Leaf Arrow deals 3 damage to target creature with flying.
+ *
+ * Modeling notes:
+ *  - "with flying" is a restriction on *which creature can be chosen*, not a condition checked on
+ *    resolution, so it lives on the target requirement: Assay compiles one `TargetObject` carrying
+ *    both `IsCreature` and `HasKeyword FLYING`, which is exactly
+ *    [Targets.CreatureWithKeyword]`(Keyword.FLYING)`. Written as a condition instead, the spell
+ *    could be aimed at a ground creature and simply do nothing — the wrong behaviour.
+ *  - Target legality is re-checked on resolution (CR 608.2b) off projected state, so a creature
+ *    that loses flying in response makes the spell fizzle. That falls out of putting the keyword
+ *    in the filter.
+ */
+val LeafArrow = card("Leaf Arrow") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Leaf Arrow deals 3 damage to target creature with flying."
+
+    spell {
+        val flier = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.DealDamage(3, flier)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Eric Deschamps"
+        flavorText = "\"Those who think the trees shall remain bystanders throughout this conflict shall be sorely mistaken.\"\n—Sutina, Speaker of the Tajuru"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg?1783941962"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LoneMissionary.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LoneMissionary.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lone Missionary
+ * {1}{W}
+ * Creature — Kor Monk
+ * 2 / 1
+ *
+ * When this creature enters, you gain 4 life.
+ *
+ * Modeling notes:
+ *  - "**When** this creature enters" is the one-shot [Triggers.EntersBattlefield]; there is no
+ *    "whenever" and no other-permanent watcher to model.
+ *  - "**You** gain 4 life" is [Effects.GainLife]'s default recipient (`EffectTarget.Controller`),
+ *    so the target argument is left off — writing it explicitly would restate a default.
+ */
+val LoneMissionary = card("Lone Missionary") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Monk"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+        description = "When this creature enters, you gain 4 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Svetlin Velinov"
+        flavorText = "His mission has become a grim pilgrimage, a tour of the Eldrazi-stricken outposts across Zendikar. But he marches on alone, stubborn as the daily dawn."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg?1783942004"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Magmaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Magmaw.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Magmaw
+ * {3}{R}{R}
+ * Creature — Elemental
+ * 4 / 4
+ *
+ * {1}, Sacrifice a nonland permanent: This creature deals 1 damage to any target.
+ *
+ * Modeling notes:
+ *  - Two cost components joined by a comma are one [Costs.Composite]: the mana half is
+ *    `Costs.Mana("{1}")` and the sacrifice half is a [Costs.Sacrifice] over
+ *    [GameObjectFilter.NonlandPermanent] — the filter whose card predicates are exactly the
+ *    `IsNonland` + `IsPermanent` pair Assay compiles this line to. The permanent is chosen and
+ *    sacrificed on activation, before the ability goes on the stack.
+ *  - A sacrifice cost can only ever take permanents its payer controls, so the filter carries no
+ *    controller predicate — the cost atom's candidate domain is already scoped to the payer.
+ *  - The printed line says "a nonland permanent", **not** "another": [Costs.Sacrifice] (not
+ *    `SacrificeAnother`) leaves Magmaw itself in the candidate pool, so feeding Magmaw to its own
+ *    ability is a legal activation. The damage still happens; last-known information covers the
+ *    source having left the battlefield.
+ *  - "any target" is [Targets.Any] — creature, player, planeswalker or battle — and the damage is
+ *    a plain [Effects.DealDamage] with the source defaulting to this creature, matching the printed
+ *    "This creature deals".
+ */
+val Magmaw = card("Magmaw") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 4
+    toughness = 4
+    oracleText = "{1}, Sacrifice a nonland permanent: This creature deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Sacrifice(GameObjectFilter.NonlandPermanent)
+        )
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "158"
+        artist = "Karl Kopinski"
+        flavorText = "\"The purpose of existence is simple: everything is fuel for the magmaw.\"\n—Jaji, magmaw worshipper"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg?1783941972"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/MakindiGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/MakindiGriffin.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Makindi Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2 / 4
+ *
+ * Flying
+ *
+ * Modeling notes:
+ *  - Vanilla flyer; a single `keywords(Keyword.FLYING)` declaration covers the printed line.
+ */
+val MakindiGriffin = card("Makindi Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 2
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Izzy"
+        flavorText = "As the hedrons began to coalesce into colossal Eldrazi superstructures, the griffins were forced to seek new territory lest their aeries be crushed between the massive stone monoliths."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg?1783942005"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/MerfolkSkyscout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/MerfolkSkyscout.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Merfolk Skyscout
+ * {2}{U}{U}
+ * Creature — Merfolk Scout
+ * 2 / 3
+ *
+ * Flying
+ * Whenever this creature attacks or blocks, untap target permanent.
+ *
+ * Modeling notes:
+ *  - "Attacks or blocks" is **two** triggered abilities sharing one effect. Attacking and blocking
+ *    are separate events, and the SDK has no combined `AttacksOrBlocks` trigger — [Triggers.Attacks]
+ *    and [Triggers.Blocks] are the two spellings, the Daemogoth Titan / Hamlet Captain / Elder
+ *    Gargaroth shape. Assay's own JSON compiles this sentence into exactly two `triggeredAbilities`
+ *    (`AttackEvent` and `BlockEvent`), so the pair is authoring to the model, not a workaround.
+ *    Two abilities is also rules-correct: a creature that attacks and is later blocked triggers
+ *    only the attack half, and each trigger picks its own target.
+ *  - Each half declares its own [Targets.Permanent] requirement — the target is chosen as the
+ *    ability goes on the stack (CR 603.3d), which is why it cannot be shared between the two.
+ *  - "Untap target permanent" is mandatory and unconditional: no `optional`, and the target is any
+ *    permanent (either controller's), matching Assay's bare `IsPermanent` predicate.
+ *  - Neither half sets a `description`: the corpus leaves the paired triggers to auto-render, so
+ *    the client shows one line per event rather than printing the joined sentence twice.
+ */
+val MerfolkSkyscout = card("Merfolk Skyscout") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Scout"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+            "Whenever this creature attacks or blocks, untap target permanent."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val permanent = target("target permanent", Targets.Permanent)
+        effect = Effects.Untap(permanent)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        val permanent = target("target permanent", Targets.Permanent)
+        effect = Effects.Untap(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "77"
+        artist = "rk post"
+        flavorText = "\"Emeria is a pleasant lie, a figment to hide Emrakul's hideous face. I can only hope to uncover a truth that lies deeper still.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg?1783941994"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/NomadsAssembly.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/NomadsAssembly.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nomads' Assembly
+ * {4}{W}{W}
+ * Sorcery
+ *
+ * Create a 1/1 white Kor Soldier creature token for each creature you control.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Modeling notes:
+ *  - Rebound has a real consumer — `StackResolver` reads [Keyword.REBOUND] off `cardDef.keywords`
+ *    when the spell resolves — so the bare keyword is the whole of the second line and the
+ *    assembly happens twice, a turn apart, from one [Effects.CreateToken].
+ *  - "for each creature you control" is the token *count*, so this is the `DynamicAmount` overload
+ *    of [Effects.CreateToken], not the `Int` one. [DynamicAmounts.creaturesYouControl] is exactly
+ *    `AggregateBattlefield(You, Creature)`, the shape Assay compiles the clause to, and it is
+ *    evaluated at resolution — the second, rebound cast counts the board as it stands *then*,
+ *    including the tokens the first cast made.
+ *  - The count includes the tokens' own controller's whole board, with no self-exclusion: a
+ *    sorcery is not on the battlefield, so there is nothing to exclude.
+ *  - No `imageUri` on the effect. ROE's token sheet (`troe`) never printed a Kor Soldier, so there
+ *    is no set-scoped art to bake, and baking another set's art would freeze it across every
+ *    printing — token art belongs on `MtgSet.tokenArt` / `tokens.json`, keyed by minting set.
+ *  - The token's name falls out of its creature types ("Kor Soldier"), which is what the printed
+ *    "1/1 white Kor Soldier creature token" wants, so no `name` override.
+ */
+val NomadsAssembly = card("Nomads' Assembly") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create a 1/1 white Kor Soldier creature token for each creature you control.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.creaturesYouControl(),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Kor", "Soldier")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Erica Yang"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg?1783942004"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/OgreSentry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/OgreSentry.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Sentry
+ * {1}{R}
+ * Creature — Ogre Warrior
+ * 3 / 3
+ *
+ * Defender
+ *
+ * Modeling notes:
+ *  - Vanilla defender; a single `keywords(Keyword.DEFENDER)` declaration covers the printed line.
+ */
+val OgreSentry = card("Ogre Sentry") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Defender"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "159"
+        artist = "Eric Deschamps"
+        flavorText = "\"You have to appreciate the genius of it. Why bother building defenses when you can just fill the pass with angry ogres?\"\n—Javad Nasrin, Ondu relic hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg?1783941972"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/OgresCleaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/OgresCleaver.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Ogre's Cleaver
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +5/+0.
+ * Equip {5}
+ *
+ * Modeling notes:
+ *  - The plainest Equipment shape in the corpus: one `staticAbility { ModifyStats(...) }` scoped
+ *    to `Filters.EquippedCreature` (`GroupFilter.attachedCreature()`), plus `equipAbility("{5}")`.
+ *  - `equipAbility(...)` is preferred over a hand-rolled `activatedAbility { }`: it sets
+ *    `equipCost` *and* builds the `ActivatedAbility.equip` lowering with `isEquipAbility = true`,
+ *    the flag every engine rule that keys off equip (free-equip grants, equip discounts,
+ *    instant-speed-equip permissions) reads. Its defaults already carry the printed reminder
+ *    text's meaning — sorcery timing and `TargetFilter.CreatureYouControl`.
+ *  - "+5/+0" is power only, hence `toughnessBonus = 0`.
+ */
+val OgresCleaver = card("Ogre's Cleaver") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +5/+0.\n" +
+            "Equip {5}"
+
+    staticAbility {
+        ability = ModifyStats(5, 0, Filters.EquippedCreature)
+    }
+
+    equipAbility("{5}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Adi Granov"
+        flavorText = "She adopted the weapon of the slave-lord Kazuul, and with it, all his cruelty."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg?1783941955"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PathrazerOfUlamog.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PathrazerOfUlamog.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByFewerThan
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pathrazer of Ulamog
+ * {11}
+ * Creature — Eldrazi
+ * 9 / 9
+ *
+ * Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents of
+ * their choice.)
+ * This creature can't be blocked except by three or more creatures.
+ *
+ * Modeling notes:
+ *  - Annihilator is a **display-only** [KeywordAbility.Numeric] in this SDK — nothing in
+ *    `rules-engine` reads it — so the card declares it for the printed line *and* lowers the
+ *    behaviour by hand, exactly as Artisan of Kozilek does for annihilator 2: a [Triggers.Attacks]
+ *    triggered ability whose effect is the edict form of [Effects.Sacrifice], where the *defending
+ *    player* chooses. Declaring the keyword ability alone would render the reminder text and do
+ *    nothing.
+ *  - The filter is [GameObjectFilter.Permanent], not `Creature`: annihilator eats any permanent of
+ *    the defending player's choice, lands and enchantments included.
+ *  - The blocking clause is the generalized-menace static [CantBeBlockedByFewerThan] with
+ *    `minBlockers = 3` (menace is the N = 2 case). It may still be left unblocked entirely — the
+ *    restriction only bites once at least one creature blocks — which is what "can't be blocked
+ *    except by three or more creatures" means.
+ */
+val PathrazerOfUlamog = card("Pathrazer of Ulamog") {
+    manaCost = "{11}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 9
+    toughness = 9
+    oracleText = "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents of their choice.)\n" +
+        "This creature can't be blocked except by three or more creatures."
+
+    keywordAbility(KeywordAbility.annihilator(3))
+
+    // Annihilator 3 — the lowering of the display-only keyword ability above.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Permanent,
+            3,
+            EffectTarget.PlayerRef(Player.DefendingPlayer)
+        )
+        description = "Annihilator 3"
+    }
+
+    staticAbility {
+        ability = CantBeBlockedByFewerThan(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Austin Hsu"
+        flavorText = "No thought but hunger. No strategy but destruction."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg?1783942012"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PestilenceDemon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PestilenceDemon.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pestilence Demon
+ * {5}{B}{B}{B}
+ * Creature — Demon
+ * 7 / 6
+ *
+ * Flying
+ * {B}: This creature deals 1 damage to each creature and each player.
+ *
+ * Modeling notes:
+ *  - "Each creature and each player" is **two iterations, not one**: a group pass over every
+ *    creature ([Effects.ForEachInGroup] with [EffectTarget.Self] naming the current iteration
+ *    entity) and a player pass where each iteration rebinds the controller
+ *    ([Effects.ForEachPlayer] over [Player.Each] with [EffectTarget.Controller]). Same idiom as
+ *    Thrashing Wumpus, whose printed line is identical, and the same shape Assay compiles.
+ *  - The creature filter is bare [GameObjectFilter.Creature] with no controller predicate — this
+ *    hits *every* creature, including the Demon itself and your own board.
+ *  - Nothing is targeted, so no `target(...)` requirement is declared; the ability can be activated
+ *    with an empty battlefield.
+ */
+val PestilenceDemon = card("Pestilence Demon") {
+    manaCost = "{5}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 7
+    toughness = 6
+    oracleText = "Flying\n" +
+        "{B}: This creature deals 1 damage to each creature and each player."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature),
+                Effects.DealDamage(1, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(1, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Justin Sweet"
+        flavorText = "\"I have schemed too long to be supplanted by dead gods. If I cannot have this world, no one can.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg?1783941981"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PreysVengeance.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PreysVengeance.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Prey's Vengeance
+ * {G}
+ * Instant
+ *
+ * Target creature gets +2/+2 until end of turn.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Modeling notes:
+ *  - Rebound has a real consumer — `StackResolver` reads [Keyword.REBOUND] off `cardDef.keywords`
+ *    when the spell resolves — so the bare keyword is the whole of the second line and the pump
+ *    arrives twice, a turn apart, from one [Effects.ModifyStats].
+ *  - Artful Maneuver's shape exactly, in green: `until end of turn` is [Effects.ModifyStats]'
+ *    default duration, so it isn't spelled here.
+ *  - The rebound cast re-targets from scratch (CR 601.2c on the new cast), so the target is chosen
+ *    again on the upkeep — nothing about the first cast's target is carried, and no context target
+ *    is needed.
+ */
+val PreysVengeance = card("Prey's Vengeance") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Jesper Ejsing"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg?1783941959"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PuncturingLight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/PuncturingLight.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Puncturing Light
+ * {1}{W}
+ * Instant
+ *
+ * Destroy target attacking or blocking creature with power 3 or less.
+ *
+ * Modeling notes:
+ *  - The whole card is its target requirement plus `Effects.Destroy`, which is the
+ *    move-to-graveyard-by-destruction effect Assay compiles "destroy" to (so regeneration and
+ *    indestructible apply as they should).
+ *  - "attacking or blocking" is the single `TargetFilter.AttackingOrBlockingCreature` predicate —
+ *    one `StatePredicate.Or`, not two separate clauses — narrowed by `.powerAtMost(3)` for
+ *    "with power 3 or less". Power is read from projected state, so a creature pumped above 3 in
+ *    response stops being a legal target.
+ *  - Both halves live on the target requirement rather than being checked on resolution: the card
+ *    says "target … creature with power 3 or less", so the restriction is part of legality.
+ */
+val PuncturingLight = card("Puncturing Light") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target attacking or blocking creature with power 3 or less."
+
+    spell {
+        val creature = target(
+            "target attacking or blocking creature with power 3 or less",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature.powerAtMost(3))
+        )
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "\"The vampires knew what was coming. I know it. And they did nothing. They deserve to feel the same agony they've caused all of us.\"\n—Anitan, Ondu cleric"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg?1783942003"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/RegressReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/RegressReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Regress reprint in ROE. Canonical CardDefinition lives in its earliest set.
+ */
+val RegressReprint = Printing(
+    oracleId = "2fa763ad-4d94-4c3a-a099-13ac22c09ce4",
+    name = "Regress",
+    setCode = "ROE",
+    collectorNumber = "83",
+    scryfallId = "b7aba8e0-34e7-43ec-bce5-b6b472daa841",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b7aba8e0-34e7-43ec-bce5-b6b472daa841.jpg",
+    releaseDate = "2010-04-23",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/ReinforcedBulwark.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/ReinforcedBulwark.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Reinforced Bulwark
+ * {3}
+ * Artifact Creature — Wall
+ * 0 / 4
+ *
+ * Defender
+ * {T}: Prevent the next 1 damage that would be dealt to you this turn.
+ *
+ * Modeling notes:
+ *  - `Effects.PreventNextDamage(1, EffectTarget.Controller)` is the capacity shield: an `amount` of
+ *    1 with the unified prevention effect's default `Duration.EndOfTurn` and default
+ *    `PreventionSourceFilter.AnySource`. The same shape as Shield of the Ages.
+ *  - "dealt to **you**" is untargeted — the shield goes on the ability's controller, not on a
+ *    chosen player — so `EffectTarget.Controller` and no `target(...)` requirement.
+ *  - Not combat-only: the printed line says "damage", so `PreventionScope.AllDamage` (the default)
+ *    is right — a burn spell aimed at you is soaked too.
+ *  - The `{T}` cost is `Costs.Tap`; DEFENDER is declared through `keywords(...)`, which the engine
+ *    reads for the can't-attack restriction as well as for the printed line.
+ */
+val ReinforcedBulwark = card("Reinforced Bulwark") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Defender\n" +
+            "{T}: Prevent the next 1 damage that would be dealt to you this turn."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.PreventNextDamage(1, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "223"
+        artist = "Ryan Pancoast"
+        flavorText = "Built of wood and iron. Held together by hope and prayer."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg?1783941955"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/RiseOfTheEldraziBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/RiseOfTheEldraziBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Rise of the Eldrazi Basic Lands
+ *
+ * ROE prints four art variants of each basic land type, cards 229-248, all
+ * booster-eligible.
+ */
+
+// =============================================================================
+// Plains (Cards 229, 230, 231, 232)
+// =============================================================================
+
+val RoePlains229 = basicLand("Plains") {
+    collectorNumber = "229"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3345553-8f04-4a83-9b6b-95ca0654921d.jpg?1783941955"
+}
+
+val RoePlains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/70dc47f2-a92d-446b-b788-8287b5d609c4.jpg?1783941953"
+}
+
+val RoePlains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf39f344-1204-4c90-93b5-c04a24f0f1f5.jpg?1783941954"
+}
+
+val RoePlains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45031d49-c82b-47a4-a652-f8904cd9bb66.jpg?1783941953"
+}
+
+// =============================================================================
+// Island (Cards 233, 234, 235, 236)
+// =============================================================================
+
+val RoeIsland233 = basicLand("Island") {
+    collectorNumber = "233"
+    artist = "Vincent Proce"
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4c799192-43bb-4c25-ab4f-b1d4ef0df660.jpg?1783941953"
+}
+
+val RoeIsland234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Vincent Proce"
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15973a22-cf86-447d-94ef-d62ac824aa49.jpg?1783941952"
+}
+
+val RoeIsland235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Vincent Proce"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e32a5e25-8e85-474e-ab32-ab28898ac87a.jpg?1783941951"
+}
+
+val RoeIsland236 = basicLand("Island") {
+    collectorNumber = "236"
+    artist = "Vincent Proce"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddcc2609-59ba-4eca-8b90-993cab90364a.jpg?1783941952"
+}
+
+// =============================================================================
+// Swamp (Cards 237, 238, 239, 240)
+// =============================================================================
+
+val RoeSwamp237 = basicLand("Swamp") {
+    collectorNumber = "237"
+    artist = "Véronique Meignaud"
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f75f4aa-cede-452b-80c1-bd3b8221dbcb.jpg?1783941951"
+}
+
+val RoeSwamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Véronique Meignaud"
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30d7edb2-3bb4-4a0f-ad66-eef31cc8ed6b.jpg?1783941952"
+}
+
+val RoeSwamp239 = basicLand("Swamp") {
+    collectorNumber = "239"
+    artist = "Véronique Meignaud"
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50bdea83-efb5-4371-8d25-5703c6efee65.jpg?1783941951"
+}
+
+val RoeSwamp240 = basicLand("Swamp") {
+    collectorNumber = "240"
+    artist = "Véronique Meignaud"
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/1660f317-d337-4c24-8523-613dc3072ca9.jpg?1783941950"
+}
+
+// =============================================================================
+// Mountain (Cards 241, 242, 243, 244)
+// =============================================================================
+
+val RoeMountain241 = basicLand("Mountain") {
+    collectorNumber = "241"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/c/f/cf940cc3-282e-4b6b-877d-5ce71ee797bc.jpg?1783941950"
+}
+
+val RoeMountain242 = basicLand("Mountain") {
+    collectorNumber = "242"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9acc9266-3a8e-4a5b-9c00-bbc30e3bf5e7.jpg?1783941950"
+}
+
+val RoeMountain243 = basicLand("Mountain") {
+    collectorNumber = "243"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/7352288b-ff7b-43c7-a5ae-3f6577d11708.jpg?1783941950"
+}
+
+val RoeMountain244 = basicLand("Mountain") {
+    collectorNumber = "244"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a56424d3-ceda-4cd3-988f-48ced72d17b8.jpg?1783941949"
+}
+
+// =============================================================================
+// Forest (Cards 245, 246, 247, 248)
+// =============================================================================
+
+val RoeForest245 = basicLand("Forest") {
+    collectorNumber = "245"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10e2588b-7781-418c-abc8-08601fbb2336.jpg?1783941949"
+}
+
+val RoeForest246 = basicLand("Forest") {
+    collectorNumber = "246"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92af153b-5cc6-4130-8694-dcdb1fd45cdc.jpg?1783941949"
+}
+
+val RoeForest247 = basicLand("Forest") {
+    collectorNumber = "247"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/776470f5-3a47-475b-a599-cb5fee156593.jpg?1783941949"
+}
+
+val RoeForest248 = basicLand("Forest") {
+    collectorNumber = "248"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4dd7a8a-a560-481a-a16e-dc60cdb440bb.jpg?1783941948"
+}
+
+/**
+ * All Rise of the Eldrazi basic land variants.
+ */
+val RiseOfTheEldraziBasicLands = listOf(
+    RoePlains229, RoePlains230, RoePlains231, RoePlains232,
+    RoeIsland233, RoeIsland234, RoeIsland235, RoeIsland236,
+    RoeSwamp237, RoeSwamp238, RoeSwamp239, RoeSwamp240,
+    RoeMountain241, RoeMountain242, RoeMountain243, RoeMountain244,
+    RoeForest245, RoeForest246, RoeForest247, RoeForest248,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SharedDiscovery.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SharedDiscovery.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Shared Discovery
+ * {U}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, tap four untapped creatures you control.
+ * Draw three cards.
+ *
+ * Modeling notes:
+ *  - The tap is an **additional cost** (CR 601.2f), not an effect — a controller without four
+ *    untapped creatures simply cannot cast the spell, and the creatures stay tapped even if the
+ *    draw is somehow replaced. `Costs.additional.TapPermanents(count = 4, ...)` is Assay's
+ *    `AdditionalAtom` → `AtomTapPermanents` with `count: 4`, the Fear of Exposure / Gaze of Justice
+ *    shape.
+ *  - Tapping this way is a cost, not the `{T}` symbol, so summoning sickness (CR 302.6) does not
+ *    apply to the creatures chosen; only untapped ones are legal choices (CR 701.26a), which is
+ *    what `.untapped()` states explicitly on the filter.
+ *  - **Divergence from Assay's JSON, deliberate.** Assay renders the cost filter as bare
+ *    `IsCreature`, dropping the printed "you control". A cost can only ever tap permanents its
+ *    payer controls, so that is Assay under-specifying rather than the card meaning something
+ *    wider; the printed restriction is written here as `.youControl()`.
+ *  - "Draw three cards" is a flat [Effects.DrawCards] with no target — the caster draws.
+ */
+val SharedDiscovery = card("Shared Discovery") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, tap four untapped creatures you control.\n" +
+            "Draw three cards."
+
+    additionalCost(
+        Costs.additional.TapPermanents(
+            count = 4,
+            filter = GameObjectFilter.Creature.untapped().youControl()
+        )
+    )
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Ryan Pancoast"
+        flavorText = "Riches must be divided, but real wealth can be shared."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg?1783941991"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SkeletalWurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SkeletalWurm.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skeletal Wurm
+ * {7}{B}
+ * Creature — Skeleton Wurm
+ * 7 / 6
+ *
+ * {B}: Regenerate this creature.
+ *
+ * Modeling notes:
+ *  - A plain mana-only activated ability: [Costs.Mana] for `{B}`, no tap symbol, so it can be
+ *    activated repeatedly and at instant speed.
+ *  - Regeneration has no `Effects.*` facade — `docs/card-sdk-language-reference.md` documents
+ *    `RegenerateEffect(target)` as the raw shape ("raw — no facade"), and every regenerating
+ *    creature in the corpus (Unworthy Dead, Sanguine Guard, Spined Fluke, Child of Gaea) constructs
+ *    it directly. `EffectTarget.Self` is Assay's `{"type": "Self"}` target: the shield lands on this
+ *    creature, not on a chosen one.
+ *  - `Effects.CantBeRegenerated` / `Destroy(noRegenerate = true)` are the *opposite* side of this
+ *    mechanic and are not involved here.
+ */
+val SkeletalWurm = card("Skeletal Wurm") {
+    manaCost = "{7}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton Wurm"
+    power = 7
+    toughness = 6
+    oracleText = "{B}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Necromancers are judged by the most powerful undead they've ever created. There are those who have animated just a single being, yet are considered the pinnacle of their dark craft."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg?1783941980"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulboundGuardians.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulboundGuardians.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soulbound Guardians
+ * {4}{W}
+ * Creature — Kor Spirit
+ * 4 / 5
+ *
+ * Defender, flying
+ *
+ * Modeling notes:
+ *  - Two vanilla keywords printed on one line; `keywords(Keyword.DEFENDER, Keyword.FLYING)` matches
+ *    the printed "Defender, flying" wording (see Monastery Flock for the same shape).
+ */
+val SoulboundGuardians = card("Soulbound Guardians") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Spirit"
+    power = 4
+    toughness = 5
+    oracleText = "Defender, flying"
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Erica Yang"
+        flavorText = "The kor's most righteous dead are given the greatest reward: an eternity tied to the land they so cherish."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg?1783942003"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulsAttendant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulsAttendant.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Soul's Attendant
+ * {W}
+ * Creature — Human Cleric
+ * 1 / 1
+ *
+ * Whenever another creature enters, you may gain 1 life.
+ *
+ * Modeling notes:
+ *  - The printed word is "**another** creature", so the binding is [TriggerBinding.OTHER] — Soul's
+ *    Attendant entering does not trigger itself, but every other creature entering does. Assay
+ *    compiles `"binding": "OTHER"` over a `ZoneChangeEvent` to the battlefield, and this matches it.
+ *  - The card prints no "you control", so the filter is a bare [GameObjectFilter.Creature]: an
+ *    opponent's creature entering triggers this just as one of yours does. This is why the trigger
+ *    is spelled with `Triggers.entersBattlefield(...)` rather than `Triggers.OtherCreatureEnters`,
+ *    whose filter is scoped to your own side — the same choice Essence Warden documents.
+ *  - "you **may** gain 1 life" is a consent gate on resolution, which is what the `optional = true`
+ *    shorthand lowers to (`Gate.MayDecide` wrapping the effect — Assay's `Gated`/`Gate.MayDecide`).
+ *    Soul Warden, the non-optional twin, is the card without this line.
+ */
+val SoulsAttendant = card("Soul's Attendant") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever another creature enters, you may gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature,
+            binding = TriggerBinding.OTHER
+        )
+        optional = true
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Steve Prescott"
+        flavorText = "In truth, her own faith was gone, trodden in Ulamog's wake. She pantomimed the blessing in the hope that it would inspire others to continue to struggle."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg?1783942003"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulsurgeElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SoulsurgeElemental.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soulsurge Elemental
+ * {3}{R}
+ * Creature — Elemental
+ * \* / 1
+ *
+ * First strike
+ * Soulsurge Elemental's power is equal to the number of creatures you control.
+ *
+ * Modeling notes:
+ *  - The printed power is a `*`, so power is a characteristic-defining ability (CR 604.3): a
+ *    Layer 7a value recomputed continuously at projection, not a one-shot pump. `dynamicPower(...)`
+ *    is that CDA, and the card emits **no** `power =` line — a printed base would be the thing the
+ *    CDA is supposed to replace.
+ *  - Only power is dynamic; toughness is a printed 1. That is exactly the split the single-stat
+ *    `dynamicPower(source)` helper exists for, so this uses it rather than the both-stats
+ *    `dynamicStats(...)` (same reasoning as Kraven, Proud Predator).
+ *  - "the number of creatures you control" is `DynamicAmounts.creaturesYouControl()`, i.e.
+ *    `battlefield(Player.You, GameObjectFilter.Creature).count()`. The Elemental is itself a
+ *    creature you control, so it counts itself — a lone Soulsurge Elemental is a 1/1, which is
+ *    what the card does.
+ *  - First strike is engine-live, so a plain `keywords(...)` declaration is the whole of it.
+ */
+val SoulsurgeElemental = card("Soulsurge Elemental") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    toughness = 1
+    dynamicPower(DynamicAmounts.creaturesYouControl())
+    oracleText = "First strike\n" +
+            "Soulsurge Elemental's power is equal to the number of creatures you control."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Jason A. Engle"
+        flavorText = "It draws its strength from those around it, but the pleasure of destruction is all its own."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg?1783941971"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SphinxOfMagosi.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SphinxOfMagosi.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sphinx of Magosi
+ * {3}{U}{U}{U}
+ * Creature — Sphinx
+ * 6 / 6
+ *
+ * Flying
+ * {2}{U}: Draw a card, then put a +1/+1 counter on this creature.
+ *
+ * Modeling notes:
+ *  - The ability is a plain [activatedAbility] with only a mana cost — no `{T}`, no timing
+ *    restriction — so it is repeatable at instant speed for as much mana as is available. That is
+ *    Assay's single `CostAtomWrapper` → `AtomMana("{2}{U}")`.
+ *  - "Draw a card, **then** put a +1/+1 counter on this creature" is one effect with an ordered
+ *    pair of steps, not two abilities: [Effects.Composite] in the printed order, mirroring Assay's
+ *    `Composite` of `DrawCards` then `AddCounters`. The order is load-bearing — the card is drawn
+ *    before the counter goes on, so a replacement that stops the draw does not stop the counter.
+ *  - The counter goes on the Sphinx itself, so the target is [EffectTarget.Self] (Assay's
+ *    `"target": {"type": "Self"}`), not a chosen target.
+ */
+val SphinxOfMagosi = card("Sphinx of Magosi") {
+    manaCost = "{3}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\n" +
+            "{2}{U}: Draw a card, then put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "89"
+        artist = "James Ryman"
+        flavorText = "\"A riddle is nothing more than a trap for small minds, baited with the promise of understanding.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg?1783941991"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SporecapSpider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SporecapSpider.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sporecap Spider
+ * {2}{G}
+ * Creature — Spider
+ * 1 / 5
+ *
+ * Reach
+ *
+ * Modeling notes:
+ *  - Vanilla reach creature; a single `keywords(Keyword.REACH)` declaration covers the printed line.
+ */
+val SporecapSpider = card("Sporecap Spider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 1
+    toughness = 5
+    oracleText = "Reach"
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "209"
+        artist = "Lars Grant-West"
+        flavorText = "\"They don't move much, but then again, if you get caught in its web, it has all the time in the world to get to you.\"\n—Saidah, Joraga hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg?1783941960"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Staggershock.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/Staggershock.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Staggershock
+ * {2}{R}
+ * Instant
+ *
+ * Staggershock deals 2 damage to any target.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Modeling notes:
+ *  - Rebound has a real consumer — `StackResolver` reads [Keyword.REBOUND] off `cardDef.keywords`
+ *    when the spell resolves — so the bare keyword is the whole of the second line and the two
+ *    damage lands twice, a turn apart, from one [Effects.DealDamage].
+ *  - "any target" is [AnyTarget], the creature-or-player-or-planeswalker requirement, not a
+ *    creature filter; the rebound cast picks a fresh one on the upkeep.
+ *  - No `damageSource` override: the spell deals the damage itself, which is the facade's default.
+ */
+val Staggershock = card("Staggershock") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Staggershock deals 2 damage to any target.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "166"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg?1783941971"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/StalwartShieldBearers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/StalwartShieldBearers.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Stalwart Shield-Bearers
+ * {1}{W}
+ * Creature — Human Soldier
+ * 0 / 3
+ *
+ * Defender
+ * Other creatures you control with defender get +0/+2.
+ *
+ * Modeling notes:
+ *  - A plain lord: one `staticAbility { ModifyStats(...) }` over a battlefield group filter.
+ *  - Three printed words shape the filter and each earns a piece of it: "**with defender**" is
+ *    `withKeyword(Keyword.DEFENDER)`, "**you control**" is `youControl()`, and "**Other**" is
+ *    `.other()` — the `GroupFilter` exclude-self flag that drops the resolving source from the
+ *    group, so Stalwart Shield-Bearers stays a 0/3 and does not pump itself.
+ *  - Contrast Gravitational Shift in this same set, where no "you control" is printed and the
+ *    filter is therefore left global. Here it is printed, so it is scoped.
+ *  - Its own Defender is a plain `keywords(...)` declaration; DEFENDER is engine-live (the
+ *    attack-declaration check reads it off projected keywords), so no further wiring.
+ */
+val StalwartShieldBearers = card("Stalwart Shield-Bearers") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 0
+    toughness = 3
+    oracleText = "Defender\n" +
+            "Other creatures you control with defender get +0/+2."
+
+    keywords(Keyword.DEFENDER)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 2,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER).youControl()
+            ).other()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Austin Hsu"
+        flavorText = "\"Hold fast the line! Either we stop them here or we wake up in their guts!\"\n—Tala Vertan, Makindi shieldmate"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg?1783942002"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/StomperCub.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/StomperCub.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stomper Cub
+ * {3}{G}{G}
+ * Creature — Beast
+ * 5 / 3
+ *
+ * Trample
+ *
+ * Modeling notes:
+ *  - Vanilla trampler; a single `keywords(Keyword.TRAMPLE)` declaration covers the printed line.
+ */
+val StomperCub = card("Stomper Cub") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 3
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Karl Kopinski"
+        flavorText = "\"This one is only a yearling, but it would be wise to move away before we provide it with excellent hunting practice.\"\n—Samila, Murasa Expeditionary House"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg?1783941959"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/TotemGuideHartebeest.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/TotemGuideHartebeest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Totem-Guide Hartebeest
+ * {4}{W}
+ * Creature — Antelope
+ * 2 / 5
+ *
+ * When this creature enters, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle.
+ *
+ * Modeling notes:
+ *  - "**When** this creature enters" is the one-shot [Triggers.EntersBattlefield].
+ *  - "You **may** search" is a decline on resolution, so `optional = true` lowers the tutor into a
+ *    `Gate.MayDecide` — the `Gated` wrapper Assay compiles from this line. It is not a `ChooseUpTo`
+ *    "find nothing": that selection freedom is separate, and both are present.
+ *  - The search itself is the stock [Patterns.Library.searchLibrary] recipe rather than a
+ *    hand-rolled composite — with `destination = HAND` and `reveal = true` it expands to exactly
+ *    Assay's Gather → Select(ChooseUpTo 1) → Move(Hand, revealed) → Shuffle → `LibrarySearchedEvent`
+ *    chain, and `shuffleAfter` already defaults to true, which is the printed "then shuffle".
+ *  - The filter is [Subtype.AURA] alone, with no `IsEnchantment` predicate beside it. Every Aura is
+ *    an enchantment, so the narrower filter would select the same cards — but the printed text
+ *    restricts by subtype and nothing else, and the extra type predicate is a divergence the Assay
+ *    differential flags against the model built from that same text.
+ */
+val TotemGuideHartebeest = card("Totem-Guide Hartebeest") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Antelope"
+    power = 2
+    toughness = 5
+    oracleText = "When this creature enters, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.AURA),
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+        description = "When this creature enters, you may search your library for an Aura card, " +
+            "reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "John Avon"
+        flavorText = "The kor track hartebeests in hopes of finding magic to help fight the Eldrazi."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg?1783942000"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/VendettaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/VendettaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vendetta reprint in ROE. Canonical CardDefinition lives in its earliest set.
+ */
+val VendettaReprint = Printing(
+    oracleId = "50a16634-ebf7-477f-ad6f-23332599f838",
+    name = "Vendetta",
+    setCode = "ROE",
+    collectorNumber = "130",
+    scryfallId = "039fc76d-3b7e-4329-a997-07c25509e421",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/039fc76d-3b7e-4329-a997-07c25509e421.jpg",
+    releaseDate = "2010-04-23",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/VirulentSwipe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/VirulentSwipe.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Virulent Swipe
+ * {B}
+ * Instant
+ *
+ * Target creature gets +2/+0 and gains deathtouch until end of turn.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Modeling notes:
+ *  - Rebound has a real consumer — `StackResolver` reads [Keyword.REBOUND] off `cardDef.keywords`
+ *    when the spell resolves — so the bare keyword is the whole of the second line and the whole
+ *    pump-plus-deathtouch package arrives twice, a turn apart.
+ *  - "gets +2/+0 **and** gains deathtouch" is one sentence over one target, so it is a single
+ *    [Effects.Composite] of [Effects.ModifyStats] and [Effects.GrantKeyword] both bound to the
+ *    same `target` handle — not two separate targets. Both default to "until end of turn", which
+ *    is what the printed line says.
+ *  - DEATHTOUCH is a live keyword in `rules-engine` (the combat-damage and state-based-action
+ *    paths both read it), so the grant needs no lowering.
+ */
+val VirulentSwipe = card("Virulent Swipe") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+0 and gains deathtouch until end of turn.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, t),
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "131"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg?1783941979"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/WallOfOmens.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/WallOfOmens.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Omens
+ * {1}{W}
+ * Creature — Wall
+ * 0 / 4
+ *
+ * Defender
+ * When this creature enters, draw a card.
+ *
+ * Modeling notes:
+ *  - Defender is the bare keyword — the engine's combat code reads `Keyword.DEFENDER` off the card,
+ *    so `keywords(...)` alone is the whole ability (the corpus convention; a separate
+ *    `keywordAbility` row would only duplicate it).
+ *  - "**When** this creature enters" is the one-shot [Triggers.EntersBattlefield].
+ *  - "Draw a card" is untargeted and drawn by the controller, which is [Effects.DrawCards]'s
+ *    default recipient, so no target argument is written.
+ */
+val WallOfOmens = card("Wall of Omens") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Defender\n" +
+            "When this creature enters, draw a card."
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "53"
+        artist = "James Paick"
+        flavorText = "\"I search for a vision of Zendikar that does not include the Eldrazi.\"\n—Expedition journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg?1783942000"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PuncturingLightReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PuncturingLightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Puncturing Light reprint in SOI. Canonical CardDefinition lives in its earliest set.
+ */
+val PuncturingLightReprint = Printing(
+    oracleId = "15e71226-feb0-4870-a3ea-d8604ca5b3dc",
+    name = "Puncturing Light",
+    setCode = "SOI",
+    collectorNumber = "35",
+    scryfallId = "5b101264-4994-43b7-9156-228f7d10d2bd",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b101264-4994-43b7-9156-228f7d10d2bd.jpg",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/SporecapSpiderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/SporecapSpiderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sporecap Spider reprint in ELD. Canonical CardDefinition lives in its earliest set.
+ */
+val SporecapSpiderReprint = Printing(
+    oracleId = "e9b5d4f3-b98a-463a-b628-289c2df81204",
+    name = "Sporecap Spider",
+    setCode = "ELD",
+    collectorNumber = "176",
+    scryfallId = "7bc33252-145f-45c0-bb70-23183c698f66",
+    artist = "Josu Hernaiz",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7bc33252-145f-45c0-bb70-23183c698f66.jpg",
+    releaseDate = "2019-10-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/WallOfOmensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/WallOfOmensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Omens reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val WallOfOmensReprint = Printing(
+    oracleId = "5f601f48-d24b-4883-9fde-b3f620e7c9ea",
+    name = "Wall of Omens",
+    setCode = "KHC",
+    collectorNumber = "35",
+    scryfallId = "2561dc8e-1ea6-43f3-8cf1-afd7ec9a2191",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/2561dc8e-1ea6-43f3-8cf1-afd7ec9a2191.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -5614,6 +5614,72 @@
     ]
 }
 
+// Vendetta
+{
+    "name": "Vendetta",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target nonblack creature. It can't be regenerated. You lose life equal to that creature's toughness.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBeRegenerated",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonblack creature"
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "Toughness"
+                    },
+                    "target": "Controller"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonblack creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target nonblack creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Dan Frazier",
+        "flavorText": "Starke knew the voice was Takara's, but the venom was Volrath's.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67ced38e-0f33-4bda-8e18-09f6ac03a3d7.jpg?1783945943"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Vine Trellis
 {
     "name": "Vine Trellis",

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -57,6 +57,55 @@
     ]
 }
 
+// Akoum Boulderfoot
+{
+    "name": "Akoum Boulderfoot",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "When this creature enters, it deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, it deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"If you're in Akoum and you glimpse a shadow overhead, the worst thing you can do is duck.\"\n—Chadir the Navigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88e8f7b6-1214-447b-8665-ff3c85845564.jpg?1783941978"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Artisan of Kozilek
 {
     "name": "Artisan of Kozilek",
@@ -130,6 +179,60 @@
     "colorIdentityOverride": []
 }
 
+// Bala Ged Scorpion
+{
+    "name": "Bala Ged Scorpion",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Scorpion",
+    "oracleText": "When this creature enters, you may destroy target creature with power 1 or less.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature with power 1 or less"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "descriptionOverride": "When this creature enters, you may destroy target creature with power 1 or less."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature pow<=1"
+                    },
+                    "id": "target creature with power 1 or less"
+                },
+                "descriptionOverride": "When this creature enters, you may destroy target creature with power 1 or less."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Daarken",
+        "flavorText": "Fast and lethal, with a penchant for the weak and infirm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4acb66bd-6abd-46dd-a272-09bea66e2917.jpg?1783941989"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Battle-Rattle Shaman
 {
     "name": "Battle-Rattle Shaman",
@@ -189,6 +292,70 @@
     ]
 }
 
+// Bloodrite Invoker
+{
+    "name": "Bloodrite Invoker",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Shaman",
+    "oracleText": "{8}: Target player loses 3 life and you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"The brood lineages unfolded across the world, each patterned after one of three progenitors, each a study in mindless consumption.\"\n—*The Invokers' Tales*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5dc36f94-2499-4d94-a506-27d42b9da667.jpg?1783941988"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bloodthrone Vampire
 {
     "name": "Bloodthrone Vampire",
@@ -233,6 +400,58 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Bramblesnap
+{
+    "name": "Bramblesnap",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nTap an untapped creature you control: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature ctrl:you"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Tap an untapped creature you control: This creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "James Ryman",
+        "flavorText": "A bramblesnap is formed by grafting together thirteen different plants that already hunger for meat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcddd71f-bb8d-4153-854f-af87189babe7.jpg?1783941966"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -317,6 +536,205 @@
     ]
 }
 
+// Death Cultist
+{
+    "name": "Death Cultist",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Sacrifice this creature: Target player loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Death inevitably seduces all who study it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd0a2fe3-45ab-4bac-aca7-a6418e28d0be.jpg?1783941987"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deathless Angel
+{
+    "name": "Deathless Angel",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\n{W}{W}: Target creature gains indestructible until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Johann Bodin",
+        "flavorText": "\"I should have died that day, but I suffered not a scratch. I awoke in a lake of blood, none of it apparently my own.\"\n—*The War Diaries*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg?1783942009"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Demonic Appetite
+{
+    "name": "Demonic Appetite",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nEnchanted creature gets +3/+3.\nAt the beginning of your upkeep, sacrifice a creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"Morality is just shorthand for the constraints of being powerless.\"\n—Ob Nixilis",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca51786a-d58c-455f-910d-01efa5ef8470.jpg?1783941986"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deprive
+{
+    "name": "Deprive",
+    "manaCost": "{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, return a land you control to its owner's hand.\nCounter target spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomReturnToHand",
+                    "filter": "land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Izzy",
+        "flavorText": "\"That would have brought shame to you as a mage. Tell you what—I'll keep your secret.\"\n—Noyan Dar, Tazeem lullmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2efecdd9-bd3a-4b79-92da-6485589d5bde.jpg?1783941998"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dreamstone Hedron
 {
     "name": "Dreamstone Hedron",
@@ -370,6 +788,45 @@
         "artist": "Eric Deschamps",
         "flavorText": "Only the Eldrazi mind thinks in the warped paths required to open the hedrons and tap the power within.",
         "imageUri": "https://cards.scryfall.io/normal/front/7/9/79090d66-19ab-456e-96c0-023c84f4e521.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Enatu Golem
+{
+    "name": "Enatu Golem",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "When this creature dies, you gain 4 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "Golems conjured from the debris of Enatu Temple provided a sturdy but expendable first line of defense against the Eldrazi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74b2e63d-61c6-46e4-9a6f-56653c49b2ea.jpg?1783941957"
     },
     "colorIdentityOverride": []
 }
@@ -522,6 +979,45 @@
     ]
 }
 
+// Flame Slash
+{
+    "name": "Flame Slash",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Flame Slash deals 4 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Raymond Swanland",
+        "flavorText": "After millennia asleep, the Eldrazi had forgotten about Zendikar's fiery temper and dislike of strangers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/006d2bf1-20f7-4b09-8d98-8233d91682bd.jpg?1783941976"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fleeting Distraction
 {
     "name": "Fleeting Distraction",
@@ -577,6 +1073,82 @@
     ]
 }
 
+// Frostwind Invoker
+{
+    "name": "Frostwind Invoker",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Flying\n{8}: Creatures you control gain flying until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"We thought Zendikar's rage was kindled by its explorers and plunderers. But the world had sensed the stirrings of the Eldrazi.\"\n—*The Invokers' Tales*",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66ec9a28-3b36-4b6a-b420-7b4266b64f69.jpg?1783941996"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Gloomhunter
+{
+    "name": "Gloomhunter",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Lars Grant-West",
+        "flavorText": "Scavengers both mundane and magical follow in its wake, feeding on the scraps of flesh and spirit it leaves behind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98db4317-9850-44c1-884b-d8d3abe1afeb.jpg?1783941985"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Goblin Tunneler
 {
     "name": "Goblin Tunneler",
@@ -620,6 +1192,113 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gravitational Shift
+{
+    "name": "Gravitational Shift",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures with flying get +2/+0.\nCreatures without flying get -2/-0.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": -2,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotKeyword",
+                                "keyword": "FLYING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "As they awakened, the Eldrazi reasserted their mastery over all of Zendikar's natural forces.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg?1783941996"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Guard Duty
+{
+    "name": "Guard Duty",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has defender.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEFENDER"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"I was told these were standard issue. Do I look standard to you?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f77efd36-f9e7-4c34-a6ee-9e1c9b273fb7.jpg?1783942008"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Harmless Assault
+{
+    "name": "Harmless Assault",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn by attacking creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly",
+            "direction": "FromTarget",
+            "sourceFilter": {
+                "type": "FromGroup",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Chippy",
+        "flavorText": "After encasing it in a paralyzing beam of light, the angel studied the Eldrazi as a child would study a bug, curiously and without fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a77fef2c-227e-474e-896e-c0ebe227f494.jpg?1783942008"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -699,6 +1378,51 @@
     ]
 }
 
+// Kor Line-Slinger
+{
+    "name": "Kor Line-Slinger",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Scout",
+    "oracleText": "{T}: Tap target creature with power 3 or less.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with power 3 or less"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=3"
+                        },
+                        "id": "target creature with power 3 or less"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Steve Prescott",
+        "flavorText": "\"I tried to tell her to stay behind, that this fight was too dangerous. I spent the next hour tied to the rafters.\"\n—Zahr Gada, Halimar expedition leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/068943d2-c456-42a3-8088-3e4923bf6d74.jpg?1783942006"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lagac Lizard
 {
     "name": "Lagac Lizard",
@@ -716,6 +1440,348 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Last Kiss
+{
+    "name": "Last Kiss",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Last Kiss deals 2 damage to target creature and you gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Vance Kovacs",
+        "flavorText": "\"Romanticize it, glamorize it, call it what you will. To me, it will always be carnal, bloody murder.\"\n—Ayli, Kamsa cleric",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/348f480f-8f68-4060-b964-f67515930549.jpg?1783941983"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lavafume Invoker
+{
+    "name": "Lavafume Invoker",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "{8}: Creatures you control get +3/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Dave Kendall",
+        "flavorText": "\"Then the ancient masters themselves, towers of rapacity, rose and began their calamitous feast.\"\n—*The Invokers' Tales*",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e773b3f-37ef-4e37-8b1e-99b7b6314877.jpg?1783941974"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Leaf Arrow
+{
+    "name": "Leaf Arrow",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Leaf Arrow deals 3 damage to target creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with flying"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"Those who think the trees shall remain bystanders throughout this conflict shall be sorely mistaken.\"\n—Sutina, Speaker of the Tajuru",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d531ba4-df99-41e4-9dd3-a27a420ad63c.jpg?1783941962"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Lone Missionary
+{
+    "name": "Lone Missionary",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Monk",
+    "oracleText": "When this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 4 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Svetlin Velinov",
+        "flavorText": "His mission has become a grim pilgrimage, a tour of the Eldrazi-stricken outposts across Zendikar. But he marches on alone, stubborn as the daily dawn.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdc00f4b-ca9a-468a-91e1-c81fe6585765.jpg?1783942004"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Magmaw
+{
+    "name": "Magmaw",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{1}, Sacrifice a nonland permanent: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "nonland permanent"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "RARE",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"The purpose of existence is simple: everything is fuel for the magmaw.\"\n—Jaji, magmaw worshipper",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/015de202-e796-4194-a06b-d74230759f38.jpg?1783941972"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Makindi Griffin
+{
+    "name": "Makindi Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Izzy",
+        "flavorText": "As the hedrons began to coalesce into colossal Eldrazi superstructures, the griffins were forced to seek new territory lest their aeries be crushed between the massive stone monoliths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f839a5e-3cbb-4179-9267-02f40645bdbc.jpg?1783942005"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Merfolk Skyscout
+{
+    "name": "Merfolk Skyscout",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "Flying\nWhenever this creature attacks or blocks, untap target permanent.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target permanent"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target permanent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "UNCOMMON",
+        "artist": "rk post",
+        "flavorText": "\"Emeria is a pleasant lie, a figment to hide Emrakul's hideous face. I can only hope to uncover a truth that lies deeper still.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1ce213c7-7835-4b81-a983-059dd97b0214.jpg?1783941994"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -737,6 +1803,179 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Nomads' Assembly
+{
+    "name": "Nomads' Assembly",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 1/1 white Kor Soldier creature token for each creature you control.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Kor",
+                "Soldier"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "Erica Yang",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd52f249-14bd-4489-aaba-03e50fe42c2e.jpg?1783942004"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ogre Sentry
+{
+    "name": "Ogre Sentry",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "oracleText": "Defender",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "159",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"You have to appreciate the genius of it. Why bother building defenses when you can just fill the pass with angry ogres?\"\n—Javad Nasrin, Ondu relic hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d71db75c-c896-4887-ba18-92416fa6cbd5.jpg?1783941972"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ogre's Cleaver
+{
+    "name": "Ogre's Cleaver",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +5/+0.\nEquip {5}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 5,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{5}",
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Adi Granov",
+        "flavorText": "She adopted the weapon of the slave-lord Kazuul, and with it, all his cruelty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec319380-bede-49e8-9d0c-473688033601.jpg?1783941955"
+    },
+    "colorIdentityOverride": []
+}
+
+// Pathrazer of Ulamog
+{
+    "name": "Pathrazer of Ulamog",
+    "manaCost": "{11}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "Annihilator 3 (Whenever this creature attacks, defending player sacrifices three permanents of their choice.)\nThis creature can't be blocked except by three or more creatures.",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "ANNIHILATOR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "ANNIHILATOR",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "permanent",
+                    "count": 3,
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "DefendingPlayer"
+                    }
+                },
+                "descriptionOverride": "Annihilator 3"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByFewerThan",
+                "minBlockers": 3
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Austin Hsu",
+        "flavorText": "No thought but hunger. No strategy but destruction.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3fdd84b5-fd93-483e-a131-028d04d9dea7.jpg?1783942012"
+    },
+    "colorIdentityOverride": []
 }
 
 // Pelakka Wurm
@@ -797,6 +2036,128 @@
     ]
 }
 
+// Pestilence Demon
+{
+    "name": "Pestilence Demon",
+    "manaCost": "{5}{B}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\n{B}: This creature deals 1 damage to each creature and each player.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "Each"
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Controller"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Justin Sweet",
+        "flavorText": "\"I have schemed too long to be supplanted by dead gods. If I cannot have this world, no one can.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6931673-20e0-410e-bc2a-d14efa2b488a.jpg?1783941981"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Prey's Vengeance
+{
+    "name": "Prey's Vengeance",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfd0d15f-8200-46a4-a9e9-e7f0ee2aa0e4.jpg?1783941959"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Prophetic Prism
 {
     "name": "Prophetic Prism",
@@ -847,6 +2208,97 @@
         "artist": "John Avon",
         "flavorText": "\"The explorer who found it got a bad deal when he sold it. He merely got rich.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Puncturing Light
+{
+    "name": "Puncturing Light",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target attacking or blocking creature with power 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target attacking or blocking creature with power 3 or less"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "PowerAtMost",
+                                "max": 3
+                            }
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target attacking or blocking creature with power 3 or less"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "\"The vampires knew what was coming. I know it. And they did nothing. They deserve to feel the same agony they've caused all of us.\"\n—Anitan, Ondu cleric",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e52d260a-e1ca-4228-855e-2e104b86fd6c.jpg?1783942003"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Reinforced Bulwark
+{
+    "name": "Reinforced Bulwark",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{T}: Prevent the next 1 damage that would be dealt to you this turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "artist": "Ryan Pancoast",
+        "flavorText": "Built of wood and iron. Held together by hope and prayer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/437a91e7-f98e-4ed8-9ab7-f4db62979f5b.jpg?1783941955"
     },
     "colorIdentityOverride": []
 }
@@ -932,6 +2384,42 @@
     ]
 }
 
+// Shared Discovery
+{
+    "name": "Shared Discovery",
+    "manaCost": "{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, tap four untapped creatures you control.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomTapPermanents",
+                    "count": 4,
+                    "filter": "creature untapped ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Ryan Pancoast",
+        "flavorText": "Riches must be divided, but real wealth can be shared.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec0b99f1-d706-4332-a1c2-86d789919069.jpg?1783941991"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shrivel
 {
     "name": "Shrivel",
@@ -969,6 +2457,507 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Skeletal Wurm
+{
+    "name": "Skeletal Wurm",
+    "manaCost": "{7}{B}",
+    "typeLine": "Creature — Skeleton Wurm",
+    "oracleText": "{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Necromancers are judged by the most powerful undead they've ever created. There are those who have animated just a single being, yet are considered the pinnacle of their dark craft.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2feedcf2-c443-4363-80cf-a90579a64342.jpg?1783941980"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Soul's Attendant
+{
+    "name": "Soul's Attendant",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Whenever another creature enters, you may gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Steve Prescott",
+        "flavorText": "In truth, her own faith was gone, trodden in Ulamog's wake. She pantomimed the blessing in the hope that it would inspire others to continue to struggle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/3223c0ac-cc22-4886-8919-11273b477cc7.jpg?1783942003"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Soulbound Guardians
+{
+    "name": "Soulbound Guardians",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Kor Spirit",
+    "oracleText": "Defender, flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Erica Yang",
+        "flavorText": "The kor's most righteous dead are given the greatest reward: an eternity tied to the land they so cherish.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62e8128f-9858-4c48-ab43-1beca3db70e5.jpg?1783942003"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Soulsurge Elemental
+{
+    "name": "Soulsurge Elemental",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "First strike\nSoulsurge Elemental's power is equal to the number of creatures you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "It draws its strength from those around it, but the pleasure of destruction is all its own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0dcb81b-dcdb-44ca-9ef5-0b45d276c0dd.jpg?1783941971"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sphinx of Magosi
+{
+    "name": "Sphinx of Magosi",
+    "manaCost": "{3}{U}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying\n{2}{U}: Draw a card, then put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "RARE",
+        "artist": "James Ryman",
+        "flavorText": "\"A riddle is nothing more than a trap for small minds, baited with the promise of understanding.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/eff88609-f55e-45c5-be10-087d88789a83.jpg?1783941991"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sporecap Spider
+{
+    "name": "Sporecap Spider",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "209",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"They don't move much, but then again, if you get caught in its web, it has all the time in the world to get to you.\"\n—Saidah, Joraga hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abb1d18f-7a94-4a2f-a60c-0af852d44501.jpg?1783941960"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Staggershock
+{
+    "name": "Staggershock",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Staggershock deals 2 damage to any target.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "any target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75624ab3-ddbd-4fe8-8a07-7d1f78ec8a84.jpg?1783941971"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Stalwart Shield-Bearers
+{
+    "name": "Stalwart Shield-Bearers",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Defender\nOther creatures you control with defender get +0/+2.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature kw:defender ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Austin Hsu",
+        "flavorText": "\"Hold fast the line! Either we stop them here or we wake up in their guts!\"\n—Tala Vertan, Makindi shieldmate",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/868256bb-d4e2-42eb-a43a-360148aec06f.jpg?1783942002"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Stomper Cub
+{
+    "name": "Stomper Cub",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"This one is only a yearling, but it would be wise to move away before we provide it with excellent hunting practice.\"\n—Samila, Murasa Expeditionary House",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89be64a8-dd78-48c3-bb47-4f2a5ad9ec10.jpg?1783941959"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Totem-Guide Hartebeest
+{
+    "name": "Totem-Guide Hartebeest",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Antelope",
+    "oracleText": "When this creature enters, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "Aura"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "descriptionOverride": "When this creature enters, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle."
+                },
+                "descriptionOverride": "When this creature enters, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "John Avon",
+        "flavorText": "The kor track hartebeests in hopes of finding magic to help fight the Eldrazi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1364a830-36b7-48b9-bf69-6fd35eed9399.jpg?1783942000"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Virulent Swipe
+{
+    "name": "Virulent Swipe",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+0 and gains deathtouch until end of turn.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b61d7f4b-e3c3-49f1-a600-6e6ac71a5515.jpg?1783941979"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wall of Omens
+{
+    "name": "Wall of Omens",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender\nWhen this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "flavorText": "\"I search for a vision of Zendikar that does not include the Eldrazi.\"\n—Expedition journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e3510f5-e450-400b-98ea-341dbf212054.jpg?1783942000"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Sweeps Rise of the Eldrazi's Assay-ready count to zero — the cards Argentum Assay reads whole that the set hadn't authored yet.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 44 | canonical authored in ROE |
| `elsewhere` | 1 | **Vendetta** — canonical authored in MMQ (its earliest real printing), `Printing` row here |
| `row-only` | 1 | **Regress** — canonical already in MRD, `Printing` row here |
| `basic` | 5 | `basicLand(...)` vals (20 art variants) + the `basicLands` override |

Plus the **reprint tail**: 11 `Printing` rows across 7 other sets that only became owed once these canonicals existed — C14 ×3 (Nomads' Assembly, Pestilence Demon, Sphinx of Magosi), DDP ×3 (Bloodrite Invoker, Magmaw, Makindi Griffin), CMD, ELD, KHC, ORI, SOI ×1 each.

## Numbers

- **Assay-ready: 51 → 0** (re-run on this branch, not inferred)
- **Differential: 6532 / 6478 / 54 → 6576 / 6519 / 57** (compared / confirmed / divergent) — +44 compared, +41 confirmed, +3 divergent, all three deliberate and explained below
- **Golden snapshots:** 44 cards added to ROE, 1 to MMQ, **0 pre-existing cards changed**
- `just check-card-printing` clean on all 45 authored names
- `just build` green

## The three divergences, all deliberate

- **Bramblesnap**, **Shared Discovery** — Assay compiles their tap-creatures cost filters to bare `IsCreature`, dropping the printed "you control". Written with the `youControl()`-scoped filter instead. Behaviourally identical (`CostPaymentService` already resolves `CostAtom.TapPermanents` through a payer-scoped, untapped-only candidate set), so this is Assay under-specifying rather than the card meaning something wider — but the card should say what it prints. In-repo precedent: `dsk/FearOfExposure.kt`, `vow/HoneymoonHearse.kt`.
- **Vendetta** — Assay orders the composite `CantBeRegenerated → Destroy → LoseLife(target's toughness)`. The life loss is written **before** the destroy. `EntityReference.Target` is `LIVE_ONLY` in `LastKnownInformation.kt`, and `DynamicAmountEvaluator.resolvePowerOrToughness` has no LKI fallback for a *spell's* target, so reading toughness after the move falls through to the creature's **printed** toughness — silently dropping counters, Auras and lord effects. Reading it while the creature is still on the battlefield yields the rules-correct last-known value. This is the same lowering, for the same reason, that `inv/AgonizingDemise.kt` already documents.

## Notes worth reading

- **Annihilator is still display-only.** Nothing in `rules-engine` reads `Keyword.ANNIHILATOR` (verified: zero hits under `rules-engine/src/main`). Pathrazer of Ulamog therefore declares `KeywordAbility.annihilator(3)` for the printed line *and* lowers the behaviour as a `Triggers.Attacks` → `Effects.Sacrifice(Permanent, 3, DefendingPlayer)` triggered ability — the shape `roe/ArtisanOfKozilek.kt` already established for annihilator 2. Rebound, by contrast, **is** live (`StackResolver`), so the four rebound spells just declare the keyword.
- **`basicLandsFallback = PortalSet` removed from ROE.** `GameBeansConfig:251` reads `(basicLandsFallback ?: this).basicLands` — the fallback *wins*. Leaving it while adding ROE's own twenty basic-land variants would have kept serving Portal art forever.
- **Demonic Appetite's sacrifice is `Effects.SacrificeOwn`, not `Effects.Sacrifice`.** The latter defaults `target` to `PlayerRef(Player.TargetOpponent)`; using it for the bare imperative "sacrifice a creature" would have shipped a silently inverted card.
- **Nomads' Assembly's Kor Soldier token has no ROE art.** Scryfall's `troe` token sheet has no Kor Soldier at all (its `all_parts` points at the Commander Masters token), so `CreateToken` deliberately carries **no** `imageUri` — baking CMM art onto the ROE canonical would mint the wrong art from every printing, which is exactly what the SDK reference warns against. Consequence: `TokenArtData.forSet("ROE")` has no Kor Soldier row and the ROE printing falls back to generic token art. The documented fix is a self-hosted `TokenPrinting` row on `RiseOfTheEldraziSet.tokenArt`; left out of this PR as art work rather than card work.

## Found but not fixed

- `Effects.PreventDamageFromAttackingCreatures()`'s KDoc reads "prevent all damage … by attacking creatures" while its body pins `PreventionScope.AllDamage` *and* a controller-only recipient. The name reads like Harmless Assault; the effect is a different card. Harmless Assault correctly uses `Effects.PreventCombatDamageFrom(GroupFilter.AttackingCreatures)` instead.
- There is no `Effects.Regenerate` facade — `RegenerateEffect(target)` is constructed directly, which is what the whole corpus and `docs/card-sdk-language-reference.md:1142` do. Skeletal Wurm follows the corpus.
- No combined "attacks or blocks" trigger exists; Merfolk Skyscout writes the two abilities the corpus (and Assay) both use.
- Several older ROE/RAV/ISD files (`PelakkaWurm.kt`, `WildheartInvoker.kt`, `HamletCaptain.kt`, `SparkmageApprentice.kt`) still carry mtgish-generated banners and use raw constructors instead of the `Effects.*` facades. Untouched — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kpueeki2pWuWMdCGPT5kYs
