### PR TITLE
Add clash (CR 701.30) and five Lorwyn clash cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3262,6 +3262,24 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `rummage(count?)` — discard then draw.
 - `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` (default Self) if the discard was a nonland (CR 701.50). Also exposed as `Effects.Connive(target)`. Returns the pipeline wrapped in `ConniveEffect(subject = target, body = …)`: the wrapper names the keyword action and its subject, which is what lets `ModifyKeywordAction` replace it and what makes it emit `PermanentConnivedEvent` (CR 701.50f). The pipeline itself is unchanged.
 - `conniveTargeting(requirement, storeAs?)` — connive whose +1/+1 counter lands on a *reflexively chosen* target: "draw a card, then discard a card. When you discard a nonland card this way, put a +1/+1 counter on target creature you control" (Teo, Spirited Glider). The recipient is selected at resolution via `SelectTargetEffect` *inside* the nonland gate — so the player never chooses up front or when the discard is a land. Pass the recipient's `TargetRequirement` (e.g. `Targets.CreatureYouControl`); do **not** also declare it as a cast-time `target(...)`. Exposed as `Effects.ConniveTargeting(requirement)`. Deliberately **not** wrapped in `ConniveEffect` — Teo's printed text spells the looting out and never says "connive", so it is not the keyword action: it fires no connive triggers and is not touched by "if a creature you control would connive" replacements.
+- `Patterns.Mechanic.clash(ifYouWin, otherwise?)` — **Clash** (CR 701.30, Lorwyn), and the only clash
+  spelling a card should author. It is the whole printed template, not just the keyword action:
+  *"Clash with an opponent. If you win, [ifYouWin]."*, with `otherwise` for the one card that prints
+  an "Otherwise, …" half (Captivating Glance). Composed from three existing pieces —
+  `ChooseOpponentForSourceEffect` (clash *chooses* an opponent, CR 701.30b; forced and promptless
+  with a single opponent, and the durable `OPPONENT` slot is what keeps the same player revealing
+  *and* deciding, which a bare `Chooser.Opponent` would not), then `ClashEffect`, wrapped in a
+  `Gate.DoAction` scored by `SuccessCriterion.CollectionNonEmpty(CLASH_WON)`. **"If you win" is an
+  action-outcome rider, not a new gate kind**: the clash writes your revealed card into the
+  `clashWon` collection only on a win, so the existing gate — and its pause/resume machinery, which
+  is what carries the two top-or-bottom decisions — does the whole job. `ClashEffect` is a *macro*
+  in the `ScryEffect` sense: the engine expands it to Gather → Select → Move over the ordinary
+  library primitives, and builds it against live state only so the two selections can be emitted in
+  APNAP order (CR 701.30c) rather than clasher-first. Both gathers are `revealed = true` (a clash is
+  a public reveal, CR 701.30a) and both precede either decision, so the reveal is simultaneous.
+  Scoring is CR 701.30d, *strictly* greater mana value: **a tie wins for nobody**, and a player with
+  an empty library reveals nothing and so can never win — though their opponent still wins with any
+  card at all, a `{0}` included. Adder-Staff Boggart, Oaken Brawler, Paperfin Rascal, Lash Out.
 - `Patterns.Mechanic.learn()` — **Learn** (CR 701.48, Strixhaven), the keyword action printed as a
   bare "Learn." with reminder text. CR 701.48a is sequential, not a choose-one: *"You may discard a
   card. If you do, draw a card. If you didn't discard a card, you may reveal a Lesson card you own
@@ -6004,6 +6022,20 @@ Triggers.youCastSpell(
   A `RingTemptedEvent` pattern with `requireBearerChosen = true`, so it fires only when the temptation
   actually designates a creature (the event's `bearerId` is non-null) — not when you control none to
   choose. Used by Call of the Ring.
+
+### Clash
+
+- `WheneverYouClash` — fires once the clash has fully ended (CR 701.30): both cards revealed, both
+  top-or-bottom decisions taken and both moves resolved, exactly as the printed reminder text says
+  ("This ability triggers after the clash ends"). **Fires for a clash you did not start** — a clash
+  names two players, and the ruling on Entangling Trap and Rebellion of the Flamekin is explicit
+  that "if you clash because of a spell or ability an opponent controls, the ability will still
+  trigger." The engine emits one `ClashedEvent` per participant for exactly this reason.
+- `WheneverYouClashAndWin` — the "and win" wording (Sylvan Echoes). The win is a condition on the
+  *trigger* (`EventPattern.ClashedEvent(requireWin = true)`), so a lost clash puts nothing on the
+  stack at all. You can win — and be paid for — a clash an opponent initiated. A card whose payoff
+  merely *differs* on a win ("… If you won, …" — Entangling Trap) uses `WheneverYouClash` and
+  branches inside its effect instead.
 
 ### Scry / Surveil
 
@@ -12645,6 +12677,13 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
     cast-time "you may promise **an opponent** a gift"-style recipient choice, use
     `Effects.ChooseOpponentForSource` + `Player.ChosenOpponent` instead — that one is stored on the source and
     persists past the resolution.)
+  - **`Chooser.ChosenOpponent`** is the decision-side twin of `Player.ChosenOpponent`: the opponent a
+    preceding `Effects.ChooseOpponentForSource` already named for this source makes the choice. Use it,
+    not `Chooser.Opponent`, whenever the *same* opponent has to appear in two steps of one mechanic —
+    `Chooser.Opponent` re-picks per step, so in a multiplayer game a mechanic that reads one opponent's
+    library and then asks that opponent to decide could split across two different players. Clash
+    (CR 701.30b) is the case in hand. Unresolvable if no choice has been made, so a card using it must
+    run `Effects.ChooseOpponentForSource` first.
 
 **Linked exile**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
@@ -15,6 +15,8 @@ import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect
+import com.wingedsheep.sdk.scripting.effects.CLASH_WON
+import com.wingedsheep.sdk.scripting.effects.ClashEffect
 import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
@@ -36,6 +38,7 @@ import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -282,6 +285,60 @@ object MechanicPatterns {
             )
         )
     }
+
+    // =========================================================================
+    // Clash Pattern (Lorwyn, CR 701.30)
+    // =========================================================================
+
+    /**
+     * "Clash with an opponent. If you win, [ifYouWin]." — the whole printed Lorwyn template
+     * (CR 701.30b), and the only clash spelling a card should ever author.
+     *
+     * Three existing pieces, composed:
+     *
+     *  1. [ChooseOpponentForSourceEffect] fixes *which* opponent clashes with you. Clash chooses an
+     *     opponent rather than targeting one, and the same player must both reveal and decide, so
+     *     the choice is written to the source's durable `OPPONENT` slot and read back by
+     *     [Player.ChosenOpponent]. A bare `Chooser.Opponent` would re-pick per step and could split
+     *     a multiplayer clash across two different opponents. With one opponent the choice is
+     *     forced and promptless.
+     *  2. [com.wingedsheep.sdk.scripting.effects.ClashEffect] performs the clash: reveal, decide,
+     *     move, score, and fire "Whenever you clash" for both participants.
+     *  3. A [Gate.DoAction] gate scored by [SuccessCriterion.CollectionNonEmpty] reads the win.
+     *     "If you win" is an action-*outcome* rider, which is exactly what that gate models — the
+     *     clash writes your revealed card into a collection only on a win, so winning is an
+     *     ordinary pipeline result and clash needs no gate kind of its own. The gate's existing
+     *     continuation plumbing is what carries the two top-or-bottom pauses.
+     *
+     * [otherwise] is the "Otherwise, …" half printed on Captivating Glance; every other Lorwyn
+     * clash card leaves it null.
+     *
+     * ```kotlin
+     * // Adder-Staff Boggart — "When this creature enters, clash with an opponent.
+     * //                        If you win, put a +1/+1 counter on this creature."
+     * Patterns.Mechanic.clash(Effects.AddCounters(Counters.plusOnePlusOne(1)))
+     * ```
+     */
+    fun clash(ifYouWin: Effect, otherwise: Effect? = null): GatedEffect = GatedEffect(
+        gate = Gate.DoAction(
+            action = CompositeEffect(
+                listOf(
+                    ChooseOpponentForSourceEffect(prompt = "Choose an opponent to clash with"),
+                    ClashEffect()
+                )
+            ),
+            successCriterion = SuccessCriterion.CollectionNonEmpty(CLASH_WON)
+        ),
+        then = ifYouWin,
+        otherwise = otherwise,
+        descriptionOverride = buildString {
+            append("Clash with an opponent. If you win, ")
+            append(ifYouWin.description.replaceFirstChar { it.lowercase() })
+            if (otherwise != null) {
+                append(". Otherwise, ${otherwise.description.replaceFirstChar { it.lowercase() }}")
+            }
+        }
+    )
 
     // =========================================================================
     // Gift Pattern (Bloomburrow)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -2541,6 +2541,36 @@ object Triggers {
     )
 
     // =========================================================================
