### PR TITLE
Expose typed entity references in actions and responses

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/InFlightEntityReferences.kt
@@ -7,7 +7,9 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.encoding.Encoder
@@ -26,21 +28,207 @@ internal interface InFlightReferenceProjector {
 }
 
 /**
+ * Exhaustive typed [EntityId] traversal for sealed engine inputs.
+ *
+ * This follows the normal engine serializer schema rather than a hand-written list of fields. The
+ * result retains every occurrence in serialization order and enough structural location to tell a
+ * map key from its value. Consumers that need a different wire representation can therefore apply
+ * their own naming policy without rediscovering engine schema shapes or collapsing repeated ids.
+ *
+ * For example, a policy adapter can replace the [EntityId] keys of a spell's damage-distribution
+ * map with viewer-safe aliases while leaving a counter name or decision id unchanged, even when
+ * that ordinary string has identical bytes. The occurrence path supplies the engine-owned schema
+ * fact; the adapter still owns what alias is safe and what the resulting payload means.
+ *
+ * This is deliberately not a JSON policy API: entity aliases, alias-key collisions, visibility, and
+ * any choice-specific canonicalization belong to the caller. A failed traversal is explicit, so a
+ * caller that cannot safely proceed must not mistake it for an empty reference list.
+ */
+object TypedEntityReferences {
+
+    /** One typed [EntityId] occurrence, including repeated occurrences of the same id. */
+    data class Occurrence(
+        val entityId: EntityId,
+        val path: List<PathSegment>,
+    )
+
+    /** Serializer-structural path to an [Occurrence], not a policy-specific JSON pointer. */
+    sealed interface PathSegment {
+        /** A named field of a serializable record or sealed payload. */
+        data class Field(val name: String) : PathSegment
+
+        /** A collection member by serializer index. */
+        data class Element(val index: Int) : PathSegment
+
+        /**
+         * The synthetic payload edge introduced by a sealed or open polymorphic serializer.
+         *
+         * Default object-polymorphic JSON flattens this payload into the containing object beside
+         * its class discriminator, so a consumer reconciling these paths to that JSON form drops
+         * only this typed segment. A real serializable property named `value` remains a
+         * `Field("value")` and must not be dropped.
+         */
+        data object PolymorphicPayload : PathSegment
+
+        /** A map entry, retaining whether the occurrence is the key or value. */
+        data class MapEntry(
+            val index: Int,
+            val role: Role,
+        ) : PathSegment {
+            enum class Role { KEY, VALUE }
+        }
+    }
+
+    sealed interface Projection {
+        data class Complete(val occurrences: List<Occurrence>) : Projection {
+            /** Compatibility view for conservative consumers that only need membership. */
+            val entityIds: Set<EntityId> get() = occurrences.mapTo(linkedSetOf()) { it.entityId }
+        }
+
+        /** The graph could not be exhaustively traversed, so its references are unknown. */
+        data class Incomplete(
+            val rootType: String,
+            val failure: String,
+        ) : Projection
+    }
+
+    fun action(action: GameAction): Projection = project(GameAction.serializer(), action)
+
+    fun response(response: DecisionResponse): Projection =
+        project(DecisionResponse.serializer(), response)
+
+    /** Internal generic seam shared with persisted in-flight traversal and failure witnesses. */
+    internal fun <T : Any> project(
+        serializer: SerializationStrategy<T>,
+        value: T,
+    ): Projection {
+        val occurrences = mutableListOf<Occurrence>()
+        return try {
+            serializer.serialize(EntityReferenceEncoder(occurrences), value)
+            Projection.Complete(occurrences)
+        } catch (failure: Exception) {
+            Projection.Incomplete(
+                rootType = value.javaClass.name,
+                failure = failure.javaClass.name,
+            )
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private class EntityReferenceEncoder(
+        private val occurrences: MutableList<Occurrence>,
+        private val path: List<PathSegment> = emptyList(),
+        private val expectsEntityId: Boolean = false,
+    ) : AbstractEncoder() {
+        private var nextPath: List<PathSegment>? = null
+
+        override val serializersModule = engineSerializersModule
+
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+            check(!expectsEntityId) {
+                "EntityId serializer changed to a structured form; projection must be updated"
+            }
+            return EntityReferenceEncoder(occurrences, consumePath())
+        }
+
+        override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+            nextPath = path + descriptor.pathSegment(index)
+            return true
+        }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        override fun encodeInline(descriptor: SerialDescriptor): Encoder =
+            EntityReferenceEncoder(
+                occurrences = occurrences,
+                path = consumePath(),
+                expectsEntityId = descriptor.serialName == entityIdSerialName,
+            )
+
+        override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
+
+        /**
+         * [CharacteristicValue] is the one engine value family whose serializer deliberately
+         * requires a JSON encoder. Traverse its actual sealed value instead: fixed values contain
+         * no references, while dynamic values retain their typed [DynamicAmount] graph. A new
+         * CharacteristicValue case therefore makes this exhaustive `when` fail to compile, and
+         * every other unknown JSON-only serializer still makes the outer projection fail closed.
+         */
+        override fun <T> encodeSerializableValue(
+            serializer: SerializationStrategy<T>,
+            value: T,
+        ) {
+            if (serializer.descriptor.serialName == characteristicValueSerialName) {
+                check(!expectsEntityId)
+                val valuePath = consumePath()
+                when (val characteristic = value as CharacteristicValue) {
+                    is CharacteristicValue.Fixed -> Unit
+                    is CharacteristicValue.Dynamic -> DynamicAmount.serializer().serialize(
+                        EntityReferenceEncoder(
+                            occurrences,
+                            valuePath + PathSegment.Field("source"),
+                        ),
+                        characteristic.source,
+                    )
+                    is CharacteristicValue.DynamicWithOffset -> DynamicAmount.serializer().serialize(
+                        EntityReferenceEncoder(
+                            occurrences,
+                            valuePath + PathSegment.Field("source"),
+                        ),
+                        characteristic.source,
+                    )
+                }
+                return
+            }
+            super.encodeSerializableValue(serializer, value)
+        }
+
+        override fun encodeString(value: String) {
+            if (expectsEntityId) occurrences += Occurrence(EntityId.of(value), path)
+            nextPath = null
+        }
+
+        override fun encodeBoolean(value: Boolean) = rejectNonStringEntityId()
+        override fun encodeByte(value: Byte) = rejectNonStringEntityId()
+        override fun encodeChar(value: Char) = rejectNonStringEntityId()
+        override fun encodeDouble(value: Double) = rejectNonStringEntityId()
+        override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = rejectNonStringEntityId()
+        override fun encodeFloat(value: Float) = rejectNonStringEntityId()
+        override fun encodeInt(value: Int) = rejectNonStringEntityId()
+        override fun encodeLong(value: Long) = rejectNonStringEntityId()
+        override fun encodeShort(value: Short) = rejectNonStringEntityId()
+        override fun encodeNull() = rejectNonStringEntityId()
+
+        private fun consumePath(): List<PathSegment> = (nextPath ?: path).also { nextPath = null }
+
+        private fun rejectNonStringEntityId() {
+            check(!expectsEntityId) {
+                "EntityId serializer changed to a non-string form; projection must be updated"
+            }
+            nextPath = null
+        }
+
+        private fun SerialDescriptor.pathSegment(index: Int): PathSegment = when (kind) {
+            StructureKind.LIST -> PathSegment.Element(index)
+            StructureKind.MAP -> PathSegment.MapEntry(
+                index = index / 2,
+                role = if (index % 2 == 0) PathSegment.MapEntry.Role.KEY else PathSegment.MapEntry.Role.VALUE,
+            )
+            PolymorphicKind.OPEN, PolymorphicKind.SEALED -> when (index) {
+                1 -> PathSegment.PolymorphicPayload
+                else -> PathSegment.Field(getElementName(index))
+            }
+            else -> PathSegment.Field(getElementName(index))
+        }
+    }
+}
+
+/**
  * Typed entity-reference projection for persisted in-flight engine execution.
  *
- * Live stack objects, pending decisions, and continuation frames are serializable graphs. Rather
- * than maintaining a second hand-written visitor over their many concrete shapes, this projection
- * walks their normal persistence serializers. It sees an [EntityId] only at its typed inline
- * serializer boundary, so a plain [String] which happens to equal an entity id is never mistaken
- * for a reference. Serialization also traverses collection values and map keys, which catches
- * nested `List`s and `Map<EntityId, ...>` shapes.
- *
- * This projection is complete only while persisted in-flight engine state is fully represented by
- * its normal serializers and [EntityId] keeps its normal typed inline serializer. The registration
- * hygiene test makes a missing sealed leaf observable, but registration alone is not proof that
- * every stored field is serializable. Any serialization failure therefore reports
- * [InFlightEntityReferences.Projection.Incomplete], and callers must fail closed rather than
- * treating an incomplete projection as empty.
+ * Live stack objects, pending decisions, and continuation frames use the same serializer-backed
+ * traversal as [TypedEntityReferences], retaining only its set-membership compatibility view.
+ * Any serialization failure remains explicit so hidden-world consumers fail closed rather than
+ * treating an incomplete graph as unreferenced.
  */
 internal object InFlightEntityReferences : InFlightReferenceProjector {
 
@@ -67,89 +255,12 @@ internal object InFlightEntityReferences : InFlightReferenceProjector {
         serializer: SerializationStrategy<T>,
         value: T,
     ): Projection {
-        val references = linkedSetOf<EntityId>()
-        return try {
-            serializer.serialize(EntityReferenceEncoder(references), value)
-            Projection.Complete(references)
-        } catch (failure: Exception) {
-            Projection.Incomplete(
-                rootType = value.javaClass.name,
-                failure = failure.javaClass.name,
+        return when (val projection = TypedEntityReferences.project(serializer, value)) {
+            is TypedEntityReferences.Projection.Complete -> Projection.Complete(projection.entityIds)
+            is TypedEntityReferences.Projection.Incomplete -> Projection.Incomplete(
+                rootType = projection.rootType,
+                failure = projection.failure,
             )
-        }
-    }
-
-    @OptIn(ExperimentalSerializationApi::class)
-    private class EntityReferenceEncoder(
-        private val references: MutableSet<EntityId>,
-        private val expectsEntityId: Boolean = false,
-    ) : AbstractEncoder() {
-        override val serializersModule = engineSerializersModule
-
-        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-            check(!expectsEntityId) {
-                "EntityId serializer changed to a structured form; projection must be updated"
-            }
-            return this
-        }
-
-        @OptIn(ExperimentalSerializationApi::class)
-        override fun encodeInline(descriptor: SerialDescriptor): Encoder =
-            EntityReferenceEncoder(
-                references = references,
-                expectsEntityId = descriptor.serialName == entityIdSerialName,
-            )
-
-        override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = true
-
-        /**
-         * [CharacteristicValue] deliberately serializes through JSON. Traverse the sealed value
-         * directly so ordinary card components do not make an otherwise exhaustive in-flight
-         * projection fail. Fixed values contain no references; dynamic values keep their typed
-         * [DynamicAmount] graph. A new CharacteristicValue case makes this `when` fail to compile,
-         * while any other unsupported serializer still reaches the outer fail-closed result.
-         */
-        override fun <T> encodeSerializableValue(
-            serializer: SerializationStrategy<T>,
-            value: T,
-        ) {
-            if (serializer.descriptor.serialName == characteristicValueSerialName) {
-                check(!expectsEntityId)
-                when (val characteristic = value as CharacteristicValue) {
-                    is CharacteristicValue.Fixed -> Unit
-                    is CharacteristicValue.Dynamic -> DynamicAmount.serializer().serialize(
-                        EntityReferenceEncoder(references),
-                        characteristic.source,
-                    )
-                    is CharacteristicValue.DynamicWithOffset -> DynamicAmount.serializer().serialize(
-                        EntityReferenceEncoder(references),
-                        characteristic.source,
-                    )
-                }
-                return
-            }
-            super.encodeSerializableValue(serializer, value)
-        }
-
-        override fun encodeString(value: String) {
-            if (expectsEntityId) references += EntityId.of(value)
-        }
-
-        override fun encodeBoolean(value: Boolean) = rejectNonStringEntityId()
-        override fun encodeByte(value: Byte) = rejectNonStringEntityId()
-        override fun encodeChar(value: Char) = rejectNonStringEntityId()
-        override fun encodeDouble(value: Double) = rejectNonStringEntityId()
-        override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = rejectNonStringEntityId()
-        override fun encodeFloat(value: Float) = rejectNonStringEntityId()
-        override fun encodeInt(value: Int) = rejectNonStringEntityId()
-        override fun encodeLong(value: Long) = rejectNonStringEntityId()
-        override fun encodeShort(value: Short) = rejectNonStringEntityId()
-        override fun encodeNull() = rejectNonStringEntityId()
-
-        private fun rejectNonStringEntityId() {
-            check(!expectsEntityId) {
-                "EntityId serializer changed to a non-string form; projection must be updated"
-            }
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TypedEntityReferencesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TypedEntityReferencesTest.kt
@@ -1,0 +1,247 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.AlternativePaymentChoice
+import com.wingedsheep.sdk.scripting.ConvokePayment
+import com.wingedsheep.sdk.scripting.DistributedCounterRemoval
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class TypedEntityReferencesTest : FunSpec({
+
+    test("action traversal retains repeated nested references and entity map-key locations") {
+        val player = EntityId.of("player")
+        val card = EntityId.of("card")
+        val target = EntityId.of("target")
+        val owner = EntityId.of("owner")
+        val manaSource = EntityId.of("mana-source")
+        val delved = EntityId.of("delved")
+        val convoked = EntityId.of("convoked")
+        val sacrificed = EntityId.of("sacrificed")
+        val counterRemoval = EntityId.of("counter-removal")
+        val damageTarget = EntityId.of("damage-target")
+        val modeDamageTarget = EntityId.of("mode-damage-target")
+        val repeated = EntityId.of("repeated")
+        val ordinaryText = EntityId.of("ordinary-text-that-looks-like-an-id")
+        val action = CastSpell(
+            playerId = player,
+            cardId = card,
+            targets = listOf(ChosenTarget.Card(target, owner, com.wingedsheep.sdk.core.Zone.HAND)),
+            paymentStrategy = PaymentStrategy.Explicit(listOf(manaSource)),
+            alternativePayment = AlternativePaymentChoice(
+                delvedCards = listOf(delved),
+                convokedCreatures = linkedMapOf(convoked to ConvokePayment()),
+                harmonizeCreature = repeated,
+                tapForGenericPermanents = linkedSetOf(repeated),
+            ),
+            additionalCostPayment = AdditionalCostPayment(
+                sacrificedPermanents = listOf(sacrificed),
+                distributedCounterRemovals = listOf(
+                    DistributedCounterRemoval(counterRemoval, ordinaryText.value, 1),
+                ),
+            ),
+            giftRecipient = repeated,
+            splicedCardIds = listOf(repeated),
+            damageDistribution = linkedMapOf(damageTarget to 2),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(repeated))),
+            modeDamageDistribution = linkedMapOf(0 to linkedMapOf(modeDamageTarget to 1)),
+            conspiredCreatures = listOf(repeated),
+            casualtyCreature = repeated,
+        )
+
+        val projection = TypedEntityReferences.action(action)
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Complete>()
+
+        projection.occurrences.count { it.entityId == repeated } shouldBe 7
+        projection.entityIds shouldBe setOf(
+            player,
+            card,
+            target,
+            owner,
+            manaSource,
+            delved,
+            convoked,
+            sacrificed,
+            counterRemoval,
+            damageTarget,
+            modeDamageTarget,
+            repeated,
+        )
+        projection.occurrences shouldContain TypedEntityReferences.Occurrence(
+            damageTarget,
+            listOf(
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("damageDistribution"),
+                TypedEntityReferences.PathSegment.MapEntry(0, TypedEntityReferences.PathSegment.MapEntry.Role.KEY),
+            ),
+        )
+        projection.occurrences shouldContain TypedEntityReferences.Occurrence(
+            modeDamageTarget,
+            listOf(
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("modeDamageDistribution"),
+                TypedEntityReferences.PathSegment.MapEntry(0, TypedEntityReferences.PathSegment.MapEntry.Role.VALUE),
+                TypedEntityReferences.PathSegment.MapEntry(0, TypedEntityReferences.PathSegment.MapEntry.Role.KEY),
+            ),
+        )
+        projection.occurrences shouldContain TypedEntityReferences.Occurrence(
+            target,
+            listOf(
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("targets"),
+                TypedEntityReferences.PathSegment.Element(0),
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("cardId"),
+            ),
+        )
+        projection.shouldResolveAgainst(
+            normalEngineJson.encodeToJsonElement(GameAction.serializer(), action),
+        )
+    }
+
+    test("nested submit-decision traversal keeps map keys values and ordinary strings distinct") {
+        val player = EntityId.of("player")
+        val blocker = EntityId.of("blocker")
+        val attacker = EntityId.of("attacker")
+        val otherBlocker = EntityId.of("other-blocker")
+        val ordinaryText = EntityId.of("ordinary-text-that-looks-like-an-id")
+        val response = CombatResolutionResponse(
+            decisionId = ordinaryText.value,
+            edges = listOf(DamageEdgeAmount(ordinaryText.value, 2)),
+            orderedBlockers = linkedMapOf(blocker to listOf(attacker, attacker)),
+            orderedAttackers = linkedMapOf(attacker to listOf(otherBlocker)),
+        )
+        val action = SubmitDecision(player, response)
+
+        val projection = TypedEntityReferences.action(action)
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Complete>()
+
+        projection.occurrences.count { it.entityId == attacker } shouldBe 3
+        projection.entityIds shouldNotContain ordinaryText
+        projection.occurrences shouldContain TypedEntityReferences.Occurrence(
+            blocker,
+            listOf(
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("response"),
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("orderedBlockers"),
+                TypedEntityReferences.PathSegment.MapEntry(0, TypedEntityReferences.PathSegment.MapEntry.Role.KEY),
+            ),
+        )
+        projection.occurrences shouldContain TypedEntityReferences.Occurrence(
+            attacker,
+            listOf(
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("response"),
+                TypedEntityReferences.PathSegment.PolymorphicPayload,
+                TypedEntityReferences.PathSegment.Field("orderedBlockers"),
+                TypedEntityReferences.PathSegment.MapEntry(0, TypedEntityReferences.PathSegment.MapEntry.Role.VALUE),
+                TypedEntityReferences.PathSegment.Element(0),
+            ),
+        )
+        projection.shouldResolveAgainst(
+            normalEngineJson.encodeToJsonElement(GameAction.serializer(), action),
+        )
+        val responseProjection = TypedEntityReferences.response(response)
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Complete>()
+        responseProjection.occurrences.count { it.entityId == attacker } shouldBe 3
+        responseProjection.shouldResolveAgainst(
+            normalEngineJson.encodeToJsonElement(DecisionResponse.serializer(), response),
+        )
+    }
+
+    test("action traversal does not mistake an equal AbilityId for an EntityId") {
+        val player = EntityId.of("player")
+        val sharedBytes = "same-entity-and-ability-bytes"
+        val source = EntityId.of(sharedBytes)
+        val action = ActivateAbility(
+            playerId = player,
+            sourceId = source,
+            abilityId = AbilityId(sharedBytes),
+        )
+
+        val projection = TypedEntityReferences.action(action)
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Complete>()
+
+        projection.entityIds shouldBe setOf(player, source)
+        projection.occurrences.count { it.entityId == source } shouldBe 1
+    }
+
+    test("action traversal reports serializer failure rather than an empty reference list") {
+        val player = EntityId.of("player")
+        val throwingSerializer = object : SerializationStrategy<GameAction> {
+            override val descriptor = GameAction.serializer().descriptor
+
+            override fun serialize(encoder: Encoder, value: GameAction): Nothing =
+                throw IllegalStateException("forced traversal failure")
+        }
+
+        val projection = TypedEntityReferences.project(throwingSerializer, PassPriority(player))
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Incomplete>()
+
+        projection.rootType shouldBe PassPriority::class.java.name
+        projection.failure shouldBe IllegalStateException::class.java.name
+    }
+
+    test("an unknown JSON-only serializer fails closed") {
+        val player = EntityId.of("player")
+        val jsonOnlySerializer = object : SerializationStrategy<GameAction> {
+            override val descriptor = GameAction.serializer().descriptor
+
+            override fun serialize(encoder: Encoder, value: GameAction) {
+                (encoder as kotlinx.serialization.json.JsonEncoder)
+                    .encodeJsonElement(JsonPrimitive("opaque"))
+            }
+        }
+
+        TypedEntityReferences.project(jsonOnlySerializer, PassPriority(player))
+            .shouldBeInstanceOf<TypedEntityReferences.Projection.Incomplete>()
+            .failure shouldBe ClassCastException::class.java.name
+    }
+})
+
+private val normalEngineJson = Json {
+    serializersModule = engineSerializersModule
+    encodeDefaults = true
+    classDiscriminator = "type"
+}
+
+private fun TypedEntityReferences.Projection.Complete.shouldResolveAgainst(encoded: JsonElement) {
+    occurrences.forEach { occurrence ->
+        val objectJsonPath = occurrence.path.filterNot {
+            it is TypedEntityReferences.PathSegment.PolymorphicPayload
+        }
+        encoded.resolve(objectJsonPath).jsonPrimitive.content shouldBe occurrence.entityId.value
+    }
+}
+
+private fun JsonElement.resolve(path: List<TypedEntityReferences.PathSegment>): JsonElement =
+    path.fold(this) { current, segment ->
+        when (segment) {
+            is TypedEntityReferences.PathSegment.Field -> current.jsonObject.getValue(segment.name)
+            is TypedEntityReferences.PathSegment.Element -> current.jsonArray[segment.index]
+            is TypedEntityReferences.PathSegment.MapEntry -> {
+                val entry = current.jsonObject.entries.elementAt(segment.index)
+                when (segment.role) {
+                    TypedEntityReferences.PathSegment.MapEntry.Role.KEY -> JsonPrimitive(entry.key)
+                    TypedEntityReferences.PathSegment.MapEntry.Role.VALUE -> entry.value
+                }
+            }
+            TypedEntityReferences.PathSegment.PolymorphicPayload ->
+                error("Object-polymorphic JSON paths must drop PolymorphicPayload")
+        }
+    }


### PR DESCRIPTION
Engine integrations that project or rewrite actions need to know which payload
values are entity references. Today they have to mirror every `GameAction` and
`DecisionResponse` shape by hand, or search serialized strings and risk treating
an ordinary decision ID, counter name, or `AbilityId` as an entity.

A cast action shows why this becomes fragile: one payload can reference the
spell, targets, mana sources, convoke creatures, damage recipients, and
entity-valued map keys. Repeated references matter too, because a transforming
adapter needs every location rather than a deduplicated set.

## What changes

`TypedEntityReferences` walks the registered serializers for `GameAction` and
`DecisionResponse` and returns every typed `EntityId` occurrence in serializer
order. Each occurrence includes a structural path through record fields,
collection indices, map key/value roles, and polymorphic payloads.

The existing in-flight reference projection now uses the same traversal. This
gives the engine one answer for which serialized values are entity references,
while preserving the materializer's set-oriented view.

Traversal is fail-closed: serializer failure or an unknown JSON-only payload is
reported as `Incomplete`, rather than silently appearing to contain no entity
references.

## Utility

A viewer-facing adapter can serialize an action normally, replace only the
reported entity leaves with safe aliases, and leave equal non-entity strings
untouched. The engine owns exhaustive schema traversal; the adapter still owns
visibility, aliasing, legality, and policy meaning.

This also removes duplicate schema knowledge from in-flight hidden-world
checks. Adding a new sealed action or response shape now reaches one generic
reference authority instead of requiring each consumer to rediscover its
payload.

## Verification

Run against upstream `b13310723a225fb81d72238c923e579128cd082c`:

- `TypedEntityReferencesTest`: 5 passed
- `InFlightEntityReferencesTest`: 3 passed
- `SerializationPolymorphicRegistrationTest`: 6 passed
- `HiddenWorldMaterializerTest`: 13 passed on the combined prospective tip
- `git diff --check`: clean

The structural paths describe serializer structure. A flattened polymorphic
JSON consumer may need to omit the explicit polymorphic-payload edge when
mapping a path onto encoded object fields.
