### PR TITLE
Simulate AI-vs-AI bracket matches instead of playing them

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1453,6 +1453,24 @@ and the sweep re-checks the roster on the way in
 already drifted. Only a seat that is *gone* may be forfeited: `removePlayer` deliberately keeps a
 disconnected player's state during a tournament so they can rejoin.
 
+**Simulated AI-vs-AI matches.** A round-robin with one human and N AI seats schedules O(N²) matches,
+and the human is in only N of them; every other game is two AI controllers driving a full engine game
+that no one is in, which on a shared box is where most of the tournament's CPU goes. When
+`game.tournament.simulate-ai-matches` is on (the default), the start sweep decides such a pair with
+`AiMatchSimulator` instead of launching a `GameSession`, and reports it through the same result path a
+played match uses — so it closes rounds, moves standings and unblocks `hasIncompleteMatchBefore` the
+same way. The winner is a fair coin flip: any cheap deck-strength proxy would be unvalidated against
+how the engine AI actually plays, and an unmeasured bias in the standings is worse than an honest
+50/50. A simulated match never gets a `gameSessionId`, so it has no replay and never appears as
+something to spectate — `TournamentMatch.isSimulated` is what lets the standings say so, and turning
+the property off is how you get the games back when somebody wants to watch them.
+
+An **all-AI bracket is never simulated**, whatever the property says. A bracket with no human seat was
+built to be watched — the AI Sandbox (`/api/dev/ai-tournament`, behind `just watch-ai-match`) and the
+model-comparison runs are exactly that — and simulating it would decide the whole tournament in one
+sweep, deleting the feature rather than speeding it up. The saving only exists next to a human: the
+AI-vs-AI games running *alongside* the matches somebody is sitting in.
+
 BYE handling (odd player counts), reconnection across matches, and spectating between rounds are
 all managed at this layer. The tournament system reuses the same `GameSession` and `ActionProcessor`
 for each match — it's purely orchestration, with no game logic of its own.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -9,6 +9,7 @@ data class GameProperties(
     val admin: AdminProperties = AdminProperties(),
     val ai: AiProperties = AiProperties(),
     val easterEggs: EasterEggProperties = EasterEggProperties(),
+    val tournament: TournamentProperties = TournamentProperties(),
     val debugMode: Boolean = false
 )
 