+    // Clash Triggers (CR 701.30)
+    // =========================================================================
+
+    /**
+     * Whenever you clash (CR 701.30) — Entangling Trap, Rebellion of the Flamekin. Fires once the
+     * clash has fully ended: both cards revealed, both top-or-bottom decisions taken and both moves
+     * resolved, exactly as the printed reminder text says.
+     *
+     * **Fires for a clash you did not start.** A clash names two players, and the ruling on these
+     * cards is explicit: "if you clash because of a spell or ability an opponent controls, the
+     * ability will still trigger." Use [WheneverYouClashAndWin] for the "and win" wording; a card
+     * whose payoff merely *differs* on a win (Entangling Trap's "If you won, …") uses this trigger
+     * and branches inside its effect.
+     */
+    val WheneverYouClash: TriggerSpec = TriggerSpec(
+        event = ClashedEvent(Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you clash **and win** (CR 701.30d) — Sylvan Echoes. The win is a condition on the
+     * trigger itself, so a clash you lose never puts the ability on the stack at all. As with
+     * [WheneverYouClash], winning a clash an opponent initiated counts.
+     */
+    val WheneverYouClashAndWin: TriggerSpec = TriggerSpec(
+        event = ClashedEvent(Player.You, requireWin = true),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Scry Triggers (CR 701.22)
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -501,6 +501,36 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * Whenever [player] clashes (CR 701.30) — "Whenever you clash, …" (Entangling Trap, Rebellion
+     * of the Flamekin) and, with [requireWin], "Whenever you clash **and win**, …" (Sylvan Echoes).
+     * Fires once per clashing player, after the clash has fully ended: both cards revealed, both
+     * top-or-bottom decisions made and both moves resolved (the printed reminder text says so
+     * outright — "this ability triggers after the clash ends").
+     *
+     * **Both participants clash, not just the initiator.** A clash names two players — the one
+     * whose spell or ability said "clash with an opponent" and the opponent they chose — and the
+     * ruling on Entangling Trap and Rebellion of the Flamekin is explicit that "if you clash
+     * because of a spell or ability an opponent controls, the ability will still trigger. Likewise,
+     * you can still win the clash even if you weren't the player to initiate it." So the engine
+     * emits one event per participant and [player] is matched against that participant, exactly as
+     * [ForagedEvent] matches the player who *paid* rather than the source's controller.
+     *
+     * @property requireWin When true the trigger fires only for a participant who **won** the
+     *   clash — the "and win" half of Sylvan Echoes' wording, which is a condition on the trigger
+     *   itself rather than a gate on its effect. Cards whose payoff differs between winning and
+     *   losing ("… If you won, …") leave this false and branch inside the effect instead.
+     */
+    @SerialName("ClashedEvent")
+    @Serializable
+    data class ClashedEvent(
+        val player: Player = Player.You,
+        val requireWin: Boolean = false
+    ) : EventPattern {
+        override val description: String =
+            "${player.description} clashes" + if (requireWin) " and wins" else ""
+    }
+
+    /**
      * Whenever [player] discovers (CR 701.57). Fires once per discover, after the whole discover
      * process is complete — including the "cast for free or put into hand" decision (CR 701.57b: a
      * player has "discovered" only after the process finishes, "even if some or all of those

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ClashEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ClashEffects.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Pipeline collection holding the clashing player's revealed card — empty unless they won. */
+const val CLASH_WON = "clashWon"
+
+/** Pipeline collection holding the clashing player's own revealed card. */
+const val CLASH_YOURS = "clashYours"
+
+/** Pipeline collection holding the chosen opponent's revealed card. */
+const val CLASH_THEIRS = "clashTheirs"
+
+/**
+ * Clash with the chosen opponent (CR 701.30) as a single compact node.
+ *
+ * This is a *macro effect* in the sense of [ScryEffect]: a serializable marker that expands at
+ * execution time into a Gather → Select → Move pipeline built from the ordinary library
+ * primitives, so it adds no new gather/select/move logic of its own. What it does add is the one
+ * thing the pipeline can't express — **who decides first**. CR 701.30c orders the two top-or-bottom
+ * decisions in APNAP order, which depends on whose turn it is, and a `CompositeEffect` has a fixed
+ * step order. The engine's clash executor therefore builds the pipeline against the live state and
+ * emits the two [SelectFromCollectionEffect] steps active-player-first.
+ *
+ * The clash proper is only half the printed template. Every clash card reads "Clash with an
+ * opponent. **If you win,** …", which is a
+ * [com.wingedsheep.sdk.scripting.effects.GatedEffect] over a
+ * [com.wingedsheep.sdk.scripting.effects.Gate.DoAction] whose
+ * [com.wingedsheep.sdk.scripting.effects.SuccessCriterion.CollectionNonEmpty] reads [storeWonAs] —
+ * see [com.wingedsheep.sdk.dsl.MechanicPatterns.clash], which is what cards actually author.
+ * Winning is a *pipeline result*, not a new gate kind, so the existing action-outcome gate and its
+ * pause/resume machinery carry the whole card.
+ *
+ * **Requires a preceding [ChooseOpponentForSourceEffect]** — "clash with an opponent" is a choice,
+ * not a target (CR 701.30b), and the chosen opponent must be the same player for the gather and
+ * the decision, which [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent] guarantees
+ * and a bare `Chooser.Opponent` would not (it re-picks per step). `MechanicPatterns.clash` prefixes
+ * it. With a single opponent the choice is forced and promptless, so two-player games see no extra
+ * decision.
+ *
+ * The nearest existing primitive is [ExileTopCardContestEffect] (Timesifter), and this deliberately
+ * copies its *interface* rather than its mechanism: answer "who won" into a pipeline collection,
+ * leave that collection empty when nobody did, and let the card compose its own payoff off it. The
+ * mechanisms genuinely differ — the contest **exiles** and re-runs tied players until one is alone,
+ * while a clash **reveals**, leaves both cards in their libraries under their owners' control, and
+ * settles a tie as "nobody won" — so there is nothing to share but the shape. Matching the shape is
+ * what keeps the two reading alike, and what makes the empty-library and no-winner cases behave the
+ * same way in both.
+ *
+ * @property storeWonAs Pipeline-storage collection that receives the clashing player's revealed
+ *   card **iff they won** the clash, and stays empty otherwise. Reading a win as "is this
+ *   collection non-empty" is what lets the printed "if you win" rider be an ordinary
+ *   [SuccessCriterion.CollectionNonEmpty] instead of a bespoke gate.
+ */
+@SerialName("Clash")
+@Serializable
+data class ClashEffect(
+    val storeWonAs: String = CLASH_WON
+) : Effect {
+    override val description: String = "Clash with an opponent"
+}
+
+/**
+ * Tail of the clash pipeline: score the clash and emit the `ClashedEvent`.
+ *
+ * The clash twin of [EmitScriedEventEffect], and the same shape — an internal marker the mechanic's
+ * pipeline appends, never authored by a card. It does two things the surrounding gather/select/move
+ * steps can't:
+ *
+ *  - **Scores the clash (CR 701.30d).** A player wins iff the card they revealed has a *strictly*
+ *    greater mana value than every other card revealed in that clash. Ties win for nobody, and an
+ *    empty library reveals nothing — a player who revealed no card can't have the greatest mana
+ *    value, so they never win, while their opponent still can. The clasher's revealed card is
+ *    written to [storeWonAs] on a win and nothing is written on a loss, which is the flag the
+ *    printed "if you win" rider gates on.
+ *  - **Fires "Whenever you clash" triggers**, once per clashing *player* — both of them. Per the
+ *    Entangling Trap / Sylvan Echoes rulings a clash you did not initiate still triggers your own
+ *    clash payoffs, and you can win a clash an opponent started, so the event names both
+ *    participants and carries who (if anyone) won.
+ *
+ * Scoring happens here, after the top/bottom moves, rather than mid-pipeline: mana value is a
+ * printed characteristic that reads the same from the library as from the top of it, so the moves
+ * can't change the answer, and emitting the event last is what CR requires ("this ability triggers
+ * after the clash ends").
+ *
+ * @property yourCollection Gather collection holding the clashing player's revealed card.
+ * @property theirCollection Gather collection holding the chosen opponent's revealed card.
+ * @property storeWonAs Collection to write the clashing player's card into on a win.
+ */
+@SerialName("EmitClashedEvent")
+@Serializable
+data class EmitClashedEventEffect(
+    val yourCollection: String = CLASH_YOURS,
+    val theirCollection: String = CLASH_THEIRS,
+    val storeWonAs: String = CLASH_WON
+) : Effect {
+    // Intentionally blank: this is an internal pipeline tail with no player-facing text.
+    override val description: String = ""
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -722,6 +722,20 @@ enum class Chooser {
      * gets its own pick.
      */
     Opponent,
+
+    /**
+     * The opponent already *chosen* for this source decides — the durable pick a preceding
+     * [ChooseOpponentForSourceEffect] wrote into the source's `OPPONENT` cast-choices slot, the
+     * decision-side twin of [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent].
+     *
+     * Distinct from [Opponent] in exactly the way clash (CR 701.30b) needs: [Opponent] picks *an*
+     * opponent afresh at each step, so a mechanic that first reads one opponent's library and then
+     * asks that same opponent to decide could split across two different players in a multiplayer
+     * game. This resolves to the one already named, so the reveal and the decision stay paired.
+     * Unresolvable when no choice has been made — a card using it must run
+     * [ChooseOpponentForSourceEffect] first.
+     */
+    ChosenOpponent,
     /** The target player decides (resolved from context.targets[0]) */
     TargetPlayer,
     /** The triggering player decides (resolved from trigger context) */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -587,6 +587,11 @@ object CardLinter {
         // exiled, in every round, as another.
         put("ExileTopCardContest" to "storeWinnerAs", write(Space.COLLECTION))
         put("ExileTopCardContest" to "storeExiledAs", write(Space.COLLECTION))
+        // Clash (CR 701.30) publishes its outcome the same way ExileTopCardContest does: the
+        // clashing player's revealed card lands here iff they won, and the collection stays empty
+        // on a loss or a tie. `Patterns.Mechanic.clash` reads it back through
+        // SuccessCriterion.CollectionNonEmpty, which is the "If you win, ..." rider.
+        put("Clash" to "storeWonAs", write(Space.COLLECTION))
         put("Discover" to "storeDiscoveredAs", write(Space.COLLECTION))
         put("CopyCardIntoCollection" to "storeAs", write(Space.COLLECTION))
         put("CopyCollectionIntoCollection" to "storeAs", write(Space.COLLECTION))

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AdderStaffBoggart.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AdderStaffBoggart.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adder-Staff Boggart
+ * {1}{R}
+ * Creature — Goblin Warrior
+ * 2/1
+ * When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this
+ * creature.
+ *
+ * The plainest of Lorwyn's "clash for a counter" commons (with Oaken Brawler and Paperfin Rascal),
+ * and the whole card is `Patterns.Mechanic.clash` — the pattern owns the opponent choice, the
+ * public reveal, both top-or-bottom decisions and the "if you win" gate (CR 701.30).
+ */
+val AdderStaffBoggart = card("Adder-Staff Boggart") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on " +
+        "this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.clash(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Jeff Miracola"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg?1783942880"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LashOut.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LashOut.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lash Out
+ * {1}{R}
+ * Instant
+ * Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, Lash Out deals
+ * 3 damage to that creature's controller.
+ *
+ * Two things worth stating, both of which the scenario test pins:
+ *
+ *  - **The clash happens whether or not the creature is still there.** The damage and the clash are
+ *    separate sentences; only the creature *targeting* can fizzle the spell. Once it resolves, the
+ *    clash runs — and per the Broken Ambitions ruling ("the clash happens regardless") that is the
+ *    general shape of Lorwyn's clash spells.
+ *  - **"That creature's controller" is [EffectTarget.TargetController], not a second target.** It
+ *    resolves through the target's controller and falls back to last-known information when the
+ *    3 damage already killed it (CR 608.2h), which is the common case: a 3-toughness creature dies
+ *    to the first sentence and its controller still takes 3.
+ */
+val LashOut = card("Lash Out") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, " +
+        "Lash Out deals 3 damage to that creature's controller."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(3, creature)
+            .then(Patterns.Mechanic.clash(Effects.DealDamage(3, EffectTarget.TargetController)))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Scott Hampton"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg?1783942872"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/OakenBrawler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/OakenBrawler.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Oaken Brawler
+ * {3}{W}
+ * Creature — Treefolk Warrior
+ * 2/4
+ * When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this
+ * creature.
+ */
+val OakenBrawler = card("Oaken Brawler") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Treefolk Warrior"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on " +
+        "this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.clash(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Jim Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg?1783942911"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PaperfinRascal.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/PaperfinRascal.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Paperfin Rascal
+ * {2}{U}
+ * Creature — Merfolk Rogue
+ * 2/2
+ * When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this
+ * creature.
+ */
+val PaperfinRascal = card("Paperfin Rascal") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on " +
+        "this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.clash(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg?1783942899"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SylvanEchoes.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SylvanEchoes.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Echoes
+ * {G}
+ * Enchantment
+ * Whenever you clash and win, you may draw a card.
+ *
+ * The clash *payoff* rather than a clash source — it never clashes itself, it watches. Two things
+ * that makes load-bearing, and both are in its ruling ("if you win a clash initiated by a spell or
+ * ability an opponent controls, the ability will still trigger"):
+ *
+ *  - The trigger is [Triggers.WheneverYouClashAndWin], which watches the `ClashedEvent` emitted for
+ *    *you as a participant*. An opponent's Adder-Staff Boggart makes you clash too, and if your
+ *    revealed card is the bigger one you drew from their trigger.
+ *  - The win is on the trigger, not inside the effect, because the printed wording is "clash **and
+ *    win**" — losing the clash puts nothing on the stack at all.
+ */
+val SylvanEchoes = card("Sylvan Echoes") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you clash and win, you may draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouClashAndWin
+        effect = Effects.DrawCards(1)
+        optional = true
+        description = "you may draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Rebecca Guay"
+        flavorText = "It takes a huntmaster's eye to discern the contours of mythical prey."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg?1783942856"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AdderStaffBoggartScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AdderStaffBoggartScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AdderStaffBoggart
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Adder-Staff Boggart (LRW #148) — "When this creature enters, clash with an opponent. If you win,
+ * put a +1/+1 counter on this creature."
+ *
+ * The clash mechanic itself is proved in `ClashScenarioTest`; what this file pins is that the
+ * *card* is wired to it — the ETB trigger runs a real clash (both players get their top-or-bottom
+ * prompt) and the counter is gated on winning it, not placed unconditionally. The rigged library
+ * tops are what make the outcome deterministic: a {5} artifact against a {0} artifact.
+ */
+class AdderStaffBoggartScenarioTest : FunSpec({
+
+    // {5} and {0} fillers, so the clash outcome is decided by the rigged top of each library and
+    // never by whatever the shuffled deck happened to leave there.
+    val Boulder = com.wingedsheep.sdk.dsl.card("Clash Boulder") {
+        manaCost = "{5}"; typeLine = "Artifact"; oracleText = ""
+    }
+    val Pebble = com.wingedsheep.sdk.dsl.card("Clash Pebble") {
+        manaCost = "{0}"; typeLine = "Artifact"; oracleText = ""
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(AdderStaffBoggart, Boulder, Pebble))
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Answer both clash prompts, leaving each revealed card on top. */
+    fun GameTestDriver.answerClash(): List<EntityId> {
+        val asked = mutableListOf<EntityId>()
+        repeat(4) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return asked
+            asked += decision.playerId
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, emptyList()))
+        }
+        return asked
+    }
+
+    /** Cast the Boggart and let its ETB trigger start resolving. */
+    fun GameTestDriver.castBoggart(): EntityId {
+        val cardId = putCardInHand(player1, "Adder-Staff Boggart")
+        giveMana(player1, Color.RED, 2)
+        castSpell(player1, cardId)
+        bothPass() // creature resolves, ETB trigger goes on the stack
+        bothPass() // trigger resolves into the clash
+        return cardId
+    }
+
+    test("winning the clash puts a +1/+1 counter on it, and both players were asked") {
+        val d = driver()
+        d.putCardOnTopOfLibrary(d.player1, "Clash Boulder") // MV 5
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")  // MV 0
+
+        val boggart = d.castBoggart()
+        val asked = d.answerClash()
+
+        withClue("clash is a two-player action — the opponent gets their own top-or-bottom choice") {
+            asked shouldBe listOf(d.player1, d.player2)
+        }
+        d.plusOneCounters(boggart) shouldBe 1
+    }
+
+    test("losing the clash leaves it a 2/1 with no counter") {
+        val d = driver()
+        d.putCardOnTopOfLibrary(d.player1, "Clash Pebble")  // MV 0
+        d.putCardOnTopOfLibrary(d.player2, "Clash Boulder") // MV 5
+
+        val boggart = d.castBoggart()
+        d.answerClash()
+
+        d.plusOneCounters(boggart) shouldBe 0
+    }
+
+    test("a tie is not a win — CR 701.30d wants a strictly greater mana value") {
+        val d = driver()
+        d.putCardOnTopOfLibrary(d.player1, "Clash Pebble")
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")
+
+        val boggart = d.castBoggart()
+        d.answerClash()
+
+        d.plusOneCounters(boggart) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LashOutScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LashOutScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.LashOut
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lash Out (LRW #183) — "Lash Out deals 3 damage to target creature. Clash with an opponent. If you
+ * win, Lash Out deals 3 damage to that creature's controller."
+ *
+ * Three things this card can get wrong, one test each:
+ *
+ *  - **The second 3 goes to the creature's controller, not to the clash opponent.** In a two-player
+ *    game those are usually the same player, so the test aims Lash Out at a creature the *caster*
+ *    controls: the only board where the two readings disagree, and where the wrong one would burn
+ *    the opponent instead of the caster.
+ *  - **"That creature's controller" survives the creature dying to the first sentence.** Three
+ *    damage kills a 2/1 before the clash even starts, so the payoff has to read last-known
+ *    information (CR 608.2h) rather than looking the creature up on the battlefield.
+ *  - **The clash still happens when the payoff can't.** The clash is its own sentence; losing it
+ *    just means no second 3.
+ */
+class LashOutScenarioTest : FunSpec({
+
+    val Boulder = com.wingedsheep.sdk.dsl.card("Clash Boulder") {
+        manaCost = "{5}"; typeLine = "Artifact"; oracleText = ""
+    }
+    val Pebble = com.wingedsheep.sdk.dsl.card("Clash Pebble") {
+        manaCost = "{0}"; typeLine = "Artifact"; oracleText = ""
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(LashOut, Boulder, Pebble))
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.answerClash() {
+        repeat(4) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, emptyList()))
+        }
+    }
+
+    fun GameTestDriver.castLashOut(target: EntityId) {
+        val cardId = putCardInHand(player1, "Lash Out")
+        giveMana(player1, Color.RED, 2)
+        castSpellWithTargets(player1, cardId, listOf(ChosenTarget.Permanent(target)))
+        bothPass()
+    }
+
+    /** Player 1 wins the clash: a {5} on their top against a {0} on the opponent's. */
+    fun GameTestDriver.rigWin() {
+        putCardOnTopOfLibrary(player1, "Clash Boulder")
+        putCardOnTopOfLibrary(player2, "Clash Pebble")
+    }
+
+    /** Player 1 loses the clash. */
+    fun GameTestDriver.rigLoss() {
+        putCardOnTopOfLibrary(player1, "Clash Pebble")
+        putCardOnTopOfLibrary(player2, "Clash Boulder")
+    }
+
+    test("winning burns the creature's controller — not the clash opponent") {
+        val d = driver()
+        d.rigWin()
+        // Aim at the caster's own creature: the one board where "that creature's controller" and
+        // "the opponent you clashed with" are different players.
+        val ownCreature = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val myLife = d.getLifeTotal(d.player1)
+        val theirLife = d.getLifeTotal(d.player2)
+
+        d.castLashOut(ownCreature)
+        d.answerClash()
+
+        withClue("the second 3 follows the creature's controller, so it hits the caster") {
+            d.getLifeTotal(d.player1) shouldBe myLife - 3
+        }
+        withClue("the clash opponent is not the damage recipient") {
+            d.getLifeTotal(d.player2) shouldBe theirLife
+        }
+    }
+
+    test("the creature's controller still takes 3 after the first 3 killed the creature") {
+        val d = driver()
+        d.rigWin()
+        // Grizzly Bears is a 2/2: dead to the first sentence, long before the clash resolves.
+        val theirCreature = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val theirLife = d.getLifeTotal(d.player2)
+
+        d.castLashOut(theirCreature)
+        d.answerClash()
+
+        d.assertInGraveyard(d.player2, "Grizzly Bears")
+        withClue("last-known information carries the controller past the creature's death") {
+            d.getLifeTotal(d.player2) shouldBe theirLife - 3
+        }
+    }
+
+    test("losing the clash deals the first 3 and nothing else") {
+        val d = driver()
+        d.rigLoss()
+        val theirCreature = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val theirLife = d.getLifeTotal(d.player2)
+
+        d.castLashOut(theirCreature)
+        d.answerClash()
+
+        d.assertInGraveyard(d.player2, "Grizzly Bears")
+        withClue("no win, no second 3") {
+            d.getLifeTotal(d.player2) shouldBe theirLife
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenBrawlerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenBrawlerScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.OakenBrawler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Oaken Brawler (LRW #33) — "When this creature enters, clash with an opponent. If you win, put a
+ * +1/+1 counter on this creature."
+ *
+ * Shares Adder-Staff Boggart's shape, so the win/lose gate is covered there; this file leans on the
+ * *other* half of CR 701.30a, the "may put that card on the bottom" choice. Each player decides for
+ * their own library only, and a card sent to the bottom never leaves the library — a clash that
+ * mills or draws would pass every counter assertion and fail these.
+ */
+class OakenBrawlerScenarioTest : FunSpec({
+
+    val Boulder = com.wingedsheep.sdk.dsl.card("Clash Boulder") {
+        manaCost = "{5}"; typeLine = "Artifact"; oracleText = ""
+    }
+    val Pebble = com.wingedsheep.sdk.dsl.card("Clash Pebble") {
+        manaCost = "{0}"; typeLine = "Artifact"; oracleText = ""
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(OakenBrawler, Boulder, Pebble))
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.library(player: EntityId) = state.getZone(ZoneKey(player, Zone.LIBRARY))
+    fun GameTestDriver.libraryTopName(player: EntityId): String? =
+        library(player).firstOrNull()?.let { getCardName(it) }
+
+    fun GameTestDriver.castBrawler(): EntityId {
+        val cardId = putCardInHand(player1, "Oaken Brawler")
+        giveMana(player1, Color.WHITE, 4)
+        castSpell(player1, cardId)
+        bothPass()
+        bothPass()
+        return cardId
+    }
+
+    /** Answer both clash prompts; [bottom] decides whether each player buries their own card. */
+    fun GameTestDriver.answerClash(bottom: Boolean) {
+        repeat(4) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return
+            val picked = if (bottom) decision.options else emptyList()
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, picked))
+        }
+    }
+
+    test("both players may bury their revealed card, and it stays in the library") {
+        val d = driver()
+        d.putCardOnTopOfLibrary(d.player1, "Clash Boulder")
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")
+        val sizeBefore1 = d.library(d.player1).size
+        val sizeBefore2 = d.library(d.player2).size
+
+        val brawler = d.castBrawler()
+        d.answerClash(bottom = true)
+
+        withClue("bottomed, not drawn or milled — the library keeps every card") {
+            d.library(d.player1).size shouldBe sizeBefore1
+            d.library(d.player2).size shouldBe sizeBefore2
+        }
+        d.libraryTopName(d.player1) shouldBe "Plains"
+        d.libraryTopName(d.player2) shouldBe "Plains"
+        withClue("burying your card afterwards doesn't undo the win it already earned") {
+            d.plusOneCounters(brawler) shouldBe 1
+        }
+    }
+
+    test("declining leaves each revealed card on top of its owner's library") {
+        val d = driver()
+        d.putCardOnTopOfLibrary(d.player1, "Clash Boulder")
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")
+
+        d.castBrawler()
+        d.answerClash(bottom = false)
+
+        d.libraryTopName(d.player1) shouldBe "Clash Boulder"
+        d.libraryTopName(d.player2) shouldBe "Clash Pebble"
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PaperfinRascalScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PaperfinRascalScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.PaperfinRascal
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Paperfin Rascal (LRW #77) — "When this creature enters, clash with an opponent. If you win, put a
+ * +1/+1 counter on this creature."
+ *
+ * The third of the clash-for-a-counter commons, and the one that takes the empty-library edge.
+ * CR 701.30d asks for a card with a *greater* mana value than every other card revealed; a player
+ * with no library reveals nothing, and nothing has no mana value. So an empty library can never
+ * win — but it also puts up no card for the other player to beat, so the other player wins with
+ * anything at all, a {0} artifact included. The naive "compare two numbers, default the missing one
+ * to 0" implementation ties instead, and this pair of tests is what separates them.
+ */
+class PaperfinRascalScenarioTest : FunSpec({
+
+    val Pebble = com.wingedsheep.sdk.dsl.card("Clash Pebble") {
+        manaCost = "{0}"; typeLine = "Artifact"; oracleText = ""
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(PaperfinRascal, Pebble))
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.emptyLibrary(player: EntityId) {
+        val key = ZoneKey(player, Zone.LIBRARY)
+        replaceState(state.copy(zones = state.zones + (key to emptyList())))
+    }
+
+    fun GameTestDriver.castRascal(): EntityId {
+        val cardId = putCardInHand(player1, "Paperfin Rascal")
+        giveMana(player1, Color.BLUE, 3)
+        castSpell(player1, cardId)
+        bothPass()
+        bothPass()
+        return cardId
+    }
+
+    fun GameTestDriver.answerClash() {
+        repeat(4) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, emptyList()))
+        }
+    }
+
+    test("a {0} card beats an opponent who has no library at all") {
+        val d = driver()
+        // The Rascal's controller keeps the cheapest possible card; the opponent reveals nothing.
+        d.putCardOnTopOfLibrary(d.player1, "Clash Pebble")
+        d.emptyLibrary(d.player2)
+
+        val rascal = d.castRascal()
+        d.answerClash()
+
+        withClue("mana value 0 still beats no card at all — nothing has no mana value") {
+            d.plusOneCounters(rascal) shouldBe 1
+        }
+    }
+
+    test("an empty library of your own cannot win, even against a {0}") {
+        val d = driver()
+        d.emptyLibrary(d.player1)
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")
+
+        val rascal = d.castRascal()
+        d.answerClash()
+
+        d.plusOneCounters(rascal) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SylvanEchoesScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SylvanEchoesScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.AdderStaffBoggart
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SylvanEchoes
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sylvan Echoes (LRW #237) — "Whenever you clash and win, you may draw a card."
+ *
+ * A clash *payoff*, never a clash source, and its ruling is the whole point of the card:
+ * "if you win a clash initiated by a spell or ability an opponent controls, the ability will still
+ * trigger." So the interesting board is the one where the **opponent's** Adder-Staff Boggart starts
+ * the clash and the Echoes controller — who did nothing — wins it and draws. An implementation that
+ * only fires the clash event for the clashing spell's controller passes a self-clash test and fails
+ * this one.
+ *
+ * The other half is "and win": a lost clash puts nothing on the stack, so there is no "you may draw"
+ * prompt to decline.
+ */
+class SylvanEchoesScenarioTest : FunSpec({
+
+    val Boulder = com.wingedsheep.sdk.dsl.card("Clash Boulder") {
+        manaCost = "{5}"; typeLine = "Artifact"; oracleText = ""
+    }
+    val Pebble = com.wingedsheep.sdk.dsl.card("Clash Pebble") {
+        manaCost = "{0}"; typeLine = "Artifact"; oracleText = ""
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SylvanEchoes, AdderStaffBoggart, Boulder, Pebble))
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.answerClash() {
+        repeat(4) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, emptyList()))
+        }
+    }
+
+    /** The active player casts an Adder-Staff Boggart, whose ETB trigger runs the clash. */
+    fun GameTestDriver.activePlayerClashes() {
+        val cardId = putCardInHand(player1, "Adder-Staff Boggart")
+        giveMana(player1, Color.RED, 2)
+        castSpell(player1, cardId)
+        bothPass()
+        bothPass()
+        answerClash()
+    }
+
+    /** Answer the "you may draw a card" prompt if one is pending; report whether there was one. */
+    fun GameTestDriver.answerMayDraw(yes: Boolean): Boolean {
+        var guard = 0
+        while (guard++ < 6) {
+            val decision = pendingDecision
+            if (decision is YesNoDecision) {
+                submitDecision(decision.playerId, YesNoResponse(decision.id, yes))
+                return true
+            }
+            if (stackSize == 0) return false
+            bothPass()
+        }
+        return false
+    }
+
+    fun GameTestDriver.handSize(player: EntityId) = getHandSize(player)
+
+    test("the Echoes controller draws off a clash the opponent started, having won it") {
+        val d = driver()
+        // Player 2 owns the Echoes and does nothing; player 1's Boggart starts the clash and loses.
+        d.putPermanentOnBattlefield(d.player2, "Sylvan Echoes")
+        d.putCardOnTopOfLibrary(d.player1, "Clash Pebble")   // clasher: MV 0
+        d.putCardOnTopOfLibrary(d.player2, "Clash Boulder")  // Echoes controller: MV 5
+        val before = d.handSize(d.player2)
+
+        d.activePlayerClashes()
+        val prompted = d.answerMayDraw(yes = true)
+
+        withClue("you can win — and be paid for — a clash you never initiated") {
+            prompted shouldBe true
+            d.handSize(d.player2) shouldBe before + 1
+        }
+    }
+
+    test("losing the clash never puts the trigger on the stack") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player2, "Sylvan Echoes")
+        d.putCardOnTopOfLibrary(d.player1, "Clash Boulder")  // clasher wins
+        d.putCardOnTopOfLibrary(d.player2, "Clash Pebble")   // Echoes controller loses
+        val before = d.handSize(d.player2)
+
+        d.activePlayerClashes()
+        val prompted = d.answerMayDraw(yes = true)
+
+        withClue("\"and win\" is on the trigger, so a loss asks nothing at all") {
+            prompted shouldBe false
+            d.handSize(d.player2) shouldBe before
+        }
+    }
+
+    test("the draw is optional — declining leaves the hand alone") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player2, "Sylvan Echoes")
+        d.putCardOnTopOfLibrary(d.player1, "Clash Pebble")
+        d.putCardOnTopOfLibrary(d.player2, "Clash Boulder")
+        val before = d.handSize(d.player2)
+
+        d.activePlayerClashes()
+        d.answerMayDraw(yes = false) shouldBe true
+
+        d.handSize(d.player2) shouldBe before
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/LashOutReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/LashOutReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lash Out reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val LashOutReprint = Printing(
+    oracleId = "398d57bb-4653-4652-aa42-7cea4317be0a",
+    name = "Lash Out",
+    setCode = "CMD",
+    collectorNumber = "127",
+    scryfallId = "d4f04300-2a03-472f-b618-20fc9dcda988",
+    artist = "Scott Hampton",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d4f04300-2a03-472f-b618-20fc9dcda988.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1,3 +1,62 @@
+// Adder-Staff Boggart
+{
+    "name": "Adder-Staff Boggart",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, put 1 +1/+1 counter on this creature"
+                },
+                "descriptionOverride": "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Jeff Miracola",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d116839f-6a3a-4a2e-a3ab-ea177c012746.jpg?1783942880"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Aethersnipe
 {
     "name": "Aethersnipe",
@@ -8316,6 +8375,78 @@
     ]
 }
 
+// Lash Out
+{
+    "name": "Lash Out",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, Lash Out deals 3 damage to that creature's controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "TargetController"
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, deal 3 damage to its controller"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Scott Hampton",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de2c0c8b-5442-44fb-9686-d3dff5742501.jpg?1783942872"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Leaf Gilder
 {
     "name": "Leaf Gilder",
@@ -10282,6 +10413,65 @@
     ]
 }
 
+// Oaken Brawler
+{
+    "name": "Oaken Brawler",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Treefolk Warrior",
+    "oracleText": "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, put 1 +1/+1 counter on this creature"
+                },
+                "descriptionOverride": "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Jim Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9fdb060-8f4d-453a-9516-92c390fbc85a.jpg?1783942911"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Oakgnarl Warrior
 {
     "name": "Oakgnarl Warrior",
@@ -10383,6 +10573,65 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Paperfin Rascal
+{
+    "name": "Paperfin Rascal",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Rogue",
+    "oracleText": "When this creature enters, clash with an opponent. If you win, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ChooseOpponentForSource",
+                                    "prompt": "Choose an opponent to clash with"
+                                },
+                                "Clash"
+                            ]
+                        },
+                        "successCriterion": {
+                            "type": "SuccessCriterion.CollectionNonEmpty",
+                            "name": "clashWon"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "Clash with an opponent. If you win, put 1 +1/+1 counter on this creature"
+                },
+                "descriptionOverride": "clash with an opponent. If you win, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a439c0ca-0cb2-4293-825e-1a72159953b9.jpg?1783942899"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -13201,6 +13450,49 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Sylvan Echoes
+{
+    "name": "Sylvan Echoes",
+    "manaCost": "{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you clash and win, you may draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ClashedEvent",
+                    "requireWin": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "descriptionOverride": "you may draw a card."
+                },
+                "descriptionOverride": "you may draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "flavorText": "It takes a huntmaster's eye to discern the contours of mythical prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5b55fa6-4c94-4ab4-bc30-4fb8b1d3e38f.jpg?1783942856"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -32,6 +32,12 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // to SCAFFOLD rather than silently dropping the restriction.
     supported("WhenACounterOfTypeIsRemovedFromAPermanent", "trigger: a counter of a type removed from this permanent (CountersRemovedEvent, SELF)")
     supported("WhenAPlayerRemovesTheLastCounterOfTypeFromAPermanent", "trigger: the last counter of a type removed from this permanent (CountersRemovedEvent, lastRemoved)")
+    // Clash (CR 701.30) — "Whenever you clash" / "Whenever you clash and win"
+    // (Triggers.WheneverYouClash / WheneverYouClashAndWin over EventPattern.ClashedEvent). The engine
+    // emits one ClashedEvent per *participant*, so both tags resolve for a clash an opponent started,
+    // which is what the Entangling Trap / Sylvan Echoes rulings require.
+    supported("WhenAPlayerClashes", "trigger: a player clashes (Triggers.WheneverYouClash)")
+    supported("WhenAPlayerClashesAndWins", "trigger: a player clashes and wins (Triggers.WheneverYouClashAndWin)")
     supported("WhenACreatureAttacks", "trigger: attacks")
     // "Whenever this creature attacks a player, …" — the attacks-a-player trigger, gated on the declared
     // defender being a player (not a planeswalker or battle; CR 508.1 + Kaalia of the Vast's 2024-06-07

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -56,6 +56,17 @@ internal fun BridgeBuilder.zoneMovement() {
     effect("Discover", "Discover", "CR 701.57 — Effects.Discover(N)")
     composed("Surveil", "Patterns.Library.surveil -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
     composed("Scry", "Patterns.Library.scry -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
+    // Clash (CR 701.30) — Patterns.Mechanic.clash expands to ChooseOpponentForSource -> Gather(top 1,
+    // both libraries, revealed) -> two APNAP-ordered Selects -> MoveCollection(bottom), scored and
+    // gated by a Gate.DoAction over SuccessCriterion.CollectionNonEmpty. `ClashOpponent` is the
+    // opponent the clash named, read back through Player.ChosenOpponent.
+    //
+    // NOTE the deliberate gap: `_Condition -> Trigger_WonTheClash` — the "…, If you won, …" rider
+    // *inside* a clash trigger's effect (Entangling Trap, Rebellion of the Flamekin) — stays
+    // unmapped, because the clash event's win flag is not yet exposed as a trigger-context value.
+    // Those cards keep blocking on it rather than being silently rendered without the rider.
+    composed("Clash", "Patterns.Mechanic.clash -> ChooseOpponentForSource + Gather/Select/MoveCollection, gated by Gate.DoAction", composes = listOf("MoveCollection"))
+    supported("ClashOpponent", "player: the opponent this clash named (Player.ChosenOpponent)")
     composed("ManifestDread", "Patterns.Library.manifestDread -> Gather/Select/MoveCollection(face-down MANIFEST)", composes = listOf("MoveCollection"))
 
     // Cloak (CR 701.58) is manifest plus ward {2}, and on our side it is exactly one FaceDownMode

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -369,6 +369,31 @@ data class ScriedEvent(
 ) : GameEvent
 
 /**
+ * A player just finished clashing (CR 701.30), after both cards were revealed, both top-or-bottom
+ * decisions were made and both moves resolved. Drives "Whenever you clash" and "Whenever you clash
+ * and win" triggers; see [com.wingedsheep.sdk.scripting.EventPattern.ClashedEvent].
+ *
+ * **Emitted once per clashing player**, so a two-player clash produces two of these — the clash
+ * names both participants, and per the Entangling Trap ruling a clash caused by an opponent's spell
+ * still fires your own clash triggers, and you can win a clash you did not initiate.
+ *
+ * @property playerId The clashing player this event is about.
+ * @property opponentId The other player in the same clash.
+ * @property won Whether [playerId] won it — CR 701.30d, a strictly greater mana value than every
+ *   other card revealed. A tie means this is false for both players, and so does an empty library
+ *   (nothing revealed can't be the greatest).
+ * @property sourceName The card/ability that caused the clash (for display).
+ */
+@Serializable
+@SerialName("ClashedEvent")
+data class ClashedEvent(
+    val playerId: EntityId,
+    val opponentId: EntityId,
+    val won: Boolean,
+    val sourceName: String
+) : GameEvent
+
+/**
  * A player just finished a `surveil N` (CR 701.25). Fires once per surveil, after the
  * kept/graveyard moves have all resolved. Drives "Whenever you surveil" and "Whenever you
  * scry or surveil" triggers; see [com.wingedsheep.sdk.scripting.EventPattern.SurveiledEvent].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -139,6 +139,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MaximumHandSizeRemovedEvent::class)
         subclass(MaximumHandSizeReducedEvent::class)
         subclass(RingTemptedEvent::class)
+        subclass(ClashedEvent::class)
         subclass(ScriedEvent::class)
         subclass(SurveiledEvent::class)
         subclass(DiscoveredEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -282,6 +282,12 @@ data class TriggerContext(
                     triggeringEntityId = event.playerId,
                     triggeringPlayerId = event.playerId
                 )
+                // Clash (CR 701.30): the clashing player this event is about is the triggering
+                // player, so "whenever you clash" resolves "you" to that participant even when
+                // the opponent's spell started the clash.
+                is com.wingedsheep.engine.core.ClashedEvent -> TriggerContext(
+                    triggeringPlayerId = event.playerId
+                )
                 is com.wingedsheep.engine.core.ScriedEvent -> TriggerContext(
                     triggeringPlayerId = event.playerId,
                     scryCount = event.count

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -77,6 +77,7 @@ enum class TriggerCategory {
     CHOOSE_TARGETS,
     DISCARD,
     RING_TEMPTED,
+    CLASHED,
     SCRIED,
     SURVEILED,
     DISCOVERED,
@@ -288,6 +289,7 @@ class TriggerIndex(
                 is SdkGameEvent.TargetsChosenEvent -> listOf(TriggerCategory.CHOOSE_TARGETS)
                 is SdkGameEvent.DiscardEvent -> listOf(TriggerCategory.DISCARD)
                 is SdkGameEvent.RingTemptedEvent -> RING_TEMPTED_LIST
+                is SdkGameEvent.ClashedEvent -> CLASHED_LIST
                 is SdkGameEvent.ScriedEvent -> SCRIED_LIST
                 is SdkGameEvent.SurveiledEvent -> SURVEILED_LIST
                 // "Whenever you scry or surveil" indexes under both buckets so either engine event
@@ -350,6 +352,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.TargetsChosenEvent -> CHOOSE_TARGETS_LIST
             is CardsDiscardedEvent -> DISCARD_LIST
             is com.wingedsheep.engine.core.RingTemptedEvent -> RING_TEMPTED_LIST
+            is com.wingedsheep.engine.core.ClashedEvent -> CLASHED_LIST
             is com.wingedsheep.engine.core.ScriedEvent -> SCRIED_LIST
             is com.wingedsheep.engine.core.SurveiledEvent -> SURVEILED_LIST
             is com.wingedsheep.engine.core.DiscoveredEvent -> DISCOVERED_LIST
@@ -400,6 +403,7 @@ class TriggerIndex(
         private val CHOOSE_TARGETS_LIST = listOf(TriggerCategory.CHOOSE_TARGETS)
         private val DISCARD_LIST = listOf(TriggerCategory.DISCARD)
         private val RING_TEMPTED_LIST = listOf(TriggerCategory.RING_TEMPTED)
+        private val CLASHED_LIST = listOf(TriggerCategory.CLASHED)
         private val SCRIED_LIST = listOf(TriggerCategory.SCRIED)
         private val SURVEILED_LIST = listOf(TriggerCategory.SURVEILED)
         private val DISCOVERED_LIST = listOf(TriggerCategory.DISCOVERED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -608,6 +608,15 @@ class TriggerMatcher(
                     matchesPlayer(state, trigger.player, event.playerId, controllerId) &&
                     (!trigger.requireBearerChosen || event.bearerId != null)
             }
+            is EventPattern.ClashedEvent -> {
+                // Both participants clash, so the event names the player it is *about* rather
+                // than the clash's initiator (Entangling Trap's ruling). `requireWin` is the
+                // "and win" half of Sylvan Echoes' wording, checked here on the trigger rather
+                // than gated inside its effect.
+                event is com.wingedsheep.engine.core.ClashedEvent &&
+                    matchesPlayer(state, trigger.player, event.playerId, controllerId) &&
+                    (!trigger.requireWin || event.won)
+            }
             is EventPattern.ScriedEvent -> {
                 event is com.wingedsheep.engine.core.ScriedEvent &&
                     matchesPlayer(state, trigger.player, event.playerId, controllerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.core.DecisionRequestedEvent
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
@@ -83,6 +84,16 @@ object ChooserResolution {
                 opponents.size == 1 -> Outcome.Resolved(opponents.single())
                 else -> Outcome.NeedsOpponentPick(opponents)
             }
+        }
+
+        // The durable pick a preceding ChooseOpponentForSourceEffect wrote onto the source, so the
+        // opponent who revealed a card is the same one who decides where it goes (CR 701.30b/c).
+        Chooser.ChosenOpponent -> {
+            val chosen = context.sourceId?.let {
+                state.getEntity(it)?.chosenOpponent()
+            }
+            chosen?.let { Outcome.Resolved(it) }
+                ?: Outcome.Unresolvable("No opponent has been chosen for this source")
         }
 
         Chooser.TargetPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ClashExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ClashExecutors.kt
@@ -1,0 +1,225 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.ClashedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.CLASH_THEIRS
+import com.wingedsheep.sdk.scripting.effects.CLASH_YOURS
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ClashEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.EmitClashedEventEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import kotlin.reflect.KClass
+
+/**
+ * Executor for the [ClashEffect] macro (CR 701.30). Like [ScryExecutor] it carries no
+ * gather/select/move logic of its own: it expands the marker into a composite of the ordinary
+ * library primitives and delegates to the registry's recursive [effectExecutor], so the
+ * `SelectCardsDecision` pauses and their continuations are the ones the pipeline machinery
+ * already owns.
+ *
+ * The expansion is built here rather than in the SDK because one part of it depends on the live
+ * state. CR 701.30c: *"Each clashing player reveals the top card of their library at the same
+ * time. Then those players decide in APNAP order (see rule 101.4) where to put those cards."* A
+ * `CompositeEffect` has a fixed step order, so the two top-or-bottom selections are emitted
+ * active-player-first — which is the clasher's own decision first on their turn, and the
+ * opponent's first when a clash spell is cast during the opponent's turn (Lash Out at instant
+ * speed). Both gathers precede both selections regardless, so the simultaneous reveal holds: each
+ * player already sees the other's card before anyone decides.
+ *
+ * Both gathers use `revealed = true` — clash is a public reveal (CR 701.30a), not a private look,
+ * so the cards go face up for every player rather than only to the gatherer.
+ *
+ * With no opponent chosen (no [com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect]
+ * ran, or the chosen player has left the game) the clash is a no-op: nothing is revealed, nothing
+ * is written to the win collection, and the printed "if you win" rider fails closed.
+ */
+class ClashExecutor(
+    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult,
+) : EffectExecutor<ClashEffect> {
+
+    override val effectType: KClass<ClashEffect> = ClashEffect::class
+
+    override fun execute(state: GameState, effect: ClashEffect, context: EffectContext): EffectResult {
+        val clasherId = context.controllerId
+        val opponentId = ClashScoring.chosenOpponentOf(state, context)
+            ?: return EffectResult.success(state)
+
+        // CR 701.30a — one card each, revealed publicly. Both gathers run before either decision
+        // so the reveal is simultaneous even though the decisions are ordered.
+        val gathers = listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.You),
+                storeAs = CLASH_YOURS,
+                revealed = true
+            ),
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.ChosenOpponent),
+                storeAs = CLASH_THEIRS,
+                revealed = true
+            )
+        )
+
+        // CR 701.30c — decisions in APNAP order. The clasher is not necessarily the active player:
+        // an instant-speed clash on the opponent's turn has them deciding first.
+        val yourSelect = SelectFromCollectionEffect(
+            from = CLASH_YOURS,
+            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+            chooser = Chooser.Controller,
+            storeSelected = YOURS_TO_BOTTOM,
+            storeRemainder = YOURS_TO_TOP,
+            selectedLabel = "Put on bottom",
+            remainderLabel = "Leave on top",
+            prompt = "Clash — put your revealed card on the bottom of your library?"
+        )
+        val theirSelect = SelectFromCollectionEffect(
+            from = CLASH_THEIRS,
+            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+            chooser = Chooser.ChosenOpponent,
+            storeSelected = THEIRS_TO_BOTTOM,
+            storeRemainder = THEIRS_TO_TOP,
+            selectedLabel = "Put on bottom",
+            remainderLabel = "Leave on top",
+            prompt = "Clash — put your revealed card on the bottom of your library?"
+        )
+        val selections =
+            if (state.activePlayerId == opponentId) listOf(theirSelect, yourSelect)
+            else listOf(yourSelect, theirSelect)
+
+        // Only the bottom moves are real: a card left on top never left the library, so moving it
+        // "back" would emit a spurious zone change. The remainder collections exist purely to give
+        // the selection a named complement.
+        val moves = listOf(
+            MoveCollectionEffect(
+                from = YOURS_TO_BOTTOM,
+                destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, placement = ZonePlacement.Bottom)
+            ),
+            MoveCollectionEffect(
+                from = THEIRS_TO_BOTTOM,
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY, Player.ChosenOpponent, placement = ZonePlacement.Bottom
+                )
+            )
+        )
+
+        val tail = EmitClashedEventEffect(
+            yourCollection = CLASH_YOURS,
+            theirCollection = CLASH_THEIRS,
+            storeWonAs = effect.storeWonAs
+        )
+
+        return effectExecutor(state, CompositeEffect(gathers + selections + moves + tail), context)
+    }
+
+    private companion object {
+        const val YOURS_TO_BOTTOM = "clashYoursToBottom"
+        const val YOURS_TO_TOP = "clashYoursToTop"
+        const val THEIRS_TO_BOTTOM = "clashTheirsToBottom"
+        const val THEIRS_TO_TOP = "clashTheirsToTop"
+    }
+}
+
+/**
+ * Tail of the clash pipeline: score the clash (CR 701.30d) and emit the [ClashedEvent].
+ *
+ * Scoring is "strictly greatest mana value among the cards revealed in this clash". Two
+ * consequences the tests pin down: a tie means **nobody** wins, and a player whose library was
+ * empty revealed nothing, so they cannot win — but their opponent still can, because the empty
+ * side contributes no card to beat.
+ *
+ * One event is emitted **per clashing player**, because both of them clashed. The Entangling Trap
+ * and Sylvan Echoes rulings are explicit that a clash caused by an opponent's spell still fires
+ * your own "whenever you clash" abilities, and that you can win a clash you did not initiate.
+ * Emitting after the pipeline's moves is what makes the printed reminder true — "this ability
+ * triggers after the clash ends".
+ */
+class EmitClashedEventExecutor : EffectExecutor<EmitClashedEventEffect> {
+
+    override val effectType: KClass<EmitClashedEventEffect> = EmitClashedEventEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: EmitClashedEventEffect,
+        context: EffectContext
+    ): EffectResult {
+        val clasherId = context.controllerId
+        val opponentId = ClashScoring.chosenOpponentOf(state, context)
+            ?: return EffectResult.success(state)
+
+        val yourCard = context.pipeline.storedCollections[effect.yourCollection]?.firstOrNull()
+        val theirCard = context.pipeline.storedCollections[effect.theirCollection]?.firstOrNull()
+
+        val yourValue = ClashScoring.manaValueOf(state, yourCard)
+        val theirValue = ClashScoring.manaValueOf(state, theirCard)
+
+        // CR 701.30d: strictly greater than every other revealed card. A null value means no card
+        // was revealed (empty library) — that player never wins, and never blocks the other from
+        // winning either.
+        val youWon = yourValue != null && (theirValue == null || yourValue > theirValue)
+        val theyWon = theirValue != null && (yourValue == null || theirValue > yourValue)
+
+        val sourceName = context.sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+            ?: "Clash"
+
+        return EffectResult(
+            state = state,
+            events = listOf(
+                ClashedEvent(
+                    playerId = clasherId,
+                    opponentId = opponentId,
+                    won = youWon,
+                    sourceName = sourceName
+                ),
+                ClashedEvent(
+                    playerId = opponentId,
+                    opponentId = clasherId,
+                    won = theyWon,
+                    sourceName = sourceName
+                )
+            ),
+            // The win flag the printed "if you win" rider gates on, expressed as a collection so
+            // the ordinary SuccessCriterion.CollectionNonEmpty can read it — see
+            // MechanicPatterns.clash. Empty on a loss or a tie.
+            updatedCollections = mapOf(
+                effect.storeWonAs to if (youWon && yourCard != null) listOf(yourCard) else emptyList()
+            )
+        )
+    }
+}
+
+/** Shared reads for the two clash executors. */
+internal object ClashScoring {
+
+    /**
+     * The opponent this clash is with — the durable pick a preceding
+     * [com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect] wrote onto the source.
+     * Null when no choice was made or the source is gone, which makes the clash a silent no-op.
+     */
+    fun chosenOpponentOf(state: GameState, context: EffectContext): EntityId? =
+        context.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
+
+    /**
+     * Mana value of a revealed card, or null when no card was revealed. Read off the printed
+     * [CardComponent] rather than projected state: the card is in a library, which the layer
+     * projector does not cover, and mana value is a printed characteristic there.
+     */
+    fun manaValueOf(state: GameState, cardId: EntityId?): Int? =
+        cardId?.let { state.getEntity(it)?.get<CardComponent>()?.manaValue }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -61,6 +61,7 @@ class LibraryExecutors(
 
     override fun executors(): List<EffectExecutor<*>> = listOf(
         ScryExecutor(recursion),
+        ClashExecutor(recursion),
         SurveilExecutor(recursion),
         ShuffleLibraryExecutor(),
         GrantMayPlayFromExileExecutor(),
@@ -116,6 +117,7 @@ class LibraryExecutors(
         StoreNumberExecutor(),
         StoreCardNameExecutor(),
         EmitScriedEventExecutor(),
+        EmitClashedEventExecutor(),
         EmitSurveiledEventExecutor(),
         EmitDiscoveredEventExecutor(),
         EmitManifestedDreadEventExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1413,6 +1413,11 @@ is PermanentsSacrificedEvent -> {
             is RingTemptedEvent,
             is ScriedEvent,
             is SurveiledEvent,
+            // Internal signal that fires "whenever you clash" watcher triggers (Sylvan Echoes,
+            // Entangling Trap). The public reveal of both top cards and any bottom-of-library
+            // move are already surfaced by their own reveal / zone-change events, so no separate
+            // client event.
+            is ClashedEvent,
             // Internal signal that fires "whenever you discover" watcher triggers (Curator of
             // Sun's Creation); the reveal/exile/cast moves are surfaced by their own events, so no
             // separate client event.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClashScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClashScenarioTest.kt
@@ -1,0 +1,485 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ClashedEvent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level tests for the clash keyword action (CR 701.30).
+ *
+ * Every clause of the rule has a test here:
+ *
+ *  - **701.30a** — each clashing player reveals their top card and *may* put it on the bottom.
+ *    Both halves are covered: declining leaves the card on top, accepting moves it to the bottom,
+ *    and each player decides only for their own library.
+ *  - **701.30b** — "clash with an opponent" is a *choice* of opponent, forced and promptless with
+ *    a single opponent (every test below is two-player, and none of them answers such a prompt).
+ *  - **701.30c** — the reveal is simultaneous and the decisions are in APNAP order. Covered by
+ *    asserting the active player is asked first on their own turn, and the *opponent* first when
+ *    the clash happens during the opponent's turn.
+ *  - **701.30d** — a player wins only with a *strictly* greater mana value than every other card
+ *    revealed. Win, loss, tie and both empty-library cases are separate tests.
+ *
+ * Plus the two printed-ruling facts that make clash a two-player event rather than the clasher's
+ * private business: the `ClashedEvent` fires for **both** participants, and an opponent can win —
+ * and collect their own "whenever you clash and win" payoff from — a clash you initiated.
+ */
+class ClashScenarioTest : FunSpec({
+
+    // ---------------------------------------------------------------------
+    // Substrate cards
+    // ---------------------------------------------------------------------
+
+    // Filler with unambiguous, well-separated mana values, so a rigged library top decides the
+    // clash without depending on whatever the deck's real cards cost.
+    fun filler(name: String, cost: String) = card(name) {
+        manaCost = cost
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+    val Pebble = filler("Clash Pebble", "{0}")
+    val Stone = filler("Clash Stone", "{2}")
+    val Boulder = filler("Clash Boulder", "{5}")
+
+    // "Clash with an opponent. If you win, you gain 5 life." — the plain gate.
+    val ClashForLife = card("Clash For Life") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Clash with an opponent. If you win, you gain 5 life."
+        spell { effect = Patterns.Mechanic.clash(Effects.GainLife(5)) }
+    }
+
+    // Captivating Glance's shape: "If you win, … Otherwise, …" — both branches exercised.
+    val ClashOrElse = card("Clash Or Else") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Clash with an opponent. If you win, you gain 5 life. Otherwise, you lose 3 life."
+        spell {
+            effect = Patterns.Mechanic.clash(
+                ifYouWin = Effects.GainLife(5),
+                otherwise = Effects.LoseLife(3, EffectTarget.Controller)
+            )
+        }
+    }
+
+    // "Whenever you clash, put a +1/+1 counter on this." — fires win or lose (Entangling Trap's
+    // trigger shape).
+    val ClashWatcher = card("Clash Watcher") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouClash
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // "Whenever you clash and win, put a +1/+1 counter on this." — Sylvan Echoes' trigger shape.
+    val ClashWinWatcher = card("Clash Win Watcher") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bird"
+        power = 1; toughness = 1
+        triggeredAbility {
+            trigger = Triggers.WheneverYouClashAndWin
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // The instant twin of ClashForLife, so a clash can happen on the *opponent's* turn and put the
+    // APNAP ordering under real strain (Lash Out is the printed case).
+    val ClashInstant = card("Clash Instant") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Clash with an opponent. If you win, you gain 5 life."
+        spell { effect = Patterns.Mechanic.clash(Effects.GainLife(5)) }
+    }
+
+    val substrate =
+        listOf(Pebble, Stone, Boulder, ClashForLife, ClashOrElse, ClashInstant, ClashWatcher, ClashWinWatcher)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + substrate)
+        return driver
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.libraryTopName(player: EntityId): String? =
+        state.getZone(ZoneKey(player, Zone.LIBRARY)).firstOrNull()?.let { getCardName(it) }
+
+    fun GameTestDriver.librarySize(player: EntityId): Int =
+        state.getZone(ZoneKey(player, Zone.LIBRARY)).size
+
+    fun GameTestDriver.emptyLibrary(player: EntityId) {
+        val key = ZoneKey(player, Zone.LIBRARY)
+        replaceState(state.copy(zones = state.zones + (key to emptyList())))
+    }
+
+    /**
+     * Answer every clash top-or-bottom prompt, keeping each card on top (select nothing), and
+     * record the order the prompts arrived in so the APNAP tests can assert on it.
+     */
+    fun GameTestDriver.answerClashKeepingAll(): List<EntityId> {
+        val askedInOrder = mutableListOf<EntityId>()
+        repeat(6) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return askedInOrder
+            askedInOrder += decision.playerId
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, emptyList()))
+        }
+        return askedInOrder
+    }
+
+    /** Answer every clash prompt by putting the revealed card on the *bottom*. */
+    fun GameTestDriver.answerClashBottomingAll() {
+        repeat(6) {
+            val decision = pendingDecision as? SelectCardsDecision ?: return
+            submitDecision(decision.playerId, CardsSelectedResponse(decision.id, decision.options))
+        }
+    }
+
+    /**
+     * Cast a clash spell from [player]'s hand and pass so it starts resolving.
+     *
+     * The priority nudge is a harness accommodation, not part of the mechanic: `SubmitDecisionHandler`
+     * hands priority to whoever answered the *last* decision of a resolution, and a clash always ends
+     * on the opponent's top-or-bottom choice — so after one clash resolves the opponent is holding
+     * priority and [player] cannot cast anything. Passing it back (the stack is empty, so a single
+     * pass is just the baton moving on) puts a second clash in the same test on the same footing as
+     * the first.
+     */
+    fun GameTestDriver.castClash(player: EntityId, cardName: String) {
+        if (stackSize == 0 && priorityPlayer != null && priorityPlayer != player) {
+            passPriority(priorityPlayer!!)
+        }
+        val cardId = putCardInHand(player, cardName)
+        castSpell(player, cardId)
+        bothPass()
+    }
+
+    /** Resolve everything left on the stack (clash triggers stack on top of the spell). */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 10) bothPass()
+    }
+
+    // ---------------------------------------------------------------------
+    // CR 701.30d — who wins
+    // ---------------------------------------------------------------------
+
+    test("the clasher wins with a strictly greater mana value and the gate's payoff runs") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")   // MV 5
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")  // MV 0
+        val lifeBefore = driver.getLifeTotal(active)
+
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        driver.getLifeTotal(active) shouldBe lifeBefore + 5
+    }
+
+    test("the clasher loses to a greater mana value and the payoff does not run") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble")    // MV 0
+        driver.putCardOnTopOfLibrary(opponent, "Clash Boulder") // MV 5
+        val lifeBefore = driver.getLifeTotal(active)
+
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        driver.getLifeTotal(active) shouldBe lifeBefore
+    }
+
+    test("a tie wins for nobody — CR 701.30d needs a strictly greater mana value") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Same mana value on both sides: "greater than all other cards revealed" fails both ways.
+        driver.putCardOnTopOfLibrary(active, "Clash Stone")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Stone")
+
+        val before = driver.events.size
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        val clashed = driver.events.drop(before).filterIsInstance<ClashedEvent>()
+        clashed.size shouldBe 2
+        clashed.none { it.won } shouldBe true
+    }
+
+    test("the else branch runs when the clash is lost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Boulder")
+        val lifeBefore = driver.getLifeTotal(active)
+
+        driver.castClash(active, "Clash Or Else")
+        driver.answerClashKeepingAll()
+
+        driver.getLifeTotal(active) shouldBe lifeBefore - 3
+    }
+
+    test("an empty library reveals nothing, so that player cannot win but the other still can") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The clasher has nothing to reveal; the opponent reveals a {0}. Even a zero-mana-value
+        // card beats revealing nothing at all, so the clasher loses rather than ties.
+        driver.emptyLibrary(active)
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+        val lifeBefore = driver.getLifeTotal(active)
+
+        val before = driver.events.size
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        driver.getLifeTotal(active) shouldBe lifeBefore
+        val clashed = driver.events.drop(before).filterIsInstance<ClashedEvent>()
+        clashed.single { it.playerId == active }.won shouldBe false
+        clashed.single { it.playerId == opponent }.won shouldBe true
+    }
+
+    test("the clasher wins against an empty opposing library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble") // MV 0 still beats nothing
+        driver.emptyLibrary(opponent)
+        val lifeBefore = driver.getLifeTotal(active)
+
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        driver.getLifeTotal(active) shouldBe lifeBefore + 5
+    }
+
+    // ---------------------------------------------------------------------
+    // CR 701.30a — the top-or-bottom choice
+    // ---------------------------------------------------------------------
+
+    test("each clashing player may put their own revealed card on the bottom") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+        val activeLibrarySize = driver.librarySize(active)
+        val opponentLibrarySize = driver.librarySize(opponent)
+
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashBottomingAll()
+
+        // Both revealed cards left the top; neither left the library.
+        driver.libraryTopName(active) shouldBe "Mountain"
+        driver.libraryTopName(opponent) shouldBe "Mountain"
+        driver.librarySize(active) shouldBe activeLibrarySize
+        driver.librarySize(opponent) shouldBe opponentLibrarySize
+    }
+
+    test("declining the choice leaves each revealed card on top") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        driver.libraryTopName(active) shouldBe "Clash Boulder"
+        driver.libraryTopName(opponent) shouldBe "Clash Pebble"
+    }
+
+    // ---------------------------------------------------------------------
+    // CR 701.30c — APNAP decision order
+    // ---------------------------------------------------------------------
+
+    test("the two top-or-bottom decisions go to both players, active player first on their turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+
+        driver.castClash(active, "Clash For Life")
+        val asked = driver.answerClashKeepingAll()
+
+        asked shouldBe listOf(active, opponent)
+    }
+
+    test("clashing on the opponent's turn asks the opponent first — APNAP, not clasher-first") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val firstPlayer = driver.activePlayer!!
+        val clasher = driver.getOpponent(firstPlayer)
+
+        // The non-active player clashes at instant speed on the active player's turn.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCardOnTopOfLibrary(clasher, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(firstPlayer, "Clash Pebble")
+
+        val cardId = driver.putCardInHand(clasher, "Clash Instant")
+        driver.passPriority(firstPlayer)
+        driver.castSpell(clasher, cardId)
+        driver.bothPass()
+        val asked = driver.answerClashKeepingAll()
+
+        // CR 701.30c defers to APNAP order (CR 101.4), so the *active* player decides first even
+        // though the other player is the one clashing.
+        asked shouldBe listOf(firstPlayer, clasher)
+    }
+
+    // ---------------------------------------------------------------------
+    // "Whenever you clash" — both participants clash
+    // ---------------------------------------------------------------------
+
+    test("a ClashedEvent fires for both participants, carrying who won") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+
+        val before = driver.events.size
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+
+        val clashed = driver.events.drop(before).filterIsInstance<ClashedEvent>()
+        clashed.size shouldBe 2
+        clashed.single { it.playerId == active }.won shouldBe true
+        clashed.single { it.playerId == active }.opponentId shouldBe opponent
+        clashed.single { it.playerId == opponent }.won shouldBe false
+        clashed.single { it.playerId == opponent }.opponentId shouldBe active
+    }
+
+    test("Whenever-you-clash fires for the clasher whether they win or lose") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Clash Watcher")
+
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+        driver.resolveStack()
+        driver.plusOneCounters(watcher) shouldBe 1
+
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Boulder")
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+        driver.resolveStack()
+        driver.plusOneCounters(watcher) shouldBe 2
+    }
+
+    test("Whenever-you-clash-and-win fires only on a win") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val watcher = driver.putCreatureOnBattlefield(active, "Clash Win Watcher")
+
+        // Lose: nothing.
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Boulder")
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+        driver.resolveStack()
+        driver.plusOneCounters(watcher) shouldBe 0
+
+        // Win: one counter.
+        driver.putCardOnTopOfLibrary(active, "Clash Boulder")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Pebble")
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+        driver.resolveStack()
+        driver.plusOneCounters(watcher) shouldBe 1
+    }
+
+    test("the opponent's own clash payoff fires off a clash you initiated, and can win it") {
+        // Entangling Trap / Sylvan Echoes ruling: "if you clash because of a spell or ability an
+        // opponent controls, the ability will still trigger. Likewise, you can still win the clash
+        // even if you weren't the player to initiate it."
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val theirWatcher = driver.putCreatureOnBattlefield(opponent, "Clash Win Watcher")
+
+        // The active player clashes and *loses*; the opponent, who never initiated anything, wins.
+        driver.putCardOnTopOfLibrary(active, "Clash Pebble")
+        driver.putCardOnTopOfLibrary(opponent, "Clash Boulder")
+        driver.castClash(active, "Clash For Life")
+        driver.answerClashKeepingAll()
+        driver.resolveStack()
+
+        driver.plusOneCounters(theirWatcher) shouldBe 1
+    }
+})


