### PR TITLE
Keep Gym observation zones complete, schema-stable, and classified in the contract

### DIFF
--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -192,11 +192,11 @@ class ObservationBuilder(
         perspectivePlayerId: EntityId,
         revealAll: Boolean
     ): List<ZoneView> {
-        // Emit a view for every (player, zone) in turn order so trainers see a
-        // consistent shape regardless of whether a zone happens to be empty.
-        val perPlayerZones = listOf(
-            Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD
-        )
+        // Emit a view for every modeled (player, zone) in turn order so trainers see a
+        // consistent shape regardless of whether a zone happens to be empty. The stack has its
+        // own ordered representation above; every other Zone is stored under a ZoneKey and must
+        // not disappear merely because this allowlist predates it (COMMAND and SIDEBOARD both did).
+        val perPlayerZones = Zone.entries.filterNot { it == Zone.STACK }
         val views = mutableListOf<ZoneView>()
         for (playerId in state.turnOrder) {
             for (zone in perPlayerZones) {

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -59,6 +59,17 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
+/** Stable serialized order for the per-player zone views in [TrainingObservation]. */
+internal val TRAINING_OBSERVATION_ZONE_ORDER = listOf(
+    Zone.HAND,
+    Zone.LIBRARY,
+    Zone.GRAVEYARD,
+    Zone.EXILE,
+    Zone.BATTLEFIELD,
+    Zone.COMMAND,
+    Zone.SIDEBOARD,
+)
+
 /**
  * Converts `(GameState, perspectivePlayerId)` into a [TrainingObservation].
  *
@@ -192,14 +203,14 @@ class ObservationBuilder(
         perspectivePlayerId: EntityId,
         revealAll: Boolean
     ): List<ZoneView> {
-        // Emit a view for every modeled (player, zone) in turn order so trainers see a
-        // consistent shape regardless of whether a zone happens to be empty. The stack has its
-        // own ordered representation above; every other Zone is stored under a ZoneKey and must
-        // not disappear merely because this allowlist predates it (COMMAND and SIDEBOARD both did).
-        val perPlayerZones = Zone.entries.filterNot { it == Zone.STACK }
+        // Emit a view for every modeled (player, zone) in the contract's stable order so trainers
+        // see a consistent shape regardless of whether a zone happens to be empty. The stack has
+        // its own ordered representation above. Keep this order explicit: changing enum declaration
+        // order must not silently reorder model-facing inputs, and adding a zone must force an
+        // intentional schema decision through the completeness regression.
         val views = mutableListOf<ZoneView>()
         for (playerId in state.turnOrder) {
-            for (zone in perPlayerZones) {
+            for (zone in TRAINING_OBSERVATION_ZONE_ORDER) {
                 val key = ZoneKey(playerId, zone)
                 val ids = state.getZone(key)
                 val wholeZoneVisible = revealAll ||

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/ObservationBuilder.kt
@@ -59,17 +59,6 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
-/** Stable serialized order for the per-player zone views in [TrainingObservation]. */
-internal val TRAINING_OBSERVATION_ZONE_ORDER = listOf(
-    Zone.HAND,
-    Zone.LIBRARY,
-    Zone.GRAVEYARD,
-    Zone.EXILE,
-    Zone.BATTLEFIELD,
-    Zone.COMMAND,
-    Zone.SIDEBOARD,
-)
-
 /**
  * Converts `(GameState, perspectivePlayerId)` into a [TrainingObservation].
  *
@@ -205,9 +194,8 @@ class ObservationBuilder(
     ): List<ZoneView> {
         // Emit a view for every modeled (player, zone) in the contract's stable order so trainers
         // see a consistent shape regardless of whether a zone happens to be empty. The stack has
-        // its own ordered representation above. Keep this order explicit: changing enum declaration
-        // order must not silently reorder model-facing inputs, and adding a zone must force an
-        // intentional schema decision through the completeness regression.
+        // its own ordered representation above; see [TRAINING_OBSERVATION_ZONE_ORDER] for why the
+        // order is spelled out rather than taken from the enum.
         val views = mutableListOf<ZoneView>()
         for (playerId in state.turnOrder) {
             for (zone in TRAINING_OBSERVATION_ZONE_ORDER) {

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/SchemaHash.kt
@@ -11,5 +11,5 @@ package com.wingedsheep.gym.contract
  * what matters.
  */
 object SchemaHash {
-    const val CURRENT: String = "argentum-gym-contract@v1.4-object-semantics"
+    const val CURRENT: String = "argentum-gym-contract@v1.5-complete-zones"
 }

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -9,6 +9,33 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Stable serialized order for the per-player zone views in [TrainingObservation.zones].
+ *
+ * The order is written out rather than derived from [Zone.entries] because it is a schema
+ * guarantee: reordering the enum's declarations must not silently permute model-facing inputs.
+ * Together with [NON_PLAYER_KEYED_ZONES] this classifies every [Zone] the engine models, so a new
+ * engine zone cannot be added without deciding here whether an agent observes it per player.
+ *
+ * Known gap: emblems are zone-less entities (they carry `EmblemSourceComponent` and live in no
+ * zone at all), so no zone view reaches them. Surfacing them needs its own contract field.
+ */
+val TRAINING_OBSERVATION_ZONE_ORDER: List<Zone> = listOf(
+    Zone.HAND,
+    Zone.LIBRARY,
+    Zone.GRAVEYARD,
+    Zone.EXILE,
+    Zone.BATTLEFIELD,
+    Zone.COMMAND,
+    Zone.SIDEBOARD,
+)
+
+/**
+ * Zones deliberately absent from [TRAINING_OBSERVATION_ZONE_ORDER] because they are not keyed per
+ * player: [TrainingObservation.stack] carries the stack's own ordered representation.
+ */
+val NON_PLAYER_KEYED_ZONES: Set<Zone> = setOf(Zone.STACK)
+
+/**
  * The payload an agent receives from any gym environment after `observe` / `step`.
  *
  * A gym env is no longer only a game of Magic — deckbuilding is its own env type
@@ -71,7 +98,11 @@ data class TrainingObservation(
     val players: List<PlayerView>,
 
     /**
-     * Per-zone entity views. A `(ownerId, zoneType)` pair appears at most once.
+     * Per-zone entity views: every player in turn order crossed with
+     * [TRAINING_OBSERVATION_ZONE_ORDER], in that order, empty zones included. So a
+     * `(ownerId, zoneType)` pair appears exactly once and the list is a fixed-width, fixed-order
+     * input a consumer may index positionally.
+     *
      * [ZoneView.hidden] means the zone is not wholly public to this perspective. [ZoneView.cards]
      * contains only the identities this perspective may know, so an individually revealed card can
      * appear while the zone remains hidden and [ZoneView.size] still reports its true size.

--- a/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/contract/TrainingObservation.kt
@@ -157,7 +157,8 @@ data class ZoneView(
  *
  * Not every field is populated for every zone:
  * - On the battlefield: all fields relevant to a permanent are set.
- * - In the library/hand/graveyard/exile: the card's static properties are set;
+ * - Outside the battlefield (library/hand/graveyard/exile/command/sideboard): the card's static
+ *   properties are set;
  *   dynamic properties (tapped, damage, counters) default to their "not present" values.
  */
 @Serializable

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
@@ -162,7 +162,7 @@ class ObservationVisibilityTest : ScenarioTestBase() {
                 view.zones
                     .filter { it.ownerId == playerId }
                     .map { it.zoneType }
-                    .toSet() shouldBe Zone.entries.filterNot { it == Zone.STACK }.toSet()
+                    .shouldContainExactly(TRAINING_OBSERVATION_ZONE_ORDER)
             }
 
             zone(view, game.player2Id, Zone.COMMAND).let {
@@ -254,7 +254,7 @@ class ObservationVisibilityTest : ScenarioTestBase() {
                 ManaPoolComponent(),
             ),
         ).copy(turnOrder = state.turnOrder + playerId)
-        for (zone in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.EXILE, Zone.BATTLEFIELD)) {
+        for (zone in TRAINING_OBSERVATION_ZONE_ORDER) {
             result = result.copy(zones = result.zones + (ZoneKey(playerId, zone) to emptyList()))
         }
         return result

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/ObservationVisibilityTest.kt
@@ -149,6 +149,37 @@ class ObservationVisibilityTest : ScenarioTestBase() {
             }
         }
 
+        test("every modeled player zone is represented with engine-owned visibility") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInCommandZone(2, "Mountain")
+                .withCardInSideboard(1, "Forest")
+                .withCardInSideboard(2, "Hill Giant")
+                .build()
+            val view = observe(game.state, game.player1Id)
+
+            game.state.turnOrder.forEach { playerId ->
+                view.zones
+                    .filter { it.ownerId == playerId }
+                    .map { it.zoneType }
+                    .toSet() shouldBe Zone.entries.filterNot { it == Zone.STACK }.toSet()
+            }
+
+            zone(view, game.player2Id, Zone.COMMAND).let {
+                it.hidden shouldBe false
+                it.cards.single().name shouldBe "Mountain"
+            }
+            zone(view, game.player1Id, Zone.SIDEBOARD).let {
+                it.hidden shouldBe false
+                it.cards.single().name shouldBe "Forest"
+            }
+            zone(view, game.player2Id, Zone.SIDEBOARD).let {
+                it.hidden shouldBe true
+                it.size shouldBe 1
+                it.cards shouldBe emptyList()
+            }
+        }
+
         test("a face-down object keeps its public characteristics and loses its identity") {
             val game = scenario()
                 .withPlayers()

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.collections.shouldNotContainAnyOf
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -93,8 +94,11 @@ class TrainingObservationTest : FunSpec({
             Zone.COMMAND,
             Zone.SIDEBOARD,
         )
-        TRAINING_OBSERVATION_ZONE_ORDER.toSet() shouldBe
-            Zone.entries.filterNot { it == Zone.STACK }.toSet()
+        // Every engine zone is classified in the contract itself, so a new one cannot be absorbed
+        // by relaxing this test — it has to be named either per-player or explicitly not.
+        TRAINING_OBSERVATION_ZONE_ORDER.toSet() + NON_PLAYER_KEYED_ZONES shouldBe
+            Zone.entries.toSet()
+        TRAINING_OBSERVATION_ZONE_ORDER.toSet() shouldNotContainAnyOf NON_PLAYER_KEYED_ZONES
 
         val env = newEnv()
         val perspective = env.playerIds[0]

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -74,8 +74,8 @@ class TrainingObservationTest : FunSpec({
         obs.stateDigest shouldMatch Regex("[0-9a-f]{64}")
         obs.legalActions.shouldNotBeEmpty()
 
-        // Hand + library + graveyard + exile + battlefield for each player.
-        obs.zones.size shouldBe 2 * 5
+        // Every player-keyed zone is present; stack has its own ordered field.
+        obs.zones.size shouldBe 2 * (Zone.entries.size - 1)
 
         val encoded = json.encodeToString(TrainingObservation.serializer(), obs)
         val decoded = json.decodeFromString(TrainingObservation.serializer(), encoded)

--- a/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
+++ b/gym/src/test/kotlin/com/wingedsheep/gym/contract/TrainingObservationTest.kt
@@ -22,6 +22,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -80,6 +81,31 @@ class TrainingObservationTest : FunSpec({
         val encoded = json.encodeToString(TrainingObservation.serializer(), obs)
         val decoded = json.decodeFromString(TrainingObservation.serializer(), encoded)
         decoded shouldBe obs
+    }
+
+    test("per-player zones have an explicit complete schema order") {
+        TRAINING_OBSERVATION_ZONE_ORDER.shouldContainExactly(
+            Zone.HAND,
+            Zone.LIBRARY,
+            Zone.GRAVEYARD,
+            Zone.EXILE,
+            Zone.BATTLEFIELD,
+            Zone.COMMAND,
+            Zone.SIDEBOARD,
+        )
+        TRAINING_OBSERVATION_ZONE_ORDER.toSet() shouldBe
+            Zone.entries.filterNot { it == Zone.STACK }.toSet()
+
+        val env = newEnv()
+        val perspective = env.playerIds[0]
+        val observation = ObservationBuilder(env.cardRegistry)
+            .build(env.state, perspective, env.legalActions())
+            .observation as TrainingObservation
+
+        observation.zones
+            .filter { it.ownerId == perspective }
+            .map { it.zoneType }
+            .shouldContainExactly(TRAINING_OBSERVATION_ZONE_ORDER)
     }
 
     test("an actionId from the observation resolves to a steppable action") {


### PR DESCRIPTION
Supersedes #2211 — it carries that PR's commits (rebased onto current `main` via a merge) plus the review fixups. Close #2211 in favour of this one, or merge #2211 first and this becomes just the fixup commit.

## What #2211 does

`ObservationBuilder` hand-selected five player zones, so cards in `COMMAND` and `SIDEBOARD` vanished from Gym state even though the engine models both and the command zone is public information. Worse, `CommandZoneAbilityEnumerator` and `CastFromZoneEnumerator` already emit legal actions for command-zone entities, so agents were handed actions referencing entities present in no zone view.

The observation now emits every modeled `(player, zone)` pair — hand, library, graveyard, exile, battlefield, command, sideboard — in a fixed order, empty zones included. `STACK` stays separate because `TrainingObservation.stack` already has its own ordered representation. Zone privacy is not re-derived: `Visibility.isZoneVisibleTo` keeps answering, so command-is-public and sideboard-is-owner-private come from the engine.

## What this PR adds on top

**The completeness gate was enforceable only from test code.** Both tests spelled the contract as `Zone.entries.filterNot { it == Zone.STACK }`. Adding an engine zone failed them — but the two ways to go green cost the same: name the zone in `TRAINING_OBSERVATION_ZONE_ORDER`, or add it to the test's `filterNot`. The second is exactly the silent omission the gate exists to prevent, reachable by a one-token test edit.

`NON_PLAYER_KEYED_ZONES` now names the exclusion in main code beside the order list, and the test asserts the two partition `Zone.entries` and don't overlap. A new engine zone has to be classified in the contract before it compiles away.

Smaller ones:

- **The order list moves to `TrainingObservation.kt` and becomes public.** It is a serialization guarantee, not an `ObservationBuilder` implementation detail, and `internal` kept a Kotlin consumer in `gym-trainer` from reading the order it is promised when building a fixed-width feature vector.
- **`TrainingObservation.zones` documents what it now provides.** It said "a `(ownerId, zoneType)` pair appears at most once"; the guarantee is *exactly* once per player × the seven zones, in that order, empty included — a fixed-width, positionally indexable input. That KDoc is what a downstream consumer reads to decide whether it may index positionally.
- **The emblem gap is recorded.** `CreatePermanentEmblemExecutor` builds the emblem with `withEntity` and never `addToZone`, so emblems are zone-less and still unobservable after a "complete zones" pass. Noted on the order list so the next reader doesn't conclude coverage is now total; surfacing them needs its own contract field.
- **`addBystander` seeded the pre-change five zones.** Harmless — `GameState.getZone` returns empty for an unseeded key — but a second, already-wrong copy of the contract. It reads from the contract now.
- **The visibility test asserts per-player zone *order*,** not just the set, for every player rather than only the perspective.

## Verification

`just test-gym` with `--rerun-tasks`: 76 tests, 0 failures, 0 errors — including `TrainingObservationTest` 12/12, `ObservationVisibilityTest` 6/6, `ObservationProjectedStateTest` 8/8. `just test-gym-server` green.

No consumer indexes `zones` positionally today: `StateDigest` sorts by `(ownerId, zoneType.name)` so digest ordering is unaffected (values change, correctly, and `SchemaHash.CURRENT` moved with them), and `EnvControllerTest` asserts only that the hash is non-empty. There is no Python client or JSON fixture in-repo pinning the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaobRBkE71n6PVA8AA5M8K
