### PR TITLE
Expose the card registry owned by GameEnvironment

### DIFF
--- a/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/GameEnvironmentRegistryAuthorityTest.kt
+++ b/gym-trainer/src/test/kotlin/com/wingedsheep/gym/trainer/GameEnvironmentRegistryAuthorityTest.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.gym.trainer
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.gym.GameEnvironment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class GameEnvironmentRegistryAuthorityTest : FunSpec({
+
+    test("external adapters can retain the environment's registry authority across forks") {
+        val registry = CardRegistry()
+        val environment = GameEnvironment.create(registry)
+
+        environment.cardRegistry shouldBeSameInstanceAs registry
+        environment.fork().cardRegistry shouldBeSameInstanceAs registry
+    }
+})

--- a/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
+++ b/gym/src/main/kotlin/com/wingedsheep/gym/GameEnvironment.kt
@@ -79,7 +79,14 @@ import com.wingedsheep.sdk.model.EntityId
  * ```
  */
 class GameEnvironment private constructor(
-    internal val cardRegistry: CardRegistry,
+    /**
+     * The card-definition authority used by this environment and every [fork].
+     *
+     * External search and observation adapters often need card definitions alongside the
+     * environment's state. They should derive that dependency here instead of accepting a second
+     * registry that might disagree with the one used by action processing and legal enumeration.
+     */
+    val cardRegistry: CardRegistry,
     private val processor: ActionProcessor,
     private val enumerator: LegalActionEnumerator,
     private val evaluator: BoardEvaluator,


### PR DESCRIPTION
`GameEnvironment` uses a `CardRegistry` to process actions and enumerate legal
choices, but integrations cannot recover that registry from the environment.
An adapter that needs definitions for the same state must accept a second
registry argument and trust that both objects describe the same card universe.

Simulation makes the split especially easy to miss. A search adapter forks an
environment, projects the forked state, and consults card definitions while it
rebinds or describes candidate actions. If that projection receives a different
registry, the state and its card semantics can disagree even though each object
looks valid in isolation.

## What changes

`GameEnvironment.cardRegistry` becomes a public read-only property. It is the
same registry supplied to `GameEnvironment.create`, used by the environment's
processors, and retained by `fork()`.

Adapters can now derive card-definition authority from the environment they
actually received. This removes a parallel dependency without changing registry
construction or mutation semantics.

## Utility

Search, replay, observation, and debugging adapters often begin with an existing
environment rather than its original constructor arguments. Reading the
environment-owned registry keeps every derived interpretation tied to the state
transition authority that produced the state.

## Verification

Run against upstream `b13310723a225fb81d72238c923e579128cd082c`:

- `GameEnvironmentRegistryAuthorityTest`: 1 passed; the created environment and
  its fork retain the supplied registry instance
- focused prospective-tip engine batch: 45 tests passed across registry,
  hidden-world/reference, exactly-one-transition, and structured-expansion
  responsibilities
- current-public MTGallium direct-pin candidate: `just check` passed, 83 tasks
- `git diff --check`: clean

This contribution is independent of the typed-reference contribution. Both are
needed by the current MTGallium direct-pin candidate, but either can be reviewed
and merged on its own.