### PR DESCRIPTION
Clash did not exist anywhere in the SDK or the engine — the only `grep` hit for "clash" was a comment mentioning *Mana Clash*. That blocked 23 of Lorwyn's remaining 51 cards. This adds the mechanic and ships five of them, taking **LRW 235/286 → 240/286**.

## The design

The whole printed template is one facade, `Patterns.Mechanic.clash(ifYouWin, otherwise?)`, composed from pieces that already existed:

```
ChooseOpponentForSource  ->  ClashEffect  ->  Gate.DoAction
                                              scored by SuccessCriterion.CollectionNonEmpty(CLASH_WON)
```

**"If you win" needed no new gate kind.** It is an action-*outcome* rider, which `Gate.DoAction` already models: the clash writes the clasher's revealed card into a `clashWon` collection only on a win, so winning is an ordinary pipeline result. That also means the gate's existing pause/resume machinery is what carries the two top-or-bottom decisions, rather than a bespoke continuation.

**`ClashEffect` is a macro in the `ScryEffect` sense** — the engine expands it to Gather → Select → Move over the ordinary library primitives and adds no gather/select/move logic of its own. It is built against live state for exactly one reason: CR 701.30c orders the two decisions APNAP, and a fixed-order `CompositeEffect` cannot express "active player first". Both gathers use `revealed = true` (a clash is a public reveal, CR 701.30a) and both precede either decision, so the reveal stays simultaneous even though the decisions are ordered.

