### PR TITLE
Materialize hidden worlds around typed in-flight references (review pass)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -20,10 +20,16 @@ import com.wingedsheep.sdk.model.GameRng
  * valid. Cards carrying runtime components are pinned because changing their definition could make
  * those components nonsensical.
  */
-class Determinizer(
+class Determinizer private constructor(
     private val cardRegistry: CardRegistry,
-    private val visibility: Visibility = Visibility(cardRegistry),
+    private val visibility: Visibility,
+    private val inFlightPinAnalysis: (GameState) -> HiddenSlotRewrite.IdentitySensitiveInFlightPins,
 ) {
+    constructor(
+        cardRegistry: CardRegistry,
+        visibility: Visibility = Visibility(cardRegistry),
+    ) : this(cardRegistry, visibility, HiddenSlotRewrite::identitySensitiveInFlightPins)
+
     /** Pure per-position entry point used by the Strategist before it simulates any candidate. */
     fun sampleForSearch(
         state: GameState,
@@ -106,15 +112,16 @@ class Determinizer(
         val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
         val library = state.getLibrary(opponentId)
         val candidates = library + state.getHand(opponentId)
-        val referencedByStack = HiddenSlotRewrite.stackReferencedEntities(state)
+        val inFlightPins = when (val pins = inFlightPinAnalysis(state)) {
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins.entityIds
+            // An incomplete traversal cannot justify sampling any hidden identity. HWM rejects the
+            // corresponding all-or-nothing request; sampling instead keeps every candidate slot.
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> return emptyList()
+        }
         return candidates.filter { id ->
             val zoneKey = if (id in library) libraryKey else handKey
             !visibility.isCardIdentityVisibleTo(state, zoneKey, id, viewerId) &&
-                id !in referencedByStack &&
-                // Continuation frames carry entity references in several different shapes.
-                // Quiet search roots normally have none; pinning while one exists is the safe
-                // fallback until those shapes share a common reference visitor.
-                state.continuationStack.isEmpty() &&
+                id !in inFlightPins &&
                 isSafeToRewrite(state, id)
         }
     }
@@ -156,5 +163,14 @@ class Determinizer(
         if (pool.size < hidden.size) return emptyList<CardDefinition>() to rng
         val (shuffled, next) = rng.shuffle(pool)
         return shuffled.take(hidden.size) to next
+    }
+
+    companion object {
+        /** Test-only seam: inject the shared final analysis, never reference traversal rules. */
+        internal fun withInFlightPinAnalysis(
+            cardRegistry: CardRegistry,
+            visibility: Visibility,
+            inFlightPinAnalysis: (GameState) -> HiddenSlotRewrite.IdentitySensitiveInFlightPins,
+        ): Determinizer = Determinizer(cardRegistry, visibility, inFlightPinAnalysis)
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -19,10 +19,19 @@ import com.wingedsheep.sdk.model.GameRng
  * ordering are sampled, which keeps continuations, targets and pending decisions structurally
  * valid. Cards carrying runtime components are pinned because changing their definition could make
  * those components nonsensical.
+ *
+ * Pinning is a coherence guarantee, not an information one, and the two pull in opposite
+ * directions: a slot pinned because in-flight execution references it keeps its **real** identity
+ * in the sampled world even when that identity is hidden from [viewerId]. That is accepted because
+ * the alternative is a world whose paused decision or continuation points at a card that was never
+ * there. It stays sound for search because the Strategist determinizes at roots where the AI holds
+ * priority, so a paused root is one the AI itself must answer — the referenced slots are its own.
+ * A caller that determinizes at someone else's pause would be handing its search the truth.
  */
-class Determinizer private constructor(
+class Determinizer internal constructor(
     private val cardRegistry: CardRegistry,
     private val visibility: Visibility,
+    /** Test-only seam: inject the shared final analysis, never reference traversal rules. */
     private val inFlightPinAnalysis: (GameState) -> HiddenSlotRewrite.IdentitySensitiveInFlightPins,
 ) {
     constructor(
@@ -163,14 +172,5 @@ class Determinizer private constructor(
         if (pool.size < hidden.size) return emptyList<CardDefinition>() to rng
         val (shuffled, next) = rng.shuffle(pool)
         return shuffled.take(hidden.size) to next
-    }
-
-    companion object {
-        /** Test-only seam: inject the shared final analysis, never reference traversal rules. */
-        internal fun withInFlightPinAnalysis(
-            cardRegistry: CardRegistry,
-            visibility: Visibility,
-            inFlightPinAnalysis: (GameState) -> HiddenSlotRewrite.IdentitySensitiveInFlightPins,
-        ): Determinizer = Determinizer(cardRegistry, visibility, inFlightPinAnalysis)
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -1,13 +1,22 @@
 package com.wingedsheep.ai.engine.hidden
 
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.hidden.HiddenSlotRewrite
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 class DeterminizerInvariantsTest : ScenarioTestBase() {
 
@@ -139,6 +148,131 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
 
             sampled.getLibrary(game.player2Id).first() shouldBe topId
             sampled.getEntity(topId)!!.require<CardComponent>() shouldBe topCard
+        }
+
+        test("a Mind Rot pause pins referenced hidden hand slots while unrelated library slots remain sampleable") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Mind Rot")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInHand(2, "Craw Wurm")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .build()
+            game.castSpellTargetingPlayer(1, "Mind Rot", 2).error shouldBe null
+            game.resolveStack()
+
+            val source = game.state
+            val decision = source.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            val referencedHandId = decision.options.first()
+            val referencedHandCard = source.getEntity(referencedHandId)!!.require<CardComponent>()
+            val unrelatedLibraryId = source.getLibrary(game.player2Id).first()
+            val originalLibraryCard = source.getEntity(unrelatedLibraryId)!!.require<CardComponent>()
+            val determinizer = Determinizer(cardRegistry)
+
+            val sampled = (1L..32L).map { seed ->
+                determinizer.sample(
+                    source,
+                    game.player1Id,
+                    OpponentModel.IdentityPermutation,
+                    GameRng.seeded(seed),
+                )
+            }
+
+            sampled.forEach {
+                it.getEntity(referencedHandId)!!.require<CardComponent>() shouldBe referencedHandCard
+            }
+            sampled.any {
+                it.getEntity(unrelatedLibraryId)!!.require<CardComponent>() != originalLibraryCard
+            } shouldBe true
+        }
+
+        test("a live Monstrous Emergence keeps its chosen hidden hand card fixed while other slots sample") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(2, "Monstrous Emergence")
+                .withCardInHand(2, "Craw Wurm")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .withLandsOnBattlefield(2, "Forest", 2)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+            val spellId = game.state.getHand(game.player2Id).first { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Monstrous Emergence"
+            }
+            val chosenHandId = game.state.getHand(game.player2Id).first { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Craw Wurm"
+            }
+            val targetId = game.findPermanent("Grizzly Bears")!!
+
+            game.execute(
+                CastSpell(
+                    game.player2Id,
+                    spellId,
+                    listOf(ChosenTarget.Permanent(targetId)),
+                    additionalCostPayment = AdditionalCostPayment(beheldCards = listOf(chosenHandId)),
+                ),
+            ).error shouldBe null
+            val source = game.state
+            val chosenHandCard = source.getEntity(chosenHandId)!!.require<CardComponent>()
+            val unrelatedLibraryId = source.getLibrary(game.player2Id).first()
+            val originalLibraryCard = source.getEntity(unrelatedLibraryId)!!.require<CardComponent>()
+
+            val sampled = (1L..32L).map { seed ->
+                Determinizer(cardRegistry).sample(
+                    source,
+                    game.player1Id,
+                    OpponentModel.IdentityPermutation,
+                    GameRng.seeded(seed),
+                )
+            }
+
+            sampled.forEach {
+                it.getEntity(chosenHandId)!!.require<CardComponent>() shouldBe chosenHandCard
+            }
+            sampled.any {
+                it.getEntity(unrelatedLibraryId)!!.require<CardComponent>() != originalLibraryCard
+            } shouldBe true
+        }
+
+        test("an incomplete shared pin analysis leaves every hidden candidate identity unchanged") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .build()
+            val source = game.state
+            val candidateIds = source.getHand(game.player2Id) + source.getLibrary(game.player2Id)
+            val candidateIdentities = candidateIds.associateWith {
+                source.getEntity(it)!!.require<CardComponent>()
+            }
+            val determinizer = Determinizer.withInFlightPinAnalysis(
+                cardRegistry,
+                Visibility(cardRegistry),
+            ) {
+                HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete(listOf("forced for test"))
+            }
+
+            val sampled = determinizer.sample(
+                source,
+                game.player1Id,
+                OpponentModel.IdentityPermutation,
+                GameRng.seeded(913L),
+            )
+
+            candidateIdentities.forEach { (entityId, identity) ->
+                sampled.getEntity(entityId)!!.require<CardComponent>() shouldBe identity
+            }
+            sampled shouldBe source
         }
 
         test("the viewer does not retain knowledge of their own library order") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -255,11 +255,8 @@ class DeterminizerInvariantsTest : ScenarioTestBase() {
             val candidateIdentities = candidateIds.associateWith {
                 source.getEntity(it)!!.require<CardComponent>()
             }
-            val determinizer = Determinizer.withInFlightPinAnalysis(
-                cardRegistry,
-                Visibility(cardRegistry),
-            ) {
-                HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete(listOf("forced for test"))
+            val determinizer = Determinizer(cardRegistry, Visibility(cardRegistry)) {
+                HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete("forced for test")
             }
 
             val sampled = determinizer.sample(

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -179,9 +179,21 @@ budget.
 
 The mechanics of a swap — which slots are safe, which are pinned by the conservative typed-`EntityId`
 projection of every live stack object, pending decision, and continuation frame, how the rebuild is
-applied — live in `HiddenSlotRewrite` in `rules-engine`, not here. Its whole-state pin projection
+applied — live in `HiddenSlotRewrite` in `rules-engine`, not here. Its in-flight pin projection
 fails closed: an incomplete in-flight graph pins every candidate hidden slot. `Determinizer` keeps
-the policy: it decides *which* slots are hidden from the viewer and *what* to put in them. The other
+the policy: it decides *which* slots are hidden from the viewer and *what* to put in them.
+
+Pinning buys coherence at the cost of information separation, and it is worth being explicit about
+which way that trades. A slot pinned because in-flight execution references it keeps its **real**
+identity in the sampled world even when the viewer is not allowed to know it — the alternative is a
+world whose paused decision points at a card that was never there. That stays sound because the
+Strategist determinizes at roots where the AI holds priority, so a paused root is one the AI itself
+must answer and the referenced slots are its own. It is still strictly less leaky than pinning every
+candidate whenever a continuation frame exists, which is what the projection replaced. A future
+caller that determinizes at *another* seat's pause would be handing its search the truth, and needs
+a policy of its own rather than this default.
+
+The other
 caller of that primitive is `HiddenWorldMaterializer`, for callers that already own an assignment:
 it takes an explicit `EntityId → CardDefinition` map plus a caller-selected RNG for future simulated
 events, and refuses the whole request rather than pinning what it cannot install. Neither accepts a

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -177,8 +177,10 @@ Phase 8 starts with one shared determinization per search. More worlds compete d
 count, so raising K requires an arena result showing it buys more strength at the same wall-clock
 budget.
 
-The mechanics of a swap — which slots are safe, which are pinned by a stack target, how the
-rebuild is applied — live in `HiddenSlotRewrite` in `rules-engine`, not here. `Determinizer` keeps
+The mechanics of a swap — which slots are safe, which are pinned by the conservative typed-`EntityId`
+projection of every live stack object, pending decision, and continuation frame, how the rebuild is
+applied — live in `HiddenSlotRewrite` in `rules-engine`, not here. Its whole-state pin projection
+fails closed: an incomplete in-flight graph pins every candidate hidden slot. `Determinizer` keeps
 the policy: it decides *which* slots are hidden from the viewer and *what* to put in them. The other
 caller of that primitive is `HiddenWorldMaterializer`, for callers that already own an assignment:
 it takes an explicit `EntityId → CardDefinition` map plus a caller-selected RNG for future simulated

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -475,8 +475,10 @@ reference pointing at it — that is what `HiddenSlotRewrite` (`rules-engine/hid
 lets the AI reason about hypothetical opponent hands. It derives the safe set from what
 `CardEntityFactory` would build for the card currently there, so a slot carrying anything else —
 last-known battlefield information, a reveal someone has been shown — is refused rather than
-transplanted. `HiddenWorldMaterializer` is the all-or-nothing caller (`docs/ai/architecture.md`
-covers the sampling one).
+transplanted. Its one whole-state in-flight-pin answer is the conservative superset of every typed
+`EntityId` in live stack objects, pending decisions, and continuation frames; an incomplete in-flight
+graph traversal pins all candidates. `HiddenWorldMaterializer` is the all-or-nothing caller
+(`docs/ai/architecture.md` covers the sampling one).
 
 ### 2.3 Rule 613: Base State vs. Projected State
 

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -475,10 +475,14 @@ reference pointing at it — that is what `HiddenSlotRewrite` (`rules-engine/hid
 lets the AI reason about hypothetical opponent hands. It derives the safe set from what
 `CardEntityFactory` would build for the card currently there, so a slot carrying anything else —
 last-known battlefield information, a reveal someone has been shown — is refused rather than
-transplanted. Its one whole-state in-flight-pin answer is the conservative superset of every typed
-`EntityId` in live stack objects, pending decisions, and continuation frames; an incomplete in-flight
-graph traversal pins all candidates. `HiddenWorldMaterializer` is the all-or-nothing caller
-(`docs/ai/architecture.md` covers the sampling one).
+transplanted. Its one in-flight-pin answer is the conservative superset of every typed `EntityId` in
+live stack objects, pending decisions, and continuation frames; an incomplete in-flight graph
+traversal pins all candidates. Those three carriers are the whole scope: `GameState` also holds
+lists that name a hand or library entity outside any in-flight execution — `grantedKeywordAbilities`,
+`mayPlayPermissions`, `lastCardDrawnThisTurnByPlayer` — and rewriting such a slot still leaves that
+entry pointing at a different card. Closing that means extending the analysis, not assuming it
+already covers them. `HiddenWorldMaterializer` is the all-or-nothing caller (`docs/ai/architecture.md`
+covers the sampling one).
 
 ### 2.3 Rule 613: Base State vs. Projected State
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.encoding.Encoder
+
+@OptIn(ExperimentalSerializationApi::class)
+private val entityIdSerialName = EntityId.serializer().descriptor.serialName
+
+/** Internal seam for testing consumers' fail-closed response to projection errors. */
+internal interface InFlightReferenceProjector {
+    fun project(stackObject: ComponentContainer): InFlightEntityReferences.Projection
+    fun project(decision: PendingDecision): InFlightEntityReferences.Projection
+    fun project(frame: ContinuationFrame): InFlightEntityReferences.Projection
+}
+
+/**
+ * Typed entity-reference projection for persisted in-flight engine execution.
+ *
+ * Live stack objects, pending decisions, and continuation frames are serializable graphs. Rather
+ * than maintaining a second hand-written visitor over their many concrete shapes, this projection
+ * walks their normal persistence serializers. It sees an [EntityId] only at its typed inline
+ * serializer boundary, so a plain [String] which happens to equal an entity id is never mistaken
+ * for a reference. Serialization also traverses collection values and map keys, which catches
+ * nested `List`s and `Map<EntityId, ...>` shapes.
+ *
+ * This projection is complete only while persisted in-flight engine state is fully represented by
+ * its normal serializers and [EntityId] keeps its normal typed inline serializer. The registration
+ * hygiene test makes a missing sealed leaf observable, but registration alone is not proof that
+ * every stored field is serializable. Any serialization failure therefore reports
+ * [InFlightEntityReferences.Projection.Incomplete], and callers must fail closed rather than
+ * treating an incomplete projection as empty.
+ */
+internal object InFlightEntityReferences : InFlightReferenceProjector {
+
+    sealed interface Projection {
+        data class Complete(val entityIds: Set<EntityId>) : Projection
+
+        /** The graph could not be exhaustively traversed, so its references are unknown. */
+        data class Incomplete(
+            val rootType: String,
+            val failure: String,
+        ) : Projection
+    }
+
+    override fun project(stackObject: ComponentContainer): Projection =
+        project(ComponentContainer.serializer(), stackObject)
+
+    override fun project(decision: PendingDecision): Projection =
+        project(PolymorphicSerializer(PendingDecision::class), decision)
+
+    override fun project(frame: ContinuationFrame): Projection =
+        project(PolymorphicSerializer(ContinuationFrame::class), frame)
+
+    private fun <T : Any> project(
+        serializer: SerializationStrategy<T>,
+        value: T,
+    ): Projection {
+        val references = linkedSetOf<EntityId>()
+        return try {
+            serializer.serialize(EntityReferenceEncoder(references), value)
+            Projection.Complete(references)
+        } catch (failure: Exception) {
+            Projection.Incomplete(
+                rootType = value.javaClass.name,
+                failure = failure.javaClass.name,
+            )
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private class EntityReferenceEncoder(
+        private val references: MutableSet<EntityId>,
+        private val expectsEntityId: Boolean = false,
+    ) : AbstractEncoder() {
+        override val serializersModule = engineSerializersModule
+
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+            check(!expectsEntityId) {
+                "EntityId serializer changed to a structured form; projection must be updated"
+            }
+            return this
+        }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        override fun encodeInline(descriptor: SerialDescriptor): Encoder =
+            EntityReferenceEncoder(
+                references = references,
+                expectsEntityId = descriptor.serialName == entityIdSerialName,
+            )
+
+        override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
+
+        override fun encodeString(value: String) {
+            if (expectsEntityId) references += EntityId.of(value)
+        }
+
+        override fun encodeBoolean(value: Boolean) = rejectNonStringEntityId()
+        override fun encodeByte(value: Byte) = rejectNonStringEntityId()
+        override fun encodeChar(value: Char) = rejectNonStringEntityId()
+        override fun encodeDouble(value: Double) = rejectNonStringEntityId()
+        override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = rejectNonStringEntityId()
+        override fun encodeFloat(value: Float) = rejectNonStringEntityId()
+        override fun encodeInt(value: Int) = rejectNonStringEntityId()
+        override fun encodeLong(value: Long) = rejectNonStringEntityId()
+        override fun encodeShort(value: Short) = rejectNonStringEntityId()
+        override fun encodeNull() = rejectNonStringEntityId()
+
+        private fun rejectNonStringEntityId() {
+            check(!expectsEntityId) {
+                "EntityId serializer changed to a non-string form; projection must be updated"
+            }
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.engine.core
 
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerializationStrategy
@@ -12,6 +14,9 @@ import kotlinx.serialization.encoding.Encoder
 
 @OptIn(ExperimentalSerializationApi::class)
 private val entityIdSerialName = EntityId.serializer().descriptor.serialName
+
+@OptIn(ExperimentalSerializationApi::class)
+private val characteristicValueSerialName = CharacteristicValue.serializer().descriptor.serialName
 
 /** Internal seam for testing consumers' fail-closed response to projection errors. */
 internal interface InFlightReferenceProjector {
@@ -96,6 +101,35 @@ internal object InFlightEntityReferences : InFlightReferenceProjector {
             )
 
         override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
+
+        /**
+         * [CharacteristicValue] deliberately serializes through JSON. Traverse the sealed value
+         * directly so ordinary card components do not make an otherwise exhaustive in-flight
+         * projection fail. Fixed values contain no references; dynamic values keep their typed
+         * [DynamicAmount] graph. A new CharacteristicValue case makes this `when` fail to compile,
+         * while any other unsupported serializer still reaches the outer fail-closed result.
+         */
+        override fun <T> encodeSerializableValue(
+            serializer: SerializationStrategy<T>,
+            value: T,
+        ) {
+            if (serializer.descriptor.serialName == characteristicValueSerialName) {
+                check(!expectsEntityId)
+                when (val characteristic = value as CharacteristicValue) {
+                    is CharacteristicValue.Fixed -> Unit
+                    is CharacteristicValue.Dynamic -> DynamicAmount.serializer().serialize(
+                        EntityReferenceEncoder(references),
+                        characteristic.source,
+                    )
+                    is CharacteristicValue.DynamicWithOffset -> DynamicAmount.serializer().serialize(
+                        EntityReferenceEncoder(references),
+                        characteristic.source,
+                    )
+                }
+                return
+            }
+            super.encodeSerializableValue(serializer, value)
+        }
 
         override fun encodeString(value: String) {
             if (expectsEntityId) references += EntityId.of(value)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -1,12 +1,12 @@
 package com.wingedsheep.engine.hidden
 
 import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.core.InFlightEntityReferences
+import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.stack.ChosenTarget
-import com.wingedsheep.engine.state.components.stack.TargetsComponent
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
 
@@ -14,14 +14,77 @@ import com.wingedsheep.sdk.model.EntityId
  * Swapping the card identity occupying a hidden zone slot, without disturbing anything else.
  *
  * Both hidden-information callers need the same three answers — is this slot safe to rewrite,
- * which slots are pinned by in-flight stack references, and how is the rewrite applied — while
- * differing entirely in *policy*: [com.wingedsheep.engine.hidden.HiddenWorldMaterializer] installs
- * a caller-supplied assignment and refuses anything it cannot install, whereas the AI's
+ * which slots are conservatively pinned by in-flight execution, and how is the rewrite applied —
+ * while differing entirely in *policy*: [com.wingedsheep.engine.hidden.HiddenWorldMaterializer]
+ * installs a caller-supplied assignment and refuses anything it cannot install, whereas the AI's
  * `Determinizer` samples an assignment from a visibility model and silently pins whatever it
  * cannot rewrite. Keeping the mechanics here means those two policies cannot drift into two
  * different notions of "safe".
  */
 object HiddenSlotRewrite {
+
+    /**
+     * The complete state-level answer to which hidden slots cannot have their identities replaced
+     * while execution is in flight.
+     *
+     * Live stack objects, pending decisions, and continuation frames contribute every typed
+     * [EntityId] their serializable graphs contain. That is a conservative superset, because not
+     * every typed occurrence intrinsically depends on a card's current identity. Callers that apply
+     * different policies (rejecting an explicit assignment or silently pinning a sampled slot) must
+     * consume this one answer rather than independently approximating only part of the state.
+     */
+    sealed interface IdentitySensitiveInFlightPins {
+        data class Complete(val entityIds: Set<EntityId>) : IdentitySensitiveInFlightPins
+
+        /** The graph is incomplete; no candidate may be rewritten, so callers reject or pin by policy. */
+        data class Incomplete(val details: List<String>) : IdentitySensitiveInFlightPins
+    }
+
+    fun identitySensitiveInFlightPins(state: GameState): IdentitySensitiveInFlightPins =
+        identitySensitiveInFlightPins(state, InFlightEntityReferences)
+
+    /** Test-only seam for consumers that need to prove their fail-closed policy. */
+    internal fun identitySensitiveInFlightPins(
+        state: GameState,
+        inFlightReferenceProjector: InFlightReferenceProjector,
+    ): IdentitySensitiveInFlightPins {
+        val referenced = mutableSetOf<EntityId>()
+        state.stack.forEachIndexed { index, stackId ->
+            val stackObject = state.getEntity(stackId)
+                ?: return IdentitySensitiveInFlightPins.Incomplete(
+                    listOf("could not traverse stack[$index] $stackId: missing entity"),
+                )
+            when (val projection = inFlightReferenceProjector.project(stackObject)) {
+                is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
+                is InFlightEntityReferences.Projection.Incomplete -> {
+                    return IdentitySensitiveInFlightPins.Incomplete(
+                        listOf("could not traverse stack[$index] ${projection.rootType}: ${projection.failure}"),
+                    )
+                }
+            }
+        }
+        state.pendingDecision?.let { decision ->
+            when (val projection = inFlightReferenceProjector.project(decision)) {
+                is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
+                is InFlightEntityReferences.Projection.Incomplete -> {
+                    return IdentitySensitiveInFlightPins.Incomplete(
+                        listOf("could not traverse pending decision ${projection.rootType}: ${projection.failure}"),
+                    )
+                }
+            }
+        }
+        state.continuationStack.forEachIndexed { index, frame ->
+            when (val projection = inFlightReferenceProjector.project(frame)) {
+                is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
+                is InFlightEntityReferences.Projection.Incomplete -> {
+                    return IdentitySensitiveInFlightPins.Incomplete(
+                        listOf("could not traverse continuation[$index] ${projection.rootType}: ${projection.failure}"),
+                    )
+                }
+            }
+        }
+        return IdentitySensitiveInFlightPins.Complete(referenced)
+    }
 
     /**
      * The components on [container] that block rewriting the slot to a different card identity,
@@ -56,27 +119,6 @@ object HiddenSlotRewrite {
             .map { component -> component::class.simpleName ?: component::class.java.name }
             .sorted()
     }
-
-    /**
-     * Every entity id a stack object's chosen targets point at.
-     *
-     * A stack object records the object it targets, so rewriting that object's identity underneath
-     * it produces a spell aimed at a card that was never there. Targets are the one in-flight
-     * reference shape with a uniform representation ([TargetsComponent]); continuation frames and
-     * pending decisions carry entity references in per-effect shapes with no common visitor, so
-     * callers gate on those wholesale rather than per slot.
-     */
-    fun stackReferencedEntities(state: GameState): Set<EntityId> =
-        state.stack.flatMapTo(mutableSetOf()) { stackId ->
-            state.getEntity(stackId)?.get<TargetsComponent>()?.targets.orEmpty().mapNotNull {
-                when (it) {
-                    is ChosenTarget.Card -> it.cardId
-                    is ChosenTarget.Permanent -> it.entityId
-                    is ChosenTarget.Spell -> it.spellEntityId
-                    is ChosenTarget.Player -> null
-                }
-            }
-        }
 
     /**
      * Rebuild [entityId] as [definition], keeping the slot itself intact.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewrite.kt
@@ -24,20 +24,35 @@ import com.wingedsheep.sdk.model.EntityId
 object HiddenSlotRewrite {
 
     /**
-     * The complete state-level answer to which hidden slots cannot have their identities replaced
-     * while execution is in flight.
+     * The one answer to which hidden slots cannot have their identities replaced while execution
+     * is *in flight* — that is, while [GameState.stack], [GameState.pendingDecision], or
+     * [GameState.continuationStack] holds work the engine has started and not finished.
      *
-     * Live stack objects, pending decisions, and continuation frames contribute every typed
-     * [EntityId] their serializable graphs contain. That is a conservative superset, because not
-     * every typed occurrence intrinsically depends on a card's current identity. Callers that apply
-     * different policies (rejecting an explicit assignment or silently pinning a sampled slot) must
-     * consume this one answer rather than independently approximating only part of the state.
+     * Those three carriers contribute every typed [EntityId] their serializable graphs contain.
+     * That is a conservative superset *of them*, because not every typed occurrence intrinsically
+     * depends on a card's current identity. Callers that apply different policies (rejecting an
+     * explicit assignment or silently pinning a sampled slot) must consume this one answer rather
+     * than independently approximating only part of in-flight execution.
+     *
+     * It is deliberately not a whole-[GameState] answer. `GameState` also carries lists that name
+     * hand or library entities outside any in-flight execution — `grantedKeywordAbilities` (a cast
+     * keyword granted to a card in hand), `mayPlayPermissions`, `lastCardDrawnThisTurnByPlayer` —
+     * and none of those is read here or visible to [runtimeBlockers], which only inspects the
+     * entity's own container. Rewriting such a slot leaves the grant pointing at a different card.
+     * That gap predates this projection; closing it means extending this analysis, not assuming it
+     * already covers them. Transient bookkeeping like `pendingSacrificeIds` and
+     * `pendingDiscardCauseControllers` is correctly out of scope: both live and die inside a single
+     * zone move, so no pause can observe them.
      */
     sealed interface IdentitySensitiveInFlightPins {
         data class Complete(val entityIds: Set<EntityId>) : IdentitySensitiveInFlightPins
 
-        /** The graph is incomplete; no candidate may be rewritten, so callers reject or pin by policy. */
-        data class Incomplete(val details: List<String>) : IdentitySensitiveInFlightPins
+        /**
+         * The graph is incomplete; no candidate may be rewritten, so callers reject or pin by
+         * policy. There is exactly one [reason] because the analysis returns on its first failure:
+         * an incomplete traversal is already fatal, so enumerating the rest buys nothing.
+         */
+        data class Incomplete(val reason: String) : IdentitySensitiveInFlightPins
     }
 
     fun identitySensitiveInFlightPins(state: GameState): IdentitySensitiveInFlightPins =
@@ -52,13 +67,13 @@ object HiddenSlotRewrite {
         state.stack.forEachIndexed { index, stackId ->
             val stackObject = state.getEntity(stackId)
                 ?: return IdentitySensitiveInFlightPins.Incomplete(
-                    listOf("could not traverse stack[$index] $stackId: missing entity"),
+                    "could not traverse stack[$index] $stackId: missing entity",
                 )
             when (val projection = inFlightReferenceProjector.project(stackObject)) {
                 is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
                 is InFlightEntityReferences.Projection.Incomplete -> {
                     return IdentitySensitiveInFlightPins.Incomplete(
-                        listOf("could not traverse stack[$index] ${projection.rootType}: ${projection.failure}"),
+                        "could not traverse stack[$index] ${projection.rootType}: ${projection.failure}",
                     )
                 }
             }
@@ -68,7 +83,7 @@ object HiddenSlotRewrite {
                 is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
                 is InFlightEntityReferences.Projection.Incomplete -> {
                     return IdentitySensitiveInFlightPins.Incomplete(
-                        listOf("could not traverse pending decision ${projection.rootType}: ${projection.failure}"),
+                        "could not traverse pending decision ${projection.rootType}: ${projection.failure}",
                     )
                 }
             }
@@ -78,7 +93,7 @@ object HiddenSlotRewrite {
                 is InFlightEntityReferences.Projection.Complete -> referenced += projection.entityIds
                 is InFlightEntityReferences.Projection.Incomplete -> {
                     return IdentitySensitiveInFlightPins.Incomplete(
-                        listOf("could not traverse continuation[$index] ${projection.rootType}: ${projection.failure}"),
+                        "could not traverse continuation[$index] ${projection.rootType}: ${projection.failure}",
                     )
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -85,23 +85,12 @@ sealed interface HiddenWorldMaterializationResult {
  * pause consume the caller's future stream. If the typed in-flight graph cannot be traversed
  * completely, the whole request is refused before either identities or randomness change.
  */
-class HiddenWorldMaterializer {
-    private val cardRegistry: CardRegistry
-    private val inFlightReferenceProjector: InFlightReferenceProjector
-
-    constructor(cardRegistry: CardRegistry) {
-        this.cardRegistry = cardRegistry
-        inFlightReferenceProjector = InFlightEntityReferences
-    }
-
+class HiddenWorldMaterializer internal constructor(
+    private val cardRegistry: CardRegistry,
     /** Test-only seam for proving that an incomplete paused-state projection fails closed. */
-    internal constructor(
-        cardRegistry: CardRegistry,
-        inFlightReferenceProjector: InFlightReferenceProjector,
-    ) {
-        this.cardRegistry = cardRegistry
-        this.inFlightReferenceProjector = inFlightReferenceProjector
-    }
+    private val inFlightReferenceProjector: InFlightReferenceProjector,
+) {
+    constructor(cardRegistry: CardRegistry) : this(cardRegistry, InFlightEntityReferences)
 
     /**
      * A request is answered as a whole: either every named slot is installed, or nothing is and the
@@ -120,7 +109,7 @@ class HiddenWorldMaterializer {
             is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> {
                 return unsupported(
                     UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES,
-                    details = pins.details,
+                    details = listOf(pins.reason),
                 )
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -80,6 +80,10 @@ sealed interface HiddenWorldMaterializationResult {
  * Consequently a hypothetical world never inherits the source state's authoritative future random
  * stream unless the caller explicitly asks for that exact generator. Search callers that require
  * information separation must derive this generator from caller-owned randomness, not [GameState.rng].
+ * A paused decision does not change that contract: choices and random results already represented
+ * in the decision or continuation remain fixed, while random operations that execute only after the
+ * pause consume the caller's future stream. If the typed in-flight graph cannot be traversed
+ * completely, the whole request is refused before either identities or randomness change.
  */
 class HiddenWorldMaterializer {
     private val cardRegistry: CardRegistry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializer.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.hidden
 
 import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.core.InFlightEntityReferences
+import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -30,7 +32,7 @@ enum class UnsupportedHiddenWorldKind {
     /** The request names a missing entity, an unknown source definition, or a non-hand/library slot. */
     INVALID_ASSIGNMENT,
 
-    /** A stack target, pending decision, or continuation frame depends on the identity being replaced. */
+    /** A stack target or conservative paused-execution pin blocks identity replacement. */
     IN_FLIGHT_REFERENCES,
 
     /** The hidden object carries state beyond its printed-definition-derived components. */
@@ -79,9 +81,24 @@ sealed interface HiddenWorldMaterializationResult {
  * stream unless the caller explicitly asks for that exact generator. Search callers that require
  * information separation must derive this generator from caller-owned randomness, not [GameState.rng].
  */
-class HiddenWorldMaterializer(
-    private val cardRegistry: CardRegistry,
-) {
+class HiddenWorldMaterializer {
+    private val cardRegistry: CardRegistry
+    private val inFlightReferenceProjector: InFlightReferenceProjector
+
+    constructor(cardRegistry: CardRegistry) {
+        this.cardRegistry = cardRegistry
+        inFlightReferenceProjector = InFlightEntityReferences
+    }
+
+    /** Test-only seam for proving that an incomplete paused-state projection fails closed. */
+    internal constructor(
+        cardRegistry: CardRegistry,
+        inFlightReferenceProjector: InFlightReferenceProjector,
+    ) {
+        this.cardRegistry = cardRegistry
+        this.inFlightReferenceProjector = inFlightReferenceProjector
+    }
+
     /**
      * A request is answered as a whole: either every named slot is installed, or nothing is and the
      * first obstruction is reported. Partial worlds are not a useful answer to "is this hypothesis
@@ -92,12 +109,17 @@ class HiddenWorldMaterializer(
         state: GameState,
         request: HiddenWorldMaterializationRequest,
     ): HiddenWorldMaterializationResult {
-        // Gated whether or not the request names slots: an empty assignment still installs
-        // `futureRng`, and rewriting the future random stream of a state that is mid-decision is
-        // the same hazard as rewriting a card in it.
-        unsupportedInFlightState(state)?.let { return it }
-
-        val stackReferenced = HiddenSlotRewrite.stackReferencedEntities(state)
+        val inFlightPins = when (
+            val pins = HiddenSlotRewrite.identitySensitiveInFlightPins(state, inFlightReferenceProjector)
+        ) {
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete -> pins
+            is HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete -> {
+                return unsupported(
+                    UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES,
+                    details = pins.details,
+                )
+            }
+        }
         var materialized = state
 
         // Slots are independent, so the order only decides *which* obstruction is reported when a
@@ -109,11 +131,11 @@ class HiddenWorldMaterializer(
                     entityId,
                     listOf("entity does not exist"),
                 )
-            if (entityId in stackReferenced) {
+            if (entityId in inFlightPins.entityIds) {
                 return unsupported(
                     UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES,
                     entityId,
-                    listOf("slot is the chosen target of a stack object"),
+                    listOf("slot is conservatively pinned by in-flight execution"),
                 )
             }
             val zones = state.zones.filterValues { entityId in it }
@@ -190,22 +212,6 @@ class HiddenWorldMaterializer(
         return HiddenWorldMaterializationResult.Materialized(
             materialized.copy(rng = request.futureRng)
         )
-    }
-
-    /**
-     * Continuation frames and pending decisions carry entity references in per-effect shapes with
-     * no common visitor, so neither can be audited slot by slot the way stack targets can. Both are
-     * therefore whole-state refusals: a search root taken at a quiet priority point has neither.
-     */
-    private fun unsupportedInFlightState(state: GameState): HiddenWorldMaterializationResult.Unsupported? {
-        val details = buildList {
-            state.pendingDecision?.let { add(it::class.simpleName ?: "PendingDecision") }
-            if (state.continuationStack.isNotEmpty()) {
-                add("continuationDepth=${state.continuationStack.size}")
-            }
-        }
-        if (details.isEmpty()) return null
-        return unsupported(UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES, details = details)
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/InFlightEntityReferencesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/InFlightEntityReferencesTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.core.spec.style.FunSpec
+
+class InFlightEntityReferencesTest : FunSpec({
+
+    test("projection follows typed references in a serializable live stack component") {
+        val casterId = EntityId.of("caster")
+        val handCardId = EntityId.of("chosen-hand-card")
+        val stackObject = ComponentContainer.of(
+            SpellOnStackComponent(
+                casterId = casterId,
+                beheldCards = listOf(handCardId),
+            ),
+        )
+
+        InFlightEntityReferences.project(stackObject)
+            .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
+            .entityIds shouldBe setOf(casterId, handCardId)
+    }
+
+    test("projection follows typed nullable nested and map-key entity references only") {
+        val playerId = EntityId.of("player")
+        val mapKeyId = EntityId.of("map-key")
+        val nestedId = EntityId.of("nested")
+        val nullableId = EntityId.of("nullable")
+        val stringOnlyId = EntityId.of("looks-like-an-id")
+
+        val decision = DistributeDecision(
+            id = "decision",
+            playerId = playerId,
+            prompt = stringOnlyId.value,
+            context = DecisionContext(
+                sourceId = nullableId,
+                sourceName = stringOnlyId.value,
+                triggeringEntityId = null,
+            ),
+            totalAmount = 1,
+            targets = listOf(nestedId),
+            maxPerTarget = mapOf(mapKeyId to 1),
+        )
+        val continuation = SelectFromCollectionContinuation(
+            decisionId = "continuation",
+            playerId = playerId,
+            sourceId = nullableId,
+            sourceName = stringOnlyId.value,
+            allCards = emptyList(),
+            storeSelected = "selected",
+            storeRemainder = null,
+            storedCollections = mapOf(stringOnlyId.value to listOf(nestedId)),
+        )
+
+        InFlightEntityReferences.project(decision)
+            .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
+            .entityIds shouldBe setOf(playerId, nullableId, nestedId, mapKeyId)
+        InFlightEntityReferences.project(continuation)
+            .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
+            .entityIds shouldBe setOf(playerId, nullableId, nestedId)
+        InFlightEntityReferences.project(continuation.copy(sourceId = null))
+            .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
+            .entityIds shouldBe setOf(playerId, nestedId)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/InFlightEntityReferencesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/InFlightEntityReferencesTest.kt
@@ -1,7 +1,11 @@
 package com.wingedsheep.engine.core
 
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -22,6 +26,24 @@ class InFlightEntityReferencesTest : FunSpec({
         InFlightEntityReferences.project(stackObject)
             .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
             .entityIds shouldBe setOf(casterId, handCardId)
+    }
+
+    test("projection crosses entity-free JSON-only characteristic values on creature stack objects") {
+        val ownerId = EntityId.of("owner")
+        val stackObject = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = "creature",
+                name = "Creature",
+                manaCost = ManaCost(emptyList()),
+                typeLine = TypeLine.creature(),
+                baseStats = CreatureStats(2, 2),
+                ownerId = ownerId,
+            ),
+        )
+
+        InFlightEntityReferences.project(stackObject)
+            .shouldBeInstanceOf<InFlightEntityReferences.Projection.Complete>()
+            .entityIds shouldBe setOf(ownerId)
     }
 
     test("projection follows typed nullable nested and map-key entity references only") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
@@ -1,8 +1,10 @@
 package com.wingedsheep.engine.hidden
 
+import com.wingedsheep.engine.core.ContinuationFrame
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
+import com.wingedsheep.engine.core.PendingDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.support.ScenarioTestBase
@@ -10,6 +12,7 @@ import com.wingedsheep.sdk.model.EntityId
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class HiddenSlotRewriteTest : ScenarioTestBase() {
@@ -41,7 +44,37 @@ class HiddenSlotRewriteTest : ScenarioTestBase() {
             pins.entityIds shouldNotContain libraryId
         }
 
-        test("an incomplete paused projection is the shared whole-state answer") {
+        // The library axis of the same rule Mind Rot covers for hands. This is the case main
+        // refused wholesale: any continuation frame at all pinned every candidate slot.
+        test("a Preordain scry pins the library slot it offers but not one buried below it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Preordain")
+                .withCardOnBattlefield(1, "Island")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .build()
+            game.castSpell(1, "Preordain").error shouldBe null
+            game.resolveStack()
+
+            // Preordain scries before it draws, so the engine is parked on a decision naming the
+            // top of the library with the rest of the resolution held in a continuation frame.
+            val source = game.state
+            source.pendingDecision shouldNotBe null
+            source.continuationStack.isNotEmpty() shouldBe true
+            val library = source.getLibrary(game.player1Id)
+
+            val pins = HiddenSlotRewrite.identitySensitiveInFlightPins(source)
+                .shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete>()
+
+            pins.entityIds shouldContain library.first()
+            pins.entityIds shouldNotContain library.last()
+        }
+
+        test("an incomplete paused projection is the shared in-flight answer") {
             val game = scenario().withPlayers().build()
             val state = game.state.copy(
                 pendingDecision = SelectCardsDecision(
@@ -55,20 +88,9 @@ class HiddenSlotRewriteTest : ScenarioTestBase() {
                 ),
             )
 
-            HiddenSlotRewrite.identitySensitiveInFlightPins(
-                state,
-                object : InFlightReferenceProjector {
-                    override fun project(stackObject: ComponentContainer) =
-                        InFlightEntityReferences.Projection.Complete(emptySet())
-
-                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
-                        InFlightEntityReferences.Projection.Incomplete("test", "forced")
-
-                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
-                        InFlightEntityReferences.Projection.Complete(emptySet())
-                },
-            ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
-                .details shouldBe listOf("could not traverse pending decision test: forced")
+            HiddenSlotRewrite.identitySensitiveInFlightPins(state, projectorFailingOn(Root.DECISION))
+                .shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
+                .reason shouldBe "could not traverse pending decision test: forced"
         }
 
         test("a missing or untraversable stack object makes the shared pin answer incomplete") {
@@ -78,27 +100,30 @@ class HiddenSlotRewriteTest : ScenarioTestBase() {
             HiddenSlotRewrite.identitySensitiveInFlightPins(
                 game.state.copy(stack = listOf(missingStackId)),
             ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
-                .details shouldBe listOf("could not traverse stack[0] missing-stack-object: missing entity")
+                .reason shouldBe "could not traverse stack[0] missing-stack-object: missing entity"
 
             val stackId = EntityId.of("untraversable-stack-object")
             val withStack = game.state.copy(
                 entities = game.state.entities + (stackId to ComponentContainer.EMPTY),
                 stack = listOf(stackId),
             )
-            HiddenSlotRewrite.identitySensitiveInFlightPins(
-                withStack,
-                object : InFlightReferenceProjector {
-                    override fun project(stackObject: ComponentContainer) =
-                        InFlightEntityReferences.Projection.Incomplete("test", "forced")
-
-                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
-                        InFlightEntityReferences.Projection.Complete(emptySet())
-
-                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
-                        InFlightEntityReferences.Projection.Complete(emptySet())
-                },
-            ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
-                .details shouldBe listOf("could not traverse stack[0] test: forced")
+            HiddenSlotRewrite.identitySensitiveInFlightPins(withStack, projectorFailingOn(Root.STACK))
+                .shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
+                .reason shouldBe "could not traverse stack[0] test: forced"
         }
+    }
+
+    private enum class Root { STACK, DECISION }
+
+    /** A projector that traverses everything but [failing], which reports an incomplete graph. */
+    private fun projectorFailingOn(failing: Root) = object : InFlightReferenceProjector {
+        override fun project(stackObject: ComponentContainer) = projection(Root.STACK)
+        override fun project(decision: PendingDecision) = projection(Root.DECISION)
+        override fun project(frame: ContinuationFrame) =
+            InFlightEntityReferences.Projection.Complete(emptySet())
+
+        private fun projection(root: Root) =
+            if (root == failing) InFlightEntityReferences.Projection.Incomplete("test", "forced")
+            else InFlightEntityReferences.Projection.Complete(emptySet())
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenSlotRewriteTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.hidden
+
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.InFlightEntityReferences
+import com.wingedsheep.engine.core.InFlightReferenceProjector
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class HiddenSlotRewriteTest : ScenarioTestBase() {
+
+    init {
+        test("a Mind Rot paused graph pins its discard options but not an unrelated library slot") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Mind Rot")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInHand(2, "Craw Wurm")
+                .withCardInLibrary(2, "Forest")
+                .build()
+            game.castSpellTargetingPlayer(1, "Mind Rot", 2).error shouldBe null
+            game.resolveStack()
+
+            val source = game.state
+            val decision = source.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            val libraryId = source.getLibrary(game.player2Id).single()
+
+            val pins = HiddenSlotRewrite.identitySensitiveInFlightPins(source)
+                .shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Complete>()
+
+            decision.options.forEach { pins.entityIds shouldContain it }
+            pins.entityIds shouldNotContain libraryId
+        }
+
+        test("an incomplete paused projection is the shared whole-state answer") {
+            val game = scenario().withPlayers().build()
+            val state = game.state.copy(
+                pendingDecision = SelectCardsDecision(
+                    id = "untraversable",
+                    playerId = game.player1Id,
+                    prompt = "choose",
+                    context = DecisionContext(),
+                    options = emptyList(),
+                    minSelections = 0,
+                    maxSelections = 0,
+                ),
+            )
+
+            HiddenSlotRewrite.identitySensitiveInFlightPins(
+                state,
+                object : InFlightReferenceProjector {
+                    override fun project(stackObject: ComponentContainer) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+
+                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
+                        InFlightEntityReferences.Projection.Incomplete("test", "forced")
+
+                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+                },
+            ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
+                .details shouldBe listOf("could not traverse pending decision test: forced")
+        }
+
+        test("a missing or untraversable stack object makes the shared pin answer incomplete") {
+            val game = scenario().withPlayers().build()
+            val missingStackId = EntityId.of("missing-stack-object")
+
+            HiddenSlotRewrite.identitySensitiveInFlightPins(
+                game.state.copy(stack = listOf(missingStackId)),
+            ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
+                .details shouldBe listOf("could not traverse stack[0] missing-stack-object: missing entity")
+
+            val stackId = EntityId.of("untraversable-stack-object")
+            val withStack = game.state.copy(
+                entities = game.state.entities + (stackId to ComponentContainer.EMPTY),
+                stack = listOf(stackId),
+            )
+            HiddenSlotRewrite.identitySensitiveInFlightPins(
+                withStack,
+                object : InFlightReferenceProjector {
+                    override fun project(stackObject: ComponentContainer) =
+                        InFlightEntityReferences.Projection.Incomplete("test", "forced")
+
+                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+
+                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+                },
+            ).shouldBeInstanceOf<HiddenSlotRewrite.IdentitySensitiveInFlightPins.Incomplete>()
+                .details shouldBe listOf("could not traverse stack[0] test: forced")
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -1,8 +1,15 @@
 package com.wingedsheep.engine.hidden
 
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.InFlightEntityReferences
+import com.wingedsheep.engine.core.InFlightReferenceProjector
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -13,7 +20,10 @@ import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.model.GameRng
 import io.kotest.assertions.withClue
@@ -27,6 +37,50 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
     private val materializer = HiddenWorldMaterializer(cardRegistry)
 
     init {
+        test("a Monstrous Emergence hand choice is pinned by the live stack object") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(2, "Monstrous Emergence")
+                .withCardInHand(2, "Craw Wurm")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Forest")
+                .withLandsOnBattlefield(2, "Forest", 2)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+            val spellId = game.state.getHand(game.player2Id).first { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Monstrous Emergence"
+            }
+            val chosenHandId = game.state.getHand(game.player2Id).first { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Craw Wurm"
+            }
+            val targetId = game.findPermanent("Grizzly Bears")!!
+
+            game.execute(
+                CastSpell(
+                    game.player2Id,
+                    spellId,
+                    listOf(ChosenTarget.Permanent(targetId)),
+                    additionalCostPayment = AdditionalCostPayment(beheldCards = listOf(chosenHandId)),
+                ),
+            ).error shouldBe null
+            val source = game.state
+            source.getHand(game.player2Id) shouldContain chosenHandId
+
+            val result = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(chosenHandId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(605L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+            result.reason.entityId shouldBe chosenHandId
+            source.getEntity(chosenHandId)?.get<CardComponent>()?.name shouldBe "Craw Wurm"
+        }
+
         test("explicit assignments preserve slots and unrelated state while installing future RNG") {
             val game = scenario()
                 .withPlayers()
@@ -230,71 +284,164 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe libraryId
-            result.reason.details shouldContain "slot is the chosen target of a stack object"
+            result.reason.details shouldContain "slot is conservatively pinned by in-flight execution"
             cardName(targeted, libraryId) shouldBe "Hill Giant"
         }
 
-        test("a pending decision and its continuation frames refuse the whole request") {
+        test("a Mind Rot pause pins the targeted opponent's referenced hand slots but not library slots") {
             val game = scenario()
                 .withPlayers()
-                .withCardInHand(1, "Preordain")
-                .withCardOnBattlefield(1, "Island")
-                .withCardInLibrary(1, "Forest")
-                .withCardInLibrary(1, "Mountain")
+                .withCardInHand(1, "Mind Rot")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
                 .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInHand(2, "Craw Wurm")
+                .withCardInLibrary(2, "Forest")
+                .withRngSeed(615L)
                 .build()
-            val hiddenId = game.state.getHand(game.player2Id).single()
-            game.castSpell(1, "Preordain").error shouldBe null
+            game.castSpellTargetingPlayer(1, "Mind Rot", 2).error shouldBe null
             game.resolveStack()
 
-            // Preordain scries before it draws, so the engine is parked on a decision with the
-            // rest of the resolution held in a continuation frame.
+            // These are hidden opponent slots from player 1's search root. Mind Rot has already
+            // targeted player 2, but the actual discard selection remains player 2's decision.
             val source = game.state
-            source.pendingDecision shouldNotBe null
+            val sourceDecision = source.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            sourceDecision.playerId shouldBe game.player2Id
             source.continuationStack.isNotEmpty() shouldBe true
+            val referencedHandId = sourceDecision.options.first()
+            val unrelatedLibraryId = source.getLibrary(game.player2Id).single()
+            val referencedHandName = cardName(source, referencedHandId)
+            val sourceRng = source.rng
 
-            val result = materializer.materialize(
+            val atomicFailure = materializer.materialize(
                 source,
                 HiddenWorldMaterializationRequest(
-                    slotAssignments = mapOf(hiddenId to cardRegistry.requireCard("Mountain")),
+                    slotAssignments = mapOf(
+                        unrelatedLibraryId to cardRegistry.requireCard("Mountain"),
+                        referencedHandId to cardRegistry.requireCard("Island"),
+                    ),
                     futureRng = GameRng.seeded(616L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
+
+            atomicFailure.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
+            atomicFailure.reason.entityId shouldBe referencedHandId
+            atomicFailure.reason.details shouldContain "slot is conservatively pinned by in-flight execution"
+            cardName(source, referencedHandId) shouldBe referencedHandName
+            cardName(source, unrelatedLibraryId) shouldBe "Forest"
+            source.rng shouldBe sourceRng
+
+            val world = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(unrelatedLibraryId to cardRegistry.requireCard("Mountain")),
+                    futureRng = GameRng.seeded(617L),
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+
+            cardName(world, unrelatedLibraryId) shouldBe "Mountain"
+            world.rng shouldBe GameRng.seeded(617L)
+            val worldDecision = world.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            val discardedIds = worldDecision.options.take(2)
+            val resumed = actionProcessor.process(
+                world,
+                SubmitDecision(
+                    game.player2Id,
+                    CardsSelectedResponse(worldDecision.id, discardedIds),
+                ),
+            ).result
+
+            resumed.error shouldBe null
+            resumed.state.pendingDecision shouldBe null
+            resumed.state.continuationStack shouldBe emptyList()
+            resumed.state.stack shouldBe emptyList()
+            discardedIds.forEach { discardedId ->
+                resumed.state.getGraveyard(game.player2Id) shouldContain discardedId
+            }
+            cardName(resumed.state, unrelatedLibraryId) shouldBe "Mountain"
+            resumed.state.rng shouldBe GameRng.seeded(617L)
+        }
+
+        test("an empty assignment traverses a Mind Rot pause and installs the caller RNG") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Mind Rot")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInHand(2, "Craw Wurm")
+                .withRngSeed(620L)
+                .build()
+            game.castSpellTargetingPlayer(1, "Mind Rot", 2).error shouldBe null
+            game.resolveStack()
+            val source = game.state
+            source.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            source.continuationStack.isNotEmpty() shouldBe true
+
+            val futureRng = GameRng.seeded(621L)
+            val world = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(emptyMap(), futureRng),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+
+            world shouldBe source.copy(rng = futureRng)
+        }
+
+        test("an incomplete paused-state projection refuses the whole request before assignments or RNG") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Forest")
+                .withRngSeed(618L)
+                .build()
+            val handId = game.state.getHand(game.player2Id).single()
+            val libraryId = game.state.getLibrary(game.player2Id).single()
+            val pending = SelectCardsDecision(
+                id = "untraversable",
+                playerId = game.player1Id,
+                prompt = "choose",
+                context = com.wingedsheep.engine.core.DecisionContext(),
+                options = emptyList(),
+                minSelections = 0,
+                maxSelections = 0,
+            )
+            val source = game.state.copy(pendingDecision = pending)
+            val sourceRng = source.rng
+            val rejectingMaterializer = HiddenWorldMaterializer(
+                cardRegistry,
+                object : InFlightReferenceProjector {
+                    override fun project(stackObject: ComponentContainer) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+
+                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
+                        InFlightEntityReferences.Projection.Incomplete("test", "forced")
+
+                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
+                        InFlightEntityReferences.Projection.Complete(emptySet())
+                },
+            )
+
+            val result = rejectingMaterializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(
+                        handId to cardRegistry.requireCard("Mountain"),
+                        libraryId to cardRegistry.requireCard("Island"),
+                    ),
+                    futureRng = GameRng.seeded(619L),
                 ),
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
 
             result.reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
             result.reason.entityId shouldBe null
-            result.reason.details shouldContain
-                (source.pendingDecision!!::class.simpleName ?: "PendingDecision")
-            result.reason.details shouldContain "continuationDepth=${source.continuationStack.size}"
-            cardName(source, hiddenId) shouldBe "Grizzly Bears"
-        }
-
-        test("an empty assignment is gated too, because it still installs the future RNG") {
-            val game = scenario()
-                .withPlayers()
-                .withCardInHand(1, "Preordain")
-                .withCardOnBattlefield(1, "Island")
-                .withCardInLibrary(1, "Forest")
-                .withCardInLibrary(1, "Mountain")
-                .build()
-            game.castSpell(1, "Preordain").error shouldBe null
-            game.resolveStack()
-            game.state.pendingDecision shouldNotBe null
-
-            materializer.materialize(
-                game.state,
-                HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(626L)),
-            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Unsupported>()
-                .reason.kind shouldBe UnsupportedHiddenWorldKind.IN_FLIGHT_REFERENCES
-
-            withClue("a quiet position accepts the same empty request") {
-                val quiet = scenario().withPlayers().withRngSeed(1L).build().state
-                val world = materializer.materialize(
-                    quiet,
-                    HiddenWorldMaterializationRequest(emptyMap(), GameRng.seeded(636L)),
-                ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
-                world shouldBe quiet.copy(rng = GameRng.seeded(636L))
-            }
+            result.reason.details shouldContain "could not traverse pending decision test: forced"
+            cardName(source, handId) shouldBe "Grizzly Bears"
+            cardName(source, libraryId) shouldBe "Forest"
+            source.rng shouldBe sourceRng
         }
 
         test("a DFC back face cannot be materialized directly into a hidden zone") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -3,9 +3,12 @@ package com.wingedsheep.engine.hidden
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ContinuationFrame
+import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
 import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PendingDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.core.PlayLand
@@ -487,7 +490,7 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
                 id = "untraversable",
                 playerId = game.player1Id,
                 prompt = "choose",
-                context = com.wingedsheep.engine.core.DecisionContext(),
+                context = DecisionContext(),
                 options = emptyList(),
                 minSelections = 0,
                 maxSelections = 0,
@@ -500,10 +503,10 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
                     override fun project(stackObject: ComponentContainer) =
                         InFlightEntityReferences.Projection.Complete(emptySet())
 
-                    override fun project(decision: com.wingedsheep.engine.core.PendingDecision) =
+                    override fun project(decision: PendingDecision) =
                         InFlightEntityReferences.Projection.Incomplete("test", "forced")
 
-                    override fun project(frame: com.wingedsheep.engine.core.ContinuationFrame) =
+                    override fun project(frame: ContinuationFrame) =
                         InFlightEntityReferences.Projection.Complete(emptySet())
                 },
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hidden/HiddenWorldMaterializerTest.kt
@@ -2,8 +2,10 @@ package com.wingedsheep.engine.hidden
 
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.InFlightEntityReferences
 import com.wingedsheep.engine.core.InFlightReferenceProjector
+import com.wingedsheep.engine.core.OptionChosenResponse
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.core.PlayLand
@@ -22,10 +24,17 @@ import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.effects.ChooseOptionEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.OptionType
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
@@ -34,9 +43,25 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 class HiddenWorldMaterializerTest : ScenarioTestBase() {
 
+    private val chooseThenShuffle = CardDefinition.sorcery(
+        name = "Choose Then Shuffle",
+        manaCost = ManaCost.parse("{B}"),
+        oracleText = "Choose a color. Shuffle your library.",
+        script = CardScript.spell(
+            CompositeEffect(
+                listOf(
+                    ChooseOptionEffect(OptionType.COLOR, storeAs = "chosenColor"),
+                    ShuffleLibraryEffect(),
+                )
+            )
+        ),
+    )
+
     private val materializer = HiddenWorldMaterializer(cardRegistry)
 
     init {
+        cardRegistry.register(chooseThenShuffle)
+
         test("a Monstrous Emergence hand choice is pinned by the live stack object") {
             val game = scenario()
                 .withPlayers()
@@ -389,6 +414,64 @@ class HiddenWorldMaterializerTest : ScenarioTestBase() {
             ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
 
             world shouldBe source.copy(rng = futureRng)
+        }
+
+        test("a paused continuation consumes the caller RNG only when its later shuffle executes") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Choose Then Shuffle")
+                .withCardOnBattlefield(1, "Swamp")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withRngSeed(622L)
+                .build()
+            game.castSpell(1, "Choose Then Shuffle").error shouldBe null
+            game.resolveStack()
+
+            val source = game.state
+            val decision = source.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+            source.continuationStack.isNotEmpty() shouldBe true
+            val opponentSlot = source.getLibrary(game.player2Id).single()
+            val libraryBefore = source.getLibrary(game.player1Id)
+            val futureRng = GameRng.seeded(623L)
+            val (expectedOrder, expectedAdvancedRng) = futureRng.shuffle(libraryBefore)
+
+            val world = materializer.materialize(
+                source,
+                HiddenWorldMaterializationRequest(
+                    slotAssignments = mapOf(opponentSlot to cardRegistry.requireCard("Mountain")),
+                    futureRng = futureRng,
+                ),
+            ).shouldBeInstanceOf<HiddenWorldMaterializationResult.Materialized>().state
+
+            withClue("materialization freezes the already-realized pause and changes only future inputs") {
+                world.pendingDecision shouldBe source.pendingDecision
+                world.continuationStack shouldBe source.continuationStack
+                world.getLibrary(game.player1Id) shouldBe libraryBefore
+                cardName(world, opponentSlot) shouldBe "Mountain"
+                world.rng shouldBe futureRng
+            }
+
+            val resumed = actionProcessor.process(
+                world,
+                SubmitDecision(
+                    game.player1Id,
+                    OptionChosenResponse(decision.id, optionIndex = 0),
+                ),
+            ).result
+
+            resumed.error shouldBe null
+            resumed.state.pendingDecision shouldBe null
+            resumed.state.continuationStack shouldBe emptyList()
+            resumed.state.stack shouldBe emptyList()
+            resumed.state.getLibrary(game.player1Id) shouldBe expectedOrder
+            resumed.state.rng shouldBe expectedAdvancedRng
+            cardName(resumed.state, opponentSlot) shouldBe "Mountain"
         }
 
         test("an incomplete paused-state projection refuses the whole request before assignments or RNG") {


### PR DESCRIPTION
Supersedes #2210 — it carries that PR's commits plus `origin/main` merged in plus one review-fix commit, so it can merge to `main` directly.

#2210 replaces two hand-rolled approximations of "which hidden slots are pinned by paused execution" with one serializer-driven projection of typed `EntityId` references. That is the right primitive: a second hand-written visitor over ~18 pending-decision and ~30 continuation-frame shapes would rot the first time someone adds a frame, whereas riding the persistence serializers inherits exhaustiveness from `SerializationPolymorphicRegistrationTest`, which already walks the sealed hierarchies *and* the open `Component` interface via compiled classes. Fail-closed is wired through both callers and tested on both. This PR keeps all of that and fixes what the review turned up.

## Scope was documented as bigger than it is

`IdentitySensitiveInFlightPins` claimed to be "the complete state-level answer". It reads `stack`, `pendingDecision`, and `continuationStack`. `GameState` also carries `grantedKeywordAbilities` — `GrantedKeywordAbility(entityId, ability, duration)`, documented as granted *to card entities*, i.e. a cast keyword on a card in hand — plus `mayPlayPermissions` and `lastCardDrawnThisTurnByPlayer`. None of those is read here, and none is visible to `runtimeBlockers`, which only inspects the entity's own `ComponentContainer`. So the determinizer will rewrite a hand card holding a granted Harmonize into a Mountain and leave the grant pointing at a land.

That gap predates the projection and is not closed here. What changes is that the KDoc and `docs/architecture-principles.md` now name the three carriers actually read and say the GameState-level grant and permission lists are out of scope, so the next reader extends the analysis instead of assuming it already covers them. `pendingSacrificeIds` and `pendingDiscardCauseControllers` are called out as correctly excluded: both are set and consumed inside a single `moveToZone`, so no pause can observe them.

## Pinning trades coherence against information separation

The `Determinizer` KDoc explained pinning purely as "changing their definition could make those components nonsensical". `hiddenCards` filters on `id !in inFlightPins` *after* the visibility check, so a card the viewer may not see keeps its **real** identity whenever in-flight execution references it, and `DeterminizerInvariantsTest` locks that in as expected.

That is the right call — the alternative is a world whose paused decision points at a card that was never there — and it is strictly less leaky than what it replaced, since main pinned every candidate whenever a continuation frame existed. It is also sound as used: the Strategist determinizes at roots where the AI holds priority, so a paused root is one the AI itself must answer and the referenced slots are its own. But it is a property, not an accident, and a future caller determinizing at another seat's pause would be handing its search the truth. Both the class KDoc and `docs/ai/architecture.md` now say so.

## Smaller things

`Incomplete` carried a `List<String>` that every construction site filled with exactly one element, because the analysis returns on its first failure. It is a single `reason`, wrapped at the one place `UnsupportedHiddenWorld.details` wants a list.

Both test seams shed their ceremony. `Determinizer`'s private constructor plus `withInFlightPinAnalysis` companion factory, and `HiddenWorldMaterializer`'s two field-assigning secondary constructors, are each now one `internal constructor` with a public secondary delegating to it — the tests are in the same modules, so nothing else was buying anything. The `InFlightReferenceProjector` test doubles were written out verbatim three times; `HiddenSlotRewriteTest` has one `projectorFailingOn(root)` helper instead, and the inline `com.wingedsheep.engine.core.*` FQNs in both test files are imports.

## The restored Preordain witness

#2210 deleted the Preordain test because its assertion (refuse the whole request) is no longer the behaviour. But Preordain was the only case covering a *decision that names library slots* — Mind Rot covers hands, and library pinning was otherwise only witnessed through stack targets. It comes back asserting the new rule: the scry pins the slot it offers, and a card buried below it stays sampleable. That is precisely the case main refused wholesale.

## Verification

`just test-class` green on `InFlightEntityReferencesTest` (3), `HiddenSlotRewriteTest` (4, up from 3), `HiddenWorldMaterializerTest` (13), and `SerializationPolymorphicRegistrationTest` (6, the hygiene test the completeness argument rests on). Full `just test-ai` green, covering `DeterminizerInvariantsTest` (9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmYDH4RwPQdztXFQckhZ36