### PR TITLE
Let external AI controllers join the game-server lifecycle

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * One lock-consistent view of the live inputs needed by a trusted server-side AI controller.
+ *
+ * The state and replay inputs must be captured together: reading them through the individual
+ * [com.wingedsheep.gameserver.session.GameSession] accessors can pair a newer state with an older
+ * action prefix while the game advances.
+ */
+data class AiRuntimeSnapshot(
+    val state: GameState,
+    val replaySetup: ReplaySetup,
+    val actions: List<GameAction>,
+)
+
+/** Inputs supplied to an AI implementation hosted outside the game-server build. */
+data class AiControllerContext(
+    val playerId: EntityId,
+    /** Null while a persisted or tournament AI identity is not yet attached to a game. */
+    val gameSessionId: String?,
+    /** Null until the attached game has started and has reproducible replay inputs. */
+    val snapshot: () -> AiRuntimeSnapshot?,
+)
+
+/**
+ * Extension point for a server-side AI implementation supplied by another build.
+ *
+ * Providers own controller policy only. Game lifecycle, callbacks, and the authoritative runtime
+ * snapshot remain game-server responsibilities.
+ */
+interface AiControllerProvider {
+    /** Case-insensitive configuration value used by `game.ai.mode`. */
+    val mode: String
+
+    fun create(context: AiControllerContext): AiPlayerController
+}
+
+/** Single authority for validating and resolving external mode names. */
+internal class AiControllerProviderRegistry(providers: List<AiControllerProvider>) {
+    private val providersByMode: Map<String, AiControllerProvider>
+
+    init {
+        val indexed = linkedMapOf<String, AiControllerProvider>()
+        for (provider in providers) {
+            val mode = normalize(provider.mode)
+            require(mode.isNotEmpty()) { "AI controller provider mode must not be blank" }
+            require(mode !in BUILT_IN_MODES) {
+                "AI controller provider mode '${provider.mode}' conflicts with a built-in mode"
+            }
+            require(indexed.put(mode, provider) == null) {
+                "Multiple AI controller providers registered for mode '${provider.mode}'"
+            }
+        }
+        providersByMode = indexed
+    }
+
+    operator fun get(mode: String): AiControllerProvider? = providersByMode[normalize(mode)]
+
+    fun supportedModes(): Set<String> = BUILT_IN_MODES + providersByMode.keys
+
+    private fun normalize(mode: String): String = mode.trim().lowercase()
+
+    private companion object {
+        val BUILT_IN_MODES = setOf("engine", "llm")
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
@@ -4,20 +4,50 @@ import com.wingedsheep.ai.AiPlayerController
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.gameserver.replay.ReplayYieldEntry
 import com.wingedsheep.sdk.model.EntityId
 
 /**
  * One lock-consistent view of the live inputs needed by a trusted server-side AI controller.
  *
- * The state and replay inputs must be captured together: reading them through the individual
- * [com.wingedsheep.gameserver.session.GameSession] accessors can pair a newer state with an older
- * action prefix while the game advances.
+ * [state] is always the authoritative live state. [replayHistory] says whether its compact inputs
+ * reproduce that state or are only the prefix retained after replay recording reached its cap.
+ * Keeping that distinction in the type prevents an external controller from treating a plausible
+ * but incomplete action list as the history of the live position.
  */
 data class AiRuntimeSnapshot(
     val state: GameState,
-    val replaySetup: ReplaySetup,
-    val actions: List<GameAction>,
+    val replayHistory: AiReplayHistory,
 )
+
+/**
+ * Replay inputs sampled atomically with an [AiRuntimeSnapshot]'s state.
+ *
+ * Persistent yield changes are inputs too: the engine can consume them without a [GameAction], so
+ * setup plus actions alone does not necessarily reconstruct the position an AI is looking at.
+ */
+sealed interface AiReplayHistory {
+    val setup: ReplaySetup
+    val actions: List<GameAction>
+    val yields: List<ReplayYieldEntry>
+
+    /** These inputs reproduce the snapshot's live state. */
+    data class Complete(
+        override val setup: ReplaySetup,
+        override val actions: List<GameAction>,
+        override val yields: List<ReplayYieldEntry>,
+    ) : AiReplayHistory
+
+    /**
+     * Recording stopped before the snapshot's live state. These inputs remain an honest replay
+     * prefix, but must not be used to reconstruct or explain the current state.
+     */
+    data class TruncatedPrefix(
+        override val setup: ReplaySetup,
+        override val actions: List<GameAction>,
+        override val yields: List<ReplayYieldEntry>,
+    ) : AiReplayHistory
+}
 
 /** Inputs supplied to an AI implementation hosted outside the game-server build. */
 data class AiControllerContext(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -24,9 +24,10 @@ private val logger = LoggerFactory.getLogger(AiGameManager::class.java)
 /**
  * Manages the lifecycle of AI opponents in games.
  *
- * Supports two AI modes:
+ * Supports built-in and externally supplied AI modes:
  * - **engine** (default): Built-in rules-engine AI. No API key needed. Fast, deterministic.
  * - **llm**: LLM-based AI via OpenAI-compatible API. Requires API key.
+ * - any unique mode registered by an [AiControllerProvider].
  */
 @Service
 class AiGameManager(
@@ -36,7 +37,9 @@ class AiGameManager(
     private val cardRegistry: CardRegistry,
     private val llmCostTracker: com.wingedsheep.gameserver.tournament.llm.LlmCostTracker,
     private val aiInsightService: AiInsightService,
+    controllerProviders: List<AiControllerProvider> = emptyList(),
 ) {
+    private val controllerProviders = AiControllerProviderRegistry(controllerProviders)
     /**
      * The live AI sessions of each game, keyed game → AI player. A multiplayer pod seats more than
      * one AI (an FFA table, a Two-Headed Giant team), so this is per *seat* and not per game: keyed
@@ -62,10 +65,13 @@ class AiGameManager(
         }
         if (ai.isEngineMode) {
             logger.info("AI opponent: enabled | mode=engine (built-in)")
-        } else {
+        } else if (ai.isLlmMode) {
             val provider = if (ai.baseUrl.contains("openrouter")) "OpenRouter" else "Local (${ai.baseUrl})"
             logger.info("AI opponent: enabled | mode=llm | provider={} | model={} | deckbuilding-model={}",
                 provider, ai.model, ai.effectiveDeckbuildingModel)
+        } else {
+            requireExternalProvider(ai.mode)
+            logger.info("AI opponent: enabled | mode={} (external)", ai.mode)
         }
     }
 
@@ -93,10 +99,10 @@ class AiGameManager(
 
     val isEnabled: Boolean get() {
         if (!gameProperties.ai.enabled) return false
-        // Engine mode doesn't need an API key
-        if (gameProperties.ai.isEngineMode) return true
-        // LLM mode requires an API key
-        return gameProperties.ai.effectiveApiKey.isNotBlank()
+        val ai = gameProperties.ai
+        if (ai.isEngineMode) return true
+        if (ai.isLlmMode) return ai.effectiveApiKey.isNotBlank()
+        return controllerProviders[ai.mode] != null
     }
 
     /**
@@ -126,6 +132,17 @@ class AiGameManager(
         modelOverride: String? = null
     ): AiPlayerController {
         val ai = gameProperties.ai
+        // A per-player model override explicitly requests the built-in LLM even when the
+        // server-wide mode is external.
+        if (modelOverride == null && !ai.isEngineMode && !ai.isLlmMode) {
+            return requireExternalProvider(ai.mode).create(
+                AiControllerContext(
+                    playerId = aiPlayerId,
+                    gameSessionId = gameSession?.sessionId,
+                    snapshot = { gameSession?.getAiRuntimeSnapshot() },
+                )
+            )
+        }
         // A model override implicitly requests LLM mode for this player,
         // regardless of the server's global mode setting.
         val aiConfig = ai.toAiConfig().let { cfg ->
@@ -157,6 +174,11 @@ class AiGameManager(
             LlmAiPlayerController(aiConfig, llmClient, aiPlayerId, fallback = engineFallback)
         }
     }
+
+    private fun requireExternalProvider(mode: String): AiControllerProvider =
+        requireNotNull(controllerProviders[mode]) {
+            "Unknown game.ai.mode '$mode'; expected ${controllerProviders.supportedModes().sorted().joinToString()}"
+        }
 
     private fun com.wingedsheep.gameserver.config.AiProperties.toAiConfig() = com.wingedsheep.ai.llm.AiConfig(
         enabled = enabled, mode = mode, baseUrl = baseUrl,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -132,6 +132,9 @@ class AiGameManager(
         modelOverride: String? = null
     ): AiPlayerController {
         val ai = gameProperties.ai
+        require(modelOverride == null || ai.effectiveApiKey.isNotBlank()) {
+            "A per-player LLM model override requires an API key"
+        }
         // A per-player model override explicitly requests the built-in LLM even when the
         // server-wide mode is external.
         if (modelOverride == null && !ai.isEngineMode && !ai.isLlmMode) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -62,7 +62,7 @@ data class AdminProperties(
 
 data class AiProperties(
     val enabled: Boolean = false,
-    /** AI mode: "engine" (built-in rules engine AI, default) or "llm" (LLM-based AI via API). */
+    /** AI mode: a built-in mode (`engine` or `llm`) or a registered external provider mode. */
     val mode: String = "engine",
     val baseUrl: String = "https://openrouter.ai/api/v1",
     val apiKey: String = "",
@@ -98,6 +98,6 @@ data class AiProperties(
     /** Whether we're using the built-in engine AI (no API key required). */
     val isEngineMode: Boolean get() = mode.equals("engine", ignoreCase = true)
 
-    /** Whether we're using the LLM-based AI. */
-    val isLlmMode: Boolean get() = !isEngineMode
+    /** Whether we're using the built-in LLM-based AI. */
+    val isLlmMode: Boolean get() = mode.equals("llm", ignoreCase = true)
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -6,11 +6,12 @@ import com.wingedsheep.engine.view.ClientGameState
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.StateDiffCalculator
 import com.wingedsheep.engine.view.LegalActionEnricher
+import com.wingedsheep.gameserver.ai.AiReplayHistory
+import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.gameserver.protocol.GameOverReason
 import com.wingedsheep.engine.view.LegalActionInfo
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.priority.AutoPassManager
-import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
@@ -1509,7 +1510,7 @@ class GameSession(
         identity: com.wingedsheep.sdk.scripting.AbilityIdentity?,
         kind: com.wingedsheep.engine.state.YieldKind?,
     ) {
-        if (replaySetup == null) return
+        if (replaySetup == null || replayTruncated) return
         recordedYields.add(
             com.wingedsheep.gameserver.replay.ReplayYieldEntry(
                 afterActionCount = recordedActions.size,
@@ -1531,16 +1532,25 @@ class GameSession(
     fun getRecordedActions(): List<GameAction> = recordedActions.toList()
 
     /**
-     * Capture the current authoritative state and its reproducible action prefix under one lock.
+     * Capture the current authoritative state and its replay history under one lock.
      *
-     * External controllers use this instead of composing the three public accessors independently;
-     * that composition can observe different game instants. Null means the session has not started
-     * with replay inputs (for example an injected development scenario).
+     * External controllers use this instead of composing the public accessors independently; that
+     * composition can observe different game instants. A recording that reached its cap is exposed
+     * as a typed prefix rather than being mistaken for inputs that reproduce the live state. Null
+     * means the session has not started with replay inputs (for example an injected development
+     * scenario).
      */
     fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? = synchronized(stateLock) {
         val state = gameState ?: return null
         val setup = replaySetup ?: return null
-        AiRuntimeSnapshot(state, setup, recordedActions.toList())
+        val actions = recordedActions.toList()
+        val yields = recordedYields.toList()
+        val history = if (replayTruncated) {
+            AiReplayHistory.TruncatedPrefix(setup, actions, yields)
+        } else {
+            AiReplayHistory.Complete(setup, actions, yields)
+        }
+        AiRuntimeSnapshot(state, history)
     }
 
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.gameserver.protocol.GameOverReason
 import com.wingedsheep.engine.view.LegalActionInfo
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.priority.AutoPassManager
+import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
@@ -1528,6 +1529,19 @@ class GameSession(
 
     /** The ordered input stream applied to this game. */
     fun getRecordedActions(): List<GameAction> = recordedActions.toList()
+
+    /**
+     * Capture the current authoritative state and its reproducible action prefix under one lock.
+     *
+     * External controllers use this instead of composing the three public accessors independently;
+     * that composition can observe different game instants. Null means the session has not started
+     * with replay inputs (for example an injected development scenario).
+     */
+    fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? = synchronized(stateLock) {
+        val state = gameState ?: return null
+        val setup = replaySetup ?: return null
+        AiRuntimeSnapshot(state, setup, recordedActions.toList())
+    }
 
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */
     fun getReplayYields(): List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = recordedYields.toList()

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.gameserver.config.AiProperties
 import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.gameserver.replay.ReplaySetup
 import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.PlayerIdentity
 import com.wingedsheep.gameserver.session.SessionRegistry
 import com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
 import com.wingedsheep.sdk.model.EntityId
@@ -69,8 +70,11 @@ class AiControllerProviderTest : FunSpec({
     test("a game-attached external controller receives the session's consistent runtime snapshot") {
         val expected = AiRuntimeSnapshot(
             state = mockk<GameState>(),
-            replaySetup = mockk<ReplaySetup>(),
-            actions = emptyList(),
+            replayHistory = AiReplayHistory.Complete(
+                setup = mockk<ReplaySetup>(),
+                actions = emptyList(),
+                yields = emptyList(),
+            ),
         )
         val game = mockk<GameSession>(relaxed = true) {
             every { sessionId } returns "game-1"
@@ -97,14 +101,96 @@ class AiControllerProviderTest : FunSpec({
         provider.controller.lastDeck shouldBe mapOf("Mountain" to 40)
         sessions.destroy()
     }
+
+    test("a model override cannot bypass the LLM credential gate when creating an identity") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+
+        shouldThrow<IllegalArgumentException> {
+            manager.createAiIdentity(modelOverride = "openai/test-model")
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
+
+    test("a credentialed model override deliberately selects the built-in LLM") {
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(
+            provider,
+            sessions,
+            aiProperties = AiProperties(
+                enabled = true,
+                mode = provider.mode,
+                apiKey = "test-key",
+            ),
+        )
+
+        val identity = manager.createAiIdentity(modelOverride = "openai/test-model")
+
+        identity.aiModelOverride shouldBe "openai/test-model"
+        provider.contexts shouldBe emptyList()
+        sessions.destroy()
+    }
+
+    test("a restored model override cannot bypass the LLM credential gate") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+        val identity = PlayerIdentity(
+            token = "restored-ai",
+            playerId = EntityId.of("restored-ai"),
+            playerName = "Restored AI",
+            isAi = true,
+            aiModelOverride = "openai/test-model",
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            manager.rehydrateAiIdentity(identity)
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
+
+    test("a model override cannot bypass the LLM credential gate when wiring a game") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+        val aiPlayerId = EntityId.of("match-ai")
+        sessions.preRegisterIdentity(
+            PlayerIdentity(
+                token = "match-ai",
+                playerId = aiPlayerId,
+                playerName = "Match AI",
+                isAi = true,
+                aiModelOverride = "openai/test-model",
+            )
+        )
+        val game = mockk<GameSession>(relaxed = true) {
+            every { sessionId } returns "game-credential-gate"
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            manager.wireAiForGame(
+                gameSession = game,
+                aiPlayerId = aiPlayerId,
+                deckList = null,
+                onActionReady = { _, _ -> },
+                onMulliganKeep = { _ -> },
+                onMulliganTake = { _ -> },
+                onBottomCards = { _, _ -> },
+            )
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
 })
 
 private fun manager(
     provider: AiControllerProvider,
     sessions: SessionRegistry,
     deckGenerator: SealedDeckGenerator = mockk(relaxed = true),
+    aiProperties: AiProperties = AiProperties(enabled = true, mode = provider.mode),
 ): AiGameManager {
-    val properties = GameProperties(ai = AiProperties(enabled = true, mode = provider.mode))
+    val properties = GameProperties(ai = aiProperties)
     return AiGameManager(
         gameProperties = properties,
         sessionRegistry = sessions,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.ActionResponse
+import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.llm.BottomCardsInfo
+import com.wingedsheep.ai.llm.CardSummary
+import com.wingedsheep.ai.llm.MulliganInfo
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.view.ClientGameState
+import com.wingedsheep.engine.view.LegalActionInfo
+import com.wingedsheep.gameserver.config.AiProperties
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.SessionRegistry
+import com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class AiControllerProviderTest : FunSpec({
+    test("provider modes are resolved case-insensitively after trimming") {
+        val provider = StubProvider(" Search-Teacher ")
+        val registry = AiControllerProviderRegistry(listOf(provider))
+
+        registry["search-teacher"] shouldBe provider
+        registry["SEARCH-TEACHER"] shouldBe provider
+        registry.supportedModes() shouldBe setOf("engine", "llm", "search-teacher")
+    }
+
+    test("blank provider modes fail during registry construction") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("  ")))
+        }
+    }
+
+    test("providers cannot replace built-in modes") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("LLM")))
+        }
+    }
+
+    test("duplicate provider modes fail instead of depending on bean order") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("custom"), StubProvider("CUSTOM")))
+        }
+    }
+
+    test("an external mode is usable without an LLM key and receives honest placeholder context") {
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions = sessions)
+
+        manager.isEnabled shouldBe true
+        manager.createAiIdentity()
+
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().gameSessionId shouldBe null
+        provider.contexts.single().snapshot() shouldBe null
+        sessions.destroy()
+    }
+
+    test("a game-attached external controller receives the session's consistent runtime snapshot") {
+        val expected = AiRuntimeSnapshot(
+            state = mockk<GameState>(),
+            replaySetup = mockk<ReplaySetup>(),
+            actions = emptyList(),
+        )
+        val game = mockk<GameSession>(relaxed = true) {
+            every { sessionId } returns "game-1"
+            every { getAiRuntimeSnapshot() } returns expected
+        }
+        val deckGenerator = mockk<SealedDeckGenerator> {
+            every { generate() } returns mapOf("Mountain" to 40)
+        }
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions, deckGenerator)
+
+        manager.createAiOpponent(
+            gameSession = game,
+            onActionReady = { _, _ -> },
+            onMulliganKeep = { _ -> },
+            onMulliganTake = { _ -> },
+            onBottomCards = { _, _ -> },
+        )
+
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().gameSessionId shouldBe "game-1"
+        provider.contexts.single().snapshot() shouldBe expected
+        provider.controller.lastDeck shouldBe mapOf("Mountain" to 40)
+        sessions.destroy()
+    }
+})
+
+private fun manager(
+    provider: AiControllerProvider,
+    sessions: SessionRegistry,
+    deckGenerator: SealedDeckGenerator = mockk(relaxed = true),
+): AiGameManager {
+    val properties = GameProperties(ai = AiProperties(enabled = true, mode = provider.mode))
+    return AiGameManager(
+        gameProperties = properties,
+        sessionRegistry = sessions,
+        deckGenerator = deckGenerator,
+        cardRegistry = mockk<CardRegistry>(relaxed = true),
+        llmCostTracker = LlmCostTracker(),
+        aiInsightService = AiInsightService(GameProperties()),
+        controllerProviders = listOf(provider),
+    )
+}
+
+private class StubProvider(override val mode: String) : AiControllerProvider {
+    override fun create(context: AiControllerContext): AiPlayerController = StubController
+}
+
+private class CapturingProvider(override val mode: String) : AiControllerProvider {
+    val contexts = mutableListOf<AiControllerContext>()
+    val controller = RecordingController()
+
+    override fun create(context: AiControllerContext): AiPlayerController {
+        contexts += context
+        return controller
+    }
+}
+
+private data object StubController : AiPlayerController {
+    override fun chooseAction(
+        state: ClientGameState,
+        legalActions: List<LegalActionInfo>,
+        pendingDecision: PendingDecision?,
+        recentGameLog: List<String>,
+    ): ActionResponse = error("not used")
+
+    override fun decideMulligan(mulliganMessage: MulliganInfo): Boolean = error("not used")
+    override fun chooseBottomCards(message: BottomCardsInfo): List<EntityId> = error("not used")
+    override fun setDeckList(deckList: Map<String, Int>, archetype: String?) = Unit
+    override fun chooseDraftPick(
+        pack: List<CardSummary>,
+        pickedSoFar: List<CardSummary>,
+        packNumber: Int,
+        pickNumber: Int,
+        picksRequired: Int,
+        passDirection: String,
+    ): List<String> = error("not used")
+
+    override fun chooseWinstonAction(
+        pileCards: List<CardSummary>,
+        pileIndex: Int,
+        pileSizes: List<Int>,
+        pickedSoFar: List<CardSummary>,
+    ): Boolean = error("not used")
+
+    override fun chooseGridDraftPick(
+        grid: List<CardSummary?>,
+        availableSelections: List<String>,
+        pickedSoFar: List<CardSummary>,
+    ): String = error("not used")
+}
+
+private class RecordingController : AiPlayerController by StubController {
+    var lastDeck: Map<String, Int>? = null
+
+    override fun setDeckList(deckList: Map<String, Int>, archetype: String?) {
+        lastDeck = deckList
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
@@ -1,10 +1,16 @@
 package com.wingedsheep.gameserver.session
 
+import com.wingedsheep.engine.state.YieldKind
 import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.ai.AiReplayHistory
 import com.wingedsheep.gameserver.protocol.GameOverReason
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.web.socket.WebSocketSession
@@ -62,6 +68,19 @@ class GameSessionBackstopTest : ScenarioTestBase() {
 
             // And the flush snapshot carries the flag, so the stored row stops claiming to be whole.
             session.replayRecordingSnapshot().shouldNotBeNull().truncated shouldBe true
+
+            // The AI API must make the same distinction structurally. Yield recording freezes with
+            // the action prefix; otherwise the purported prefix could contain mutations from later
+            // in the live game.
+            val yieldCountAtTruncation = session.getReplayYields().size
+            session.setAbilityYield(
+                EntityId.of("backstop-p1"),
+                AbilityIdentity("Test#1", AbilityId("ability_after_truncation")),
+                YieldKind.ALWAYS_ANSWER_YES,
+            )
+            session.getReplayYields().size shouldBe yieldCountAtTruncation
+            session.getAiRuntimeSnapshot().shouldNotBeNull().replayHistory
+                .shouldBeInstanceOf<AiReplayHistory.TruncatedPrefix>()
         }
 
         test("a game that stops making progress is ended as a draw that explains itself") {
@@ -85,8 +104,18 @@ class GameSessionBackstopTest : ScenarioTestBase() {
 
             session.autoPass(40)
 
+            session.setAbilityYield(
+                EntityId.of("backstop-p1"),
+                AbilityIdentity("Test#1", AbilityId("ability_in_complete_history")),
+                YieldKind.ALWAYS_ANSWER_YES,
+            )
+
             session.stallMessage() shouldBe null
             session.isReplayTruncated() shouldBe false
+            val history = session.getAiRuntimeSnapshot().shouldNotBeNull().replayHistory
+                .shouldBeInstanceOf<AiReplayHistory.Complete>()
+            history.actions shouldBe session.getRecordedActions()
+            history.yields shouldBe session.getReplayYields()
         }
     }
 }


### PR DESCRIPTION
The game server can construct only its built-in engine and LLM controllers. A trusted controller supplied by another build can implement `AiPlayerController`, but it cannot join the normal AI-seat lifecycle or obtain a coherent view of the live game.

Reading that view through separate getters is unsafe. The game can advance between the state read and the replay-input read, and persistent yields can affect resolution without appearing in the action list. Once replay recording reaches its cap, the retained inputs are only a prefix and must not be presented as though they reproduce the current state.

## What changes

`AiControllerProvider` registers a case-insensitive mode and creates a controller from `AiControllerContext`. Built-in `engine` and `llm` modes remain reserved; external mode names are checked for blanks, duplicates, and conflicts.

Once attached to a game, a provider receives:

- the controlled player ID;
- the game-session ID; and
- a lazy, lock-consistent `AiRuntimeSnapshot`.

The snapshot contains the authoritative live `GameState` plus typed replay history:

- `Complete` carries setup, actions, and persistent-yield mutations that reproduce the live state;
- `TruncatedPrefix` carries the honest frozen prefix while making it impossible to mistake that prefix for the live state's complete history.

Replay action and yield recording now freeze together. The snapshot is sampled under the session state lock, so its pieces describe one instant.

External controllers use the existing server lifecycle for deck delivery, placeholder identities, match attachment, rewiring, callbacks, and cleanup. They do not need an LLM credential. A per-player model override deliberately selects the built-in LLM instead, and every controller bring-up path now requires an effective API key before doing so.

## Example

The integration witness registers `search-teacher` as an external mode, creates an AI seat without LLM credentials, attaches it to a game, and verifies that the provider receives the matching game ID, complete runtime snapshot, and generated deck. Separate cases show that create, restore, and match-rewire paths all reject an uncredentialed LLM model override, while a credentialed override selects the built-in LLM rather than the external provider.

## Verification

13 focused tests pass on `db172f504deeb1df1e9446a1af270f0c98a5fff7`:

- `AiControllerProviderTest` — 10
- `GameSessionBackstopTest` — 3

They compile the full `game-server` dependency path and cover mode registration, external operation without an LLM key, placeholder and game-attached contexts, deck delivery, all model-override bring-up paths, complete replay history, truncated-prefix typing, and synchronized action/yield freezing.