**Scoring is CR 701.30d, *strictly* greater mana value.** A tie wins for nobody, and a player with an empty library reveals nothing and so can never win — though their opponent still wins with any card at all, a `{0}` included. The naive "compare two numbers, default the missing one to 0" implementation ties instead; `PaperfinRascalScenarioTest` is the pair of tests that separates them.

The interface deliberately copies **`ExileTopCardContestEffect`** (Timesifter), the nearest existing primitive: publish the winner into a pipeline collection, leave it empty when there isn't one, and let the card compose its own payoff. The mechanisms genuinely differ (the contest *exiles* and re-runs tied players; a clash *reveals*, leaves both cards in their libraries, and settles a tie as no winner), so there was nothing to share but the shape — but matching the shape is what makes the empty-library and no-winner cases behave alike in both.

## New vocabulary

| Type | Why |
|---|---|
| `ClashEffect` / `EmitClashedEventEffect` | the keyword action and its scoring tail (the `EmitScriedEventEffect` pattern) |
| `EventPattern.ClashedEvent(player, requireWin)` + `Triggers.WheneverYouClash` / `WheneverYouClashAndWin` | "Whenever you clash [and win]" |
| `Chooser.ChosenOpponent` | the decision-side twin of `Player.ChosenOpponent`. **`Chooser.Opponent` re-picks per step**, so in a multiplayer game a mechanic that reads one opponent's library and then asks that opponent to decide could split across two different players. |
| `GameEvent.ClashedEvent` | emitted **once per participant** |

