### PR TITLE
Add Screeching Griffin with a pairwise can't-block restriction

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2097,7 +2097,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   prompt is raised.
 - `GiftGivenEffect(target)` — "gift" temporary control.
 - `CantAttackEffect(target, unless?)` — target can't attack.
-- `CantBlockEffect(target, unless?)` — target can't block.
+- `CantBlockEffect(target, duration = EndOfTurn, attacker = null)` — target can't block. With
+  `attacker` set the restriction is **pairwise** — "target creature can't block *this creature* this
+  turn" (Screeching Griffin: `Effects.CantBlock(attacker = EffectTarget.Self)`), leaving the target
+  free to block everything else. The blanket form projects `SetCantBlock`; the pairwise form stores
+  `CantBlockSpecificAttacker(attackerId)` (the restriction mirror of provoke's
+  `MustBlockSpecificAttacker`) and is enforced by `CantBlockSpecificAttackerRule` at block
+  declaration, because a per-blocker projected flag can't express a pair.
 - `CantAttackGroupEffect(filter, condition?)` — group-scoped can't-attack.
 - `CantBlockGroupEffect(filter, condition?)` — group-scoped can't-block.
 - `Effects.Suspect(target, duration = Permanent)` (`SuspectEffect`) — target becomes suspected (MKM,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -4245,9 +4245,16 @@ object Effects {
 
     /**
      * Target creature can't block this turn.
+     *
+     * Pass [attacker] for the *pairwise* form — "target creature can't block **this creature**
+     * this turn" (Screeching Griffin: `CantBlock(attacker = EffectTarget.Self)`). The target is
+     * then free to block anything else; only the named attacker is off limits.
      */
-    fun CantBlock(target: EffectTarget = EffectTarget.ContextTarget(0), duration: Duration = Duration.EndOfTurn): Effect =
-        CantBlockEffect(target, duration)
+    fun CantBlock(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        duration: Duration = Duration.EndOfTurn,
+        attacker: EffectTarget? = null
+    ): Effect = CantBlockEffect(target, duration, attacker)
 
     /**
      * Target creature can't attack or block this turn.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -467,20 +467,28 @@ data class GrantCantBeBlockedExceptByEffect(
 }
 
 /**
- * Target creature can't block this turn.
+ * Target creature can't block this turn — either at all, or only [attacker].
  *
  * For multi-target spells, wrap in ForEachTargetEffect with EffectTarget.ContextTarget(0).
  *
  * @property target The creature that can't block
+ * @property attacker When set, the restriction is *pairwise*: [target] may still block anything
+ *   else, it just can't block this one creature ("target creature can't block this creature this
+ *   turn" — Screeching Griffin, where [attacker] is [EffectTarget.Self]). The mirror of
+ *   `MustBlockSpecificAttacker` (provoke) on the restriction side. Null (the default) is the
+ *   blanket "can't block at all" the card pool spells far more often.
  * @property duration How long the restriction lasts
  */
 @SerialName("CantBlockTargetCreatures")
 @Serializable
 data class CantBlockEffect(
     val target: EffectTarget,
-    val duration: Duration = Duration.EndOfTurn
+    val duration: Duration = Duration.EndOfTurn,
+    val attacker: EffectTarget? = null
 ) : Effect {
-    override val description: String = "${target.description} can't block this turn"
+    override val description: String =
+        if (attacker == null) "${target.description} can't block this turn"
+        else "${target.description} can't block ${attacker.description} this turn"
 }
 
 /**

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ScreechingGriffin.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/ScreechingGriffin.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Screeching Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2/2
+ * Flying
+ * {R}: Target creature can't block this creature this turn.
+ *
+ * The restriction is *pairwise* — the target is still free to block anything else, so this is
+ * [Effects.CantBlock] with `attacker = EffectTarget.Self` (the Griffin) rather than the blanket
+ * "can't block" the same effect spells without it.
+ */
+val ScreechingGriffin = card("Screeching Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    oracleText = "Flying\n{R}: Target creature can't block this creature this turn."
+    power = 2
+    toughness = 2
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.CantBlock(target = t, attacker = EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Greg Hildebrandt"
+        flavorText = "They were master fishers, but their seas are now the streets and their catch, the goblins that run pell-mell from the screeching in the sky."
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg?1783943695"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreechingGriffinScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreechingGriffinScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.rav.cards.ScreechingGriffin
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Screeching Griffin (RAV #29) — {3}{W} 2/2 flying, "{R}: Target creature can't block this
+ * creature this turn."
+ *
+ * The point of the card, and of this test, is that the restriction is **pairwise**. The blanket
+ * `SetCantBlock` that [com.wingedsheep.sdk.scripting.effects.CantBlockEffect] projects without an
+ * `attacker` would take the target out of combat entirely; the Griffin only bars it from blocking
+ * *the Griffin*. So the second test is the load-bearing one: the same creature that was refused
+ * against the Griffin must still be able to block the other attacker in the same declaration.
+ *
+ * Both attackers fly, because the Griffin does — a ground blocker would be refused by `FlyingRule`
+ * and prove nothing about the new rule.
+ */
+class ScreechingGriffinScenarioTest : ScenarioTestBase() {
+
+    private val cantBlockAbility = ScreechingGriffin.activatedAbilities.single().id
+
+    private fun TestGame.drain() {
+        var guard = 0
+        while (guard++ < 15) {
+            when (val decision = getPendingDecision()) {
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                null -> if (state.stack.isNotEmpty()) resolveStack() else break
+                else -> error("unexpected decision $decision")
+            }
+        }
+    }
+
+    private fun board(): ScenarioBuilder = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardOnBattlefield(1, "Screeching Griffin", summoningSickness = false)
+        .withCardOnBattlefield(1, "Storm Crow", summoningSickness = false)
+        .withLandsOnBattlefield(1, "Mountain", 1)
+        .withCardOnBattlefield(2, "Wind Drake")
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+    /** Point the Griffin's ability at the Wind Drake and let it resolve. */
+    private fun nameTheDrake(game: TestGame) {
+        val griffin = game.findPermanent("Screeching Griffin").shouldNotBeNull()
+        val drake = game.findPermanent("Wind Drake").shouldNotBeNull()
+        val result = game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = griffin,
+                abilityId = cantBlockAbility,
+                targets = listOf(ChosenTarget.Permanent(drake)),
+            )
+        )
+        withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+        game.drain()
+    }
+
+    init {
+        test("without the ability the Drake blocks the Griffin normally") {
+            val game = board().build()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Screeching Griffin" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            game.declareBlockers(mapOf("Wind Drake" to listOf("Screeching Griffin")))
+                .error shouldBe null
+        }
+
+        test("the named creature can't block the Griffin, but can still block the other attacker") {
+            val game = board().build()
+
+            nameTheDrake(game)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Screeching Griffin" to 2, "Storm Crow" to 2))
+                .error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            withClue("the Drake was named, so blocking the Griffin must be rejected") {
+                game.declareBlockers(mapOf("Wind Drake" to listOf("Screeching Griffin")))
+                    .error shouldNotBe null
+            }
+            withClue("the restriction is pairwise — every other attacker is still fair game") {
+                game.declareBlockers(mapOf("Wind Drake" to listOf("Storm Crow")))
+                    .error shouldBe null
+            }
+        }
+
+        test("a creature that wasn't named is unaffected") {
+            val game = board()
+                .withCardOnBattlefield(2, "Snapping Drake")
+                .build()
+
+            nameTheDrake(game)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Screeching Griffin" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            withClue("only the targeted creature is barred; the Snapping Drake still blocks") {
+                game.declareBlockers(mapOf("Snapping Drake" to listOf("Screeching Griffin")))
+                    .error shouldBe null
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -9365,6 +9365,61 @@
     ]
 }
 
+// Screeching Griffin
+{
+    "name": "Screeching Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\n{R}: Target creature can't block this creature this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "attacker": "Self"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "They were master fishers, but their seas are now the streets and their catch, the goblins that run pell-mell from the screeching in the sky.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e2fa710-4615-42de-8716-41b009b56d32.jpg?1783943695"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Searing Meditation
 {
     "name": "Searing Meditation",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CantBlockExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CantBlockExecutor.kt
@@ -15,7 +15,9 @@ import kotlin.reflect.KClass
 /**
  * Executor for CantBlockEffect.
  *
- * Creates a floating effect with SetCantBlock for the targeted creature.
+ * Creates a floating effect with SetCantBlock for the targeted creature, or — when the effect
+ * names an [CantBlockEffect.attacker] — the pairwise CantBlockSpecificAttacker, which leaves the
+ * blocker free to block everything else.
  * For multi-target spells, wrap in ForEachTargetEffect.
  */
 class CantBlockExecutor : EffectExecutor<CantBlockEffect> {
@@ -36,9 +38,20 @@ class CantBlockExecutor : EffectExecutor<CantBlockEffect> {
         container.get<CardComponent>()
             ?: return EffectResult.success(state)
 
+        val attacker = effect.attacker
+        val modification = if (attacker == null) {
+            SerializableModification.SetCantBlock
+        } else {
+            // "can't block this creature this turn" — if the named attacker is already gone the
+            // restriction has nothing to bite on, so the whole effect does nothing.
+            val attackerId = TargetResolutionUtils.resolveTarget(attacker, context, state)
+                ?: return EffectResult.success(state)
+            SerializableModification.CantBlockSpecificAttacker(attackerId)
+        }
+
         val newState = state.addFloatingEffect(
             layer = Layer.ABILITY,
-            modification = SerializableModification.SetCantBlock,
+            modification = modification,
             affectedEntities = setOf(entityId),
             duration = effect.duration,
             context = context

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -275,6 +275,31 @@ class CantBeBlockedByRule(
 }
 
 /**
+ * CantBlockSpecificAttacker: this blocker can't block *this one* attacker (floating effect).
+ *
+ * The restriction mirror of provoke's `MustBlockSpecificAttacker`, and unlike the blanket
+ * `SetCantBlock` it is pairwise — the blocker is free to block every other attacker, so it can't
+ * be a projected per-creature flag. Screeching Griffin's "{R}: Target creature can't block this
+ * creature this turn"; the floating effect's affectedEntities holds the blocker and the
+ * modification holds the attacker it may not block.
+ */
+class CantBlockSpecificAttackerRule : BlockEvasionRule {
+    override fun check(ctx: BlockCheckContext): String? {
+        val forbidden = ctx.state.floatingEffects.any { floatingEffect ->
+            val modification = floatingEffect.effect.modification
+            modification is SerializableModification.CantBlockSpecificAttacker &&
+                modification.attackerId == ctx.attackerId &&
+                ctx.blockerId in floatingEffect.effect.affectedEntities
+        }
+        if (!forbidden) return null
+
+        val blockerName = ctx.state.getEntity(ctx.blockerId)?.get<CardComponent>()?.name ?: "Creature"
+        val attackerName = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
+        return "$blockerName can't block $attackerName this turn"
+    }
+}
+
+/**
  * CantBeBlockedExceptByColor: Can only be blocked by creatures of the specified color (floating effect).
  */
 class CantBeBlockedExceptByColorRule : BlockEvasionRule {
@@ -720,6 +745,7 @@ fun defaultBlockEvasionRules(
     IntimidateRule(),
     LandwalkRule(),
     CantBeBlockedByRule(predicateEvaluator),
+    CantBlockSpecificAttackerRule(),
     CantBeBlockedExceptByColorRule(),
     CantBeBlockedByColorRule(),
     CantBeBlockedExceptByRule(predicateEvaluator),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -239,6 +239,16 @@ sealed interface SerializableModification {
     data class MustBlockSpecificAttacker(val attackerId: EntityId) : SerializableModification
 
     /**
+     * Combat restriction: a specific creature can't block a specific attacker (Screeching Griffin's
+     * "target creature can't block this creature this turn"). The mirror of
+     * [MustBlockSpecificAttacker]: affectedEntities holds the blocker, [attackerId] the one attacker
+     * it may not block. Unlike [SetCantBlock] the blocker is otherwise free to block, so this is
+     * enforced pairwise by `CantBlockSpecificAttackerRule` rather than projected onto the blocker.
+     */
+    @Serializable
+    data class CantBlockSpecificAttacker(val attackerId: EntityId) : SerializableModification
+
+    /**
      * Damage prevention: prevent all combat damage that would be dealt to a player
      * by attacking creatures this turn.
      * Used by Deep Wood and similar effects.
@@ -757,6 +767,9 @@ fun SerializableModification.toModification(): Modification = when (this) {
     is SerializableModification.MustBeBlockedByAll -> Modification.NoOp
     is SerializableModification.MustBeBlockedIfAble -> Modification.NoOp
     is SerializableModification.MustBlockSpecificAttacker -> Modification.NoOp
+    // CantBlockSpecificAttacker is pairwise, so it can't be a per-blocker projected flag —
+    // CantBlockSpecificAttackerRule reads the floating effect directly at block declaration.
+    is SerializableModification.CantBlockSpecificAttacker -> Modification.NoOp
     // PreventDamageFromAttackingCreatures doesn't map to a layer modification - it's checked by CombatManager directly
     is SerializableModification.PreventDamageFromAttackingCreatures -> Modification.NoOp
     // CantBeBlockedExceptBy maps to the real Layer.ABILITY modification, so it flows through the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2828,6 +2828,24 @@ class ClientStateTransformer(
                         )
                     )
                 }
+                // The restriction mirror. Same reason to badge it: the defender otherwise discovers
+                // the pairwise ban only when the block declaration bounces back.
+                is SerializableModification.CantBlockSpecificAttacker -> {
+                    val attackerName = state.getEntity(modification.attackerId)
+                        ?.get<CardComponent>()?.name
+                    effects.add(
+                        ClientCardEffect(
+                            effectId = "cant_block_${modification.attackerId}",
+                            name = "Can't Block",
+                            description = if (attackerName != null) {
+                                "This creature can't block $attackerName this turn"
+                            } else {
+                                "This creature can't block a specific attacker this turn"
+                            },
+                            icon = "cant-block"
+                        )
+                    )
+                }
                 // The unrestricted requirement (Culvert Ambusher). Badged for the same reason as
                 // "Must Attack": the defending player finds out about it when their declaration is
                 // rejected, which is far too late to be the first they hear of it.


### PR DESCRIPTION
Takes Ravnica: City of Guilds to **236/291**.

## Screeching Griffin

`{3}{W}` 2/2 Griffin — Flying, "{R}: Target creature can't block this creature this turn."

The restriction is **pairwise**, and that is the whole reason the card was still open. `CantBlockEffect` projected a blanket `SetCantBlock`, which takes the target out of combat entirely; the Griffin only bars it from blocking *the Griffin*. A per-blocker projected boolean cannot express a pair, so this needed a real (if small) addition rather than a reuse.

**The missing axis.** `CantBlockEffect` gains `attacker: EffectTarget?`:

- `null` (every existing caller) — unchanged blanket "can't block".
- set — the executor stores `SerializableModification.CantBlockSpecificAttacker(attackerId)`.

That modification is the restriction mirror of provoke's `MustBlockSpecificAttacker`, which already carried exactly this shape on the *requirement* side, so the pair now reads symmetrically. Like its twin it maps to `Modification.NoOp` — it is deliberately not projected.

**Enforcement is one rule, not a new code path.** `CantBlockSpecificAttackerRule` joins `defaultBlockEvasionRules`, so it reaches both block declaration (`validateCanBlock`) and legal-action enumeration (`canCreatureBlockAttacker`) through the registry those already share. Two consequences fall out for free:

- *Restrictions beat requirements* — `getMandatoryBlockerAssignments` already routes provoke constraints through `canCreatureBlockAttacker`, so a creature both provoked onto and barred from the same attacker is no longer required to make an illegal block.
- The client gets a `Can't Block` badge naming the attacker, mirroring the existing `Must Block` one. The defender otherwise discovers a pairwise ban only when their declaration bounces back.

If the named attacker has already left when the ability resolves, the effect does nothing rather than falling back to the blanket form.

## Tests

`ScreechingGriffinScenarioTest` — three cases. The load-bearing one is the second: the creature refused against the Griffin must still block the other attacker in the same declaration, which is exactly what the blanket form would have gotten wrong. Both attackers fly, since a ground blocker would be refused by `FlyingRule` and prove nothing.

## Dropped from this PR: Shadow of Doubt

Written, then reverted rather than shipped. "Players can't search libraries this turn" was implemented as a `CantSearchLibraries` sibling of the `CantCastSpells` family, with the guard keyed off *a gather over a whole library*. That shape is not exclusively a search: Jace, the Mind Sculptor's `-12` is `gather(FromZone(LIBRARY, Any))` → `exile` with no search in it, and the guard would have silently neutered it whenever Shadow of Doubt was up.

Telling the two apart needs the pipeline to carry "this collection came from a search" — `EffectResult` has `updatedCollections` and friends but no provenance channel — which is `add-feature` work, not a card. Rather than ship an approximation that only holds in the common case, it is out.

## Verification

Not run locally — the box was at load average 91 with every Gradle slot held by other agents (two runs were queued out and one was OOM-killed). Pushed for CI to gate, at the user's direction. Expect a `CardDefinitionSnapshotTest` diff for the new card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awerg5xdXFZ9jXuELDzFPq
