### PR TITLE
External AI controller providers, with review fixes on top of #2213

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Copy `.env.example` to `.env` to configure:
 | `REDIS_HOST` | `localhost` | Redis host |
 | `REDIS_PORT` | `6379` | Redis port |
 | `GAME_AI_ENABLED` | `true` | Enable AI opponent |
-| `GAME_AI_MODE` | `engine` | AI mode: `engine` (built-in) or `llm` (requires API key) |
+| `GAME_AI_MODE` | `engine` | AI mode: `engine` (built-in), `llm` (requires API key), or the mode of a registered `AiControllerProvider`. An unrecognised value fails startup. |
 | `OPENROUTER_API_KEY` | | OpenRouter API key (only needed for `llm` mode) |
 | `GAME_AI_MODEL` | `google/gemini-3.1-flash-lite-preview` | LLM model (only for `llm` mode) |
 
@@ -180,7 +180,7 @@ The LLM AI receives the same masked game state as a human player and responds th
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GAME_AI_ENABLED` | `true` | Enable the AI opponent feature |
-| `GAME_AI_MODE` | `llm` | `engine` — built-in AI (no API key needed); `llm` — LLM-powered AI |
+| `GAME_AI_MODE` | `llm` | `engine` — built-in AI (no API key needed); `llm` — LLM-powered AI; or the mode of an `AiControllerProvider` bean supplied by another build. An unrecognised value fails startup. |
 | `GAME_AI_BASE_URL` | `https://openrouter.ai/api/v1` | LLM API endpoint (LLM mode only) |
 | `GAME_AI_API_KEY` | | API key for LLM provider (LLM mode only) |
 | `GAME_AI_MODEL` | `google/gemini-3.1-flash-lite-preview` | LLM model name (LLM mode only) |