That last one is load-bearing, not bookkeeping: per the Entangling Trap and Sylvan Echoes rulings, *"if you clash because of a spell or ability an opponent controls, the ability will still trigger. Likewise, you can still win the clash even if you weren't the player to initiate it."* An implementation that fires the event only for the clashing spell's controller passes a self-clash test and fails the Sylvan Echoes one.

## Cards

- **Adder-Staff Boggart**, **Oaken Brawler**, **Paperfin Rascal** — the ETB clash-for-a-counter commons
- **Lash Out** — spell. "That creature's controller" is `EffectTarget.TargetController` and has to read last-known information (CR 608.2h), because 3 damage usually kills the creature before the clash even starts. The test aims it at the *caster's own* creature — the only board where "that creature's controller" and "the opponent you clashed with" are different players.
- **Sylvan Echoes** — the payoff. Its test has the **opponent's** Boggart start the clash and the Echoes controller, who did nothing, win it and draw.

Lash Out needed a CMD `Printing` row; `just check-card-printing` is clean for all five.

## Tests

**14 engine tests** in `ClashScenarioTest`, one per clause of CR 701.30: win / loss / tie, both empty-library directions, both halves of the top-or-bottom choice (bottomed cards stay *in* the library — a clash that milled or drew would pass every counter assertion and fail these), APNAP order on each player's turn including an instant-speed clash on the opponent's turn, and the event firing for both participants with the right `won` flags. Plus **a scenario test per card** (13 more).

