### PR TITLE
Forfeit bracket seats the lobby no longer has

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1441,6 +1441,18 @@ holds a later-round match back while either seat still owes an earlier-round gam
 blocked to launchable when a *third* pair's game finishes, with no change to the ready set at all.
 Every result therefore re-runs the sweep; looking only at ready *transitions* stalls the bracket.
 
+The same guard is why the bracket and the lobby roster must not drift apart. The schedule is built
+once, from the seats the lobby had then, and nothing rebuilds it — so a seat that leaves afterwards
+stays scheduled while no longer being something the server can put in a game. Its matches never
+complete, and `hasIncompleteMatchBefore` then blocks every later match of every opponent it was
+paired against, idling the whole bracket a player per round. Every path that drops a player from
+`lobby.players` therefore forfeits what the bracket still has them down for
+(`LobbyHandler.forfeitBracketMatchesIfSeatGone`, through the same `handleAbandon` a disconnect uses),
+and the sweep re-checks the roster on the way in
+(`TournamentManager.unseatedPlayersWithMatchesLeft`) as a backstop that also repairs a bracket which
+already drifted. Only a seat that is *gone* may be forfeited: `removePlayer` deliberately keeps a
+disconnected player's state during a tournament so they can rejoin.
+
 BYE handling (odd player counts), reconnection across matches, and spectating between rounds are
 all managed at this layer. The tournament system reuses the same `GameSession` and `ActionProcessor`
 for each match — it's purely orchestration, with no game logic of its own.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -443,6 +443,14 @@ class ConnectionHandler(
                 when (lobby.state) {
                     LobbyState.WAITING_FOR_PLAYERS, LobbyState.DRAFTING, LobbyState.DECK_BUILDING -> {
                         lobby.removePlayer(identity.playerId)
+                        // `removePlayer` only really removes while WAITING_FOR_PLAYERS; during a draft
+                        // or deck building it keeps the seat so the player can rejoin. A bracket can
+                        // already exist by then (it is created early, for matchups), so when the seat
+                        // *is* gone its scheduled matches have to be forfeited — otherwise nothing can
+                        // ever start them and they block every opponent behind them.
+                        if (!lobby.players.containsKey(identity.playerId)) {
+                            handleAbandonCallback?.invoke(lobbyId, identity.playerId)
+                        }
                         if (lobby.playerCount == 0) {
                             tournamentResultSink.recordAbandoned(lobbyId)
                             lobbyRepository.removeLobby(lobbyId)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -1524,6 +1524,7 @@ class LobbyHandler(
         }
 
         lobby.forceRemovePlayer(aiPlayerId)
+        forfeitBracketMatchesIfSeatGone(lobby, aiPlayerId)
         sessionRegistry.removeIdentity(aiPlayerState.identity.token)
         lobbyRepository.saveLobby(lobby)
 
@@ -2110,6 +2111,7 @@ class LobbyHandler(
 
         // Use forceRemovePlayer for explicit leave - player cannot rejoin
         lobby.forceRemovePlayer(identity.playerId)
+        forfeitBracketMatchesIfSeatGone(lobby, identity.playerId)
         identity.currentLobbyId = null
 
         logger.info("Player ${identity.playerName} left lobby $lobbyId (cannot rejoin)")
@@ -2128,6 +2130,27 @@ class LobbyHandler(
     }
 
     /**
+     * Forfeit a departed seat's remaining bracket matches, if the seat really is gone.
+     *
+     * The `TournamentManager` is built once, from the roster the lobby had then, and nothing rebuilds
+     * it afterwards — so every path that drops a player from `lobby.players` has to settle what the
+     * bracket still has them scheduled for. Only the disconnect-timeout path did (via
+     * [TournamentMatchHandler.handleAbandon]); an explicit Leave and a removed AI seat did not, and
+     * left a seat in the bracket that can never be put in a game. Its matches then sit unplayed
+     * forever, and `hasIncompleteMatchBefore` blocks every later match of whoever it was paired
+     * against, idling the tournament a player at a time.
+     *
+     * Guarded on the seat actually being gone, because [TournamentLobby.removePlayer] deliberately
+     * *keeps* the state during a tournament so the player can rejoin — forfeiting one of those would
+     * decide matches they are still entitled to play. [TournamentMatchHandler.handleAbandon] is a
+     * no-op when the lobby has no bracket yet, which covers everything before the tournament starts.
+     */
+    private fun forfeitBracketMatchesIfSeatGone(lobby: TournamentLobby, playerId: EntityId) {
+        if (lobby.players.containsKey(playerId)) return
+        tournamentMatchHandler.handleAbandon(lobby.lobbyId, playerId)
+    }
+
+    /**
      * Helper to leave current lobby if the player is in one.
      * Used when creating/joining a new lobby to auto-leave the old one.
      */
@@ -2140,6 +2163,7 @@ class LobbyHandler(
         }
 
         lobby.removePlayer(identity.playerId)
+        forfeitBracketMatchesIfSeatGone(lobby, identity.playerId)
         identity.currentLobbyId = null
 
         logger.info("Player ${identity.playerName} auto-left lobby $lobbyId")

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -489,6 +489,8 @@ class TournamentMatchHandler(
      * match runs this pass.
      */
     fun startReadyMatches(lobby: TournamentLobby, tournament: TournamentManager) {
+        forfeitUnseatedMatches(lobby, tournament)
+
         var startedAny = false
         for ((round, match) in tournament.startableMatches(lobby.getReadyPlayerIds())) {
             val player2Id = match.player2Id ?: continue
@@ -508,23 +510,93 @@ class TournamentMatchHandler(
         if (startedAny) broadcastReadyStatus(lobby)
     }
 
+    /**
+     * Forfeit every match still owed by a bracket seat the lobby no longer has, and open the round
+     * that clears.
+     *
+     * Removal paths forfeit as they go (see `LobbyHandler.forfeitBracketMatchesIfSeatGone`), so this
+     * is the backstop rather than the first line: it also repairs a bracket that drifted before that
+     * existed, or through a path nobody has thought of yet. It sits at the top of [startReadyMatches]
+     * because that is the one pass every readiness change and every match result already runs through
+     * — see [TournamentManager.unseatedPlayersWithMatchesLeft] for what a ghost seat does to the rest
+     * of the bracket if nothing forfeits it.
+     *
+     * Closing the round here is not optional: the forfeits can decide the open round outright, and if
+     * this is the pass that unstuck a bracket with nothing left to play, no later result is coming to
+     * notice.
+     */
+    private fun forfeitUnseatedMatches(lobby: TournamentLobby, tournament: TournamentManager) {
+        val unseated = tournament.unseatedPlayersWithMatchesLeft(lobby.players.keys)
+        if (unseated.isEmpty()) return
+
+        for (playerId in unseated) {
+            logger.warn(
+                "Tournament {}: bracket seat {} is no longer in the lobby; forfeiting its remaining matches",
+                lobby.lobbyId,
+                playerId.value,
+            )
+            tournament.recordAbandon(playerId)
+        }
+        ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+        recordTournamentProgress(lobby.lobbyId)
+
+        // Report it the way a real last result would: [doHandleRoundComplete] broadcasts the standings,
+        // advances the bracket, and completes the tournament if nothing is left. It re-enters this
+        // sweep, which is why the forfeits above come first — the second pass finds nothing and stops.
+        if (tournament.isRoundComplete()) {
+            doHandleRoundComplete(lobby.lobbyId)
+        }
+    }
+
     fun startSingleMatch(
         lobby: TournamentLobby,
         tournament: TournamentManager,
         round: TournamentRound,
         match: TournamentMatch
     ): Boolean {
-        val player1State = lobby.players[match.player1Id] ?: return false
-        val player2State = lobby.players[match.player2Id ?: return false] ?: return false
+        // A BYE has no game to start; [TournamentManager.startableMatches] already filters them out.
+        val player2Id = match.player2Id ?: return false
 
-        val baseDeck1 = BoosterGenerator.withBasicLandArt(
-            lobby.getSubmittedDeck(match.player1Id) ?: return false,
-            lobby.basicLands
-        )
-        val baseDeck2 = BoosterGenerator.withBasicLandArt(
-            lobby.getSubmittedDeck(match.player2Id) ?: return false,
-            lobby.basicLands
-        )
+        // Both refusals below used to be bare `?: return false`. They cost us a production stall: the
+        // sweep re-picked the same unstartable match on every pass, refused it without a word, and left
+        // the pair incomplete forever — so the only symptom in the log was silence. Say which seat and
+        // why; the two causes want opposite handling.
+        val player1State = lobby.players[match.player1Id]
+        val player2State = lobby.players[player2Id]
+        if (player1State == null || player2State == null) {
+            // Structural, and [forfeitUnseatedMatches] should already have forfeited it: reaching here
+            // means a seat left between that reconcile and this call.
+            logger.warn(
+                "Tournament {}: cannot start round {} match — no lobby seat for {}",
+                lobby.lobbyId,
+                round.roundNumber,
+                listOfNotNull(
+                    match.player1Id.value.takeIf { player1State == null },
+                    player2Id.value.takeIf { player2State == null },
+                ).joinToString(", "),
+            )
+            return false
+        }
+
+        val submittedDeck1 = lobby.getSubmittedDeck(match.player1Id)
+        val submittedDeck2 = lobby.getSubmittedDeck(player2Id)
+        if (submittedDeck1 == null || submittedDeck2 == null) {
+            // Transient — an AI seat whose deck build hasn't landed yet, most likely. Deliberately not
+            // forfeited: the next sweep starts the match once the deck arrives.
+            logger.warn(
+                "Tournament {}: cannot start round {} match yet — no submitted deck for {}",
+                lobby.lobbyId,
+                round.roundNumber,
+                listOfNotNull(
+                    player1State.identity.playerName.takeIf { submittedDeck1 == null },
+                    player2State.identity.playerName.takeIf { submittedDeck2 == null },
+                ).joinToString(", "),
+            )
+            return false
+        }
+
+        val baseDeck1 = BoosterGenerator.withBasicLandArt(submittedDeck1, lobby.basicLands)
+        val baseDeck2 = BoosterGenerator.withBasicLandArt(submittedDeck2, lobby.basicLands)
         val deckPrintings1 = player1State.cardPool + lobby.basicLands.values
         val deckPrintings2 = player2State.cardPool + lobby.basicLands.values
         val deck1WithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
@@ -646,6 +646,28 @@ class TournamentManager(
     }
 
     /**
+     * Bracket seats that the lobby no longer holds and that still owe at least one match.
+     *
+     * The bracket is built once, from the roster the lobby had at the time, and nothing rebuilds it
+     * when a seat leaves afterwards. A departed seat can never be put in a game — the match handler
+     * needs its lobby state for the deck, the identity and the socket — so its unplayed matches would
+     * stay incomplete forever, and [hasIncompleteMatchBefore] would then block every later match of
+     * every opponent it was scheduled against. One stranded pair idles the whole bracket, a player at
+     * a time, as each round reaches it.
+     *
+     * Naming them is a pure query, like [startableMatches], so the caller can forfeit them through the
+     * same [recordAbandon] a disconnect uses. [seatedPlayerIds] is the lobby's roster right now.
+     */
+    fun unseatedPlayersWithMatchesLeft(seatedPlayerIds: Set<EntityId>): List<EntityId> =
+        playerIds.filter { playerId ->
+            playerId !in seatedPlayerIds && rounds.any { round ->
+                round.matches.any {
+                    !it.isComplete && (it.player1Id == playerId || it.player2Id == playerId)
+                }
+            }
+        }
+
+    /**
      * Get the round containing a specific match (by gameSessionId).
      */
     fun getRoundForMatch(gameSessionId: String): TournamentRound? {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 
 /**
@@ -183,15 +184,25 @@ class TournamentProgressionTest : FunSpec({
         // Only three of the four round-1 matches can start: the ghost is never in the ready set,
         // because it is no longer a lobby seat that could be readied.
         manager.startableMatches(seated).size shouldBe 3
-        manager.startableMatches(seated).forEach { (_, match) -> match.gameSessionId = "r1-${match.player1Id.value}" }
-        round1.matches
-            .filter { it.gameSessionId != null }
-            .forEach { manager.reportMatchResult(it.gameSessionId!!, it.player1Id) }
 
-        // Round 1 can never close, and the stranded seat can never play again, in any round.
+        // Drive the bracket to exhaustion — start and resolve everything that ever becomes startable.
+        // The stall is progressive, not immediate, which is what made it hard to spot in production:
+        // the bracket keeps launching the pairs the ghost hasn't reached yet and gives out a player at
+        // a time, as each round arrives at it.
+        var sweeps = 0
+        while (true) {
+            val startable = manager.startableMatches(seated)
+            if (startable.isEmpty()) break
+            startable.forEach { (round, match) -> match.gameSessionId = "r${round.roundNumber}-${match.player1Id.value}" }
+            startable.forEach { (_, match) -> manager.reportMatchResult(match.gameSessionId!!, match.player1Id) }
+            check(sweeps++ < 20) { "the sweep never settled" }
+        }
+
+        // It runs out of work with the bracket unfinished and round 1 still open — nothing will ever
+        // start again, and the stranded seat never got to play at all.
+        manager.isComplete shouldBe false
         manager.isRoundComplete() shouldBe false
         manager.hasIncompleteMatchBefore(stranded, 2) shouldBe true
-        manager.startableMatches(seated).shouldBeEmpty()
 
         // Naming the ghost is what breaks the deadlock; forfeiting it uses the same path a disconnect
         // does, and the bracket moves again.
@@ -200,8 +211,7 @@ class TournamentProgressionTest : FunSpec({
 
         manager.isRoundComplete() shouldBe true
         manager.hasIncompleteMatchBefore(stranded, 2) shouldBe false
-        manager.startNextRound()!!.roundNumber shouldBe 2
-        manager.startableMatches(seated).map { it.first.roundNumber }.toSet() shouldBe setOf(2)
+        manager.startableMatches(seated).shouldNotBeEmpty()
     }
 
     test("the ghost sweep names nobody when the roster is intact, and nobody twice") {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
@@ -17,6 +17,11 @@ import io.kotest.matchers.shouldBe
  * handler used to look for a startable match only on a false→true ready transition, so once every AI
  * was marked ready nothing ever re-asked and the round-2 slate sat idle — permanently, whenever the
  * round-complete fallback was skipped because the round had already been advanced.
+ *
+ * The same guard has a second way to fail, and it also reached production: the bracket is built once
+ * from the lobby's roster, so a seat that leaves afterwards stays scheduled. Nothing can seat it, its
+ * matches never complete, and `hasIncompleteMatchBefore` then blocks every opponent behind it —
+ * see [TournamentManager.unseatedPlayersWithMatchesLeft].
  */
 class TournamentProgressionTest : FunSpec({
 
@@ -161,6 +166,58 @@ class TournamentProgressionTest : FunSpec({
         manager.hasActiveMatch(human) shouldBe true
         manager.reportMatchResult(humanRound1.gameSessionId!!, human)
         manager.hasActiveMatch(human) shouldBe false
+    }
+
+    test("a seat that left the lobby strands its opponent, and every opponent behind them") {
+        // The production stall this guards: the bracket is built once from the lobby's roster, and a
+        // seat that leaves afterwards stays in it. Nothing can put a departed seat in a game, so its
+        // matches never complete — and `hasIncompleteMatchBefore` turns that one dead pair into a
+        // block on every later match of whoever it was scheduled against.
+        val ghost = ai.last()
+        val seated = everyone - ghost
+
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val stranded = round1.matchFor(ghost).opponentOf(ghost)
+
+        // Only three of the four round-1 matches can start: the ghost is never in the ready set,
+        // because it is no longer a lobby seat that could be readied.
+        manager.startableMatches(seated).size shouldBe 3
+        manager.startableMatches(seated).forEach { (_, match) -> match.gameSessionId = "r1-${match.player1Id.value}" }
+        round1.matches
+            .filter { it.gameSessionId != null }
+            .forEach { manager.reportMatchResult(it.gameSessionId!!, it.player1Id) }
+
+        // Round 1 can never close, and the stranded seat can never play again, in any round.
+        manager.isRoundComplete() shouldBe false
+        manager.hasIncompleteMatchBefore(stranded, 2) shouldBe true
+        manager.startableMatches(seated).shouldBeEmpty()
+
+        // Naming the ghost is what breaks the deadlock; forfeiting it uses the same path a disconnect
+        // does, and the bracket moves again.
+        manager.unseatedPlayersWithMatchesLeft(seated) shouldContainExactly listOf(ghost)
+        manager.recordAbandon(ghost)
+
+        manager.isRoundComplete() shouldBe true
+        manager.hasIncompleteMatchBefore(stranded, 2) shouldBe false
+        manager.startNextRound()!!.roundNumber shouldBe 2
+        manager.startableMatches(seated).map { it.first.roundNumber }.toSet() shouldBe setOf(2)
+    }
+
+    test("the ghost sweep names nobody when the roster is intact, and nobody twice") {
+        // The backstop runs on every readiness change and every result, so it has to be quiet when
+        // there is nothing to repair — otherwise it re-forfeits a settled seat on each pass.
+        val ghost = ai.first()
+        val seated = everyone - ghost
+
+        val manager = tournament()
+        manager.startNextRound()
+
+        manager.unseatedPlayersWithMatchesLeft(everyone).shouldBeEmpty()
+
+        manager.unseatedPlayersWithMatchesLeft(seated) shouldContainExactly listOf(ghost)
+        manager.recordAbandon(ghost)
+        manager.unseatedPlayersWithMatchesLeft(seated).shouldBeEmpty()
     }
 
     test("a seat that is not ready keeps its match out of the sweep") {


### PR DESCRIPTION
## The bug

A tournament deadlocks when the bracket and the lobby roster drift apart.

`TournamentManager` is built once, from the seats the lobby had at the time, and nothing rebuilds it. A seat that leaves afterwards stays scheduled while no longer being something the server can put in a game — `startSingleMatch` needs its `LobbyPlayerState` for the deck, the identity and the socket, and refused it with a bare `?: return false`. Its matches therefore sat unplayed forever, and `hasIncompleteMatchBefore` then blocked every later match of every opponent it was paired against. One stranded pair idles the whole bracket, a player per round, as each round reaches it.

Only the disconnect-timeout path forfeited a departing seat's remaining matches (`handleAbandon`). An explicit "Leave Tournament", a host-removed AI seat, and auto-leave-on-join did not.

## How it showed up

Reported on Discord against `magic.wingedsheep.com/tournament/dd983b9a-…` — "draft tournament stuck, 2 of them never even started a game". It was misattributed to #1952, whose fix (#1958) has been live since 2026-08-20.

Three tournaments are stuck this way right now, and the tell is visible from the public API — `GET /api/stats/tournaments/<id>` returns the *bracket* size as its standings row count and `lobby.players.size` as `playerCount`:

| id | date | standings rows | playerCount | status |
|----|------|---------------|-------------|--------|
| 268 | Sep 4 | 8 | 7 | IN_PROGRESS (stuck) |
| 263 | Aug 31 | 8 | 7 | IN_PROGRESS (stuck) |
| 240 | Aug 23 | 8 | 7 | IN_PROGRESS (stuck) |
| 246 | Aug 25 | no mismatch | 8 | **COMPLETED** |

268's standings fit the mechanism exactly: 6 matches played, then nothing. Two seats at 0-0 (the round-1 pair that never started), two at 0-1 (blocked in round 2), two at 1-1 (blocked in round 3).

## The fix

- **`TournamentManager.unseatedPlayersWithMatchesLeft(seatedPlayerIds)`** — names the drifted seats. A pure query alongside `startableMatches`; `playerIds` is persisted with the bracket, so it sees the drift across a restart too.
- **`LobbyHandler.forfeitBracketMatchesIfSeatGone`** — every path that drops a player from `lobby.players` now settles what the bracket still has them down for, through the same `handleAbandon` a disconnect uses. Wired into explicit Leave, host-removes-AI, auto-leave-on-join, and the disconnect-timeout branch in `ConnectionHandler`. Guarded on the seat actually being gone: `removePlayer` deliberately *keeps* a disconnected player's state during a tournament so they can rejoin, and forfeiting one of those would decide matches they are still entitled to play.
- **`TournamentMatchHandler.forfeitUnseatedMatches`** — the backstop, at the top of `startReadyMatches` (the one pass every readiness change and every result already runs through). **This is what repairs the three already-broken tournaments**: they heal on the next ready click or server restart rather than needing a data fix. It closes the round through `doHandleRoundComplete` when the forfeits decided it — the forfeits happen first, so the re-entrant sweep finds nothing and stops.
- **Both silent refusals in `startSingleMatch`** now name the seat and the reason. The two causes want opposite handling: a missing lobby seat is structural (and should already have been forfeited), while a missing deck is transient — an AI deck build still in flight — and is deliberately left for the next sweep rather than forfeited.

## Tests

Two cases in `TournamentProgressionTest`, in the same pure-`TournamentManager` style as the #1952 ones: a seat leaving strands its opponent and cascades to everyone behind them (and forfeiting it unblocks the bracket), and the sweep is quiet on an intact roster and doesn't re-forfeit a settled seat on every pass.

`docs/architecture-principles.md` §3.6 gains a paragraph on the invariant, next to the existing eager-start one.

## Verification

`test (server)` green in CI (541 tests), and `just test-class TournamentProgressionTest` green locally.

The first CI run caught an over-claim in one of the new tests rather than anything in the fix: it asserted the bracket stops dead the moment the ghost's match is refused. It doesn't — the seats the ghost hasn't reached yet keep playing, and the bracket gives out a player at a time as each round arrives at it, which is exactly the six-matches-over-three-rounds shape 268 shows. The test now drives the bracket to exhaustion and asserts it runs dry with the tournament unfinished, which proves the deadlock rather than one symptom of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfFBzs3WLCdUfsffYTjmNa