@@ -19,6 +20,26 @@ data class GameProperties(
  */
 data class EasterEggProperties(
     val enabled: Boolean = false
+)
+
+/**
+ * Bracket tournament behaviour.
+ */
+data class TournamentProperties(
+    /**
+     * Decide an AI-vs-AI bracket match by simulation instead of actually playing it.
+     *
+     * A round-robin bracket with one human and N AI seats schedules O(N²) matches, and all but N of
+     * them are AI against AI — games nobody is in, each one running a full engine game plus two AI
+     * controllers on the server. On a shared box that is the bulk of the tournament's CPU, spent on
+     * results the human only ever reads off the standings table.
+     *
+     * On by default; set `GAME_TOURNAMENT_SIMULATE_AI_MATCHES=false` to play every match out (which is
+     * what you want on a box where somebody is spectating the AI games). An all-AI bracket — the AI
+     * Sandbox, a model-comparison run — is never simulated whatever this says: it was built to be
+     * watched, and there would be nothing left of it.
+     */
+    val simulateAiMatches: Boolean = true,
 )
 
 data class HandSmootherProperties(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.gameserver.repository.GameRepository
 import com.wingedsheep.gameserver.session.GameSession
 import com.wingedsheep.gameserver.session.PlayerIdentity
 import com.wingedsheep.gameserver.session.PlayerSession
+import com.wingedsheep.gameserver.tournament.AiMatchSimulator
 import com.wingedsheep.gameserver.tournament.TournamentManager
 import com.wingedsheep.gameserver.tournament.TournamentMatch
 import com.wingedsheep.gameserver.tournament.TournamentRound
@@ -31,9 +32,17 @@ class TournamentMatchHandler(
     private val gameProperties: GameProperties,
     private val gameRepository: GameRepository,
     private val aiGameManager: AiGameManager,
+    private val aiMatchSimulator: AiMatchSimulator,
     private val tournamentResultSink: com.wingedsheep.gameserver.stats.TournamentResultSink
 ) {
     private val logger = LoggerFactory.getLogger(TournamentMatchHandler::class.java)
+
+    /** One in-flight [startReadyMatches] trampoline. Thread-confined: the sweep never leaves its thread. */
+    private class Sweep(val lobbyId: String) {
+        var again: Boolean = false
+    }
+
+    private val activeSweep = ThreadLocal<Sweep?>()
 
     fun handleReadyForNextRound(session: WebSocketSession) {
         val token = ctx.sessionRegistry.getTokenByWsId(session.id)
@@ -120,41 +129,57 @@ class TournamentMatchHandler(
             tournament.reportMatchResult(gameSessionId, winnerId, winnerLifeRemaining)
             ctx.lobbyRepository.saveTournament(lobbyId, tournament)
 
-            handleMatchComplete(lobbyId, gameSessionId)
-            // Persist the freshly-updated standings so profiles/dashboard show live results.
-            recordTournamentProgress(lobbyId)
-            spectatingHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId)
-
-            // Test round completion *before* touching ready state: `autoReadyAiPlayers` prepares the
-            // next round when the current one is done, which would make `isRoundComplete()` report on
-            // the fresh round and swallow this round's `RoundComplete` broadcast entirely. The
-            // round-complete path readies the AI itself, so either branch ends with a start sweep.
-            //
-            // Only a result *from* the current round can close it. Matches from later rounds run
-            // concurrently with it (eager starting), and letting one of those answer for the current
-            // round would re-report a round already closed — announcing stale results and clearing
-            // every player's game-session pointer, including seats mid-game.
             val resultRound = tournament.getRoundForMatch(gameSessionId)
-            val closesCurrentRound = resultRound != null &&
-                    resultRound.roundNumber == tournament.currentRound?.roundNumber
-            if (closesCurrentRound && tournament.isRoundComplete()) {
-                doHandleRoundComplete(lobbyId)
-            } else {
-                val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
-                if (lobby != null) {
-                    // Ready the AI, but not the human: they must click "Ready for Next Round" after
-                    // dismissing the game-over overlay, so the next game can't start underneath it.
-                    // The sweep inside also retries pairs this result just unblocked.
-                    autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
-                    ctx.lobbyRepository.saveLobby(lobby)
-                }
-            }
-
-            // `MatchComplete` / `RoundComplete` make the client drop its ready list, and the readies
-            // that survive a round boundary would otherwise vanish from the lobby's counter. Re-state
-            // the authoritative set once everything above has settled.
-            ctx.lobbyRepository.findLobbyById(lobbyId)?.let { broadcastReadyStatus(it) }
+            val match = resultRound?.matches?.find { it.gameSessionId == gameSessionId }
+            afterMatchResult(lobbyId, resultRound, match)
         }
+    }
+
+    /**
+     * Everything a decided match sets in motion, once the result itself is recorded: announce it,
+     * persist the standings, re-advertise the active matches, close the round if this was its last
+     * game, and sweep for whatever that just unblocked.
+     *
+     * Shared by the played path ([handleMatchResult]) and the simulated one ([simulateMatch]) so a
+     * simulated result moves the bracket in exactly the same way a played one does — the only thing
+     * that differs about it is that no game was run. Assumes the per-lobby round lock is held.
+     */
+    private fun afterMatchResult(lobbyId: String, resultRound: TournamentRound?, match: TournamentMatch?) {
+        val tournament = ctx.lobbyRepository.findTournamentById(lobbyId) ?: return
+
+        if (resultRound != null && match != null) announceMatchComplete(lobbyId, resultRound, match)
+        // Persist the freshly-updated standings so profiles/dashboard show live results.
+        recordTournamentProgress(lobbyId)
+        spectatingHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId)
+
+        // Test round completion *before* touching ready state: `autoReadyAiPlayers` prepares the
+        // next round when the current one is done, which would make `isRoundComplete()` report on
+        // the fresh round and swallow this round's `RoundComplete` broadcast entirely. The
+        // round-complete path readies the AI itself, so either branch ends with a start sweep.
+        //
+        // Only a result *from* the current round can close it. Matches from later rounds run
+        // concurrently with it (eager starting), and letting one of those answer for the current
+        // round would re-report a round already closed — announcing stale results and clearing
+        // every player's game-session pointer, including seats mid-game.
+        val closesCurrentRound = resultRound != null &&
+                resultRound.roundNumber == tournament.currentRound?.roundNumber
+        if (closesCurrentRound && tournament.isRoundComplete()) {
+            doHandleRoundComplete(lobbyId)
+        } else {
+            val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
+            if (lobby != null) {
+                // Ready the AI, but not the human: they must click "Ready for Next Round" after
+                // dismissing the game-over overlay, so the next game can't start underneath it.
+                // The sweep inside also retries pairs this result just unblocked.
+                autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
+                ctx.lobbyRepository.saveLobby(lobby)
+            }
+        }
+
+        // `MatchComplete` / `RoundComplete` make the client drop its ready list, and the readies
+        // that survive a round boundary would otherwise vanish from the lobby's counter. Re-state
+        // the authoritative set once everything above has settled.
+        ctx.lobbyRepository.findLobbyById(lobbyId)?.let { broadcastReadyStatus(it) }
     }
 
     fun handleAbandon(lobbyId: String, playerId: EntityId) {
@@ -371,18 +396,21 @@ class TournamentMatchHandler(
         }
     }
 
-    private fun handleMatchComplete(lobbyId: String, gameSessionId: String) {
+    /**
+     * Tell the two seats of a decided match how the bracket now stands.
+     *
+     * Keyed by the match rather than by a game session id: a simulated match never had a session, and
+     * it still has to report itself the same way a played one does.
+     */
+    private fun announceMatchComplete(lobbyId: String, completedRound: TournamentRound, match: TournamentMatch) {
         val lobby = ctx.lobbyRepository.findLobbyById(lobbyId) ?: return
         val tournament = ctx.lobbyRepository.findTournamentById(lobbyId) ?: return
-
-        val completedRound = tournament.getRoundForMatch(gameSessionId) ?: return
 
         val connectedIds = lobby.players.values
             .filter { it.identity.isConnected }
             .map { it.identity.playerId }
             .toSet()
 
-        val match = completedRound.matches.find { it.gameSessionId == gameSessionId } ?: return
         val matchPlayerIds = listOfNotNull(match.player1Id, match.player2Id)
 
         for (playerId in matchPlayerIds) {
@@ -487,13 +515,53 @@ class TournamentMatchHandler(
      * ready, and `markPlayerReady` will never transition false→true for them a second time. Nothing
      * else would ever reconsider them, so every caller that changes the ready set *or* completes a
      * match runs this pass.
+     *
+     * Re-entrant by trampoline rather than by recursion. Reporting a result runs the sweep again (a
+     * finished match unblocks other pairs), and with simulated AI matches that result comes back
+     * *inside* this call — so an all-AI bracket resolves as one cascade and per-match recursion would
+     * nest one level per match, hundreds deep on a long schedule. A nested call therefore asks the
+     * outermost sweep for another pass and returns; the loop below re-queries the live ready set, so
+     * the deferred pass sees everything the nested one would have.
      */
     fun startReadyMatches(lobby: TournamentLobby, tournament: TournamentManager) {
+        val enclosing = activeSweep.get()
+        if (enclosing != null && enclosing.lobbyId == lobby.lobbyId) {
+            enclosing.again = true
+            return
+        }
+
+        val sweep = Sweep(lobby.lobbyId)
+        activeSweep.set(sweep)
+        try {
+            do {
+                sweep.again = false
+                sweepReadyMatches(lobby, tournament)
+            } while (sweep.again)
+        } finally {
+            activeSweep.set(enclosing)
+        }
+    }
+
+    /** One pass of [startReadyMatches]; never call directly — the trampoline owns the repetition. */
+    private fun sweepReadyMatches(lobby: TournamentLobby, tournament: TournamentManager) {
         forfeitUnseatedMatches(lobby, tournament)
 
         var startedAny = false
         for ((round, match) in tournament.startableMatches(lobby.getReadyPlayerIds())) {
             val player2Id = match.player2Id ?: continue
+
+            // The list above was snapshotted before anything in this loop ran, and simulating a match
+            // decides it on the spot — which re-enters this sweep through the result path (to open the
+            // next round, to re-ready the AI). A later entry can therefore already be decided or
+            // launched by the time we reach it; acting on it again would run the pair twice.
+            if (match.isComplete || match.gameSessionId != null) continue
+
+            if (shouldSimulate(lobby, match, player2Id)) {
+                simulateMatch(lobby, tournament, round, match, player2Id)
+                startedAny = true
+                continue
+            }
+
             logger.info(
                 "Both players ready, starting round ${round.roundNumber} match: " +
                     "${lobby.players[match.player1Id]?.identity?.playerName} vs " +
@@ -546,6 +614,72 @@ class TournamentMatchHandler(
         if (tournament.isRoundComplete()) {
             doHandleRoundComplete(lobby.lobbyId)
         }
+    }
+
+    /**
+     * Whether this match can be decided without playing it: the server has
+     * `game.tournament.simulate-ai-matches` on, and [AiMatchSimulator.shouldSimulate] agrees on the
+     * shape of the bracket.
+     *
+     * The cost this avoids is the point: a round-robin with one human and N AI seats schedules O(N²)
+     * matches and the human is in only N of them, so nearly every game the server runs is two AI
+     * controllers grinding out a result that reaches nobody but the standings table. See
+     * [AiMatchSimulator] for what "decide" means (a coin flip, deliberately).
+     */
+    private fun shouldSimulate(lobby: TournamentLobby, match: TournamentMatch, player2Id: EntityId): Boolean =
+        gameProperties.tournament.simulateAiMatches &&
+            aiMatchSimulator.shouldSimulate(
+                bracketSeats = lobby.players.keys,
+                aiSeats = aiSeats(lobby),
+                player1Id = match.player1Id,
+                player2Id = player2Id,
+            )
+
+    /**
+     * The lobby's AI seats. A seat counts as AI if either the live AI registry or its persisted
+     * identity says so. The two can disagree for a window after a restart — the registry is rebuilt by
+     * rehydration, the identity flag survives in the lobby — and an AI seat the registry hasn't
+     * re-wired yet is exactly the seat whose game would hang, so treating it as AI is also the safe
+     * reading.
+     */
+    private fun aiSeats(lobby: TournamentLobby): Set<EntityId> =
+        lobby.players.keys.filterTo(mutableSetOf()) { playerId ->
+            aiGameManager.isAiPlayer(playerId) || lobby.players[playerId]?.identity?.isAi == true
+        }
+
+    /**
+     * Decide an AI-vs-AI match without running a game, and report it exactly as a played one reports.
+     *
+     * Consuming both ready flags mirrors a real start: a flag is spent the moment the seat is put in a
+     * match, and [afterMatchResult] re-readies the AI for whatever comes next. Nothing else about the
+     * bracket knows the difference — the match keeps no `gameSessionId`, so it never shows up as
+     * something to spectate and has no replay, which is what [TournamentMatch.isSimulated] tells the
+     * standings to say.
+     */
+    private fun simulateMatch(
+        lobby: TournamentLobby,
+        tournament: TournamentManager,
+        round: TournamentRound,
+        match: TournamentMatch,
+        player2Id: EntityId,
+    ) {
+        val winnerId = aiMatchSimulator.pickWinner(match.player1Id, player2Id)
+        logger.info(
+            "Simulating round {} AI match in tournament {}: {} vs {} — winner {}",
+            round.roundNumber,
+            lobby.lobbyId,
+            lobby.players[match.player1Id]?.identity?.playerName,
+            lobby.players[player2Id]?.identity?.playerName,
+            lobby.players[winnerId]?.identity?.playerName,
+        )
+
+        tournament.reportSimulatedResult(match, winnerId)
+        lobby.clearPlayerReady(match.player1Id)
+        lobby.clearPlayerReady(player2Id)
+        ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+        ctx.lobbyRepository.saveLobby(lobby)
+
+        afterMatchResult(lobby.lobbyId, round, match)
     }
 
     fun startSingleMatch(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
@@ -297,7 +297,8 @@ fun TournamentManager.toPersistent(lobbyId: String): PersistentTournament {
                         isDraw = match.isDraw,
                         isComplete = match.isComplete,
                         player1GameWins = match.player1GameWins,
-                        player2GameWins = match.player2GameWins
+                        player2GameWins = match.player2GameWins,
+                        isSimulated = match.isSimulated
                     )
                 }
             )
@@ -342,7 +343,8 @@ fun restoreTournamentManager(persistent: PersistentTournament): TournamentManage
                     isDraw = persistentMatch.isDraw,
                     isComplete = persistentMatch.isComplete,
                     player1GameWins = persistentMatch.player1GameWins,
-                    player2GameWins = persistentMatch.player2GameWins
+                    player2GameWins = persistentMatch.player2GameWins,
+                    isSimulated = persistentMatch.isSimulated
                 )
             }
         )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentTournament.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentTournament.kt
@@ -52,5 +52,7 @@ data class PersistentMatch(
     val isDraw: Boolean,
     val isComplete: Boolean,
     val player1GameWins: Int = 0,
-    val player2GameWins: Int = 0
+    val player2GameWins: Int = 0,
+    /** Defaulted so a payload written before simulated matches existed still decodes. */
+    val isSimulated: Boolean = false
 )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -745,7 +745,10 @@ sealed interface ServerMessage {
         val player2Id: String?,
         val winnerId: String?,
         val isDraw: Boolean = false,
-        val isBye: Boolean = false
+        val isBye: Boolean = false,
+        /** True when the result was simulated rather than played — an AI-vs-AI match on a server that
+         *  has `game.tournament.simulate-ai-matches` on. Such a match has no replay to open. */
+        val isSimulated: Boolean = false
     )
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/AiMatchSimulator.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/AiMatchSimulator.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.gameserver.tournament
+
+import com.wingedsheep.sdk.model.EntityId
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+/**
+ * Decides a bracket match between two AI seats without playing it.
+ *
+ * A round-robin bracket with one human and N AI seats schedules O(N²) matches, of which only N
+ * involve the human; the rest are AI against AI. Each of those costs a full engine game plus two AI
+ * controllers on the server, and nobody is in it — the human only ever sees the result as a row in
+ * the standings. Simulating them is what keeps a large bracket affordable on a small box.
+ *
+ * **The winner is a fair coin flip.** That is deliberate, not a placeholder: any cheap deck-strength
+ * proxy we could compute here (curve, card ratings, colour count) is unvalidated against how the
+ * engine AI actually plays, and baking an unmeasured bias into the standings is worse than an honest
+ * 50/50 — it would look like a judgement while being noise with a story attached. If a validated
+ * model of AI-vs-AI win probability ever exists, this is the one place it plugs in.
+ *
+ * Draws are never simulated. A real AI-vs-AI game can draw (the runaway-game backstops), but a coin
+ * flip has no principled draw rate, and a simulated draw would move both players' match points on
+ * invented grounds.
+ */
+@Component
+class AiMatchSimulator(private val random: Random = Random.Default) {
+
+    /**
+     * Whether a match between [player1Id] and [player2Id] may be decided instead of played, given the
+     * bracket's [bracketSeats] and which of them are [aiSeats].
+     *
+     * Two rules, and the second is the one that isn't obvious. Both seats in the match must be AI —
+     * a human never has a game decided for them. And the *bracket* must have a human somewhere: a
+     * bracket with no human seat was built to be watched (the AI Sandbox at
+     * `/api/dev/ai-tournament`, which `just watch-ai-match` drives; a model-comparison run), and
+     * simulating there would resolve the whole tournament in a single sweep and leave nothing to
+     * open. The saving this exists for is the AI-vs-AI games running *alongside* a human's matches.
+     */
+    fun shouldSimulate(
+        bracketSeats: Set<EntityId>,
+        aiSeats: Set<EntityId>,
+        player1Id: EntityId,
+        player2Id: EntityId,
+    ): Boolean =
+        player1Id in aiSeats &&
+            player2Id in aiSeats &&
+            bracketSeats.any { it !in aiSeats }
+
+    /** The winning seat of a simulated [player1Id] vs [player2Id] match. */
+    fun pickWinner(player1Id: EntityId, player2Id: EntityId): EntityId =
+        if (random.nextBoolean()) player1Id else player2Id
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
@@ -74,7 +74,13 @@ data class TournamentMatch(
     var isDraw: Boolean = false,
     var isComplete: Boolean = false,
     var player1GameWins: Int = 0,
-    var player2GameWins: Int = 0
+    var player2GameWins: Int = 0,
+    /**
+     * True when this result came from [AiMatchSimulator] rather than a played game. Such a match never
+     * had a [gameSessionId], so it has no replay and never appeared as an active match to spectate;
+     * the flag is what lets the standings say so instead of passing it off as a played result.
+     */
+    var isSimulated: Boolean = false
 ) {
     val isBye: Boolean get() = player2Id == null
 
@@ -242,7 +248,30 @@ class TournamentManager(
             .find { m -> m.gameSessionId == gameSessionId }
             ?: return
 
-        if (match.isComplete) return
+        if (!applyResult(match, winnerId, winnerLifeRemaining)) return
+        logger.info("Match result reported for game $gameSessionId: winner=${winnerId?.value ?: "draw"}, life=$winnerLifeRemaining")
+    }
+
+    /**
+     * Record a match decided by [AiMatchSimulator] instead of played out — see
+     * [TournamentMatch.isSimulated]. Takes the match itself because a simulated match has no game
+     * session to look it up by, and reports no life total: no game was played, so there is none to
+     * report. The standings tiebreakers (match points, OMW%, GW%, OGW%) don't read life; only the
+     * displayed life differential does, and inventing a number for it would be inventing data.
+     */
+    fun reportSimulatedResult(match: TournamentMatch, winnerId: EntityId) {
+        if (!applyResult(match, winnerId, winnerLifeRemaining = 0)) return
+        match.isSimulated = true
+        logger.info("Simulated match result in lobby $lobbyId: winner=${winnerId.value}")
+    }
+
+    /**
+     * Apply a decided [match] to the standings. Shared by the played and the simulated path so both
+     * move wins/losses/draws, game wins and the life differential the same way. Returns false when the
+     * match was already decided, so neither caller announces a result it didn't record.
+     */
+    private fun applyResult(match: TournamentMatch, winnerId: EntityId?, winnerLifeRemaining: Int): Boolean {
+        if (match.isComplete) return false
 
         match.isComplete = true
 
@@ -275,8 +304,7 @@ class TournamentManager(
                 standings[p2]?.draws = (standings[p2]?.draws ?: 0) + 1
             }
         }
-
-        logger.info("Match result reported for game $gameSessionId: winner=${winnerId?.value ?: "draw"}, life=$winnerLifeRemaining")
+        return true
     }
 
     /**
@@ -532,7 +560,8 @@ class TournamentManager(
                 player2Id = match.player2Id?.value,
                 winnerId = match.winnerId?.value,
                 isDraw = match.isDraw,
-                isBye = match.isBye
+                isBye = match.isBye,
+                isSimulated = match.isSimulated
             )
         }
     }
@@ -688,7 +717,8 @@ class TournamentManager(
                 player2Id = match.player2Id?.value,
                 winnerId = match.winnerId?.value,
                 isDraw = match.isDraw,
-                isBye = match.isBye
+                isBye = match.isBye,
+                isSimulated = match.isSimulated
             )
         }
     }

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -108,6 +108,13 @@ game:
     # production stays clean — the deploy passes no GAME_EASTER_EGGS_ENABLED, so a redeploy can't
     # switch them back on. Local dev opts in via .env.
     enabled: ${GAME_EASTER_EGGS_ENABLED:false}
+  tournament:
+    # Decide AI-vs-AI bracket matches by simulation instead of playing them out. A round-robin with
+    # one human and N AI seats spends most of its CPU on games nobody is in; simulating them keeps the
+    # standings moving for a fraction of the cost. Set to false to play every match (e.g. on a box
+    # where the AI games are being spectated). An all-AI bracket (the AI Sandbox) is never simulated
+    # whatever this says — it exists to be watched.
+    simulate-ai-matches: ${GAME_TOURNAMENT_SIMULATE_AI_MATCHES:true}
   admin:
     # Password for admin replay feature. Feature is disabled if not set.
     password: ${GAME_ADMIN_PASSWORD:}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/AiMatchSimulationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/AiMatchSimulationTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.gameserver.tournament
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+/**
+ * Deciding an AI-vs-AI bracket match without playing it.
+ *
+ * The saving is why the feature exists: a round-robin with one human and seven AI seats plays 28
+ * matches, and only seven of them have the human in them. The other 21 are two AI controllers driving
+ * a full engine game that nobody watches, and on a small box that is where the tournament's CPU goes.
+ *
+ * What has to survive the shortcut is the bracket's liveness. A simulated match is complete but never
+ * had a `gameSessionId`, and [TournamentManager.hasIncompleteMatchBefore] — the guard that stops a
+ * seat being handed two games at once — keys off completion, not off having been played. So a
+ * simulated result must unblock the next round exactly as a played one does; if it didn't, the
+ * shortcut would trade compute for the stall it was meant to avoid.
+ */
+class AiMatchSimulationTest : FunSpec({
+
+    val human = EntityId("human")
+    val ai = (1..7).map { EntityId("ai$it") }
+    val everyone = (listOf(human) + ai).toSet()
+
+    fun tournament(): TournamentManager = TournamentManager(
+        lobbyId = "lobby-sim",
+        players = (listOf(human to "Vincent") + ai.mapIndexed { i, id -> id to "AI ${i + 1}" }),
+        gamesPerMatch = 1
+    )
+
+    fun TournamentRound.matchFor(playerId: EntityId): TournamentMatch =
+        matches.first { it.player1Id == playerId || it.player2Id == playerId }
+
+    fun TournamentMatch.opponentOf(playerId: EntityId): EntityId =
+        (if (player1Id == playerId) player2Id else player1Id)!!
+
+    test("only an AI pair in a bracket that also has a human is simulated") {
+        val simulator = AiMatchSimulator(Random(1))
+        val aiSeats = ai.toSet()
+
+        // The case this exists for: two AI seats in a bracket the human is also playing in.
+        simulator.shouldSimulate(everyone, aiSeats, ai[0], ai[1]) shouldBe true
+
+        // A human seat is never decided for them, on either side of the pairing.
+        simulator.shouldSimulate(everyone, aiSeats, human, ai[0]) shouldBe false
+        simulator.shouldSimulate(everyone, aiSeats, ai[0], human) shouldBe false
+
+        // An all-AI bracket is the AI Sandbox / a model-comparison run: it was built to be watched,
+        // and simulating would resolve the whole thing in one sweep with nothing to open.
+        simulator.shouldSimulate(aiSeats, aiSeats, ai[0], ai[1]) shouldBe false
+    }
+
+    test("the simulator picks one of the two seats, and both of them") {
+        val simulator = AiMatchSimulator(Random(20260904))
+        val picks = (1..200).map { simulator.pickWinner(ai[0], ai[1]) }.toSet()
+        picks shouldBe setOf(ai[0], ai[1])
+    }
+
+    test("a simulated result moves the standings like a played one, and says it was simulated") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val match = round1.matchFor(ai[0])
+        val winner = ai[0]
+        val loser = match.opponentOf(ai[0])
+
+        manager.reportSimulatedResult(match, winner)
+
+        match.isComplete shouldBe true
+        match.isSimulated shouldBe true
+        match.winnerId shouldBe winner
+        // No game ran, so there is nothing to spectate and nothing to open a replay on.
+        match.gameSessionId shouldBe null
+
+        val standings = manager.getStandingsForPersistence()
+        standings.getValue(winner).wins shouldBe 1
+        standings.getValue(winner).gamesWon shouldBe 1
+        // No game was played, so no life total was invented for the displayed differential.
+        standings.getValue(winner).lifeDifferential shouldBe 0
+        standings.getValue(loser).losses shouldBe 1
+        standings.getValue(loser).gamesLost shouldBe 1
+
+        manager.getRoundResults(round1).single { it.player1Id == match.player1Id.value }
+            .isSimulated shouldBe true
+    }
+
+    test("a simulated result unblocks the next round the same way a played result does") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+
+        // The human's game is the only one actually played; every other round-1 pair is AI vs AI.
+        val humanMatch = round1.matchFor(human)
+        humanMatch.gameSessionId = "r1-human"
+
+        val simulated = round1.matches.filter { it !== humanMatch }
+        simulated.size shouldBe 3
+        simulated.forEach { manager.reportSimulatedResult(it, it.player1Id) }
+
+        // The round isn't over — the human is still playing — but every AI whose round-1 match was
+        // simulated is free to move on, which is the whole point: their round-2 pairs are startable
+        // (and, in the handler, immediately simulated too) while the human is still in game one. Only
+        // the two seats still owed a round-1 result are held back.
+        manager.isRoundComplete() shouldBe false
+        val stillOwed = setOf(human, humanMatch.opponentOf(human))
+        val earlyStartable = manager.startableMatches(everyone)
+        earlyStartable.map { it.first.roundNumber }.toSet() shouldBe setOf(2)
+        earlyStartable.flatMap { (_, m) -> listOfNotNull(m.player1Id, m.player2Id) }
+            .none { it in stillOwed } shouldBe true
+
+        // The human finishes. Now round 2 opens in full: no seat is still owed a round-1 game,
+        // because the simulated ones are complete.
+        manager.reportMatchResult("r1-human", human)
+        manager.isRoundComplete() shouldBe true
+
+        val startable = manager.startableMatches(everyone)
+        startable.map { it.first.roundNumber }.toSet() shouldBe setOf(2)
+        startable.flatMap { (_, m) -> listOfNotNull(m.player1Id, m.player2Id) }.toSet() shouldBe everyone
+    }
+
+    test("a simulated result is refused for a match that already has one") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val match = round1.matchFor(ai[0])
+        val first = match.player1Id
+        val second = match.opponentOf(first)
+
+        manager.reportSimulatedResult(match, first)
+        manager.reportSimulatedResult(match, second)
+
+        match.winnerId shouldBe first
+        manager.getStandingsForPersistence().getValue(first).wins shouldBe 1
+        manager.getStandingsForPersistence().getValue(second).wins shouldBe 0
+    }
+
+    test("simulated matches are excluded from the replayable game list") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val humanMatch = round1.matchFor(human)
+        humanMatch.gameSessionId = "r1-human"
+        manager.reportMatchResult("r1-human", human)
+        round1.matches.filter { it !== humanMatch }.forEach { manager.reportSimulatedResult(it, it.player1Id) }
+
+        manager.getCompletedGameSessionIds() shouldContainExactly listOf("r1-human")
+    }
+})

--- a/web-client/src/components/tournament/TournamentOverlay.tsx
+++ b/web-client/src/components/tournament/TournamentOverlay.tsx
@@ -493,6 +493,14 @@ export function TournamentOverlay({
                   : result.isDraw
                     ? 'Draw'
                     : `Winner: ${result.winnerId === result.player1Id ? result.player1Name : result.player2Name}`}
+                {result.isSimulated && (
+                  <span
+                    className={styles.resultSimulated}
+                    title="Both seats were AI, so the server decided this match instead of playing it. There is no replay."
+                  >
+                    simulated
+                  </span>
+                )}
               </span>
               <span>{result.isBye ? '' : result.player2Name}</span>
             </div>

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -3143,6 +3143,15 @@
   border-radius: var(--radius-sm);
 }
 
+/* Badge on an AI-vs-AI result the server decided without playing the game. */
+.resultSimulated {
+  margin-left: 6px;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
 /* =========================================================================
  * Fullscreen Button
  * ========================================================================= */

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1664,6 +1664,8 @@ export interface MatchResultInfo {
   readonly winnerId: string | null
   readonly isDraw: boolean
   readonly isBye: boolean
+  /** True when the server decided this AI-vs-AI match without playing it. No game, so no replay. */
+  readonly isSimulated?: boolean
 }
 
 export interface TournamentStartedMessage {


### PR DESCRIPTION
## Why

A round-robin tournament with one human and N AI seats schedules O(N²) matches, and the human is in only N of them. Every other game is two AI controllers driving a full engine game that nobody is in — on prd that is the bulk of the tournament's CPU, spent producing results the human only ever reads off the standings table.

## What

`game.tournament.simulate-ai-matches` (`GAME_TOURNAMENT_SIMULATE_AI_MATCHES`, **on by default**). When on, the start sweep decides an AI-vs-AI pair with the new `AiMatchSimulator` instead of opening a `GameSession`, and reports it through the same result path a played match uses — so it closes rounds, moves standings, and unblocks `hasIncompleteMatchBefore` exactly as a played result does. Nothing else in the bracket knows the difference.

**The winner is a fair coin flip, deliberately.** Any cheap deck-strength proxy available here (curve, card ratings, colour count) is unvalidated against how the engine AI actually plays; baking an unmeasured bias into the standings would look like a judgement while being noise with a story attached. `AiMatchSimulator` is the one place a validated win-probability model would plug in. No life total is invented either — the standings tiebreakers (points, OMW%, GW%, OGW%) don't read one, and only the displayed life differential would.

**An all-AI bracket is never simulated, whatever the property says.** A bracket with no human seat was built to be watched — the AI Sandbox (`/api/dev/ai-tournament`, which `just watch-ai-match` drives) and model-comparison runs are exactly that — and simulating it would resolve the whole tournament in one sweep, deleting the feature rather than speeding it up. The saving only exists next to a human: the AI games running *alongside* the matches somebody is sitting in.

A simulated match keeps no `gameSessionId`, so it never shows up as something to spectate and has no replay. `TournamentMatch.isSimulated` rides the wire on `MatchResultInfo` so the round-results list marks it `simulated` rather than passing it off as a played game.

### Two structural bits worth a look

- `handleMatchResult`'s post-result bookkeeping is factored into `afterMatchResult`, shared with the simulated path, and `handleMatchComplete` is now keyed by the match instead of by a game-session id (a simulated match has no session).
- `startReadyMatches` is re-entrant by **trampoline** rather than recursion. A simulated result comes back *inside* the sweep, so an all-AI cascade would otherwise nest one stack level per match — hundreds deep on an 8-seat / 9-games-per-match schedule. A nested call now asks the outermost sweep for another pass; the loop re-queries the live ready set, so the deferred pass sees everything the nested one would have.

## Trade-off

A waiting human can no longer spectate the AI-vs-AI games in their own bracket — that is the compute this saves. Set `GAME_TOURNAMENT_SIMULATE_AI_MATCHES=false` to play them all out. A per-lobby host toggle is the natural follow-up if you want it per tournament rather than per server.

## Verification

- `just test-class AiMatchSimulationTest` — 6 new tests: the gating rules, both seats can win, a simulated result moves standings / marks itself / invents no life total, it unblocks the next round the same way a played one does, it's refused twice, and it stays out of the replayable game list.
- `just test-server` — full game-server suite green (includes `SealedTournamentReconnectionTest` and the Spring context, which now builds the new bean).
- `npm run typecheck` + `npm run build` in `web-client` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3rtBhdGXF9KCZ681CYAbr