## Two things found on the way, left for their own changes

- **`SubmitDecisionHandler` hands priority to whoever answered the last decision** (`withPriority(action.playerId)`), so a resolution that *ends* on an opponent's decision leaves priority with them rather than the active player (CR 117.3b). This is pre-existing and affects every mechanic with an opponent-side decision (pile splitting, `Chooser.Opponent` selections) — clash is just the first one that always ends that way. Changing priority assignment is cross-cutting and belongs in its own PR; `castClash` in the test carries a documented one-line accommodation for it.
- **`_Condition -> Trigger_WonTheClash`** — the "…, If you won, …" rider *inside* a clash trigger's effect (Entangling Trap, Rebellion of the Flamekin) — needs the win flag exposed as a trigger-context value. It stays **unmapped** in the mtgish bridge so those cards keep blocking on it rather than being silently rendered without the rider.

## Verification

`:mtg-sdk:test :rules-engine:test :mtg-sets:test :mtg-sets:2003-2007:tests:test :mtg-sets:2008-2016:tests:test :oracle-assay:test :mtgish-tooling:compileKotlin` — green. `just check` — green. `just assay-gate --limit 2000` — exit 0, 0 print mismatches. `just assay-differential --set LRW` — 10 divergences, all pre-existing (the Harbinger cycle, Boggart Sprite-Chaser, Epic Proportions, Kithkin Greatheart); none of the five cards here. Card snapshot golden re-blessed; `LRW.json` is additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122J7pbffxwniS8aW1MA3rr
