### PR TITLE
Add 50 Assay-ready cards to Shadows over Innistrad

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/ShadowsOverInnistradSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/ShadowsOverInnistradSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.soi
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -18,11 +17,14 @@ object ShadowsOverInnistradSet : MtgSet {
     override val displayName = "Shadows over Innistrad"
     override val releaseDate = "2016-04-08"
     override val block = "Shadows over Innistrad"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AlwaysWatching.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AlwaysWatching.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Always Watching (Shadows over Innistrad #1)
+ * {1}{W}{W}
+ * Enchantment
+ *
+ * Nontoken creatures you control get +1/+1 and have vigilance.
+ *
+ * A two-part lord: the stat bump and the keyword grant are separate static abilities over the
+ * same group ([GameObjectFilter.Creature].nontoken().youControl()), the shape Howlpack
+ * Resurgence already uses.
+ */
+val AlwaysWatching = card("Always Watching") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Nontoken creatures you control get +1/+1 and have vigilance."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.nontoken().youControl())
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.VIGILANCE,
+            GroupFilter(GameObjectFilter.Creature.nontoken().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Chase Stone"
+        flavorText = "\"We pray to Avacyn on high. On snow-white wings fearless you fly. Keep safe our souls. Keep safe our lives. May angels watch us from the skies.\"\n—Children's prayer"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg?1783937828"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AnguishedUnmaking.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AnguishedUnmaking.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Anguished Unmaking (Shadows over Innistrad #242)
+ * {1}{W}{B}
+ * Instant
+ *
+ * Exile target nonland permanent. You lose 3 life.
+ *
+ * The life loss is not a cost and not conditional — it happens on resolution even if the exile
+ * did nothing, so it is simply the second half of the composite.
+ */
+val AnguishedUnmaking = card("Anguished Unmaking") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Instant"
+    oracleText = "Exile target nonland permanent. You lose 3 life."
+
+    spell {
+        val permanent = target("target", Targets.NonlandPermanent)
+        effect = Effects.Exile(permanent) then Effects.LoseLife(3, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "242"
+        artist = "Wesley Burt"
+        flavorText = "Sorin had created Avacyn, so it was a cruelty beyond imagining, a pain beyond description, that it fell upon him to end her forever."
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg?1783937714"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/BitingRain.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/BitingRain.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Biting Rain (Shadows over Innistrad #102)
+ * {2}{B}{B}
+ * Sorcery
+ *
+ * All creatures get -2/-2 until end of turn.
+ * Madness {2}{B}
+ *
+ * "All creatures" is untargeted and controller-agnostic — a plain group iteration that applies
+ * the -2/-2 to each iterated creature (Infest is the same shape).
+ */
+val BitingRain = card("Biting Rain") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "All creatures get -2/-2 until end of turn.\n" +
+        "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature),
+            Effects.ModifyStats(-2, -2, EffectTarget.Self)
+        )
+    }
+
+    madness("{2}{B}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "John Stanko"
+        flavorText = "On Innistrad, it is seldom wrong to stay indoors."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg?1783937780"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/BrokenConcentration.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/BrokenConcentration.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Concentration (Shadows over Innistrad #50)
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell.
+ * Madness {3}{U}
+ */
+val BrokenConcentration = card("Broken Concentration") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\n" +
+        "Madness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        target("target", Targets.Spell)
+        effect = Effects.CounterSpell()
+    }
+
+    madness("{3}{U}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Clint Cearley"
+        flavorText = "Some minds bend under pressure. Others break."
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg?1783937804"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/CallTheBloodline.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/CallTheBloodline.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Call the Bloodline (Shadows over Innistrad #103)
+ * {1}{B}
+ * Enchantment
+ *
+ * {1}, Discard a card: Create a 1/1 black Vampire Knight creature token with lifelink.
+ * Activate only once each turn.
+ *
+ * "Activate only once each turn" is [ActivationRestriction.OncePerTurn] — a restriction on the
+ * ability, not a condition on the effect. The discard is part of the *cost*, so it is paid on
+ * activation (and enables madness on the discarded card).
+ */
+val CallTheBloodline = card("Call the Bloodline") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "{1}, Discard a card: Create a 1/1 black Vampire Knight creature token with lifelink. Activate only once each turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.DiscardCard)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Vampire", "Knight"),
+            keywords = setOf(Keyword.LIFELINK)
+        )
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Lake Hurwitz"
+        flavorText = "At Sorin's appeal, Olivia Voldaren summoned the full might of her bloodline to gather at Lurenbraum Fortress."
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg?1783937778"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ChaplainsBlessing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ChaplainsBlessing.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chaplain's Blessing (Shadows over Innistrad #10)
+ * {W}
+ * Sorcery
+ *
+ * You gain 5 life.
+ */
+val ChaplainsBlessing = card("Chaplain's Blessing") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "You gain 5 life."
+
+    spell {
+        effect = Effects.GainLife(5)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "John Stanko"
+        flavorText = "\"There was a time when the purpose of the church was to heal and protect. I would see that time return.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg?1783937824"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DeadWeightReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DeadWeightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dead Weight reprint in SOI. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadWeightReprint = Printing(
+    oracleId = "b1804304-fac1-4b19-a48d-6ade9407972a",
+    name = "Dead Weight",
+    setCode = "SOI",
+    collectorNumber = "106",
+    scryfallId = "f09a09de-35c9-4a4e-a4ac-1ce24e166ad9",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f09a09de-35c9-4a4e-a4ac-1ce24e166ad9.jpg",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DrogskolCavalry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DrogskolCavalry.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Drogskol Cavalry (Shadows over Innistrad #15)
+ * {5}{W}{W}
+ * Creature — Spirit Knight
+ * 4 / 4
+ *
+ * Flying
+ * Whenever another Spirit you control enters, you gain 2 life.
+ * {3}{W}: Create a 1/1 white Spirit creature token with flying.
+ *
+ * Modeling notes:
+ *  - "Another Spirit you control" is the bare tribal noun, so the filter is
+ *    `GameObjectFilter.Permanent.withSubtype(SPIRIT)` rather than the creature-only form —
+ *    `TriggerBinding.OTHER` is what carries the "another".
+ *  - The token is the set's own 1/1 white flying Spirit, the same shape [DauntlessCathar] makes.
+ */
+val DrogskolCavalry = card("Drogskol Cavalry") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Knight"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever another Spirit you control enters, you gain 2 life.\n" +
+        "{3}{W}: Create a 1/1 white Spirit creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.SPIRIT).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.GainLife(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Igor Kieryluk"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg?1783937821"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DrownyardTemple.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DrownyardTemple.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drownyard Temple (Shadows over Innistrad #271)
+ *
+ * Land
+ *
+ * {T}: Add {C}.
+ * {3}: Return this card from your graveyard to the battlefield tapped.
+ *
+ * Modeling notes:
+ *  - The recursion is an activated ability that functions from the graveyard
+ *    (`activateFromZone = Zone.GRAVEYARD`), and the return carries the graveyard guard plus the
+ *    `tapped` axis — [Effects.PutOntoBattlefieldFromGraveyard] with `tapped = true`. Nothing
+ *    re-checks `activateFromZone` at resolution, so the guard is what stops a Temple exiled from
+ *    the graveyard in response coming back from exile.
+ */
+val DrownyardTemple = card("Drownyard Temple") {
+    manaCost = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}: Return this card from your graveyard to the battlefield tapped."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.PutOntoBattlefieldFromGraveyard(EffectTarget.Self, tapped = true)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "271"
+        artist = "John Avon"
+        flavorText = "\"This is it! All the cryptoliths point here!\"\n—Jace Beleren"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg?1783937699"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EmberEyeWolf.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EmberEyeWolf.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ember-Eye Wolf (Shadows over Innistrad #154)
+ * {1}{R}
+ * Creature — Wolf
+ * 1 / 2
+ *
+ * Haste
+ * {1}{R}: This creature gets +2/+0 until end of turn.
+ */
+val EmberEyeWolf = card("Ember-Eye Wolf") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wolf"
+    power = 1
+    toughness = 2
+    oracleText = "Haste\n" +
+        "{1}{R}: This creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Anthony Palumbo"
+        flavorText = "No howl. No snarl. Just the roar of flames."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg?1783937754"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EtherealGuidance.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EtherealGuidance.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ethereal Guidance (Shadows over Innistrad #18)
+ * {2}{W}
+ * Sorcery
+ *
+ * Creatures you control get +2/+1 until end of turn.
+ *
+ * The team pump is the corpus's standard shape: [Effects.ForEachInGroup] over the creatures you
+ * control, with the per-member body pumping the iteration's own member ([EffectTarget.Self]).
+ */
+val EtherealGuidance = card("Ethereal Guidance") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +2/+1 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(2, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Ben Maier"
+        flavorText = "\"The call of the Blessed Sleep is not so strong as the call to protect those in need.\"\n—Saint Traft"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg?1783937821"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/Ghoulsteed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/Ghoulsteed.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ghoulsteed (Shadows over Innistrad #113)
+ * {4}{B}
+ * Creature — Zombie Horse
+ * 4 / 4
+ *
+ * {2}{B}, Discard two cards: Return this card from your graveyard to the battlefield tapped.
+ *
+ * Modeling notes:
+ *  - [DrownyardTemple]'s recursion shape with a discard rider on the cost: the composite is
+ *    mana + [Costs.Discard], and the return keeps the graveyard guard and the `tapped` axis.
+ */
+val Ghoulsteed = card("Ghoulsteed") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Horse"
+    power = 4
+    toughness = 4
+    oracleText = "{2}{B}, Discard two cards: Return this card from your graveyard to the battlefield tapped."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Discard(count = 2))
+        effect = Effects.PutOntoBattlefieldFromGraveyard(EffectTarget.Self, tapped = true)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Jason Kang"
+        flavorText = "It once served a cathar roadwatcher, patrolling the crossways between villages. Its hooves still carry it along the same path."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg?1783937774"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GroundskeeperReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GroundskeeperReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Groundskeeper reprint in SOI. Canonical CardDefinition lives in its earliest set.
+ */
+val GroundskeeperReprint = Printing(
+    oracleId = "f2c19fba-9b06-461f-bb5e-e827ba41204d",
+    name = "Groundskeeper",
+    setCode = "SOI",
+    collectorNumber = "208",
+    scryfallId = "ae029a5b-bcfb-4004-86aa-aaeca561545c",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae029a5b-bcfb-4004-86aa-aaeca561545c.jpg",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HauntedCloak.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HauntedCloak.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Haunted Cloak (Shadows over Innistrad #257)
+ * {3}
+ * Artifact — Equipment
+ *
+ * Equipped creature has vigilance, trample, and haste.
+ * Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * Modeling notes:
+ *  - Three separate [GrantKeyword] statics, one per printed keyword; each keeps the default
+ *    `GroupFilter.attachedCreature()` scope, which is what "equipped creature has" means.
+ *  - `equipAbility("{1}")` sets `equipCost` *and* builds the `ActivatedAbility.equip` lowering
+ *    with `isEquipAbility = true`; its defaults already carry sorcery timing and
+ *    `TargetFilter.CreatureYouControl`, so the reminder text needs no extra spelling.
+ */
+val HauntedCloak = card("Haunted Cloak") {
+    manaCost = "{3}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has vigilance, trample, and haste.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "257"
+        artist = "Volkan Baǵa"
+        flavorText = "Bear the weight of so many spirits and you'll surrender civility and restraint to savagery and instinct."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg?1783937706"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/IncorrigibleYouths.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/IncorrigibleYouths.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Incorrigible Youths (Shadows over Innistrad #166)
+ * {3}{R}{R}
+ * Creature — Vampire
+ * 4 / 3
+ *
+ * Haste (This creature can attack and {T} as soon as it comes under your control.)
+ * Madness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * Madness (CR 702.35) on a creature is what makes the haste matter: the card is cast for {2}{R}
+ * while the madness trigger resolves, so a discard outlet turns a five-drop into a three-mana
+ * 4/3 that can attack the turn it lands.
+ */
+val IncorrigibleYouths = card("Incorrigible Youths") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 4
+    toughness = 3
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "Madness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    keywords(Keyword.HASTE)
+
+    madness("{2}{R}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Winona Nelson"
+        flavorText = "\"Ah, to be young again.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg?1783937749"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/InsolentNeonate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/InsolentNeonate.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Insolent Neonate (Shadows over Innistrad #168)
+ * {R}
+ * Creature — Vampire
+ * 1 / 1
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Discard a card, Sacrifice this creature: Draw a card.
+ *
+ * The activated ability has no mana cost at all — the whole cost is the discard plus the
+ * self-sacrifice, which is why it doubles as a free madness/delirium outlet at instant speed.
+ */
+val InsolentNeonate = card("Insolent Neonate") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 1
+    toughness = 1
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Discard a card, Sacrifice this creature: Draw a card."
+
+    keywords(Keyword.MENACE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.DiscardCard, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"Manners are for mortals.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg?1783937748"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/JustTheWind.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/JustTheWind.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Just the Wind (Shadows over Innistrad #71)
+ * {1}{U}
+ * Instant
+ *
+ * Return target creature to its owner's hand.
+ * Madness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * A plain bounce: [Effects.ReturnToHand] already sends the permanent to its *owner's* hand, so
+ * stealing a creature and bouncing it doesn't keep the card. Madness (CR 702.35) is the reason
+ * the spell reads as a one-mana trick — the cast happens while the madness trigger resolves.
+ */
+val JustTheWind = card("Just the Wind") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature to its owner's hand.\n" +
+        "Madness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(creature)
+    }
+
+    madness("{U}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Christopher Moeller"
+        flavorText = "\"There's nothing to worry about.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg?1783937795"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/LoamDryad.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/LoamDryad.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Loam Dryad (Shadows over Innistrad #216)
+ * {G}
+ * Creature — Dryad Horror
+ * 1 / 2
+ *
+ * {T}, Tap an untapped creature you control: Add one mana of any color.
+ *
+ * A mana ability: it produces mana and takes no target, so `manaAbility = true` — which derives
+ * the timing rule; there is no separate `timing` to author. The tap-a-creature half is a cost,
+ * not the `{T}` symbol, so the creature tapped that way needn't be free of summoning sickness.
+ */
+val LoamDryad = card("Loam Dryad") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad Horror"
+    power = 1
+    toughness = 2
+    oracleText = "{T}, Tap an untapped creature you control: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.TapPermanents(1, GameObjectFilter.Creature))
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Jose Cabrera"
+        flavorText = "\"I've never known dryads to suffer visitors in their woods. Beware the Ulvenwald when she welcomes you.\"\n—Alena, trapper of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg?1783937727"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MarkovDreadknight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MarkovDreadknight.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Markov Dreadknight (Shadows over Innistrad #122)
+ * {3}{B}{B}
+ * Creature — Vampire Knight
+ * 3 / 3
+ *
+ * Flying
+ * {2}{B}, Discard a card: Put two +1/+1 counters on this creature.
+ *
+ * The discard is part of the cost, so it happens on activation and can't be responded to
+ * separately — which is what makes this a madness enabler as well as a mana sink.
+ */
+val MarkovDreadknight = card("Markov Dreadknight") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Knight"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{2}{B}, Discard a card: Put two +1/+1 counters on this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.DiscardCard)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Darek Zabrocki"
+        flavorText = "The destruction of Markov Manor made the surviving members of the bloodline more dangerous."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg?1783937770"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MercilessResolve.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MercilessResolve.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Merciless Resolve (Shadows over Innistrad #123)
+ * {2}{B}
+ * Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a creature or land.
+ * Draw two cards.
+ *
+ * The sacrifice is an additional *cost* (CR 601.2h), so it is paid as the spell is cast: the
+ * creature is already gone when the spell resolves, and countering the spell doesn't give it back.
+ */
+val MercilessResolve = card("Merciless Resolve") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature or land.\n" +
+        "Draw two cards."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.CreatureOrLand))
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Chase Stone"
+        flavorText = "\"You sought to anger me, Nahiri. Soon you will see how well you have succeeded.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg?1783937770"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NaggingThoughts.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NaggingThoughts.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nagging Thoughts (Shadows over Innistrad #74)
+ * {1}{U}
+ * Sorcery
+ *
+ * Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
+ * Madness {1}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * The dig is the standard [Patterns.Library.lookAtTopAndKeep] recipe — gather the top two, keep
+ * exactly one (the default hand destination), rest to the graveyard (the default remainder
+ * destination). Both prompt labels come from those destinations, so nothing here is bespoke.
+ */
+val NaggingThoughts = card("Nagging Thoughts") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\n" +
+        "Madness {1}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(count = 2, keepCount = 1)
+    }
+
+    madness("{1}{U}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Seb McKinnon"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg?1783937793"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NahirisMachinations.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NahirisMachinations.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Nahiri's Machinations (Shadows over Innistrad #28)
+ * {1}{W}
+ * Enchantment
+ *
+ * At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.
+ * {1}{R}: This enchantment deals 1 damage to target blocking creature.
+ *
+ * "On your turn" is [Triggers.BeginCombat]'s own scope, and "target blocking creature" is
+ * [TargetFilter.BlockingCreature] — the blocking check is read live from combat state, so the
+ * ability is only activatable once blockers are declared.
+ */
+val NahirisMachinations = card("Nahiri's Machinations") {
+    manaCost = "{1}{W}"
+    colorIdentity = "RW"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.\n" +
+        "{1}{R}: This enchantment deals 1 damage to target blocking creature."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target("target", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        val t = target("target", TargetCreature(filter = TargetFilter.BlockingCreature))
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Lake Hurwitz"
+        flavorText = "\"Sorin, I'm going to take everything from you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg?1783937817"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NiblisOfDusk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NiblisOfDusk.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Niblis of Dusk (Shadows over Innistrad #76)
+ * {2}{U}
+ * Creature — Spirit
+ * 2 / 1
+ *
+ * Flying
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ *
+ * Both lines are engine-live keywords; the reminder text is printed oracle text, so it stays in
+ * `oracleText` while the behaviour comes entirely from [Keyword.FLYING] and [Keyword.PROWESS].
+ */
+val NiblisOfDusk = card("Niblis of Dusk") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.FLYING, Keyword.PROWESS)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Nils Hamm"
+        flavorText = "It fuels its lanterns by leaching the warmth from its surroundings."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg?1783937792"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/OliviasBloodsworn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/OliviasBloodsworn.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Olivia's Bloodsworn (Shadows over Innistrad #127)
+ * {1}{B}
+ * Creature — Vampire Soldier
+ * 2 / 1
+ *
+ * Flying
+ * This creature can't block.
+ * {R}: Target Vampire gains haste until end of turn.
+ *
+ * "Target Vampire" is a bare tribal noun, so it is any Vampire *permanent* — not just a Vampire
+ * creature — hence [TargetFilter.Permanent] narrowed by the subtype rather than
+ * [TargetFilter.Creature].
+ */
+val OliviasBloodsworn = card("Olivia's Bloodsworn") {
+    manaCost = "{1}{B}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Vampire Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "This creature can't block.\n" +
+        "{R}: Target Vampire gains haste until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withSubtype(Subtype.VAMPIRE)))
+        effect = Effects.GrantKeyword(Keyword.HASTE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Daarken"
+        flavorText = "\"As we muster for war, I have little patience for lethargy or recalcitrance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg?1783937768"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PyreHound.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PyreHound.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pyre Hound (Shadows over Innistrad #174)
+ * {3}{R}
+ * Creature — Elemental Dog
+ * 2 / 3
+ *
+ * Trample
+ * Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature.
+ *
+ * The counters are permanent — this is the counter-stacking cousin of prowess, so
+ * [Triggers.YouCastInstantOrSorcery] plus a plain [Effects.AddCounters] on the source.
+ */
+val PyreHound = card("Pyre Hound") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Dog"
+    power = 2
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Jama Jurabaev"
+        flavorText = "Its growl is the crackling and popping of a wildfire untamed."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg?1783937746"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/QuilledWolf.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/QuilledWolf.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Quilled Wolf (Shadows over Innistrad #222)
+ * {1}{G}
+ * Creature — Wolf
+ * 2 / 2
+ *
+ * {5}{G}: This creature gets +4/+4 until end of turn.
+ */
+val QuilledWolf = card("Quilled Wolf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 2
+    toughness = 2
+    oracleText = "{5}{G}: This creature gets +4/+4 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = Effects.ModifyStats(4, 4, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "222"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"I know a ranger that thought to make a cloak of its hide. He ended up losing an eye for his trouble.\"\n—Raf Gyel of the Quiver of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg?1783937724"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RavenousBloodseeker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RavenousBloodseeker.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ravenous Bloodseeker (Shadows over Innistrad #175)
+ * {1}{R}
+ * Creature — Vampire Berserker
+ * 1 / 3
+ *
+ * Discard a card: This creature gets +2/-2 until end of turn.
+ *
+ * The whole ability is a cost and a pump: [Costs.DiscardCard] is the discard atom, and the pump
+ * targets the source itself rather than a chosen creature, so there is no target requirement. The
+ * toughness modifier is negative, which is what lets the ability kill its own creature — the state-
+ * based check runs after each activation.
+ */
+val RavenousBloodseeker = card("Ravenous Bloodseeker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire Berserker"
+    power = 1
+    toughness = 3
+    oracleText = "Discard a card: This creature gets +2/-2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.DiscardCard
+        effect = Effects.ModifyStats(2, -2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "James Ryman"
+        flavorText = "\"Nothing will cool the fire in their blood. They are too far gone. We must keep them away from our towns at any cost.\"\n—Cosper Lowe of the Silbern Guard"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg?1783937746"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RottenheartGhoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RottenheartGhoul.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rottenheart Ghoul (Shadows over Innistrad #132)
+ * {3}{B}
+ * Creature — Zombie
+ * 2 / 4
+ *
+ * When this creature dies, target player discards a card.
+ *
+ * [Effects.Discard] against a bound target player is the Gather → Select → Move pipeline, so the
+ * discarding player is the one who chooses which card leaves their hand.
+ */
+val RottenheartGhoul = card("Rottenheart Ghoul") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature dies, target player discards a card."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val player = target("target", Targets.Player)
+        effect = Effects.Discard(1, player)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Dave Kendall"
+        flavorText = "\"To die failing to save a loved one is just so sad—or, more to the point, pathetic.\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg?1783937765"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RunawayCarriage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RunawayCarriage.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Runaway Carriage (Shadows over Innistrad #261)
+ * {4}
+ * Artifact Creature — Construct
+ * 5 / 6
+ *
+ * Trample
+ * When this creature attacks or blocks, sacrifice it at end of combat.
+ *
+ * One printed sentence, two triggered abilities — the same spelling Mardu Blazebringer uses. A
+ * creature can never both attack and block in one combat, so the disjunction fires at most once
+ * either way. The sacrifice is [SacrificeSelfEffect], the verb with no object that reads the
+ * delayed trigger's own source.
+ */
+val RunawayCarriage = card("Runaway Carriage") {
+    manaCost = "{4}"
+    typeLine = "Artifact Creature — Construct"
+    power = 5
+    toughness = 6
+    oracleText = "Trample\n" +
+        "When this creature attacks or blocks, sacrifice it at end of combat."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END_COMBAT,
+            effect = SacrificeSelfEffect
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END_COMBAT,
+            effect = SacrificeSelfEffect
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "261"
+        artist = "Kev Walker"
+        flavorText = "\"They left in one piece. I can't speak to how they arrived.\"\n—Rupirk, porter at the Rusted Anchor Inn"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg?1783937706"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SanguinaryMage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SanguinaryMage.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanguinary Mage (Shadows over Innistrad #178)
+ * {1}{R}
+ * Creature — Vampire Wizard
+ * 1 / 3
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ *
+ * The reminder text stays in `oracleText`; the behaviour comes entirely from [Keyword.PROWESS],
+ * which the engine reads directly.
+ */
+val SanguinaryMage = card("Sanguinary Mage") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.PROWESS)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "David Gaillet"
+        flavorText = "New cults rising in Nephalia have found allies in the Stromkirk bloodline, whose progenitor worships ancient and terrible forces."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg?1783937744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SenselessRage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SenselessRage.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Senseless Rage (Shadows over Innistrad #180)
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2.
+ * Madness {1}{R}
+ *
+ * Madness (CR 702.35) on an Aura still puts the card on the stack as a normal Aura spell — it just
+ * costs {1}{R} and is cast while the madness trigger resolves, so the enchant restriction is chosen
+ * then like any other target.
+ */
+val SenselessRage = card("Senseless Rage") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2.\n" +
+        "Madness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    madness("{1}{R}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "180"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg?1783937744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ShadowsOverInnistradBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ShadowsOverInnistradBasicLands.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Shadows over Innistrad Basic Lands
+ *
+ * Shadows over Innistrad contains 3 art variants of each basic land type.
+ * Cards 283-297 (Plains 283-285, Island 286-288, Swamp 289-291, Mountain 292-294, Forest 295-297)
+ */
+
+// =============================================================================
+// Plains (Cards 283-285)
+// =============================================================================
+
+val ShadowsOverInnistradPlains283 = basicLand("Plains") {
+    collectorNumber = "283"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/56bbcfb7-cfbc-4752-9b6c-ffbd5d3dd678.jpg?1783937694"
+}
+
+val ShadowsOverInnistradPlains284 = basicLand("Plains") {
+    collectorNumber = "284"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/6401c6e7-3415-4e68-b40c-9777c33785eb.jpg?1783937694"
+}
+
+val ShadowsOverInnistradPlains285 = basicLand("Plains") {
+    collectorNumber = "285"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fcab7eaa-5e16-40b5-992b-9cc51a95376b.jpg?1783937694"
+}
+
+// =============================================================================
+// Island (Cards 286-288)
+// =============================================================================
+
+val ShadowsOverInnistradIsland286 = basicLand("Island") {
+    collectorNumber = "286"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bffca348-2af9-44bb-815f-f7f7240ac975.jpg?1783937694"
+}
+
+val ShadowsOverInnistradIsland287 = basicLand("Island") {
+    collectorNumber = "287"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d74e713-11f7-4341-9b22-5300a4587a51.jpg?1783937692"
+}
+
+val ShadowsOverInnistradIsland288 = basicLand("Island") {
+    collectorNumber = "288"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/125e4610-9bdc-4ee2-8aac-26cbdee13046.jpg?1783937692"
+}
+
+// =============================================================================
+// Swamp (Cards 289-291)
+// =============================================================================
+
+val ShadowsOverInnistradSwamp289 = basicLand("Swamp") {
+    collectorNumber = "289"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/19f62f5c-ddea-4564-bc47-5845ab15d8e2.jpg?1783937693"
+}
+
+val ShadowsOverInnistradSwamp290 = basicLand("Swamp") {
+    collectorNumber = "290"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6fae7689-a9df-4f69-8040-9fbe24f64838.jpg?1783937691"
+}
+
+val ShadowsOverInnistradSwamp291 = basicLand("Swamp") {
+    collectorNumber = "291"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87861e3c-d445-4452-b7e0-19b53e69b6e3.jpg?1783937692"
+}
+
+// =============================================================================
+// Mountain (Cards 292-294)
+// =============================================================================
+
+val ShadowsOverInnistradMountain292 = basicLand("Mountain") {
+    collectorNumber = "292"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7878436-bf83-45c6-a040-e2fad447862a.jpg?1783937692"
+}
+
+val ShadowsOverInnistradMountain293 = basicLand("Mountain") {
+    collectorNumber = "293"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d55384ef-6e5e-4e0b-8156-edad0fc9b25b.jpg?1783937692"
+}
+
+val ShadowsOverInnistradMountain294 = basicLand("Mountain") {
+    collectorNumber = "294"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b37dc16e-3631-46df-acc4-19040fb8a86e.jpg?1783937691"
+}
+
+// =============================================================================
+// Forest (Cards 295-297)
+// =============================================================================
+
+val ShadowsOverInnistradForest295 = basicLand("Forest") {
+    collectorNumber = "295"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42efdb6a-1c54-497a-9058-af4256241649.jpg?1783937691"
+}
+
+val ShadowsOverInnistradForest296 = basicLand("Forest") {
+    collectorNumber = "296"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2c8c30af-055a-4921-99a8-f99c472c7315.jpg?1783937692"
+}
+
+val ShadowsOverInnistradForest297 = basicLand("Forest") {
+    collectorNumber = "297"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee1ebe0b-995f-4239-aad3-bfe471a88b6e.jpg?1783937691"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SilentObserver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SilentObserver.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silent Observer (Shadows over Innistrad #86)
+ * {3}{U}
+ * Creature — Spirit
+ * 1 / 5
+ *
+ * Flying
+ */
+val SilentObserver = card("Silent Observer") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 5
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Lake Hurwitz"
+        flavorText = "It's not just a feeling—you *are* being watched."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg?1783937787"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/Silverstrike.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/Silverstrike.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silverstrike (Shadows over Innistrad #37)
+ * {3}{W}
+ * Instant
+ *
+ * Destroy target attacking creature. You gain 3 life.
+ */
+val Silverstrike = card("Silverstrike") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target attacking creature. You gain 3 life."
+
+    spell {
+        val victim = target("target", Targets.AttackingCreature)
+        effect = Effects.Composite(
+            Effects.Destroy(victim),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "Lius Lasahido"
+        flavorText = "\"Shield yourself with faith. Arm yourself with silver.\"\n—Slayer Kastinne"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg?1783937812"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SinisterConcoction.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SinisterConcoction.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sinister Concoction (Shadows over Innistrad #135)
+ * {B}
+ * Enchantment
+ *
+ * {B}, Pay 1 life, Mill a card, Discard a card, Sacrifice this enchantment: Destroy target creature.
+ */
+val SinisterConcoction = card("Sinister Concoction") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "{B}, Pay 1 life, Mill a card, Discard a card, Sacrifice this enchantment: Destroy target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{B}"),
+            Costs.PayLife(1),
+            Costs.MillCard,
+            Costs.DiscardCard,
+            Costs.SacrificeSelf
+        )
+        val victim = target("target", Targets.Creature)
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Zack Stella"
+        flavorText = "An old family recipe for an old family grudge."
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg?1783937766"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SpitefulMotives.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SpitefulMotives.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Spiteful Motives (Shadows over Innistrad #183)
+ * {3}{R}
+ * Enchantment — Aura
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Enchant creature
+ * Enchanted creature gets +3/+0 and has first strike.
+ */
+val SpitefulMotives = card("Spiteful Motives") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +3/+0 and has first strike."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(3, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Marco Nelor"
+        flavorText = "Having infiltrated the Lunarch Council, the Skirsdag await the perfect moment to strike."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg?1783937741"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SternConstable.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SternConstable.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stern Constable (Shadows over Innistrad #39)
+ * {W}
+ * Creature — Human Soldier
+ * 1 / 1
+ *
+ * {T}, Discard a card: Tap target creature.
+ */
+val SternConstable = card("Stern Constable") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Discard a card: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Svetlin Velinov"
+        flavorText = "\"I'm sure you have a story. Everyone has a story. You can tell it to the bars.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg?1783937809"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StitchwingSkaab.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StitchwingSkaab.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stitchwing Skaab (Shadows over Innistrad #90)
+ * {3}{U}
+ * Creature — Zombie Horror
+ * 3 / 1
+ *
+ * Flying
+ * {1}{U}, Discard two cards: Return this card from your graveyard to the battlefield tapped.
+ */
+val StitchwingSkaab = card("Stitchwing Skaab") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Horror"
+    power = 3
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{1}{U}, Discard two cards: Return this card from your graveyard to the battlefield tapped."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Discard(count = 2))
+        effect = Effects.PutOntoBattlefieldFromGraveyard(EffectTarget.Self, tapped = true)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Nils Hamm"
+        flavorText = "\"Amazing, isn't it, how scraps can come together to create such a wonder?\"\n—Stitcher Geralf"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg?1783937783"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StoicBuilder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StoicBuilder.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Stoic Builder (Shadows over Innistrad #231)
+ * {2}{G}
+ * Creature — Human
+ * 2 / 3
+ *
+ * When this creature enters, you may return target land card from your graveyard to your hand.
+ */
+val StoicBuilder = card("Stoic Builder") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, you may return target land card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Land.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Howard Lyon"
+        flavorText = "Some have returned to Hollowhenge, the ruins of Avabruck, to restore the lost capital of Kessig."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg?1783937720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StormriderSpirit.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StormriderSpirit.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stormrider Spirit (Shadows over Innistrad #91)
+ * {4}{U}
+ * Creature — Spirit
+ * 3 / 3
+ *
+ * Flash
+ * Flying
+ */
+val StormriderSpirit = card("Stormrider Spirit") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Flying"
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Lake Hurwitz"
+        flavorText = "Thunder isn't all that follows lightning."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg?1783937784"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TwinsOfMaurerEstate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TwinsOfMaurerEstate.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Twins of Maurer Estate (Shadows over Innistrad #142)
+ * {4}{B}
+ * Creature — Vampire
+ * 3 / 5
+ *
+ * Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ */
+val TwinsOfMaurerEstate = card("Twins of Maurer Estate") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 5
+    oracleText = "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    madness("{2}{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Darek Zabrocki"
+        flavorText = "\"Children, where are your parents?\"\n—Reig, wandering monk, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg?1783937761"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfEphemera.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfEphemera.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vessel of Ephemera (Shadows over Innistrad #48)
+ * {1}{W}
+ * Enchantment
+ *
+ * {2}{W}, Sacrifice this enchantment: Create two 1/1 white Spirit creature tokens with flying.
+ */
+val VesselOfEphemera = card("Vessel of Ephemera") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "{2}{W}, Sacrifice this enchantment: Create two 1/1 white Spirit creature tokens with flying."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Kieran Yanner"
+        flavorText = "Geists seeking redemption must first be given the opportunity."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg?1783937806"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfMalignity.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfMalignity.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Vessel of Malignity (Shadows over Innistrad #144)
+ * {1}{B}
+ * Enchantment
+ *
+ * {1}{B}, Sacrifice this enchantment: Target opponent exiles two cards from their hand. Activate only as a sorcery.
+ */
+val VesselOfMalignity = card("Vessel of Malignity") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "{1}{B}, Sacrifice this enchantment: Target opponent exiles two cards from their hand. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.Opponent)
+        effect = Patterns.Hand.exileFromHand(2, t)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Kieran Yanner"
+        flavorText = "From within its prison, the book endlessly whispers words of cruelty and spite."
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg?1783937759"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfParamnesia.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfParamnesia.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vessel of Paramnesia (Shadows over Innistrad #95)
+ * {1}{U}
+ * Enchantment
+ *
+ * {U}, Sacrifice this enchantment: Target player mills three cards. Draw a card.
+ */
+val VesselOfParamnesia = card("Vessel of Paramnesia") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "{U}, Sacrifice this enchantment: Target player mills three cards. Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.Player)
+        effect = Effects.Composite(
+            Patterns.Library.mill(3, t),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Kieran Yanner"
+        flavorText = "\"Write everything down. Trust me.\"\n—Vallon, Thraben inspector"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg?1783937782"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfVolatility.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VesselOfVolatility.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Vessel of Volatility (Shadows over Innistrad #189)
+ * {1}{R}
+ * Enchantment
+ *
+ * {1}{R}, Sacrifice this enchantment: Add {R}{R}{R}{R}.
+ */
+val VesselOfVolatility = card("Vessel of Volatility") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{1}{R}, Sacrifice this enchantment: Add {R}{R}{R}{R}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.SacrificeSelf)
+        effect = Effects.AddMana(Color.RED, 4)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Kieran Yanner"
+        flavorText = "\"To be honest, I'm not quite sure what's going to happen.\"\n—Renna, Selhoff alchemist"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg?1783937739"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VeteranCathar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VeteranCathar.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Veteran Cathar (Shadows over Innistrad #238)
+ * {1}{G}
+ * Creature — Human Soldier
+ * 2 / 2
+ *
+ * {3}{W}: Target Human gains double strike until end of turn.
+ *
+ * "Human" is a **bare tribal noun**, so it names every *permanent* with the subtype rather than
+ * only a creature — [TargetFilter.Permanent] with the subtype, not `TargetFilter.Creature`.
+ */
+val VeteranCathar = card("Veteran Cathar") {
+    manaCost = "{1}{G}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "{3}{W}: Target Human gains double strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withSubtype("Human")))
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"Prayers can be powerful, but I prefer to put faith in my own two hands.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg?1783937716"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DrownyardTempleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DrownyardTempleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drownyard Temple reprint in CLB. Canonical CardDefinition lives in its earliest set.
+ */
+val DrownyardTempleReprint = Printing(
+    oracleId = "c30f9be4-c274-4ad0-b5d7-7d3421aa4277",
+    name = "Drownyard Temple",
+    setCode = "CLB",
+    collectorNumber = "892",
+    scryfallId = "06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06c61b1b-d8fa-4c8b-9ddb-ca2682a3f5ef.jpg",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/HauntedCloakReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/HauntedCloakReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Haunted Cloak reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val HauntedCloakReprint = Printing(
+    oracleId = "74fc88d5-19c3-4516-9a06-e9573d659caa",
+    name = "Haunted Cloak",
+    setCode = "CMR",
+    collectorNumber = "313",
+    scryfallId = "9fc9a637-352a-45bd-a43a-6406f9da56af",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9fc9a637-352a-45bd-a43a-6406f9da56af.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/StormriderSpiritReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/StormriderSpiritReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stormrider Spirit reprint in MID. Canonical CardDefinition lives in its earliest set.
+ */
+val StormriderSpiritReprint = Printing(
+    oracleId = "2c378f72-917c-49d4-ba68-51ebaf18d976",
+    name = "Stormrider Spirit",
+    setCode = "MID",
+    collectorNumber = "79",
+    scryfallId = "81a95edb-9f5b-4e42-8b27-0b3d978dcefe",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81a95edb-9f5b-4e42-8b27-0b3d978dcefe.jpg",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -240,6 +240,43 @@
     ]
 }
 
+// Always Watching
+{
+    "name": "Always Watching",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Nontoken creatures you control get +1/+1 and have vigilance.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature nontoken ctrl:you"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature nontoken ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "Chase Stone",
+        "flavorText": "\"We pray to Avacyn on high. On snow-white wings fearless you fly. Keep safe our souls. Keep safe our lives. May angels watch us from the skies.\"\n—Children's prayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84826f49-b5fb-4bd6-ab46-98e84b0d25c8.jpg?1783937828"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Angelic Purge
 {
     "name": "Angelic Purge",
@@ -280,6 +317,57 @@
         "imageUri": "https://cards.scryfall.io/normal/front/d/3/d38bae3e-95f3-413a-bb4d-6a0814112a7a.jpg?1782712158"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Anguished Unmaking
+{
+    "name": "Anguished Unmaking",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target nonland permanent. You lose 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Controller"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "RARE",
+        "artist": "Wesley Burt",
+        "flavorText": "Sorin had created Avacyn, so it was a cruelty beyond imagining, a pain beyond description, that it fell upon him to end her forever.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90ced4fa-6509-4f7a-9da7-efc70de6f90c.jpg?1783937714"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "WHITE"
     ]
 }
@@ -825,6 +913,56 @@
     ]
 }
 
+// Biting Rain
+{
+    "name": "Biting Rain",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "All creatures get -2/-2 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "John Stanko",
+        "flavorText": "On Innistrad, it is seldom wrong to stay indoors.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5ac62d2f-6834-4d98-b69d-bd7b5831d981.jpg?1783937780"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bloodmad Vampire
 {
     "name": "Bloodmad Vampire",
@@ -953,6 +1091,105 @@
     ]
 }
 
+// Broken Concentration
+{
+    "name": "Broken Concentration",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell.\nMadness {3}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Clint Cearley",
+        "flavorText": "Some minds bend under pressure. Others break.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/252eef1f-0a62-420d-aad8-e3d7f1e07c1b.jpg?1783937804"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Call the Bloodline
+{
+    "name": "Call the Bloodline",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}, Discard a card: Create a 1/1 black Vampire Knight creature token with lifelink. Activate only once each turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Vampire",
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ]
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "Lake Hurwitz",
+        "flavorText": "At Sorin's appeal, Olivia Voldaren summoned the full might of her bloodline to gather at Lurenbraum Fortress.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3ec85cca-ac2c-4b1b-850b-6a762df72bd0.jpg?1783937778"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cathar's Companion
 {
     "name": "Cathar's Companion",
@@ -990,6 +1227,32 @@
         "artist": "Svetlin Velinov",
         "flavorText": "\"Unwavering and loyal, they represent stability in uncertain times.\"\n—Rem Karolus, Slayer of Angels",
         "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg?1783937824"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Chaplain's Blessing
+{
+    "name": "Chaplain's Blessing",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "You gain 5 life.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "John Stanko",
+        "flavorText": "\"There was a time when the purpose of the church was to heal and protect. I would see that time return.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f70ea481-1751-4097-af41-2d13fe79e788.jpg?1783937824"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -1198,6 +1461,126 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Drogskol Cavalry
+{
+    "name": "Drogskol Cavalry",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Spirit Knight",
+    "oracleText": "Flying\nWhenever another Spirit you control enters, you gain 2 life.\n{3}{W}: Create a 1/1 white Spirit creature token with flying.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Spirit ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Igor Kieryluk",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg?1783937821"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Drownyard Temple
+{
+    "name": "Drownyard Temple",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}: Return this card from your graveyard to the battlefield tapped.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield",
+                    "placement": "Tapped",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "\"This is it! All the cryptoliths point here!\"\n—Jace Beleren",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5bb5657-18a1-455c-a87a-4e67971184ac.jpg?1783937699"
+    }
 }
 
 // Drunau Corpse Trawler
@@ -1441,6 +1824,56 @@
     ]
 }
 
+// Ember-Eye Wolf
+{
+    "name": "Ember-Eye Wolf",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Haste\n{1}{R}: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Anthony Palumbo",
+        "flavorText": "No howl. No snarl. Just the roar of flames.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98fe1e1e-b14a-4efe-894b-b9da635f007f.jpg?1783937754"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Epitaph Golem
 {
     "name": "Epitaph Golem",
@@ -1564,6 +1997,46 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Ethereal Guidance
+{
+    "name": "Ethereal Guidance",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +2/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Ben Maier",
+        "flavorText": "\"The call of the Blessed Sleep is not so strong as the call to protect those in need.\"\n—Saint Traft",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f47dd220-6193-4e31-a1df-591b6424ad27.jpg?1783937821"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1940,6 +2413,62 @@
     ]
 }
 
+// Ghoulsteed
+{
+    "name": "Ghoulsteed",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Horse",
+    "oracleText": "{2}{B}, Discard two cards: Return this card from your graveyard to the battlefield tapped.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield",
+                    "placement": "Tapped",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Kang",
+        "flavorText": "It once served a cathar roadwatcher, patrolling the crossways between villages. Its hooves still carry it along the same path.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed5ba8dd-d2cd-4ee6-bdb4-390968f1ff54.jpg?1783937774"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gisa's Bidding
 {
     "name": "Gisa's Bidding",
@@ -2212,6 +2741,68 @@
     "colorIdentityOverride": []
 }
 
+// Haunted Cloak
+{
+    "name": "Haunted Cloak",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has vigilance, trample, and haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Bear the weight of so many spirits and you'll surrender civility and restraint to savagery and instinct.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef142a2a-08e8-4344-8626-239690b3bb87.jpg?1783937706"
+    }
+}
+
 // Highland Lake
 {
     "name": "Highland Lake",
@@ -2435,6 +3026,38 @@
     ]
 }
 
+// Incorrigible Youths
+{
+    "name": "Incorrigible Youths",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE",
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{2}{R}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "\"Ah, to be young again.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e826571-6f00-4b40-975b-d51b2b17b4a4.jpg?1783937749"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Indulgent Aristocrat
 {
     "name": "Indulgent Aristocrat",
@@ -2498,6 +3121,54 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Insolent Neonate
+{
+    "name": "Insolent Neonate",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nDiscard a card, Sacrifice this creature: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"Manners are for mortals.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/813104f6-e6e4-4709-8626-12fe4262a11f.jpg?1783937748"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2724,6 +3395,95 @@
     ]
 }
 
+// Just the Wind
+{
+    "name": "Just the Wind",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature to its owner's hand.\nMadness {U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"There's nothing to worry about.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98b3d18c-7029-4eff-a918-f75e7d9d79d7.jpg?1783937795"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Loam Dryad
+{
+    "name": "Loam Dryad",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Dryad Horror",
+    "oracleText": "{T}, Tap an untapped creature you control: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Jose Cabrera",
+        "flavorText": "\"I've never known dryads to suffer visitors in their woods. Beware the Ulvenwald when she welcomes you.\"\n—Alena, trapper of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61c9441d-18d9-4ec6-859e-e9a7893b54e3.jpg?1783937727"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Magnifying Glass
 {
     "name": "Magnifying Glass",
@@ -2785,6 +3545,95 @@
         ]
     },
     "colorIdentityOverride": []
+}
+
+// Markov Dreadknight
+{
+    "name": "Markov Dreadknight",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "Flying\n{2}{B}, Discard a card: Put two +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "Darek Zabrocki",
+        "flavorText": "The destruction of Markov Manor made the surviving members of the bloodline more dangerous.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg?1783937770"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Merciless Resolve
+{
+    "name": "Merciless Resolve",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature or land.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature|land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Chase Stone",
+        "flavorText": "\"You sought to anger me, Nahiri. Soon you will see how well you have succeeded.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/356af156-a059-416c-b78b-d9058b742818.jpg?1783937770"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Moonlight Hunt
@@ -2880,6 +3729,158 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Nagging Thoughts
+{
+    "name": "Nagging Thoughts",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.\nMadness {1}{U} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put in graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Seb McKinnon",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8a6d6e4-e91f-444f-9eed-88fceaf1a4b8.jpg?1783937793"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Nahiri's Machinations
+{
+    "name": "Nahiri's Machinations",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of combat on your turn, target creature you control gains indestructible until end of turn.\n{1}{R}: This enchantment deals 1 damage to target blocking creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature blocking"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "UNCOMMON",
+        "artist": "Lake Hurwitz",
+        "flavorText": "\"Sorin, I'm going to take everything from you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9ba0f1c-8641-4f5a-8f2e-f969fc7a058a.jpg?1783937817"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -3011,6 +4012,31 @@
         ]
     },
     "colorIdentityOverride": []
+}
+
+// Niblis of Dusk
+{
+    "name": "Niblis of Dusk",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "PROWESS"
+    ],
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Nils Hamm",
+        "flavorText": "It fuels its lanterns by leaching the warmth from its surroundings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/394dd931-e34e-4314-88c9-774a2f3c8c1b.jpg?1783937792"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Odric, Lunarch Marshal
@@ -3383,6 +4409,66 @@
     ]
 }
 
+// Olivia's Bloodsworn
+{
+    "name": "Olivia's Bloodsworn",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Flying\nThis creature can't block.\n{R}: Target Vampire gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Vampire"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"As we muster for war, I have little patience for lethargy or recalcitrance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdda34e9-f28b-4606-8298-b2d0c15033e6.jpg?1783937768"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Open the Armory
 {
     "name": "Open the Armory",
@@ -3532,6 +4618,150 @@
     ]
 }
 
+// Pyre Hound
+{
+    "name": "Pyre Hound",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Jama Jurabaev",
+        "flavorText": "Its growl is the crackling and popping of a wildfire untamed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d19c5fb-01af-4ca4-af7e-00ec2a748afd.jpg?1783937746"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Quilled Wolf
+{
+    "name": "Quilled Wolf",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "{5}{G}: This creature gets +4/+4 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"I know a ranger that thought to make a cloak of its hide. He ended up losing an eye for his trouble.\"\n—Raf Gyel of the Quiver of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa1569b5-94ef-4ba5-98c6-f1bd4f73c7d5.jpg?1783937724"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ravenous Bloodseeker
+{
+    "name": "Ravenous Bloodseeker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Vampire Berserker",
+    "oracleText": "Discard a card: This creature gets +2/-2 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "James Ryman",
+        "flavorText": "\"Nothing will cool the fire in their blood. They are too far gone. We must keep them away from our towns at any cost.\"\n—Cosper Lowe of the Silbern Guard",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc4d04bc-6263-43b0-9b01-894a532cd3ed.jpg?1783937746"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rise from the Tides
 {
     "name": "Rise from the Tides",
@@ -3568,6 +4798,131 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Rottenheart Ghoul
+{
+    "name": "Rottenheart Ghoul",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature dies, target player discards a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Dave Kendall",
+        "flavorText": "\"To die failing to save a loved one is just so sad—or, more to the point, pathetic.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/933f0504-c611-4557-b1e6-f5be72154805.jpg?1783937765"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Runaway Carriage
+{
+    "name": "Runaway Carriage",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Trample\nWhen this creature attacks or blocks, sacrifice it at end of combat.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END_COMBAT",
+                    "effect": "SacrificeSelf"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END_COMBAT",
+                    "effect": "SacrificeSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"They left in one piece. I can't speak to how they arrived.\"\n—Rupirk, porter at the Rusted Anchor Inn",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c8ce5d3-0184-4cfb-a41d-3d58229b2a5f.jpg?1783937706"
+    }
 }
 
 // Rush of Adrenaline
@@ -3620,6 +4975,30 @@
         "artist": "Chris Rallis",
         "flavorText": "Scarecrows only go so far in sending the message to stay away.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg?1783937744"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sanguinary Mage
+{
+    "name": "Sanguinary Mage",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Vampire Wizard",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "David Gaillet",
+        "flavorText": "New cults rising in Nephalia have found allies in the Stromkirk bloodline, whose progenitor worships ancient and terrible forces.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ace86fac-769c-4440-9a40-318d7172555b.jpg?1783937744"
     },
     "colorIdentityOverride": [
         "RED"
@@ -3721,6 +5100,191 @@
     ]
 }
 
+// Senseless Rage
+{
+    "name": "Senseless Rage",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c779cb6-3454-4d5a-85a1-bea5cf8005b1.jpg?1783937744"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Silent Observer
+{
+    "name": "Silent Observer",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Lake Hurwitz",
+        "flavorText": "It's not just a feeling—you *are* being watched.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/535e3d1b-b71b-406a-bec6-73b2cb45f6c8.jpg?1783937787"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Silverstrike
+{
+    "name": "Silverstrike",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target attacking creature. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Shield yourself with faith. Arm yourself with silver.\"\n—Slayer Kastinne",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f27b92a-cde9-41bc-9b23-d83b74b167d4.jpg?1783937812"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sinister Concoction
+{
+    "name": "Sinister Concoction",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "{B}, Pay 1 life, Mill a card, Discard a card, Sacrifice this enchantment: Destroy target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomMill"
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "UNCOMMON",
+        "artist": "Zack Stella",
+        "flavorText": "An old family recipe for an old family grudge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/815ca911-ccc1-4466-8d12-054b8d241992.jpg?1783937766"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spectral Shepherd
 {
     "name": "Spectral Shepherd",
@@ -3774,6 +5338,46 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Spiteful Motives
+{
+    "name": "Spiteful Motives",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +3/+0 and has first strike.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Nelor",
+        "flavorText": "Having infiltrated the Lunarch Council, the Skirsdag await the perfect moment to strike.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/592d7349-d066-49b0-9920-c1ec1595e00d.jpg?1783937741"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3835,6 +5439,60 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Stern Constable
+{
+    "name": "Stern Constable",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{T}, Discard a card: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"I'm sure you have a story. Everyone has a story. You can tell it to the bars.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f0f87d4-5fed-415c-918a-c3546697a3da.jpg?1783937809"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -3900,6 +5558,117 @@
     ]
 }
 
+// Stitchwing Skaab
+{
+    "name": "Stitchwing Skaab",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Zombie Horror",
+    "oracleText": "Flying\n{1}{U}, Discard two cards: Return this card from your graveyard to the battlefield tapped.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield",
+                    "placement": "Tapped",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Amazing, isn't it, how scraps can come together to create such a wonder?\"\n—Stitcher Geralf",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f84bb1ce-a8a0-4a29-9129-b1d7041fd01a.jpg?1783937783"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stoic Builder
+{
+    "name": "Stoic Builder",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human",
+    "oracleText": "When this creature enters, you may return target land card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Howard Lyon",
+        "flavorText": "Some have returned to Hollowhenge, the ruins of Avabruck, to restore the lost capital of Kessig.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0820f17c-ab4a-4a14-84ff-4ea200bef112.jpg?1783937720"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Stone Quarry
 {
     "name": "Stone Quarry",
@@ -3943,6 +5712,31 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// Stormrider Spirit
+{
+    "name": "Stormrider Spirit",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flash\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Lake Hurwitz",
+        "flavorText": "Thunder isn't all that follows lightning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c0fb4be-df73-43a9-bd48-fd47a4190fc1.jpg?1783937784"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4839,6 +6633,36 @@
     ]
 }
 
+// Twins of Maurer Estate
+{
+    "name": "Twins of Maurer Estate",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{2}{B}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Darek Zabrocki",
+        "flavorText": "\"Children, where are your parents?\"\n—Reig, wandering monk, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cc13a00-bd58-44fa-93af-846001ca4f84.jpg?1783937761"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ulrich's Kindred
 {
     "name": "Ulrich's Kindred",
@@ -5041,6 +6865,337 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vessel of Ephemera
+{
+    "name": "Vessel of Ephemera",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "{2}{W}, Sacrifice this enchantment: Create two 1/1 white Spirit creature tokens with flying.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Kieran Yanner",
+        "flavorText": "Geists seeking redemption must first be given the opportunity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4051020-688c-473a-9a08-b62f0fd75675.jpg?1783937806"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Vessel of Malignity
+{
+    "name": "Vessel of Malignity",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}{B}, Sacrifice this enchantment: Target opponent exiles two cards from their hand. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "exiled",
+                            "prompt": "Choose 2 cards to exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Kieran Yanner",
+        "flavorText": "From within its prison, the book endlessly whispers words of cruelty and spite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81b44857-1edb-4de4-b646-917101faf881.jpg?1783937759"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vessel of Paramnesia
+{
+    "name": "Vessel of Paramnesia",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "{U}, Sacrifice this enchantment: Target player mills three cards. Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        },
+                                        "player": {
+                                            "type": "ContextPlayer",
+                                            "index": 0
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard",
+                                        "player": {
+                                            "type": "ContextPlayer",
+                                            "index": 0
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"Write everything down. Trust me.\"\n—Vallon, Thraben inspector",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4596140-1113-4349-aabe-4e828ea574e8.jpg?1783937782"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vessel of Volatility
+{
+    "name": "Vessel of Volatility",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}{R}, Sacrifice this enchantment: Add {R}{R}{R}{R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"To be honest, I'm not quite sure what's going to happen.\"\n—Renna, Selhoff alchemist",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81647b86-2c84-4a14-8d5a-919f7a5b8bc7.jpg?1783937739"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Veteran Cathar
+{
+    "name": "Veteran Cathar",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{3}{W}: Target Human gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Human"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"Prayers can be powerful, but I prefer to put faith in my own two hands.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a471e83e-c0e0-4af6-bfcf-7f4a39f6fccf.jpg?1783937716"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Sweeps SOI's ⚡ Assay-ready backlog to zero — every card Argentum Assay reads whole that the set had not authored yet.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 43 | canonical authored here — SOI is the earliest real printing |
| `row-only` | 2 | Dead Weight (canonical in ISD), Groundskeeper (canonical in MMQ) — `Printing` rows only |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override, 3 art variants each (#283–297) |
| `elsewhere` | 0 | — |
| `unscaffolded` | 0 | — |

**Reprint tail: 3 rows** owed in other scaffolded sets — invisible to `check-card-printing` until these canonicals existed, so they belong in this PR: CLB (Drownyard Temple), CMR (Haunted Cloak), MID (Stormrider Spirit).

## Before / after

| Gate | Before | After |
|---|---|---|
| `just assay-ready SOI` | 50 Assay-ready | **0** — "this set's tail is grammar work, not authoring work" |
| Differential — compared | 6576 | 6619 (+43) |
| Differential — confirmed | 6519 | 6562 (+43) |
| Differential — divergent | 57 | **57 (unchanged — zero new divergences)** |
| Golden would not decode | 0 | 0 |

The `assay-ready` number was re-run on the branch, not inferred. SOI's remaining 151 missing cards are all declines (130 `LINE_DECLINED`, 21 `MULTI_FACE`).

## Method

Every card was authored to `assay compile`'s JSON rather than to the oracle text, which is why the differential delta is zero. Metadata came from SOI's own Scryfall payload and was then re-checked mechanically, field by field, scoped inside each `metadata { }` block — 43/43 clean. The compile output's `setCode`/`metadata.imageUri` are **not** authoritative for placement: Haunted Cloak compiles tagged `CMM`, Pyre Hound `A25`, Just the Wind / Twins of Maurer Estate / Ghoulsteed `UMA`, Stormrider Spirit `MID`, Drownyard Temple `TDC`, Always Watching `GNT`, Anguished Unmaking `SOC`. All eight are genuinely earliest-printed in SOI.

**Capability pre-flight.** Madness is the one mechanic cluster (7 cards) and it was traced through `rules-engine` before authoring — it is live (`mechanics/MadnessGrants.kt`, `state/components/identity/MadnessComponents.kt`, `StackResolver`), not a display-only keyword. Everything else in the batch is standard vocabulary. No new `Effect` type, executor, or SDK spelling was needed, so `docs/card-sdk-language-reference.md` is unchanged.

SOI now declares its own basic lands, so `basicLandsFallback = PortalSet` is dropped.

## Verification

- `just build` — SUCCESSFUL, 10270 tests passed, zero failures
- `just rebless-cards` — only `snapshots/cards/SOI.json` moved
- `just assay-differential` — 57 divergences, byte-identical to the baseline set (taken with this same freshly-built binary)
- `just check-card-printing` — clean for all 43 authored canonicals
- `just assay-ready SOI` on the branch — 0

## Findings the sweep surfaced

- **No parser bugs and no card bugs found.** The one shape worth naming: Assay reads Loam Dryad's "Tap an untapped creature you control" cost with no `controllerPredicate`. That is correct, not a drop — `CostAtom.TapPermanents` bakes "you control" into the atom's own semantics, and `CostPaymentService` resolves its candidate pool through `controlledUntapped(state, payerId, …)`. Authoring the filter as `GameObjectFilter.Creature` is right; adding `.youControl()` would have been the divergence.
- **Machine saturation produces convincing false failures.** An earlier full-build run on a box holding three concurrent Gradle builds reported six failures — five `TimeoutCancellationException`s in `ArenaHarnessTest`/`PodArenaHarnessTest` and one `AssertionFailedError` in `FrozenBaselineTest`. All six were saturation artefacts: `FrozenBaselineTest` registers only `PortalSet.cards` and is provably untouched by this change, and it passes on both pristine `main` and this branch when run alone. The re-run on a quiet box is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01886f57Btxpjb2u4NZmkWMa