### PR TITLE
Exact finite ordering expansion, with a caller-owned ceiling

### DIFF
--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -130,10 +130,12 @@ folded responses `:gym`'s `ActionRegistry` produces. At a complex
 pending decision (targets, distribute, order, search, etc.) the
 `StructuredDecisionExpander` may return a complete response list. The built-in
 exact expander covers one target slot — required or optional — drawn from an
-explicit finite legal target list; each validator-approved response becomes its
-own edge, and declining an optional slot is the empty selection. Other structured
-decisions retain one `StructuredDecisionResolver` fallback edge, which is
-policy-selected rather than exhaustive.
+explicit finite legal target list, plus unique ordering/reordering through four
+objects. Each validator-approved response becomes its own edge, declining an
+optional target slot is the empty selection, and ordering shapes beyond the
+24-response capability ceiling remain unsupported rather than partially
+expanded. Other structured decisions retain one `StructuredDecisionResolver`
+fallback edge, which is policy-selected rather than exhaustive.
 
 Cancellation is not among the expanded responses. A `CancelDecisionResponse`
 rewinds a cast-time decision to the priority state that offered the cast, so a
@@ -166,7 +168,7 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `ExactStructuredDecisionExpander` | Complete single-target-slot response source, required or optional. |
+| `ExactStructuredDecisionExpander` | Complete exact required/optional single-target responses and unique ordering/reordering through four objects (24); larger or duplicate shapes are Unsupported — a capability ceiling, not legality, with no partial expansion. |
 | `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions; redraws until the engine's validator accepts. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended

--- a/gym-trainer/README.md
+++ b/gym-trainer/README.md
@@ -133,9 +133,13 @@ exact expander covers one target slot — required or optional — drawn from an
 explicit finite legal target list, plus unique ordering/reordering through four
 objects. Each validator-approved response becomes its own edge, declining an
 optional target slot is the empty selection, and ordering shapes beyond the
-24-response capability ceiling remain unsupported rather than partially
-expanded. Other structured decisions retain one `StructuredDecisionResolver`
-fallback edge, which is policy-selected rather than exhaustive.
+response ceiling remain unsupported rather than partially expanded. That
+ceiling is a search-budget knob the caller owns
+(`ExactStructuredDecisionExpander(maxOrderingResponses = n)`), not an engine
+legality rule: at 24 responses one ordering costs a quarter of `SelfPlayLoop`'s
+default 100 simulations per move just to visit each child once. Other
+structured decisions retain one `StructuredDecisionResolver` fallback edge,
+which is policy-selected rather than exhaustive.
 
 Cancellation is not among the expanded responses. A `CancelDecisionResponse`
 rewinds a cast-time decision to the priority state that offered the cast, so a
@@ -168,7 +172,7 @@ bloat everyone's classpath.
 | `StructuralStateFeaturizer` | Simple `Map<String, Float>` from life, zone sizes, projected P/T totals, mana. Replace for real training. |
 | `DynamicSlotActionFeaturizer` | Single-head, hash-keyed slot assignment. Replace for serious training to avoid collisions. |
 | `JsonlSelfPlaySink` | One JSON line per step, outcome label included. Easy Python ingest. |
-| `ExactStructuredDecisionExpander` | Complete exact required/optional single-target responses and unique ordering/reordering through four objects (24); larger or duplicate shapes are Unsupported — a capability ceiling, not legality, with no partial expansion. |
+| `ExactStructuredDecisionExpander` | Complete exact required/optional single-target responses, and unique orderings through a caller-set ceiling (24 by default). Larger or duplicate shapes are Unsupported, never partial. |
 | `RandomStructuredResolver` | Random minimum-cardinality fallback for supported target/card/mode decisions; redraws until the engine's validator accepts. |
 
 Defaults exist so a training loop runs in 30 lines. Every one is intended

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -2,7 +2,10 @@ package com.wingedsheep.gym.trainer.defaults
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
 import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
 import com.wingedsheep.engine.state.GameState
@@ -19,7 +22,10 @@ import com.wingedsheep.sdk.model.EntityId
  * requirement is optional. Every candidate is filtered through [DecisionValidators] before it is
  * exposed. Variable-cardinality and multi-requirement target decisions remain unsupported because
  * current MCTS materializes every edge and has no caller-owned widening or response-budget policy.
- * Other structured families remain unsupported.
+ * Small unique orderings are likewise finite: they have one semantic response for every
+ * permutation. The explicit [MAX_ORDERING_RESPONSES] materialization ceiling is this expander's
+ * capability bound, not an engine legality restriction. Larger, duplicate, or otherwise
+ * non-materializable orderings remain unsupported.
  *
  * Cancellation is deliberately not one of the responses. A
  * [com.wingedsheep.engine.core.CancelDecisionResponse] on a cast-time target decision rewinds to the
@@ -60,7 +66,65 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
             }
         }
 
+        is OrderObjectsDecision -> completeOrdering(
+            state = state,
+            decision = decision,
+            objects = decision.objects
+        )
+
+        is ReorderLibraryDecision -> completeOrdering(
+            state = state,
+            decision = decision,
+            objects = decision.cards
+        )
+
         else -> StructuredDecisionExpansion.Unsupported
+    }
+
+    private fun completeOrdering(
+        state: GameState,
+        decision: PendingDecision,
+        objects: List<EntityId>
+    ): StructuredDecisionExpansion {
+        // An ordering has every and only validator-accepted semantic responses precisely when its
+        // IDs are unique: then those responses are its permutations. The engine owns legality;
+        // this guard keeps the exact-expansion claim well-defined even if a malformed pending
+        // decision repeats an ID.
+        if (!permutationCountFitsCeiling(objects.size) || objects.distinct().size != objects.size) {
+            return StructuredDecisionExpansion.Unsupported
+        }
+        return complete(state, decision, orderingResponses(decision.id, objects))
+    }
+
+    private fun permutationCountFitsCeiling(size: Int): Boolean {
+        var permutations = 1
+        for (factor in 2..size) {
+            // Check before multiplying, so a malformed arbitrarily large input cannot overflow
+            // its way back under the materialization ceiling.
+            if (permutations > MAX_ORDERING_RESPONSES / factor) return false
+            permutations *= factor
+        }
+        return true
+    }
+
+    private fun orderingResponses(
+        decisionId: String,
+        objects: List<EntityId>
+    ): List<DecisionResponse> = buildList {
+        fun appendPermutations(prefix: MutableList<EntityId>, remaining: List<EntityId>) {
+            if (remaining.isEmpty()) {
+                add(OrderedResponse(decisionId, prefix.toList()))
+                return
+            }
+
+            for ((index, objectId) in remaining.withIndex()) {
+                prefix += objectId
+                appendPermutations(prefix, remaining.filterIndexed { candidateIndex, _ -> candidateIndex != index })
+                prefix.removeAt(prefix.lastIndex)
+            }
+        }
+
+        appendPermutations(mutableListOf(), objects)
     }
 
     private fun targetResponses(
@@ -90,4 +154,7 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
             StructuredDecisionExpansion.Complete(legal)
         }
     }
+
+    /** Four objects have exactly 24 permutations; the fifth would require 120 search edges. */
+    private const val MAX_ORDERING_RESPONSES = 24
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/defaults/ExactStructuredDecisionExpander.kt
@@ -23,9 +23,16 @@ import com.wingedsheep.sdk.model.EntityId
  * exposed. Variable-cardinality and multi-requirement target decisions remain unsupported because
  * current MCTS materializes every edge and has no caller-owned widening or response-budget policy.
  * Small unique orderings are likewise finite: they have one semantic response for every
- * permutation. The explicit [MAX_ORDERING_RESPONSES] materialization ceiling is this expander's
- * capability bound, not an engine legality restriction. Larger, duplicate, or otherwise
- * non-materializable orderings remain unsupported.
+ * permutation. [maxOrderingResponses] is a search-budget knob, not an engine legality restriction —
+ * every permutation of a unique list is legal, so the ceiling only decides how many of them this
+ * expander is willing to materialize as edges. It is a constructor parameter because the budget it
+ * spends belongs to the caller: at `SelfPlayLoop`'s default 100 simulations per move, a 24-edge
+ * ordering costs a quarter of the move's search just to visit each child once. Larger, duplicate,
+ * or otherwise non-materializable orderings remain unsupported.
+ *
+ * The [DecisionValidators] pass is a cross-check rather than a live filter for orderings: the
+ * uniqueness guard already makes every generated permutation validator-accepted. It stays because
+ * it is what makes the exact-expansion claim checkable against the engine rather than asserted.
  *
  * Cancellation is deliberately not one of the responses. A
  * [com.wingedsheep.engine.core.CancelDecisionResponse] on a cast-time target decision rewinds to the
@@ -38,7 +45,15 @@ import com.wingedsheep.sdk.model.EntityId
  * [StructuredDecisionExpansion.Unsupported], not as an empty [StructuredDecisionExpansion.Complete]:
  * an empty complete set is unsearchable, so the caller's resolver fallback owns that degenerate case.
  */
-object ExactStructuredDecisionExpander : StructuredDecisionExpander {
+class ExactStructuredDecisionExpander(
+    private val maxOrderingResponses: Int = DEFAULT_MAX_ORDERING_RESPONSES
+) : StructuredDecisionExpander {
+
+    init {
+        require(maxOrderingResponses >= 1) {
+            "maxOrderingResponses must be at least 1 (got $maxOrderingResponses)"
+        }
+    }
 
     override fun expand(
         state: GameState,
@@ -101,7 +116,7 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
         for (factor in 2..size) {
             // Check before multiplying, so a malformed arbitrarily large input cannot overflow
             // its way back under the materialization ceiling.
-            if (permutations > MAX_ORDERING_RESPONSES / factor) return false
+            if (permutations > maxOrderingResponses / factor) return false
             permutations *= factor
         }
         return true
@@ -155,6 +170,12 @@ object ExactStructuredDecisionExpander : StructuredDecisionExpander {
         }
     }
 
-    /** Four objects have exactly 24 permutations; the fifth would require 120 search edges. */
-    private const val MAX_ORDERING_RESPONSES = 24
+    companion object {
+
+        /** Four objects have exactly 24 permutations; the fifth would require 120 search edges. */
+        const val DEFAULT_MAX_ORDERING_RESPONSES = 24
+
+        /** Shared instance for callers that take the default ceiling. */
+        val Default = ExactStructuredDecisionExpander()
+    }
 }

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -92,7 +92,9 @@ import java.util.Random as JavaRandom
  * @param dirichletWeight `(1-w) * prior + w * dirichlet` mix weight
  * @param rng seed for noise sampling
  * @param structuredExpander policy-free source of complete structured
- *        response sets; defaults to exact required-single-target expansion
+ *        response sets; defaults to exact required/optional single targets and unique orderings
+ *        or library reorders through four objects (24 responses). This is a capability ceiling,
+ *        not an engine legality rule: larger or duplicate shapes are Unsupported, never partial.
  */
 class AlphaZeroSearch<T>(
     private val env: GameEnvironment,

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/search/AlphaZeroSearch.kt
@@ -93,8 +93,11 @@ import java.util.Random as JavaRandom
  * @param rng seed for noise sampling
  * @param structuredExpander policy-free source of complete structured
  *        response sets; defaults to exact required/optional single targets and unique orderings
- *        or library reorders through four objects (24 responses). This is a capability ceiling,
- *        not an engine legality rule: larger or duplicate shapes are Unsupported, never partial.
+ *        or library reorders through four objects (24 responses). That width is a search-budget
+ *        ceiling, not an engine legality rule — pass
+ *        `ExactStructuredDecisionExpander(maxOrderingResponses = n)` to trade ordering breadth
+ *        against the per-move simulation count. Larger or duplicate shapes are Unsupported,
+ *        never partial.
  */
 class AlphaZeroSearch<T>(
     private val env: GameEnvironment,
@@ -106,7 +109,7 @@ class AlphaZeroSearch<T>(
     private val dirichletAlpha: Double? = null,
     private val dirichletWeight: Double = 0.25,
     private val rng: Random = Random.Default,
-    private val structuredExpander: StructuredDecisionExpander = ExactStructuredDecisionExpander
+    private val structuredExpander: StructuredDecisionExpander = ExactStructuredDecisionExpander.Default
 ) {
     private val workingEnv: GameEnvironment = env.fork()
     private val javaRng: JavaRandom = JavaRandom(rng.nextLong())

--- a/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
+++ b/gym-trainer/src/main/kotlin/com/wingedsheep/gym/trainer/selfplay/SelfPlayLoop.kt
@@ -49,7 +49,7 @@ class SelfPlayLoop<T>(
     private val maxSteps: Int = 2000,
     private val rng: Random = Random.Default,
     private val structuredExpander: StructuredDecisionExpander =
-        com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander
+        com.wingedsheep.gym.trainer.defaults.ExactStructuredDecisionExpander.Default
 ) {
     /** Run one game. Returns the winner (null = draw / truncation). */
     fun playGame(config: GameConfig, gameId: String = UUID.randomUUID().toString()): GameOutcome {

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.gym.trainer.spi.StructuredDecisionExpansion
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.asClue
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 class ExactStructuredDecisionExpanderTest : FunSpec({
 
+    val expander = ExactStructuredDecisionExpander.Default
     val playerId = EntityId.of("player")
     val first = EntityId.of("first")
     val second = EntityId.of("second")
@@ -50,7 +52,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("required single-target expansion is complete") {
         val decision = targetDecision("targets", listOf(first, second))
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.shouldContainExactly(
@@ -69,7 +71,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("optional single-target expansion offers the empty selection") {
         val decision = targetDecision("optional", listOf(first, second), minTargets = 0)
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.shouldContainExactly(
@@ -90,7 +92,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("cancellation is never offered as a response") {
         val decision = targetDecision("cancellable", listOf(first, second), canCancel = true)
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.none { it is CancelDecisionResponse } shouldBe true
@@ -100,7 +102,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("duplicate legal targets collapse to one response each") {
         val decision = targetDecision("duplicates", listOf(first, second, first))
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.shouldContainExactly(
@@ -112,7 +114,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("variable-cardinality target expansion is explicitly unsupported") {
         val decision = targetDecision("many-targets", listOf(first, second, third), minTargets = 0, maxTargets = 2)
 
-        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+        expander.expand(state, decision) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
@@ -129,7 +131,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             legalTargets = mapOf(0 to listOf(first), 1 to listOf(second))
         )
 
-        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+        expander.expand(state, decision) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
@@ -138,7 +140,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     test("supported family with no legal response reports unsupported") {
         val decision = targetDecision("no-targets", emptyList())
 
-        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+        expander.expand(state, decision) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
@@ -151,7 +153,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             objects = listOf(first, second, third)
         )
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.shouldContainExactly(
@@ -179,7 +181,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             cardInfo = emptyMap()
         )
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+        val expansion = expander.expand(state, decision)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
 
         expansion.responses.shouldContainExactly(
@@ -210,14 +212,14 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             cardInfo = emptyMap()
         )
 
-        val expansion = ExactStructuredDecisionExpander.expand(state, atCeiling)
+        val expansion = expander.expand(state, atCeiling)
             .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
         expansion.responses.size shouldBe 24
         expansion.responses.toSet().size shouldBe 24
         expansion.responses.forEach { response ->
             DecisionValidators.validate(atCeiling, response, state) shouldBe null
         }
-        ExactStructuredDecisionExpander.expand(state, overCeiling) shouldBe
+        expander.expand(state, overCeiling) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
@@ -238,9 +240,9 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             cardInfo = emptyMap()
         )
 
-        ExactStructuredDecisionExpander.expand(state, duplicateObjects) shouldBe
+        expander.expand(state, duplicateObjects) shouldBe
             StructuredDecisionExpansion.Unsupported
-        ExactStructuredDecisionExpander.expand(state, duplicateCards) shouldBe
+        expander.expand(state, duplicateCards) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 
@@ -261,10 +263,32 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             cardInfo = emptyMap()
         )
 
-        ExactStructuredDecisionExpander.expand(state, emptyObjects) shouldBe
+        expander.expand(state, emptyObjects) shouldBe
             StructuredDecisionExpansion.Complete(listOf(OrderedResponse("empty-order", emptyList())))
-        ExactStructuredDecisionExpander.expand(state, oneCard) shouldBe
+        expander.expand(state, oneCard) shouldBe
             StructuredDecisionExpansion.Complete(listOf(OrderedResponse("one-card", listOf(first))))
+    }
+
+    // The ceiling is the caller's search budget, not a legality rule, so a caller that wants
+    // narrower ordering fan-out must be able to say so without a second expander implementation.
+    test("a caller-supplied ceiling narrows ordering fan-out without touching legality") {
+        val threeObjects = OrderObjectsDecision(
+            id = "three-objects",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second, third)
+        )
+
+        ExactStructuredDecisionExpander(maxOrderingResponses = 2)
+            .expand(state, threeObjects) shouldBe StructuredDecisionExpansion.Unsupported
+
+        val narrowed = ExactStructuredDecisionExpander(maxOrderingResponses = 6)
+            .expand(state, threeObjects)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        narrowed.responses.size shouldBe 6
+
+        shouldThrow<IllegalArgumentException> { ExactStructuredDecisionExpander(maxOrderingResponses = 0) }
     }
 
     test("unrelated structured family remains unsupported") {
@@ -277,7 +301,7 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             numberOfPiles = 2
         )
 
-        ExactStructuredDecisionExpander.expand(state, decision) shouldBe
+        expander.expand(state, decision) shouldBe
             StructuredDecisionExpansion.Unsupported
     }
 })

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/ExactStructuredDecisionExpanderTest.kt
@@ -4,6 +4,9 @@ import com.wingedsheep.engine.core.CancelDecisionResponse
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SplitPilesDecision
 import com.wingedsheep.engine.core.TargetRequirementInfo
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.handlers.actions.decision.DecisionValidators
@@ -22,6 +25,8 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
     val first = EntityId.of("first")
     val second = EntityId.of("second")
     val third = EntityId.of("third")
+    val fourth = EntityId.of("fourth")
+    val fifth = EntityId.of("fifth")
     val state = GameState(turnOrder = listOf(playerId))
 
     fun targetDecision(
@@ -137,13 +142,139 @@ class ExactStructuredDecisionExpanderTest : FunSpec({
             StructuredDecisionExpansion.Unsupported
     }
 
-    test("unsupported family returns unsupported") {
+    test("small object ordering expands every validator-accepted permutation deterministically") {
         val decision = OrderObjectsDecision(
             id = "order",
             playerId = playerId,
             prompt = "Order objects",
             context = DecisionContext(),
-            objects = listOf(first, second)
+            objects = listOf(first, second, third)
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            OrderedResponse("order", listOf(first, second, third)),
+            OrderedResponse("order", listOf(first, third, second)),
+            OrderedResponse("order", listOf(second, first, third)),
+            OrderedResponse("order", listOf(second, third, first)),
+            OrderedResponse("order", listOf(third, first, second)),
+            OrderedResponse("order", listOf(third, second, first))
+        )
+        expansion.responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("small library reorder expands every validator-accepted permutation") {
+        val decision = ReorderLibraryDecision(
+            id = "reorder",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second),
+            cardInfo = emptyMap()
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, decision)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+
+        expansion.responses.shouldContainExactly(
+            OrderedResponse("reorder", listOf(first, second)),
+            OrderedResponse("reorder", listOf(second, first))
+        )
+        expansion.responses.forEach { response ->
+            response.asClue {
+                DecisionValidators.validate(decision, response, state) shouldBe null
+            }
+        }
+    }
+
+    test("ordering materializes exactly through the response ceiling and not beyond it") {
+        val atCeiling = OrderObjectsDecision(
+            id = "four-objects",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second, third, fourth)
+        )
+        val overCeiling = ReorderLibraryDecision(
+            id = "five-cards",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second, third, fourth, fifth),
+            cardInfo = emptyMap()
+        )
+
+        val expansion = ExactStructuredDecisionExpander.expand(state, atCeiling)
+            .shouldBeInstanceOf<StructuredDecisionExpansion.Complete>()
+        expansion.responses.size shouldBe 24
+        expansion.responses.toSet().size shouldBe 24
+        expansion.responses.forEach { response ->
+            DecisionValidators.validate(atCeiling, response, state) shouldBe null
+        }
+        ExactStructuredDecisionExpander.expand(state, overCeiling) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("duplicate ordering IDs are unsupported rather than conflated into fewer permutations") {
+        val duplicateObjects = OrderObjectsDecision(
+            id = "duplicate-objects",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = listOf(first, second, first)
+        )
+        val duplicateCards = ReorderLibraryDecision(
+            id = "duplicate-cards",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first, second, first),
+            cardInfo = emptyMap()
+        )
+
+        ExactStructuredDecisionExpander.expand(state, duplicateObjects) shouldBe
+            StructuredDecisionExpansion.Unsupported
+        ExactStructuredDecisionExpander.expand(state, duplicateCards) shouldBe
+            StructuredDecisionExpansion.Unsupported
+    }
+
+    test("degenerate unique orderings retain their single validator-approved response") {
+        val emptyObjects = OrderObjectsDecision(
+            id = "empty-order",
+            playerId = playerId,
+            prompt = "Order objects",
+            context = DecisionContext(),
+            objects = emptyList()
+        )
+        val oneCard = ReorderLibraryDecision(
+            id = "one-card",
+            playerId = playerId,
+            prompt = "Reorder library",
+            context = DecisionContext(),
+            cards = listOf(first),
+            cardInfo = emptyMap()
+        )
+
+        ExactStructuredDecisionExpander.expand(state, emptyObjects) shouldBe
+            StructuredDecisionExpansion.Complete(listOf(OrderedResponse("empty-order", emptyList())))
+        ExactStructuredDecisionExpander.expand(state, oneCard) shouldBe
+            StructuredDecisionExpansion.Complete(listOf(OrderedResponse("one-card", listOf(first))))
+    }
+
+    test("unrelated structured family remains unsupported") {
+        val decision = SplitPilesDecision(
+            id = "piles",
+            playerId = playerId,
+            prompt = "Split piles",
+            context = DecisionContext(),
+            cards = listOf(first, second),
+            numberOfPiles = 2
         )
 
         ExactStructuredDecisionExpander.expand(state, decision) shouldBe

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -2,9 +2,13 @@ package com.wingedsheep.gym.trainer.search
 
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.MoveCollectionOrderContinuation
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.SubmitDecision
@@ -28,6 +32,7 @@ import com.wingedsheep.gym.trainer.spi.TrainerContext
 import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.assertions.throwables.shouldThrow
@@ -146,6 +151,68 @@ class StructuredDecisionSearchTest : FunSpec({
         }
         responsesByTarget.getValue(ownCreature).child!!.state shouldNotBe
             responsesByTarget.getValue(opposingCreature).child!!.state
+    }
+
+    test("default MCTS exposes and executes every small library ordering") {
+        val driver = newDriver("Mountain")
+        val player = driver.activePlayer!!
+        val cards = driver.state.getLibrary(player).take(2)
+        val decision = ReorderLibraryDecision(
+            id = "search-ordering",
+            playerId = player,
+            prompt = "Put them back in any order",
+            context = DecisionContext(),
+            cards = cards,
+            cardInfo = emptyMap(),
+        )
+        val rootState = driver.state
+            .withPendingDecision(decision)
+            .pushContinuation(
+                MoveCollectionOrderContinuation(
+                    decisionId = decision.id,
+                    playerId = player,
+                    sourceId = null,
+                    sourceName = "Search ordering probe",
+                    cards = cards,
+                    destinationZone = Zone.LIBRARY,
+                    destinationPlayerId = player,
+                )
+            )
+        val env = GameEnvironment.create(driver.cardRegistry).also {
+            it.restore(rootState, listOf(driver.player1, driver.player2))
+        }
+
+        val result = AlphaZeroSearch(
+            env = env,
+            featurizer = stateFeaturizer,
+            actionFeaturizer = sharedSlotFeaturizer,
+            evaluator = uniformEvaluator,
+            structuredResolver = StructuredDecisionResolver { _, pending ->
+                error("exact expansion unexpectedly fell back for ${pending::class.simpleName}")
+            },
+            dirichletAlpha = null,
+        ).run(simulations = 2)
+
+        result.root.edges.size shouldBe 2
+        result.visits.toList().shouldContainExactly(1, 1)
+        val responses = result.root.edges.map { edge ->
+            (edge.action as SubmitDecision).response.shouldBeInstanceOf<OrderedResponse>()
+        }
+        responses.map { it.orderedObjects }.toSet() shouldBe setOf(
+            cards,
+            cards.reversed(),
+        )
+
+        result.root.edges.zip(responses).forEach { (edge, response) ->
+            val branch = GameEnvironment.create(driver.cardRegistry).also {
+                it.restore(rootState, listOf(driver.player1, driver.player2))
+            }
+            branch.step(edge.action)
+
+            branch.lastRejection shouldBe null
+            branch.state.getLibrary(player).take(2) shouldBe response.orderedObjects
+        }
+        result.root.edges[0].child!!.state shouldNotBe result.root.edges[1].child!!.state
     }
 
     test("existing yes-no folding remains a complete two-edge decision") {

--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/search/StructuredDecisionSearchTest.kt
@@ -39,10 +39,20 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.floats.shouldBeExactly
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+
+private const val ORDERING_HEAD = "ordering"
+
+/** Lexicographic-by-input-index permutations — the same enumeration the expander produces. */
+private fun <T> permutationsOf(items: List<T>): List<List<T>> =
+    if (items.isEmpty()) listOf(emptyList())
+    else items.indices.flatMap { index ->
+        permutationsOf(items.filterIndexed { other, _ -> other != index }).map { listOf(items[index]) + it }
+    }
 
 class StructuredDecisionSearchTest : FunSpec({
 
@@ -153,10 +163,14 @@ class StructuredDecisionSearchTest : FunSpec({
             responsesByTarget.getValue(opposingCreature).child!!.state
     }
 
-    test("default MCTS exposes and executes every small library ordering") {
+    test("default MCTS exposes every small library ordering and selects the best-evaluated one") {
         val driver = newDriver("Mountain")
         val player = driver.activePlayer!!
-        val cards = driver.state.getLibrary(player).take(2)
+        val cards = driver.state.getLibrary(player).take(3)
+        val orders = permutationsOf(cards)
+        orders.size shouldBe 6
+        val favoured = orders[4]
+
         val decision = ReorderLibraryDecision(
             id = "search-ordering",
             playerId = player,
@@ -182,37 +196,66 @@ class StructuredDecisionSearchTest : FunSpec({
             it.restore(rootState, listOf(driver.player1, driver.player2))
         }
 
+        // One head per ordering slot, so the evaluator can prefer a single permutation. A shared
+        // featurizer would collapse all six onto one slot and make "best evaluated" untestable —
+        // exactly the gap that a two-object ordering hides.
+        val orderingFeaturizer = object : ActionFeaturizer {
+            override val heads: List<PolicyHead> =
+                listOf(PolicyHead(ORDERING_HEAD, orders.size), PolicyHead("shared", 1))
+
+            override fun slot(action: GameAction, ctx: TrainerContext): SlotEncoding {
+                val response = (action as? SubmitDecision)?.response
+                val index = (response as? OrderedResponse)?.let { orders.indexOf(it.orderedObjects) } ?: -1
+                return if (index >= 0) SlotEncoding(ORDERING_HEAD, index) else SlotEncoding("shared", 0)
+            }
+        }
+        val favouringEvaluator = Evaluator<Unit> { _, _, _ ->
+            val orderingPriors = FloatArray(orders.size) { if (it == orders.indexOf(favoured)) 10f else 1f }
+            EvaluationResult(
+                priors = mapOf(ORDERING_HEAD to orderingPriors, "shared" to floatArrayOf(1f)),
+                value = 0f,
+            )
+        }
+
         val result = AlphaZeroSearch(
             env = env,
             featurizer = stateFeaturizer,
-            actionFeaturizer = sharedSlotFeaturizer,
-            evaluator = uniformEvaluator,
+            actionFeaturizer = orderingFeaturizer,
+            evaluator = favouringEvaluator,
             structuredResolver = StructuredDecisionResolver { _, pending ->
                 error("exact expansion unexpectedly fell back for ${pending::class.simpleName}")
             },
             dirichletAlpha = null,
-        ).run(simulations = 2)
+        ).run(simulations = 12)
 
-        result.root.edges.size shouldBe 2
-        result.visits.toList().shouldContainExactly(1, 1)
+        result.root.edges.size shouldBe 6
         val responses = result.root.edges.map { edge ->
             (edge.action as SubmitDecision).response.shouldBeInstanceOf<OrderedResponse>()
         }
-        responses.map { it.orderedObjects }.toSet() shouldBe setOf(
-            cards,
-            cards.reversed(),
-        )
+        responses.map { it.orderedObjects }.toSet() shouldBe orders.toSet()
+        result.root.edges.map { it.slot }.toSet().size shouldBe 6
+        result.visits.sum() shouldBe 12
 
-        result.root.edges.zip(responses).forEach { (edge, response) ->
+        val bestEdge = result.bestEdge.shouldNotBeNull()
+        (bestEdge.action as SubmitDecision).response
+            .shouldBeInstanceOf<OrderedResponse>().orderedObjects shouldBe favoured
+        val others = result.root.edges.filter { it !== bestEdge }
+        others.forEach { bestEdge.visits shouldBeGreaterThan it.visits }
+
+        // Executed rather than read off the tree: a 10:1 prior leaves the weakest orders unvisited,
+        // so the tree holds fewer children than edges. Every edge must still be a distinct, legal,
+        // engine-accepted branch.
+        val branchStates = result.root.edges.zip(responses).map { (edge, response) ->
             val branch = GameEnvironment.create(driver.cardRegistry).also {
                 it.restore(rootState, listOf(driver.player1, driver.player2))
             }
             branch.step(edge.action)
 
             branch.lastRejection shouldBe null
-            branch.state.getLibrary(player).take(2) shouldBe response.orderedObjects
+            branch.state.getLibrary(player).take(3) shouldBe response.orderedObjects
+            branch.state
         }
-        result.root.edges[0].child!!.state shouldNotBe result.root.edges[1].child!!.state
+        branchStates.toSet().size shouldBe 6
     }
 
     test("existing yes-no folding remains a complete two-edge decision") {


### PR DESCRIPTION
Supersedes #2207 — it carries that PR's commit unchanged plus the review fixes on top, so merging this one lands both.

## What #2207 got right

The permutation generator, the overflow-safe ceiling check (`permutations > MAX / factor` *before* the multiply, so a malformed 10⁶-element list can't wrap back into range), the duplicate-ID guard and the degenerate 0/1-object cases all hold. The duplicate guard in particular is the correct precondition rather than a defensive reflex: `validateOrder`/`validateLibraryReorder` compare with `isSameCollection` (size + set), so with duplicate IDs the permutation set genuinely stops being the response set, and `Unsupported` is the honest answer instead of a silently-deduped "complete" claim.

## What this adds

**The ceiling is now the caller's.** `ExactStructuredDecisionExpander` becomes a class taking `maxOrderingResponses` (default 24), with a shared `Default` instance for the existing call sites in `AlphaZeroSearch` and `SelfPlayLoop`. The old KDoc argued the ceiling exists because MCTS "has no caller-owned widening or response-budget policy" — which is the argument for the caller owning the number, not for burying it in a `private const`. Concretely: `SelfPlayLoop` defaults to 100 simulations per move, so a 24-edge library reorder spends a quarter of the move's search just visiting each child once. A tuner can now pass `maxOrderingResponses = 6`. New test covers the narrowed ceiling, the widened one, and the `require` on a zero ceiling.

**The end-to-end search test now tests what it claimed.** #2207's body described "a three-object ordering decision… All six legal orders become edges, receive evaluations, and the best evaluated order is selected"; the test used two cards, `simulations = 2`, a uniform evaluator and a shared-slot featurizer, asserted `visits == (1, 1)`, and never asserted selection. Two edges is also the one width that can't distinguish exact expansion from a lucky fallback shape. The test now uses three cards, gives each of the six permutations its own policy slot, has the evaluator favour one, and asserts the search selects it, that every edge carries a distinct slot, and that all six edges execute into distinct engine-accepted library orders. Branch states are executed rather than read off the tree, because a 10:1 prior leaves the weakest orders unvisited — the tree legitimately holds fewer children than edges.

**Doc corrections.** The README table row was a 40-word paragraph among one-sentence rows; trimmed, with the budget rationale moved to the prose section above it. The `AlphaZeroSearch` KDoc now points at the constructor parameter.

## One thing left as-is, deliberately

`OrderObjectsDecision` is dead in this engine — nothing constructs it. The only creation site is `DecisionHandler.createOrderDecision`, which has zero callers; blocker damage-assignment order moved to `CombatResolutionDecision` (see the comment at `BlockPhaseManager.kt:222`, "no longer collected in a standalone OrderObjectsDecision pre-step"), and trigger ordering is not a decision at all — the engine sorts APNAP itself in `TriggerDetector`. So #2207's framing that this "lets search choose a trigger order" isn't reachable by any path, and the live win is `ReorderLibraryDecision` alone.

I kept the `OrderObjectsDecision` branch anyway: it's five lines, the type is still serialized, client-rendered and handled by the AI layer, and `createOrderDecision` still exists for something to call again. But no doc in this PR claims a combat or trigger-ordering capability, and nothing asserts in code that the type is unused — that fact would go stale.

## Verification

`just test-gym-trainer` green (24 tests: 14 expander, 4 structured-decision search, 3 AlphaZero, 1 resolver, 1 self-play, 1 other). `just test-gym` green. Only `:gym-trainer` sources and its README changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8ggsHbsfg8ZGP9yGPTBw1