--- a/ai/src/main/kotlin/com/wingedsheep/ai/llm/AiConfig.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/llm/AiConfig.kt
@@ -16,5 +16,4 @@ data class AiConfig(
     val effectiveDeckbuildingModel: String get() = deckbuildingModel.ifBlank { model }
     val effectiveApiKey: String get() = apiKey.ifBlank { openRouterApiKey }
     val isEngineMode: Boolean get() = mode.equals("engine", ignoreCase = true)
-    val isLlmMode: Boolean get() = !isEngineMode
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
@@ -10,10 +10,15 @@ import com.wingedsheep.sdk.model.EntityId
 /**
  * One lock-consistent view of the live inputs needed by a trusted server-side AI controller.
  *
- * [state] is always the authoritative live state. [replayHistory] says whether its compact inputs
- * reproduce that state or are only the prefix retained after replay recording reached its cap.
- * Keeping that distinction in the type prevents an external controller from treating a plausible
- * but incomplete action list as the history of the live position.
+ * [state] is the *unmasked* authoritative state — both players' hands and libraries — the same view
+ * [com.wingedsheep.ai.engine.EngineAiPlayerController] reads, and strictly more than the masked
+ * `ClientGameState` an [AiPlayerController] is handed at decision time. Only trusted in-process
+ * providers get one.
+ *
+ * [replayHistory] says whether compact inputs reproducing that state exist at all, and if so whether
+ * they are complete or only the prefix retained after replay recording reached its cap. Keeping that
+ * distinction in the type prevents an external controller from treating a plausible but incomplete
+ * action list as the history of the live position.
  */
 data class AiRuntimeSnapshot(
     val state: GameState,
@@ -27,16 +32,26 @@ data class AiRuntimeSnapshot(
  * setup plus actions alone does not necessarily reconstruct the position an AI is looking at.
  */
 sealed interface AiReplayHistory {
-    val setup: ReplaySetup
-    val actions: List<GameAction>
-    val yields: List<ReplayYieldEntry>
+    /**
+     * The session records no replay inputs at all, so the snapshot's state cannot be reached from
+     * any input stream. Injected sessions — dev scenarios, hotseat — are built this way. The live
+     * state is still authoritative and still worth reading; only its history is missing.
+     */
+    data object Unavailable : AiReplayHistory
+
+    /** Replay inputs that were recorded for this session. */
+    sealed interface Recorded : AiReplayHistory {
+        val setup: ReplaySetup
+        val actions: List<GameAction>
+        val yields: List<ReplayYieldEntry>
+    }
 
     /** These inputs reproduce the snapshot's live state. */
     data class Complete(
         override val setup: ReplaySetup,
         override val actions: List<GameAction>,
         override val yields: List<ReplayYieldEntry>,
-    ) : AiReplayHistory
+    ) : Recorded
 
     /**
      * Recording stopped before the snapshot's live state. These inputs remain an honest replay
@@ -46,7 +61,7 @@ sealed interface AiReplayHistory {
         override val setup: ReplaySetup,
         override val actions: List<GameAction>,
         override val yields: List<ReplayYieldEntry>,
-    ) : AiReplayHistory
+    ) : Recorded
 }
 
 /** Inputs supplied to an AI implementation hosted outside the game-server build. */
@@ -54,7 +69,7 @@ data class AiControllerContext(
     val playerId: EntityId,
     /** Null while a persisted or tournament AI identity is not yet attached to a game. */
     val gameSessionId: String?,
-    /** Null until the attached game has started and has reproducible replay inputs. */
+    /** Null until the attached game has started and has a live state. */
     val snapshot: () -> AiRuntimeSnapshot?,
 )
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * One lock-consistent view of the live inputs needed by a trusted server-side AI controller.
+ *
+ * The state and replay inputs must be captured together: reading them through the individual
+ * [com.wingedsheep.gameserver.session.GameSession] accessors can pair a newer state with an older
+ * action prefix while the game advances.
+ */
+data class AiRuntimeSnapshot(
+    val state: GameState,
+    val replaySetup: ReplaySetup,
+    val actions: List<GameAction>,
+)
+
+/** Inputs supplied to an AI implementation hosted outside the game-server build. */
+data class AiControllerContext(
+    val playerId: EntityId,
+    /** Null while a persisted or tournament AI identity is not yet attached to a game. */
+    val gameSessionId: String?,
+    /** Null until the attached game has started and has reproducible replay inputs. */
+    val snapshot: () -> AiRuntimeSnapshot?,
+)
+
+/**
+ * Extension point for a server-side AI implementation supplied by another build.
+ *
+ * Providers own controller policy only. Game lifecycle, callbacks, and the authoritative runtime
+ * snapshot remain game-server responsibilities.
+ */
+interface AiControllerProvider {
+    /** Case-insensitive configuration value used by `game.ai.mode`. */
+    val mode: String
+
+    fun create(context: AiControllerContext): AiPlayerController
+}
+
+/** Single authority for validating and resolving external mode names. */
+internal class AiControllerProviderRegistry(providers: List<AiControllerProvider>) {
+    private val providersByMode: Map<String, AiControllerProvider>
+
+    init {
+        val indexed = linkedMapOf<String, AiControllerProvider>()
+        for (provider in providers) {
+            val mode = normalize(provider.mode)
+            require(mode.isNotEmpty()) { "AI controller provider mode must not be blank" }
+            require(mode !in BUILT_IN_MODES) {
+                "AI controller provider mode '${provider.mode}' conflicts with a built-in mode"
+            }
+            require(indexed.put(mode, provider) == null) {
+                "Multiple AI controller providers registered for mode '${provider.mode}'"
+            }
+        }
+        providersByMode = indexed
+    }
+
+    operator fun get(mode: String): AiControllerProvider? = providersByMode[normalize(mode)]
+
+    fun supportedModes(): Set<String> = BUILT_IN_MODES + providersByMode.keys
+
+    private fun normalize(mode: String): String = mode.trim().lowercase()
+
+    private companion object {
+        val BUILT_IN_MODES = setOf("engine", "llm")
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiControllerProvider.kt
@@ -4,20 +4,50 @@ import com.wingedsheep.ai.AiPlayerController
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.gameserver.replay.ReplayYieldEntry
 import com.wingedsheep.sdk.model.EntityId
 
 /**
  * One lock-consistent view of the live inputs needed by a trusted server-side AI controller.
  *
- * The state and replay inputs must be captured together: reading them through the individual
- * [com.wingedsheep.gameserver.session.GameSession] accessors can pair a newer state with an older
- * action prefix while the game advances.
+ * [state] is always the authoritative live state. [replayHistory] says whether its compact inputs
+ * reproduce that state or are only the prefix retained after replay recording reached its cap.
+ * Keeping that distinction in the type prevents an external controller from treating a plausible
+ * but incomplete action list as the history of the live position.
  */
 data class AiRuntimeSnapshot(
     val state: GameState,
-    val replaySetup: ReplaySetup,
-    val actions: List<GameAction>,
+    val replayHistory: AiReplayHistory,
 )
+
+/**
+ * Replay inputs sampled atomically with an [AiRuntimeSnapshot]'s state.
+ *
+ * Persistent yield changes are inputs too: the engine can consume them without a [GameAction], so
+ * setup plus actions alone does not necessarily reconstruct the position an AI is looking at.
+ */
+sealed interface AiReplayHistory {
+    val setup: ReplaySetup
+    val actions: List<GameAction>
+    val yields: List<ReplayYieldEntry>
+
+    /** These inputs reproduce the snapshot's live state. */
+    data class Complete(
+        override val setup: ReplaySetup,
+        override val actions: List<GameAction>,
+        override val yields: List<ReplayYieldEntry>,
+    ) : AiReplayHistory
+
+    /**
+     * Recording stopped before the snapshot's live state. These inputs remain an honest replay
+     * prefix, but must not be used to reconstruct or explain the current state.
+     */
+    data class TruncatedPrefix(
+        override val setup: ReplaySetup,
+        override val actions: List<GameAction>,
+        override val yields: List<ReplayYieldEntry>,
+    ) : AiReplayHistory
+}
 
 /** Inputs supplied to an AI implementation hosted outside the game-server build. */
 data class AiControllerContext(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -24,9 +24,10 @@ private val logger = LoggerFactory.getLogger(AiGameManager::class.java)
 /**
  * Manages the lifecycle of AI opponents in games.
  *
- * Supports two AI modes:
+ * Supports built-in and externally supplied AI modes:
  * - **engine** (default): Built-in rules-engine AI. No API key needed. Fast, deterministic.
  * - **llm**: LLM-based AI via OpenAI-compatible API. Requires API key.
+ * - any unique mode registered by an [AiControllerProvider].
  */
 @Service
 class AiGameManager(
@@ -36,7 +37,9 @@ class AiGameManager(
     private val cardRegistry: CardRegistry,
     private val llmCostTracker: com.wingedsheep.gameserver.tournament.llm.LlmCostTracker,
     private val aiInsightService: AiInsightService,
+    controllerProviders: List<AiControllerProvider> = emptyList(),
 ) {
+    private val controllerProviders = AiControllerProviderRegistry(controllerProviders)
     /**
      * The live AI sessions of each game, keyed game → AI player. A multiplayer pod seats more than
      * one AI (an FFA table, a Two-Headed Giant team), so this is per *seat* and not per game: keyed
@@ -62,10 +65,13 @@ class AiGameManager(
         }
         if (ai.isEngineMode) {
             logger.info("AI opponent: enabled | mode=engine (built-in)")
-        } else {
+        } else if (ai.isLlmMode) {
             val provider = if (ai.baseUrl.contains("openrouter")) "OpenRouter" else "Local (${ai.baseUrl})"
             logger.info("AI opponent: enabled | mode=llm | provider={} | model={} | deckbuilding-model={}",
                 provider, ai.model, ai.effectiveDeckbuildingModel)
+        } else {
+            requireExternalProvider(ai.mode)
+            logger.info("AI opponent: enabled | mode={} (external)", ai.mode)
         }
     }
 
@@ -93,10 +99,10 @@ class AiGameManager(
 
     val isEnabled: Boolean get() {
         if (!gameProperties.ai.enabled) return false
-        // Engine mode doesn't need an API key
-        if (gameProperties.ai.isEngineMode) return true
-        // LLM mode requires an API key
-        return gameProperties.ai.effectiveApiKey.isNotBlank()
+        val ai = gameProperties.ai
+        if (ai.isEngineMode) return true
+        if (ai.isLlmMode) return ai.effectiveApiKey.isNotBlank()
+        return controllerProviders[ai.mode] != null
     }
 
     /**
@@ -126,6 +132,17 @@ class AiGameManager(
         modelOverride: String? = null
     ): AiPlayerController {
         val ai = gameProperties.ai
+        // A per-player model override explicitly requests the built-in LLM even when the
+        // server-wide mode is external.
+        if (modelOverride == null && !ai.isEngineMode && !ai.isLlmMode) {
+            return requireExternalProvider(ai.mode).create(
+                AiControllerContext(
+                    playerId = aiPlayerId,
+                    gameSessionId = gameSession?.sessionId,
+                    snapshot = { gameSession?.getAiRuntimeSnapshot() },
+                )
+            )
+        }
         // A model override implicitly requests LLM mode for this player,
         // regardless of the server's global mode setting.
         val aiConfig = ai.toAiConfig().let { cfg ->
@@ -157,6 +174,11 @@ class AiGameManager(
             LlmAiPlayerController(aiConfig, llmClient, aiPlayerId, fallback = engineFallback)
         }
     }
+
+    private fun requireExternalProvider(mode: String): AiControllerProvider =
+        requireNotNull(controllerProviders[mode]) {
+            "Unknown game.ai.mode '$mode'; expected ${controllerProviders.supportedModes().sorted().joinToString()}"
+        }
 
     private fun com.wingedsheep.gameserver.config.AiProperties.toAiConfig() = com.wingedsheep.ai.llm.AiConfig(
         enabled = enabled, mode = mode, baseUrl = baseUrl,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -124,7 +124,12 @@ class AiGameManager(
 
     /**
      * Create the appropriate AI controller based on configuration.
+     *
      * @param modelOverride If non-null, overrides the server's configured model for LLM mode.
+     *        An override needs an API key to mean anything, so the two bring-up paths that have a
+     *        caller to report to reject an uncredentialed one up front (see
+     *        [requireCredentialedOverride]); the paths that recover or re-wire an *existing* AI
+     *        drop the override instead — see [usableModelOverride].
      */
     private fun createController(
         aiPlayerId: EntityId,
@@ -132,9 +137,6 @@ class AiGameManager(
         modelOverride: String? = null
     ): AiPlayerController {
         val ai = gameProperties.ai
-        require(modelOverride == null || ai.effectiveApiKey.isNotBlank()) {
-            "A per-player LLM model override requires an API key"
-        }
         // A per-player model override explicitly requests the built-in LLM even when the
         // server-wide mode is external.
         if (modelOverride == null && !ai.isEngineMode && !ai.isLlmMode) {
@@ -182,6 +184,42 @@ class AiGameManager(
         requireNotNull(controllerProviders[mode]) {
             "Unknown game.ai.mode '$mode'; expected ${controllerProviders.supportedModes().sorted().joinToString()}"
         }
+
+    /**
+     * Reject a per-player LLM model override that no key can serve.
+     *
+     * Only for the paths that *mint* an AI ([createAiOpponent], [createAiIdentity]): there is a live
+     * caller to hand the error to, nothing exists yet to be left half-built, and silently seating a
+     * model-labelled AI that is really the engine fallback would make an LLM tournament a lie about
+     * what it compared.
+     */
+    private fun requireCredentialedOverride(modelOverride: String?) {
+        require(modelOverride == null || gameProperties.ai.effectiveApiKey.isNotBlank()) {
+            "A per-player LLM model override requires an API key"
+        }
+    }
+
+    /**
+     * The same check for the paths that adopt an AI that already exists — [rehydrateAiIdentity] on
+     * startup and [wireAiForGame] at match start — where throwing costs more than degrading.
+     *
+     * Rehydration runs inside [com.wingedsheep.gameserver.persistence.SessionRecoveryService]'s
+     * `@PostConstruct`, so an override persisted while a key was configured would fail bean
+     * initialisation and take the whole server down on the next restart after the key went away.
+     * Wiring runs after both seats have already been told the match is starting, so throwing leaves
+     * a live table whose AI never acts. Both drop the override and fall back to the server-wide
+     * mode, which is what the LLM controller's engine fallback did anyway — loudly, so the operator
+     * can see that a model-specific AI is no longer playing its model.
+     */
+    private fun usableModelOverride(modelOverride: String?, context: String): String? {
+        if (modelOverride == null || gameProperties.ai.effectiveApiKey.isNotBlank()) return modelOverride
+        logger.warn(
+            "Ignoring LLM model override '{}' while {}: no API key is configured. " +
+                "This AI falls back to game.ai.mode={}.",
+            modelOverride, context, gameProperties.ai.mode
+        )
+        return null
+    }
 
     private fun com.wingedsheep.gameserver.config.AiProperties.toAiConfig() = com.wingedsheep.ai.llm.AiConfig(
         enabled = enabled, mode = mode, baseUrl = baseUrl,
@@ -404,6 +442,7 @@ class AiGameManager(
      */
     fun createAiIdentity(modelOverride: String? = null): PlayerIdentity {
         require(isEnabled) { "AI is not enabled. Set game.ai.enabled=true." }
+        requireCredentialedOverride(modelOverride)
 
         val aiPlayerId = EntityId("ai-${UUID.randomUUID().toString().take(8)}")
         val aiProperties = gameProperties.ai
@@ -463,7 +502,11 @@ class AiGameManager(
         val aiPlayerId = identity.playerId
         val aiProperties = gameProperties.ai
 
-        val controller = createController(aiPlayerId, modelOverride = identity.aiModelOverride)
+        val modelOverride = usableModelOverride(
+            identity.aiModelOverride,
+            "rehydrating AI identity ${identity.playerName}"
+        )
+        val controller = createController(aiPlayerId, modelOverride = modelOverride)
         // Replaced when a match (or draft) wires this AI, so no callbacks and no step gate here.
         val aiSession = buildAiSession(aiPlayerId, controller, gameSession = null)
 
@@ -478,7 +521,7 @@ class AiGameManager(
         aiPlayerIds.add(aiPlayerId)
 
         logger.info("Rehydrated AI identity: {} ({}) [model={}]",
-            identity.playerName, aiPlayerId.value, identity.aiModelOverride ?: aiProperties.model)
+            identity.playerName, aiPlayerId.value, modelOverride ?: aiProperties.model)
     }
 
     /**
@@ -501,7 +544,10 @@ class AiGameManager(
         }
 
         val aiProperties = gameProperties.ai
-        val modelOverride = lookupModelOverride(aiPlayerId)
+        val modelOverride = usableModelOverride(
+            lookupModelOverride(aiPlayerId),
+            "wiring AI ${aiPlayerId.value} for game ${gameSession.sessionId}"
+        )
         val controller = createController(aiPlayerId, gameSession, modelOverride)
 
         // Give the AI knowledge of its deck composition

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -132,6 +132,9 @@ class AiGameManager(
         modelOverride: String? = null
     ): AiPlayerController {
         val ai = gameProperties.ai
+        require(modelOverride == null || ai.effectiveApiKey.isNotBlank()) {
+            "A per-player LLM model override requires an API key"
+        }
         // A per-player model override explicitly requests the built-in LLM even when the
         // server-wide mode is external.
         if (modelOverride == null && !ai.isEngineMode && !ai.isLlmMode) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -62,7 +62,7 @@ data class AdminProperties(
 
 data class AiProperties(
     val enabled: Boolean = false,
-    /** AI mode: "engine" (built-in rules engine AI, default) or "llm" (LLM-based AI via API). */
+    /** AI mode: a built-in mode (`engine` or `llm`) or a registered external provider mode. */
     val mode: String = "engine",
     val baseUrl: String = "https://openrouter.ai/api/v1",
     val apiKey: String = "",
@@ -98,6 +98,6 @@ data class AiProperties(
     /** Whether we're using the built-in engine AI (no API key required). */
     val isEngineMode: Boolean get() = mode.equals("engine", ignoreCase = true)
 
-    /** Whether we're using the LLM-based AI. */
-    val isLlmMode: Boolean get() = !isEngineMode
+    /** Whether we're using the built-in LLM-based AI. */
+    val isLlmMode: Boolean get() = mode.equals("llm", ignoreCase = true)
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -6,11 +6,12 @@ import com.wingedsheep.engine.view.ClientGameState
 import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.view.StateDiffCalculator
 import com.wingedsheep.engine.view.LegalActionEnricher
+import com.wingedsheep.gameserver.ai.AiReplayHistory
+import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.gameserver.protocol.GameOverReason
 import com.wingedsheep.engine.view.LegalActionInfo
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.priority.AutoPassManager
-import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
@@ -1509,7 +1510,7 @@ class GameSession(
         identity: com.wingedsheep.sdk.scripting.AbilityIdentity?,
         kind: com.wingedsheep.engine.state.YieldKind?,
     ) {
-        if (replaySetup == null) return
+        if (replaySetup == null || replayTruncated) return
         recordedYields.add(
             com.wingedsheep.gameserver.replay.ReplayYieldEntry(
                 afterActionCount = recordedActions.size,
@@ -1531,16 +1532,25 @@ class GameSession(
     fun getRecordedActions(): List<GameAction> = recordedActions.toList()
 
     /**
-     * Capture the current authoritative state and its reproducible action prefix under one lock.
+     * Capture the current authoritative state and its replay history under one lock.
      *
-     * External controllers use this instead of composing the three public accessors independently;
-     * that composition can observe different game instants. Null means the session has not started
-     * with replay inputs (for example an injected development scenario).
+     * External controllers use this instead of composing the public accessors independently; that
+     * composition can observe different game instants. A recording that reached its cap is exposed
+     * as a typed prefix rather than being mistaken for inputs that reproduce the live state. Null
+     * means the session has not started with replay inputs (for example an injected development
+     * scenario).
      */
     fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? = synchronized(stateLock) {
         val state = gameState ?: return null
         val setup = replaySetup ?: return null
-        AiRuntimeSnapshot(state, setup, recordedActions.toList())
+        val actions = recordedActions.toList()
+        val yields = recordedYields.toList()
+        val history = if (replayTruncated) {
+            AiReplayHistory.TruncatedPrefix(setup, actions, yields)
+        } else {
+            AiReplayHistory.Complete(setup, actions, yields)
+        }
+        AiRuntimeSnapshot(state, history)
     }
 
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.gameserver.protocol.GameOverReason
 import com.wingedsheep.engine.view.LegalActionInfo
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.priority.AutoPassManager
+import com.wingedsheep.gameserver.ai.AiRuntimeSnapshot
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
@@ -1528,6 +1529,19 @@ class GameSession(
 
     /** The ordered input stream applied to this game. */
     fun getRecordedActions(): List<GameAction> = recordedActions.toList()
+
+    /**
+     * Capture the current authoritative state and its reproducible action prefix under one lock.
+     *
+     * External controllers use this instead of composing the three public accessors independently;
+     * that composition can observe different game instants. Null means the session has not started
+     * with replay inputs (for example an injected development scenario).
+     */
+    fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? = synchronized(stateLock) {
+        val state = gameState ?: return null
+        val setup = replaySetup ?: return null
+        AiRuntimeSnapshot(state, setup, recordedActions.toList())
+    }
 
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */
     fun getReplayYields(): List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = recordedYields.toList()

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -1536,21 +1536,19 @@ class GameSession(
      *
      * External controllers use this instead of composing the public accessors independently; that
      * composition can observe different game instants. A recording that reached its cap is exposed
-     * as a typed prefix rather than being mistaken for inputs that reproduce the live state. Null
-     * means the session has not started with replay inputs (for example an injected development
-     * scenario).
+     * as a typed prefix rather than being mistaken for inputs that reproduce the live state, and a
+     * session that records nothing at all still hands back its live state — the history is what is
+     * missing there, not the position. Null only before [startGame].
      */
-    fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? = synchronized(stateLock) {
-        val state = gameState ?: return null
-        val setup = replaySetup ?: return null
-        val actions = recordedActions.toList()
-        val yields = recordedYields.toList()
-        val history = if (replayTruncated) {
-            AiReplayHistory.TruncatedPrefix(setup, actions, yields)
-        } else {
-            AiReplayHistory.Complete(setup, actions, yields)
+    fun getAiRuntimeSnapshot(): AiRuntimeSnapshot? {
+        val sample = sampleUnderLock() ?: return null
+        val setup = sample.setup
+        val history = when {
+            setup == null -> AiReplayHistory.Unavailable
+            sample.truncated -> AiReplayHistory.TruncatedPrefix(setup, sample.actions, sample.yields)
+            else -> AiReplayHistory.Complete(setup, sample.actions, sample.yields)
         }
-        AiRuntimeSnapshot(state, history)
+        return AiRuntimeSnapshot(sample.state, history)
     }
 
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */
@@ -1592,22 +1590,56 @@ class GameSession(
      * fingerprint it stores describe the *same* position — see
      * [com.wingedsheep.gameserver.replay.ReplayRecordingSnapshot] for why sampling them separately
      * is unsound. Null for sessions that aren't being recorded, or aren't started yet.
+     *
+     * The fingerprint is computed outside the lock: [LockedSample.state] is an immutable snapshot,
+     * so hashing it later gives the same answer, and hashing a whole position is long enough that
+     * holding the game's lock for it would stall play.
      */
-    internal fun replayRecordingSnapshot(): com.wingedsheep.gameserver.replay.ReplayRecordingSnapshot? =
-        synchronized(stateLock) {
-            val setup = replaySetup ?: return null
-            val state = gameState ?: return null
-            com.wingedsheep.gameserver.replay.ReplayRecordingSnapshot(
-                setup = setup,
-                actions = recordedActions.toList(),
-                yields = recordedYields.toList(),
-                checkpoints = recordedCheckpoints.toList(),
-                fingerprint = com.wingedsheep.gameserver.replay.ReplayFingerprint.of(state),
-                startedAt = replayStartedAt,
-                gameOver = state.gameOver,
-                truncated = replayTruncated,
-            )
-        }
+    internal fun replayRecordingSnapshot(): com.wingedsheep.gameserver.replay.ReplayRecordingSnapshot? {
+        val sample = sampleUnderLock() ?: return null
+        val setup = sample.setup ?: return null
+        return com.wingedsheep.gameserver.replay.ReplayRecordingSnapshot(
+            setup = setup,
+            actions = sample.actions,
+            yields = sample.yields,
+            checkpoints = sample.checkpoints,
+            fingerprint = com.wingedsheep.gameserver.replay.ReplayFingerprint.of(sample.state),
+            startedAt = sample.startedAt,
+            gameOver = sample.state.gameOver,
+            truncated = sample.truncated,
+        )
+    }
+
+    /**
+     * Everything sampled under [stateLock] in one read: the live state plus the whole replay
+     * recording. [replayRecordingSnapshot] and [getAiRuntimeSnapshot] both derive from this rather
+     * than repeating the lock-and-copy, so a field added to the recording cannot reach one caller
+     * and silently miss the other. [setup] is null for injected sessions (dev scenarios, hotseat),
+     * which have a live state but no reproducible inputs.
+     */
+    private class LockedSample(
+        val state: GameState,
+        val setup: com.wingedsheep.gameserver.replay.ReplaySetup?,
+        val actions: List<GameAction>,
+        val yields: List<com.wingedsheep.gameserver.replay.ReplayYieldEntry>,
+        val checkpoints: List<com.wingedsheep.gameserver.replay.ReplayCheckpoint>,
+        val truncated: Boolean,
+        val startedAt: Instant?,
+    )
+
+    /** Null before [startGame]; see [LockedSample]. */
+    private fun sampleUnderLock(): LockedSample? = synchronized(stateLock) {
+        val state = gameState ?: return null
+        LockedSample(
+            state = state,
+            setup = replaySetup,
+            actions = recordedActions.toList(),
+            yields = recordedYields.toList(),
+            checkpoints = recordedCheckpoints.toList(),
+            truncated = replayTruncated,
+            startedAt = replayStartedAt,
+        )
+    }
 
     /**
      * Total number of replay frames: the initial state plus one per recorded action. Zero until the

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -113,7 +113,9 @@ game:
     password: ${GAME_ADMIN_PASSWORD:}
   ai:
     enabled: ${GAME_AI_ENABLED:true}
-    # AI mode: "engine" (built-in, no API key needed) or "llm" (requires API key)
+    # AI mode: "engine" (built-in, no API key needed), "llm" (requires API key), or the mode
+    # of a registered AiControllerProvider. Anything else fails startup rather than silently
+    # disabling the AI.
     mode: ${GAME_AI_MODE:engine}
     base-url: ${GAME_AI_BASE_URL:https://openrouter.ai/api/v1}
     api-key: ${GAME_AI_API_KEY:${OPENROUTER_API_KEY:}}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.gameserver.config.AiProperties
 import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.gameserver.replay.ReplaySetup
 import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.PlayerIdentity
 import com.wingedsheep.gameserver.session.SessionRegistry
 import com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
 import com.wingedsheep.sdk.model.EntityId
@@ -69,8 +70,11 @@ class AiControllerProviderTest : FunSpec({
     test("a game-attached external controller receives the session's consistent runtime snapshot") {
         val expected = AiRuntimeSnapshot(
             state = mockk<GameState>(),
-            replaySetup = mockk<ReplaySetup>(),
-            actions = emptyList(),
+            replayHistory = AiReplayHistory.Complete(
+                setup = mockk<ReplaySetup>(),
+                actions = emptyList(),
+                yields = emptyList(),
+            ),
         )
         val game = mockk<GameSession>(relaxed = true) {
             every { sessionId } returns "game-1"
@@ -97,14 +101,96 @@ class AiControllerProviderTest : FunSpec({
         provider.controller.lastDeck shouldBe mapOf("Mountain" to 40)
         sessions.destroy()
     }
+
+    test("a model override cannot bypass the LLM credential gate when creating an identity") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+
+        shouldThrow<IllegalArgumentException> {
+            manager.createAiIdentity(modelOverride = "openai/test-model")
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
+
+    test("a credentialed model override deliberately selects the built-in LLM") {
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(
+            provider,
+            sessions,
+            aiProperties = AiProperties(
+                enabled = true,
+                mode = provider.mode,
+                apiKey = "test-key",
+            ),
+        )
+
+        val identity = manager.createAiIdentity(modelOverride = "openai/test-model")
+
+        identity.aiModelOverride shouldBe "openai/test-model"
+        provider.contexts shouldBe emptyList()
+        sessions.destroy()
+    }
+
+    test("a restored model override cannot bypass the LLM credential gate") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+        val identity = PlayerIdentity(
+            token = "restored-ai",
+            playerId = EntityId.of("restored-ai"),
+            playerName = "Restored AI",
+            isAi = true,
+            aiModelOverride = "openai/test-model",
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            manager.rehydrateAiIdentity(identity)
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
+
+    test("a model override cannot bypass the LLM credential gate when wiring a game") {
+        val provider = StubProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions)
+        val aiPlayerId = EntityId.of("match-ai")
+        sessions.preRegisterIdentity(
+            PlayerIdentity(
+                token = "match-ai",
+                playerId = aiPlayerId,
+                playerName = "Match AI",
+                isAi = true,
+                aiModelOverride = "openai/test-model",
+            )
+        )
+        val game = mockk<GameSession>(relaxed = true) {
+            every { sessionId } returns "game-credential-gate"
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            manager.wireAiForGame(
+                gameSession = game,
+                aiPlayerId = aiPlayerId,
+                deckList = null,
+                onActionReady = { _, _ -> },
+                onMulliganKeep = { _ -> },
+                onMulliganTake = { _ -> },
+                onBottomCards = { _, _ -> },
+            )
+        }.message shouldBe "A per-player LLM model override requires an API key"
+        sessions.destroy()
+    }
 })
 
 private fun manager(
     provider: AiControllerProvider,
     sessions: SessionRegistry,
     deckGenerator: SealedDeckGenerator = mockk(relaxed = true),
+    aiProperties: AiProperties = AiProperties(enabled = true, mode = provider.mode),
 ): AiGameManager {
-    val properties = GameProperties(ai = AiProperties(enabled = true, mode = provider.mode))
+    val properties = GameProperties(ai = aiProperties)
     return AiGameManager(
         gameProperties = properties,
         sessionRegistry = sessions,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -133,8 +133,13 @@ class AiControllerProviderTest : FunSpec({
         sessions.destroy()
     }
 
-    test("a restored model override cannot bypass the LLM credential gate") {
-        val provider = StubProvider("search-teacher")
+    // Recovery and match-wiring adopt an AI that already exists, so an override they cannot serve
+    // is dropped rather than thrown: rehydration runs in SessionRecoveryService's @PostConstruct
+    // (a throw fails bean init and the server never starts), and wiring runs after both seats have
+    // been told the match is starting (a throw leaves a live table whose AI never acts).
+
+    test("an uncredentialed restored model override is dropped instead of failing recovery") {
+        val provider = CapturingProvider("search-teacher")
         val sessions = SessionRegistry()
         val manager = manager(provider, sessions)
         val identity = PlayerIdentity(
@@ -145,14 +150,18 @@ class AiControllerProviderTest : FunSpec({
             aiModelOverride = "openai/test-model",
         )
 
-        shouldThrow<IllegalArgumentException> {
-            manager.rehydrateAiIdentity(identity)
-        }.message shouldBe "A per-player LLM model override requires an API key"
+        manager.rehydrateAiIdentity(identity)
+
+        // Falls back to the server-wide mode, which here is the external provider.
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().playerId shouldBe EntityId.of("restored-ai")
+        // The override stays on the identity, so a restart with the key back honours it again.
+        identity.aiModelOverride shouldBe "openai/test-model"
         sessions.destroy()
     }
 
-    test("a model override cannot bypass the LLM credential gate when wiring a game") {
-        val provider = StubProvider("search-teacher")
+    test("an uncredentialed model override is dropped instead of failing match wiring") {
+        val provider = CapturingProvider("search-teacher")
         val sessions = SessionRegistry()
         val manager = manager(provider, sessions)
         val aiPlayerId = EntityId.of("match-ai")
@@ -169,17 +178,31 @@ class AiControllerProviderTest : FunSpec({
             every { sessionId } returns "game-credential-gate"
         }
 
-        shouldThrow<IllegalArgumentException> {
-            manager.wireAiForGame(
-                gameSession = game,
-                aiPlayerId = aiPlayerId,
-                deckList = null,
-                onActionReady = { _, _ -> },
-                onMulliganKeep = { _ -> },
-                onMulliganTake = { _ -> },
-                onBottomCards = { _, _ -> },
-            )
-        }.message shouldBe "A per-player LLM model override requires an API key"
+        manager.wireAiForGame(
+            gameSession = game,
+            aiPlayerId = aiPlayerId,
+            deckList = null,
+            onActionReady = { _, _ -> },
+            onMulliganKeep = { _ -> },
+            onMulliganTake = { _ -> },
+            onBottomCards = { _, _ -> },
+        )
+
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().gameSessionId shouldBe "game-credential-gate"
+        sessions.destroy()
+    }
+
+    test("an unregistered mode fails at startup rather than silently disabling the AI") {
+        val sessions = SessionRegistry()
+        val manager = manager(
+            StubProvider("search-teacher"),
+            sessions,
+            aiProperties = AiProperties(enabled = true, mode = "typo-teacher"),
+        )
+
+        shouldThrow<IllegalArgumentException> { manager.logConfig() }
+            .message shouldBe "Unknown game.ai.mode 'typo-teacher'; expected engine, llm, search-teacher"
         sessions.destroy()
     }
 })

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiControllerProviderTest.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.ActionResponse
+import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.llm.BottomCardsInfo
+import com.wingedsheep.ai.llm.CardSummary
+import com.wingedsheep.ai.llm.MulliganInfo
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.view.ClientGameState
+import com.wingedsheep.engine.view.LegalActionInfo
+import com.wingedsheep.gameserver.config.AiProperties
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.replay.ReplaySetup
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.SessionRegistry
+import com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class AiControllerProviderTest : FunSpec({
+    test("provider modes are resolved case-insensitively after trimming") {
+        val provider = StubProvider(" Search-Teacher ")
+        val registry = AiControllerProviderRegistry(listOf(provider))
+
+        registry["search-teacher"] shouldBe provider
+        registry["SEARCH-TEACHER"] shouldBe provider
+        registry.supportedModes() shouldBe setOf("engine", "llm", "search-teacher")
+    }
+
+    test("blank provider modes fail during registry construction") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("  ")))
+        }
+    }
+
+    test("providers cannot replace built-in modes") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("LLM")))
+        }
+    }
+
+    test("duplicate provider modes fail instead of depending on bean order") {
+        shouldThrow<IllegalArgumentException> {
+            AiControllerProviderRegistry(listOf(StubProvider("custom"), StubProvider("CUSTOM")))
+        }
+    }
+
+    test("an external mode is usable without an LLM key and receives honest placeholder context") {
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions = sessions)
+
+        manager.isEnabled shouldBe true
+        manager.createAiIdentity()
+
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().gameSessionId shouldBe null
+        provider.contexts.single().snapshot() shouldBe null
+        sessions.destroy()
+    }
+
+    test("a game-attached external controller receives the session's consistent runtime snapshot") {
+        val expected = AiRuntimeSnapshot(
+            state = mockk<GameState>(),
+            replaySetup = mockk<ReplaySetup>(),
+            actions = emptyList(),
+        )
+        val game = mockk<GameSession>(relaxed = true) {
+            every { sessionId } returns "game-1"
+            every { getAiRuntimeSnapshot() } returns expected
+        }
+        val deckGenerator = mockk<SealedDeckGenerator> {
+            every { generate() } returns mapOf("Mountain" to 40)
+        }
+        val provider = CapturingProvider("search-teacher")
+        val sessions = SessionRegistry()
+        val manager = manager(provider, sessions, deckGenerator)
+
+        manager.createAiOpponent(
+            gameSession = game,
+            onActionReady = { _, _ -> },
+            onMulliganKeep = { _ -> },
+            onMulliganTake = { _ -> },
+            onBottomCards = { _, _ -> },
+        )
+
+        provider.contexts.size shouldBe 1
+        provider.contexts.single().gameSessionId shouldBe "game-1"
+        provider.contexts.single().snapshot() shouldBe expected
+        provider.controller.lastDeck shouldBe mapOf("Mountain" to 40)
+        sessions.destroy()
+    }
+})
+
+private fun manager(
+    provider: AiControllerProvider,
+    sessions: SessionRegistry,
+    deckGenerator: SealedDeckGenerator = mockk(relaxed = true),
+): AiGameManager {
+    val properties = GameProperties(ai = AiProperties(enabled = true, mode = provider.mode))
+    return AiGameManager(
+        gameProperties = properties,
+        sessionRegistry = sessions,
+        deckGenerator = deckGenerator,
+        cardRegistry = mockk<CardRegistry>(relaxed = true),
+        llmCostTracker = LlmCostTracker(),
+        aiInsightService = AiInsightService(GameProperties()),
+        controllerProviders = listOf(provider),
+    )
+}
+
+private class StubProvider(override val mode: String) : AiControllerProvider {
+    override fun create(context: AiControllerContext): AiPlayerController = StubController
+}
+
+private class CapturingProvider(override val mode: String) : AiControllerProvider {
+    val contexts = mutableListOf<AiControllerContext>()
+    val controller = RecordingController()
+
+    override fun create(context: AiControllerContext): AiPlayerController {
+        contexts += context
+        return controller
+    }
+}
+
+private data object StubController : AiPlayerController {
+    override fun chooseAction(
+        state: ClientGameState,
+        legalActions: List<LegalActionInfo>,
+        pendingDecision: PendingDecision?,
+        recentGameLog: List<String>,
+    ): ActionResponse = error("not used")
+
+    override fun decideMulligan(mulliganMessage: MulliganInfo): Boolean = error("not used")
+    override fun chooseBottomCards(message: BottomCardsInfo): List<EntityId> = error("not used")
+    override fun setDeckList(deckList: Map<String, Int>, archetype: String?) = Unit
+    override fun chooseDraftPick(
+        pack: List<CardSummary>,
+        pickedSoFar: List<CardSummary>,
+        packNumber: Int,
+        pickNumber: Int,
+        picksRequired: Int,
+        passDirection: String,
+    ): List<String> = error("not used")
+
+    override fun chooseWinstonAction(
+        pileCards: List<CardSummary>,
+        pileIndex: Int,
+        pileSizes: List<Int>,
+        pickedSoFar: List<CardSummary>,
+    ): Boolean = error("not used")
+
+    override fun chooseGridDraftPick(
+        grid: List<CardSummary?>,
+        availableSelections: List<String>,
+        pickedSoFar: List<CardSummary>,
+    ): String = error("not used")
+}
+
+private class RecordingController : AiPlayerController by StubController {
+    var lastDeck: Map<String, Int>? = null
+
+    override fun setDeckList(deckList: Map<String, Int>, archetype: String?) {
+        lastDeck = deckList
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/AiRuntimeSnapshotTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/AiRuntimeSnapshotTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.ai.AiReplayHistory
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * [GameSession.getAiRuntimeSnapshot] against the two session shapes that differ in what they can
+ * offer an AI: a recorded game, and an injected one that records nothing.
+ *
+ * The distinction that matters is that "no replay inputs" is not "no position". A dev-scenario or
+ * hotseat session has a perfectly good live state and no way to reach it from an input stream, and
+ * a controller reading that session should get the state and be told the history is missing —
+ * withholding both is what the [AiReplayHistory.Unavailable] case exists to prevent.
+ */
+class AiRuntimeSnapshotTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    private fun recordedGame(): GameSession {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+        val p1 = com.wingedsheep.sdk.model.EntityId.of("snap-p1")
+        val p2 = com.wingedsheep.sdk.model.EntityId.of("snap-p2")
+        session.addPlayer(PlayerSession(mockWs("snap-ws1"), p1, "Alice"), mapOf("Forest" to 40))
+        session.addPlayer(PlayerSession(mockWs("snap-ws2"), p2, "Bob"), mapOf("Forest" to 40))
+        session.startGame()
+        return session
+    }
+
+    init {
+        test("a session that has not started offers no snapshot at all") {
+            val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+
+            session.getAiRuntimeSnapshot().shouldBeNull()
+        }
+
+        test("a recorded game reports its state with a complete history") {
+            val session = recordedGame()
+
+            val snapshot = session.getAiRuntimeSnapshot().shouldNotBeNull()
+            snapshot.state shouldBe session.getStateSnapshot()
+            val history = snapshot.replayHistory.shouldBeInstanceOf<AiReplayHistory.Complete>()
+            history.setup shouldBe session.getReplaySetup()
+            history.actions shouldBe session.getRecordedActions()
+            history.yields shouldBe session.getReplayYields()
+        }
+
+        test("an injected session still reports its live state, with the history typed as missing") {
+            val injected = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+            injected.injectStateForDevScenario(recordedGame().getStateSnapshot()!!)
+
+            val snapshot = injected.getAiRuntimeSnapshot().shouldNotBeNull()
+            snapshot.state shouldBe injected.getStateSnapshot()
+            snapshot.replayHistory shouldBe AiReplayHistory.Unavailable
+            // The flush path still declines it — an unrecorded session has nothing to store.
+            injected.replayRecordingSnapshot().shouldBeNull()
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
@@ -1,10 +1,16 @@
 package com.wingedsheep.gameserver.session
 
+import com.wingedsheep.engine.state.YieldKind
 import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.ai.AiReplayHistory
 import com.wingedsheep.gameserver.protocol.GameOverReason
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.web.socket.WebSocketSession
@@ -62,6 +68,19 @@ class GameSessionBackstopTest : ScenarioTestBase() {
 
             // And the flush snapshot carries the flag, so the stored row stops claiming to be whole.
             session.replayRecordingSnapshot().shouldNotBeNull().truncated shouldBe true
+
+            // The AI API must make the same distinction structurally. Yield recording freezes with
+            // the action prefix; otherwise the purported prefix could contain mutations from later
+            // in the live game.
+            val yieldCountAtTruncation = session.getReplayYields().size
+            session.setAbilityYield(
+                EntityId.of("backstop-p1"),
+                AbilityIdentity("Test#1", AbilityId("ability_after_truncation")),
+                YieldKind.ALWAYS_ANSWER_YES,
+            )
+            session.getReplayYields().size shouldBe yieldCountAtTruncation
+            session.getAiRuntimeSnapshot().shouldNotBeNull().replayHistory
+                .shouldBeInstanceOf<AiReplayHistory.TruncatedPrefix>()
         }
 
         test("a game that stops making progress is ended as a draw that explains itself") {
@@ -85,8 +104,18 @@ class GameSessionBackstopTest : ScenarioTestBase() {
 
             session.autoPass(40)
 
+            session.setAbilityYield(
+                EntityId.of("backstop-p1"),
+                AbilityIdentity("Test#1", AbilityId("ability_in_complete_history")),
+                YieldKind.ALWAYS_ANSWER_YES,
+            )
+
             session.stallMessage() shouldBe null
             session.isReplayTruncated() shouldBe false
+            val history = session.getAiRuntimeSnapshot().shouldNotBeNull().replayHistory
+                .shouldBeInstanceOf<AiReplayHistory.Complete>()
+            history.actions shouldBe session.getRecordedActions()
+            history.yields shouldBe session.getReplayYields()
         }
     }
 }


### PR DESCRIPTION
Supersedes #2213 — it carries that PR's two commits plus the fixes from reviewing it, so it can merge to `main` on its own. #2213 can be closed if this lands.

## What #2213 does

The game server could construct only its built-in `engine` and `llm` controllers. `AiControllerProvider` lets another build register a case-insensitive mode and create a controller from an `AiControllerContext` carrying the controlled player id, the game-session id, and a lazy `AiRuntimeSnapshot` sampled under the session state lock. `AiReplayHistory` keeps "these inputs reproduce the live state" and "this is only the prefix retained after recording hit its cap" apart in the type, so an external controller cannot mistake one for the other.

It also fixes a pre-existing replay bug that stands on its own: `recordYield` now freezes with the action log. Before, a yield set after the log was capped was appended with `afterActionCount` at the frozen tail, so reconstruction re-applied a late-game yield at an early position and produced a game nobody played. The live yield still applies — only the recording stops.

## What this PR changes on top

**An unusable model override degrades instead of throwing.** #2213 rejected an uncredentialed per-player LLM model override on all four bring-up paths. Two of them adopt an AI that already exists:

- `rehydrateAiIdentity` runs inside `SessionRecoveryService`'s `@PostConstruct`, so an override persisted while a key was configured fails bean initialisation and the server never starts. Deploying #2213 is itself a way to reach that — AI tournaments created before it accepted a model override with no key (`LobbyHandler:271`/`343`), and those identities are still in Redis.
- `wireAiForGame` runs after both seats have been sent `TournamentMatchStarting` and is uncaught at `TournamentMatchHandler:655`, `FreeForAllHandler:227` and `GamePlayHandler:399`/`1215`, so a throw leaves a live table whose AI never acts.

Both now drop the override, log why, and fall back to the server-wide mode — what the LLM controller's engine fallback did anyway. The override stays on the identity, so a restart with the key back honours it again. `createAiOpponent` and `createAiIdentity` keep the hard failure: a caller is there to see it, and seating a model-labelled AI that is really the engine fallback would make an LLM tournament a lie about what it compared.

**One under-lock sample.** `getAiRuntimeSnapshot` had re-implemented `replayRecordingSnapshot`'s lock-and-copy of the same six fields, alongside a doc comment making the same "sampling them separately is unsound" argument. Both now derive from a private `sampleUnderLock`. The fingerprint moves outside the lock, which is equivalent on an immutable state and stops a whole-position hash from stalling play.

**A session with no replay setup keeps its live state.** "No replay inputs" is not "no position": a dev-scenario or hotseat game has a good state and no way to reach it from an input stream. `AiReplayHistory.Unavailable` says that, rather than the snapshot returning null and withholding the state too. `Complete`/`TruncatedPrefix` move under a `Recorded` sub-interface so `setup` stays reachable after one check.

**Smaller ones.** `AiConfig.isLlmMode` is dropped — unused, and after #2213 redefined the `AiProperties` twin as `mode == "llm"` the two same-named properties disagreed for an external mode. `AiRuntimeSnapshot`'s KDoc now says the state is unmasked (strictly more than the `ClientGameState` a controller sees at decision time), which is what "trusted" is carrying. README and `application.yml` document the third mode shape and that an unrecognised mode now fails startup.

## Verification

`just test-server` green on `d73ee58c44`: 74 suites, including the `@SpringBootTest` ones — which is what proves the Kotlin-default `List<AiControllerProvider>` injection resolves with zero provider beans, the one wiring risk the hand-built unit tests can't reach.

- `AiControllerProviderTest` — 11 (was 10; the two credential-gate tests now assert the degrade, plus a new one for the boot failure on an unregistered mode)
- `AiRuntimeSnapshotTest` — 3 (new: unstarted, recorded, injected)
- `GameSessionBackstopTest` — 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2UzRGK1m1pHgC9ZV2Crxk
