### PR TITLE
Add two Lorwyn cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NettlevineBlight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NettlevineBlight.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Nettlevine Blight
+ * {4}{B}{B}
+ * Enchantment — Aura
+ * Enchant creature or land
+ * Enchanted permanent has "At the beginning of your end step, sacrifice this permanent and attach
+ * Nettlevine Blight to a creature or land you control."
+ *
+ * The whole card turns on *who* the quoted "you" is, and the 2007-10-01 ruling spells it out: the
+ * ability is granted to the enchanted permanent, so it triggers on that permanent's controller's
+ * end step, that player sacrifices, and that player picks the new host from permanents *they*
+ * control. Printing the ability on the Aura instead would hand every one of those to the Aura's
+ * controller — precisely backwards for a card you play on an opponent's permanent, and it would
+ * walk the Blight through your own board instead of eating theirs. [GrantTriggeredAbility] over the
+ * default `Scope.AttachedTo` filter is what makes it right: the engine indexes a granted trigger on
+ * the permanent it was granted to, so [Triggers.YourEndStep]'s `Player.You` and the pipeline's
+ * [CardSource.ControlledPermanents] both read that permanent's controller. Inevitable End is the
+ * same shape one step smaller.
+ *
+ * Inside the granted ability the two nouns are *different objects*, and each has its own handle:
+ *
+ * - **"this permanent"** is [EffectTarget.Self] — in a granted ability, Self is the host that
+ *   received the ability, not the granter.
+ * - **"Nettlevine Blight"** is [EffectTarget.GrantingSource] — the Aura whose static granted this
+ *   ability, captured when the trigger went on the stack. Using `Self` for both would sacrifice the
+ *   host and then attach the host to something.
+ *
+ * [Effects.AttachTargetEquipmentToCreature] is named for the Equipment case it was written for, but
+ * its executor reads neither type: it moves an `AttachedToComponent` from one permanent to another.
+ * An Aura moving onto a land is exactly what it does.
+ *
+ * The re-attach is a resolution-time *choice*, not a target (the printed line has no "target"), so
+ * it is a gather over the permanents that player controls followed by `chooseExactly(1)`. Gathering
+ * *after* the sacrifice is what makes the just-sacrificed host ineligible without an explicit
+ * exclusion, and `ChooseExactly`'s clamp handles the empty board: with nothing left to enchant the
+ * selection is empty, `ifNotEmpty` skips the attach, and the now-hostless Aura is put into its
+ * owner's graveyard by the unattached-Auras state-based action (CR 704.5m) — which runs after the
+ * resolution, never inside it, so the attach above still lands while the Aura is briefly host-less.
+ * That mid-resolution window is the one Breath of Fury opened (#2203).
+ */
+val NettlevineBlight = card("Nettlevine Blight") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature or land\n" +
+        "Enchanted permanent has \"At the beginning of your end step, sacrifice this permanent " +
+        "and attach Nettlevine Blight to a creature or land you control.\""
+
+    auraTarget = TargetPermanent(filter = TargetFilter.CreatureOrLandPermanent)
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YourEndStep.event,
+                binding = Triggers.YourEndStep.binding,
+                effect = Effects.Pipeline {
+                    run(Effects.SacrificeTarget(EffectTarget.Self))
+                    val hosts = gather(
+                        CardSource.ControlledPermanents(filter = GameObjectFilter.CreatureOrLand),
+                        name = "newHosts"
+                    )
+                    val newHost = chooseExactly(
+                        1,
+                        from = hosts,
+                        prompt = "Choose a creature or land to attach Nettlevine Blight to",
+                        useTargetingUI = true
+                    )
+                    ifNotEmpty(newHost) {
+                        run(
+                            Effects.AttachTargetEquipmentToCreature(
+                                equipmentTarget = EffectTarget.GrantingSource,
+                                creatureTarget = EffectTarget.PipelineTarget(newHost.key)
+                            )
+                        )
+                    }
+                },
+                descriptionOverride = "At the beginning of your end step, sacrifice this permanent " +
+                    "and attach Nettlevine Blight to a creature or land you control."
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg?1783942885"
+        ruling(
+            "2007-10-01",
+            "Nettlevine Blight grants the triggered ability to the enchanted permanent, so \"you\" " +
+                "refers to that permanent's controller. The ability will trigger at the end of " +
+                "that player's turn, and that player chooses the new creature or land to attach " +
+                "Nettlevine Blight to. The player must choose a creature or land they control."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/RingsOfBrighthearth.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/RingsOfBrighthearth.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rings of Brighthearth
+ * {3}
+ * Artifact
+ * Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy
+ * that ability. You may choose new targets for the copy.
+ *
+ * The whole card is three existing pieces stacked in the order the sentence reads:
+ *
+ * - **"if it isn't a mana ability" is part of the trigger, not an intervening "if".** It reads as a
+ *   condition because Oracle templating puts it after the comma, but a mana ability never uses the
+ *   stack (CR 605.1a) and so can never be the object of a "whenever you activate" trigger in the
+ *   first place. [Triggers.YouActivateAbility] already carries that gate —
+ *   `AbilityActivatedEvent(player = Player.You)` excludes mana abilities by default — so wiring the
+ *   clause a second time as an `interveningIf` would be redundant, and worse, would re-check it on
+ *   resolution where the printed clause never does.
+ * - **The {2} is a resolution-time optional cost, not an additional cost of the trigger.**
+ *   [OptionalCostEffect] (a `Gate.MayPay` over [PayManaCostEffect]) is the "you may pay … If you
+ *   do, …" shape, and its one-yes-per-resolution nature is exactly the 2020-11-10 ruling: "You
+ *   can't pay {2} more than once for each time the triggered ability of Rings of Brighthearth
+ *   resolves."
+ * - **The copy is [Effects.CopyTargetSpellOrAbility] over [EffectTarget.TriggeringEntity]** — the
+ *   activated ability still sitting on the stack underneath this trigger. That executor already
+ *   prompts for new targets per CR 707.10c, so the printed "You may choose new targets for the
+ *   copy" needs no separate effect, and it copies the ability's chosen value of X along with its
+ *   targets (the third ruling). Pit Automaton is the same pairing, reached through a delayed
+ *   trigger instead of a printed one.
+ *
+ * The "activated an ability" event fires only *after* all costs are paid (CR 602.2), which is why
+ * the sixth ruling holds for free: an ability whose cost sacrifices the Rings is activated at a
+ * moment when the Rings is already gone, so the static index no longer carries this trigger.
+ *
+ * "An ability" is unrestricted by source — an ability of a permanent an opponent controls that
+ * *you* activate (a granted "any player may activate" ability) still counts, as does a loyalty
+ * ability, which is an activated ability.
+ */
+val RingsOfBrighthearth = card("Rings of Brighthearth") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. " +
+        "If you do, copy that ability. You may choose new targets for the copy."
+
+    triggeredAbility {
+        trigger = Triggers.YouActivateAbility
+        effect = OptionalCostEffect(
+            cost = PayManaCostEffect(ManaCost.parse("{2}")),
+            ifPaid = Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity),
+            descriptionOverride = "Pay {2}? If you do, copy that ability. You may choose new " +
+                "targets for the copy."
+        )
+        description = "Whenever you activate an ability, if it isn't a mana ability, you may pay " +
+            "{2}. If you do, copy that ability. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Howard Lyon"
+        flavorText = "\"Without flame, there would be no iron tools, no cooked meals, no purge of " +
+            "old growth to make room for new.\"\n—Brighthearth creed"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg?1783942851"
+        ruling(
+            "2020-11-10",
+            "An activated mana ability is one that produces mana as it resolves, not one that " +
+                "costs mana to activate."
+        )
+        ruling(
+            "2020-11-10",
+            "You can't pay {2} more than once for each time the triggered ability of Rings of " +
+                "Brighthearth resolves."
+        )
+        ruling("2020-11-10", "If the ability has {X} in its cost, the copy uses the same value of X.")
+        ruling(
+            "2020-11-10",
+            "The triggered ability of Rings of Brighthearth and the copy it creates both resolve " +
+                "before the ability that caused it to trigger. They resolve even if that ability " +
+                "is countered."
+        )
+        ruling(
+            "2020-11-10",
+            "The copy will have the same targets as the ability it's copying unless you choose " +
+                "new ones. You may change any number of the targets, including all of them or " +
+                "none of them. If, for one of the targets, you can't choose a new legal target, " +
+                "then it remains unchanged (even if the current target is illegal)."
+        )
+        ruling(
+            "2020-11-10",
+            "If paying the activation cost of the ability includes sacrificing Rings of " +
+                "Brighthearth, the ability won't be copied. At the time the ability is considered " +
+                "activated (after all costs are paid), Rings of Brighthearth is no longer on the " +
+                "battlefield."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NettlevineBlightScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NettlevineBlightScenarioTest.kt
@@ -1,0 +1,177 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Nettlevine Blight (LRW #131, {4}{B}{B}, Enchantment — Aura).
+ *
+ *   Enchant creature or land
+ *   Enchanted permanent has "At the beginning of your end step, sacrifice this permanent and
+ *   attach Nettlevine Blight to a creature or land you control."
+ *
+ * Every test here aims at the same axis, because it is the whole card and the 2007-10-01 ruling
+ * exists to spell it out: the ability is *granted to the enchanted permanent*, so the quoted "you"
+ * is that permanent's controller — not the Aura's. Play it on an opponent's creature (the only way
+ * anyone plays it) and the wrong wiring gives the opposite card: the Aura's controller would be
+ * prompted, would pick from their own board, and the Blight would walk through their permanents
+ * instead of their opponent's. So the assertions are on *who* decides, *whose* permanents are
+ * offered, and *whose* end step fires it.
+ *
+ * The fourth question is a type one: "creature or land" has to hold on both ends. A land is offered
+ * as a new host, and picking it must leave the Aura attached rather than falling off — the printed
+ * `AttachTargetEquipmentToCreature` is named for Equipment, and its executor reads neither type.
+ */
+class NettlevineBlightScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Nettlevine Blight") {
+
+            test("the enchanted permanent's controller sacrifices it and re-attaches the Aura") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Nettlevine Blight", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aura = game.findPermanent("Nettlevine Blight")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val forest = game.findPermanent("Forest")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("\"you\" is the enchanted permanent's controller, so Bob chooses") {
+                    decision.playerId shouldBe game.player2Id
+                }
+                withClue("the pool is Bob's creatures and lands — never Alice's Craw Wurm, and " +
+                    "never the Grizzly Bears he just sacrificed") {
+                    decision.options.toSet() shouldBe setOf(giant, forest)
+                }
+
+                game.selectCards(listOf(giant)).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("the host was sacrificed by its own controller") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("the Aura moved to the chosen permanent rather than falling off") {
+                    game.isOnBattlefield("Nettlevine Blight") shouldBe true
+                    game.state.getEntity(aura)!!.get<AttachedToComponent>()!!.targetId shouldBe giant
+                }
+            }
+
+            test("a land is a legal new host — \"creature or land\" holds on the re-attach too") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Nettlevine Blight", "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aura = game.findPermanent("Nettlevine Blight")!!
+                val forest = game.findPermanent("Forest")!!
+
+                // Two lands, so `chooseExactly(1)` raises a real prompt instead of auto-picking the
+                // single candidate — the shape the first test's creature-and-land board also has.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                game.selectCards(listOf(forest)).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("an Aura on a land survives the unattached-Auras and illegal-attachment SBAs") {
+                    game.isOnBattlefield("Nettlevine Blight") shouldBe true
+                    game.state.getEntity(aura)!!.get<AttachedToComponent>()!!.targetId shouldBe forest
+                }
+            }
+
+            test("a single candidate is taken without a prompt — the choice is forced") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Nettlevine Blight", "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Swamp", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aura = game.findPermanent("Nettlevine Blight")!!
+                val swamp = game.findPermanent("Swamp")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("with one legal host, `chooseExactly(1)` auto-picks rather than asking") {
+                    game.hasPendingDecision() shouldBe false
+                    game.state.getEntity(aura)!!.get<AttachedToComponent>()!!.targetId shouldBe swamp
+                }
+            }
+
+            test("with nothing left to move to, the host still dies and the Aura follows it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Nettlevine Blight", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("Alice's Craw Wurm is not a candidate, so Bob is never asked") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("the sacrifice is not conditional on there being a new host") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("an unattached Aura is put into its owner's graveyard (CR 704.5m)") {
+                    game.isOnBattlefield("Nettlevine Blight") shouldBe false
+                    game.isInGraveyard(1, "Nettlevine Blight") shouldBe true
+                }
+            }
+
+            test("the Aura's controller's end step does nothing — the trigger is not hers") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Nettlevine Blight", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("printing the ability on the Aura would have fired it here") {
+                    game.hasPendingDecision() shouldBe false
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Nettlevine Blight") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RingsOfBrighthearthScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RingsOfBrighthearthScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lea.cards.ProdigalSorcerer
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.RingsOfBrighthearth
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rings of Brighthearth (LRW #259) — "Whenever you activate an ability, if it isn't a mana ability,
+ * you may pay {2}. If you do, copy that ability. You may choose new targets for the copy."
+ *
+ * Three axes, and each is a place the card would read right and resolve wrong:
+ *
+ *  - **The copy has to find the ability that fired it.** `EffectTarget.TriggeringEntity` on an
+ *    `AbilityActivatedEvent` is the activated ability still on the stack beneath this trigger; if it
+ *    resolved to nothing, the whole card would be a silent no-op that the snapshot golden cannot
+ *    see. The happy path asserts *two* pings landed, not just that a decision was offered.
+ *  - **The {2} is optional.** Declining must leave the original ability untouched — one ping, not
+ *    zero and not two.
+ *  - **A mana ability must not trigger it at all.** This is the clause that is easiest to wire
+ *    twice or not at all; Llanowar Elves' "{T}: Add {G}" is the cheapest proof, and the assertion is
+ *    that no decision is ever raised.
+ *
+ * The copy's "you may choose new targets" prompt is a `ChooseTargetsDecision` raised by the shared
+ * copy executor (CR 707.10c), so the happy path re-submits the same target rather than skipping it.
+ */
+class RingsOfBrighthearthScenarioTest : FunSpec({
+
+    val pingAbility = ProdigalSorcerer.activatedAbilities.single().id
+    val elvesMana = TestCards.LlanowarElves.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ProdigalSorcerer + RingsOfBrighthearth)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Rings out, a ready pinger, and {2} floating to pay the optional cost with. */
+    fun GameTestDriver.setUpPinger(): EntityId {
+        putPermanentOnBattlefield(player1, "Rings of Brighthearth")
+        val tim = putCreatureOnBattlefield(player1, "Prodigal Sorcerer")
+        removeSummoningSickness(tim)
+        giveColorlessMana(player1, 2)
+        return tim
+    }
+
+    test("paying {2} copies the activated ability — the opponent takes the ping twice") {
+        val d = driver()
+        val tim = d.setUpPinger()
+
+        d.submit(
+            ActivateAbility(d.player1, tim, pingAbility, targets = listOf(ChosenTarget.Player(d.player2)))
+        ).isSuccess shouldBe true
+
+        withClue("the Rings trigger goes on the stack above the ping it copies") {
+            d.pendingDecision shouldBe null
+        }
+        d.bothPass()
+
+        withClue("the trigger resolves first and asks its controller for the {2}") {
+            d.pendingDecision?.playerId shouldBe d.player1
+        }
+        d.submitYesNo(d.player1, true)
+
+        // The copy offers new targets (CR 707.10c); keep the opponent.
+        if (d.pendingDecision != null) {
+            d.submitTargetSelection(d.player1, listOf(d.player2))
+        }
+        d.bothPass()
+        d.bothPass()
+
+        withClue("the copy and the original each deal 1 — 20 - 2 = 18") {
+            d.getLifeTotal(d.player2) shouldBe 18
+        }
+    }
+
+    test("declining the {2} leaves the original ability alone — one ping, not two") {
+        val d = driver()
+        val tim = d.setUpPinger()
+
+        d.submit(
+            ActivateAbility(d.player1, tim, pingAbility, targets = listOf(ChosenTarget.Player(d.player2)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.submitYesNo(d.player1, false)
+        d.bothPass()
+
+        withClue("no copy was made, but the ability that triggered it still resolves") {
+            d.getLifeTotal(d.player2) shouldBe 19
+        }
+    }
+
+    test("a mana ability never triggers it — no {2} is ever offered") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Rings of Brighthearth")
+        val elves = d.putCreatureOnBattlefield(d.player1, "Llanowar Elves")
+        d.removeSummoningSickness(elves)
+        d.giveColorlessMana(d.player1, 2)
+
+        d.submit(ActivateAbility(d.player1, elves, elvesMana)).isSuccess shouldBe true
+
+        withClue("a mana ability doesn't use the stack, so there is nothing to copy and nothing to ask") {
+            d.pendingDecision shouldBe null
+            d.state.stack.isEmpty() shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RingsOfBrighthearthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RingsOfBrighthearthReprint.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rings of Brighthearth reprint in Commander Legends. The canonical CardDefinition lives in Lorwyn
+ * (`lrw`), the card's earliest real printing; this file contributes only per-printing presentation
+ * data. Commander Legends printed it twice — the draft-frame #335 and the extended-art #698 — and
+ * printings are keyed by `(setCode, collectorNumber)`, so each number needs its own row.
+ */
+val RingsOfBrighthearthReprint = Printing(
+    oracleId = "bbf9494c-c4bb-4d36-98fe-8387846b342e",
+    name = "Rings of Brighthearth",
+    setCode = "CMR",
+    collectorNumber = "335",
+    scryfallId = "838ffc87-517a-4d94-8ce0-bc9ed01ecc52",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/838ffc87-517a-4d94-8ce0-bc9ed01ecc52.jpg?1783928748",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)
+
+/** The extended-art printing of the same card in the same set. */
+val RingsOfBrighthearthExtendedArtReprint = Printing(
+    oracleId = "bbf9494c-c4bb-4d36-98fe-8387846b342e",
+    name = "Rings of Brighthearth",
+    setCode = "CMR",
+    collectorNumber = "698",
+    scryfallId = "1dbc00c6-5df2-4953-95c2-6c79dc86f409",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1dbc00c6-5df2-4953-95c2-6c79dc86f409.jpg?1783928597",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+    frameEffects = listOf("extendedart"),
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -10165,6 +10165,94 @@
     ]
 }
 
+// Nettlevine Blight
+{
+    "name": "Nettlevine Blight",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature or land\nEnchanted permanent has \"At the beginning of your end step, sacrifice this permanent and attach Nettlevine Blight to a creature or land you control.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "END"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SacrificeTarget",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "ControlledPermanents",
+                                    "filter": "creature|land"
+                                },
+                                "storeAs": "newHosts"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "newHosts",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected2",
+                                "prompt": "Choose a creature or land to attach Nettlevine Blight to",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "selected2",
+                                "ifNotEmpty": {
+                                    "type": "AttachTargetEquipmentToCreature",
+                                    "equipmentTarget": "GrantingSource",
+                                    "creatureTarget": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "selected2"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "At the beginning of your end step, sacrifice this permanent and attach Nettlevine Blight to a creature or land you control."
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|land"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg?1783942885",
+        "rulings": [
+            {
+                "date": "2007-10-01",
+                "text": "Nettlevine Blight grants the triggered ability to the enchanted permanent, so \"you\" refers to that permanent's controller. The ability will trigger at the end of that player's turn, and that player chooses the new creature or land to attach Nettlevine Blight to. The player must choose a creature or land they control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nightshade Stinger
 {
     "name": "Nightshade Stinger",
@@ -10962,6 +11050,72 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Rings of Brighthearth
+{
+    "name": "Rings of Brighthearth",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AbilityActivatedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "CopyTargetSpellOrAbility",
+                        "target": "TriggeringEntity"
+                    },
+                    "descriptionOverride": "Pay {2}? If you do, copy that ability. You may choose new targets for the copy."
+                },
+                "descriptionOverride": "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability. You may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Without flame, there would be no iron tools, no cooked meals, no purge of old growth to make room for new.\"\n—Brighthearth creed",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbfd3898-cb06-4bb9-9d52-b319e1fa2217.jpg?1783942851",
+        "rulings": [
+            {
+                "date": "2020-11-10",
+                "text": "An activated mana ability is one that produces mana as it resolves, not one that costs mana to activate."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "You can't pay {2} more than once for each time the triggered ability of Rings of Brighthearth resolves."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "If the ability has {X} in its cost, the copy uses the same value of X."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "The triggered ability of Rings of Brighthearth and the copy it creates both resolve before the ability that caused it to trigger. They resolve even if that ability is countered."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "The copy will have the same targets as the ability it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. If, for one of the targets, you can't choose a new legal target, then it remains unchanged (even if the current target is illegal)."
+            },
+            {
+                "date": "2020-11-10",
+                "text": "If paying the activation cost of the ability includes sacrificing Rings of Brighthearth, the ability won't be copied. At the time the ability is considered activated (after all costs are paid), Rings of Brighthearth is no longer on the battlefield."
+            }
+        ]
+    }
 }
 
 // Rootgrapple


### PR DESCRIPTION
Two Lorwyn rares, both pure composition over existing primitives. Lorwyn 233/286 → **235/286**.

- **Rings of Brighthearth** ({3} Artifact) — "Whenever you activate an ability, if it isn't a mana ability, you may pay {2}. If you do, copy that ability." `Triggers.YouActivateAbility` (which already carries the mana-ability gate, since a mana ability never uses the stack and so can never be the object of the trigger) → `OptionalCostEffect` (`Gate.MayPay` over `PayManaCostEffect`) → `Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)`. The copy executor raises the "you may choose new targets" prompt itself (CR 707.10c), so the printed third clause needs no effect of its own. Pit Automaton is the same pairing, reached through a delayed trigger.
- **Nettlevine Blight** ({4}{B}{B} Aura) — "Enchant creature or land. Enchanted permanent has 'At the beginning of your end step, sacrifice this permanent and attach Nettlevine Blight to a creature or land you control.'" `GrantTriggeredAbility` so the quoted "you" is the *enchanted permanent's* controller (the 2007-10-01 ruling), with `EffectTarget.Self` for "this permanent" and `EffectTarget.GrantingSource` for the Aura — the first use of `GrantingSource` from a triggered granted ability rather than an activated one. The re-attach is a gather-after-sacrifice plus `chooseExactly(1)`, Breath of Fury's shape.

Also adds the two Commander Legends `Printing` rows for Rings of Brighthearth (#335 and the extended-art #698) that `just check-card-printing` demanded.

### Notes on the rest of Lorwyn's tail

Of the 51 still missing, 46 are blocked on absent mechanics already triaged as `add-feature` — clash (23 cards), champion (9), the "reveal a \<type\> card from your hand or pay {3}" `AdditionalCost` leg (5), switching P/T, a −X loyalty cost, and the prevention `onPrevented` rider the three Incarnations need. Of the five that were untriaged, these two were composable; **Cairn Wanderer** (13 conditional keyword grants, of which landwalk and protection need the *specific* granted ability and have no SDK spelling), **Guile** (a "would be countered" replacement, plus the put-into-a-graveyard-from-anywhere trigger zones Dread also needs) and **Twinning Glass** (no "shares a name with a spell cast this turn" predicate) all need new vocabulary and were left out.

### Verification

- `just build` — green except the expected `CardDefinitionSnapshotTest` LRW diff; re-blessed with `just rebless-cards`, and only these two cards moved in the golden.
- `:mtg-sets:test :mtg-sets:2003-2007:tests:test` — 1427 tests, BUILD SUCCESSFUL, including 8 new scenario tests (3 for Rings, 5 for Nettlevine).
- `just assay-differential --set LRW` — 101/111 confirmed; all 10 divergences are pre-existing (the Harbinger cycle's "you may search" fold, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart). Neither new card diverges.
- `just check-card-printing` — clean for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DitoSa7rF1u7UeFoGpfBuZ