### PR TITLE
Preserve viewer-specific identity across face-down casts

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EventCardPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EventCardPresentation.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+
+/**
+ * The semantic and public identities of one card at event time, plus the viewers entitled to the
+ * semantic identity.
+ *
+ * This is trusted engine data: [semanticName] may be private and [identityViewers] records private
+ * audience facts. Only the value returned by [nameFor] is safe to expose to the requested
+ * recipient. Client projection must never infer a past audience from a later state.
+ */
+@Serializable
+data class EventCardPresentation(
+    val semanticName: String,
+    val publicName: String,
+    val identityViewers: Set<EntityId> = emptySet(),
+) {
+    /** The name this recipient was entitled to see when the event was emitted. */
+    fun nameFor(viewingPlayerId: EntityId, isSpectator: Boolean = false): String =
+        if (!isSpectator && viewingPlayerId in identityViewers) semanticName else publicName
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -626,12 +626,13 @@ data class SpellCastEvent(
     val targetNames: List<String> = emptyList(),
     val xValue: Int? = null,
     /**
-     * Trusted semantic identity and viewer entitlement snapshot captured from event-time
-     * [com.wingedsheep.engine.view.Visibility]. Rules and knowledge consumers use
-     * [semanticCardName]; client projection selects one safe name through this snapshot.
+     * Trusted underlying card identity and viewer entitlement snapshot captured from event-time
+     * [com.wingedsheep.engine.view.Visibility]. Knowledge bookkeeping uses [underlyingCardName];
+     * client projection selects one safe display name through this snapshot.
      *
      * `null` represents serialized events produced before this field existed. Their [cardName]
-     * remains a safe presentation fallback and the best semantic name that historical event kept.
+     * remains a safe presentation fallback and the only identity information that historical
+     * event retained.
      */
     val cardPresentation: EventCardPresentation? = null,
     /**
@@ -702,8 +703,11 @@ data class SpellCastEvent(
      */
     val sacrificedAsCostNames: List<String> = emptyList()
 ) : GameEvent {
-    /** Exact cast identity when current event-time capture retained it; legacy events kept only [cardName]. */
-    val semanticCardName: String get() = cardPresentation?.semanticName ?: cardName
+    /**
+     * Underlying card-definition identity when current event-time capture retained it; legacy
+     * events kept only [cardName]. This is not the name characteristic of a face-down spell.
+     */
+    val underlyingCardName: String get() = cardPresentation?.semanticName ?: cardName
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -13,7 +13,11 @@ import kotlinx.serialization.Serializable
 
 /**
  * Sealed hierarchy of all game events.
- * Events are emitted by the engine to describe what happened.
+ *
+ * These are trusted engine events, not player-safe transport objects. Events may retain private
+ * rules facts needed by trigger processing and later audience-aware projection. A player-facing
+ * integration must project them through [com.wingedsheep.engine.view.ClientEventTransformer] (or
+ * its own perspective-safe equivalent) rather than serialize them directly.
  */
 @Serializable
 sealed interface GameEvent
@@ -612,10 +616,24 @@ data class CreatureTypeChangedEvent(
 @SerialName("SpellCastEvent")
 data class SpellCastEvent(
     val spellEntityId: EntityId,
+    /**
+     * The name safe to show every audience at the moment of the cast. This remains the historical
+     * serialized contract: an ordinary face-up cast stores its real name, while a face-down cast
+     * stores [com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME].
+     */
     val cardName: String,
     val casterId: EntityId,
     val targetNames: List<String> = emptyList(),
     val xValue: Int? = null,
+    /**
+     * Trusted semantic identity and viewer entitlement snapshot captured from event-time
+     * [com.wingedsheep.engine.view.Visibility]. Rules and knowledge consumers use
+     * [semanticCardName]; client projection selects one safe name through this snapshot.
+     *
+     * `null` represents serialized events produced before this field existed. Their [cardName]
+     * remains a safe presentation fallback and the best semantic name that historical event kept.
+     */
+    val cardPresentation: EventCardPresentation? = null,
     /**
      * Which optional-additional-cost mechanic this cast declared, or null when none — the fact
      * "whenever you cast a kicked spell" filters on (`SpellCastPredicate.WasKicked` matches
@@ -683,7 +701,10 @@ data class SpellCastEvent(
      * [com.wingedsheep.engine.view.CastProvenance.logPhrase].
      */
     val sacrificedAsCostNames: List<String> = emptyList()
-) : GameEvent
+) : GameEvent {
+    /** Exact cast identity when current event-time capture retained it; legacy events kept only [cardName]. */
+    val semanticCardName: String get() = cardPresentation?.semanticName ?: cardName
+}
 
 /**
  * An ability was activated.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
@@ -108,15 +108,15 @@ object RevealedInHandTracker {
     }
 
     private fun onSpellCast(state: GameState, event: SpellCastEvent): GameState {
-        // The cast card is public on the stack regardless; dropping its hand-knowledge also
-        // stops a bounced-then-cast-face-down card from leaking its real identity.
+        // The card has left its hand. Dropping that hand-knowledge also stops a
+        // bounced-then-cast-face-down card from leaking its real identity.
         var newState = LibraryRevealUtils.clearReveals(state, listOf(event.spellEntityId))
         val castFromZone = state.getEntity(event.spellEntityId)
             ?.get<SpellOnStackComponent>()?.castFromZone
         // Only a card played *from hand* makes the known copies of its name ambiguous;
         // casting the same name from the graveyard/exile leaves the hand copy identifiable.
         if (castFromZone == Zone.HAND) {
-            newState = forgetSameNamedInHand(newState, event.casterId, event.cardName)
+            newState = forgetSameNamedInHand(newState, event.casterId, event.semanticCardName)
         }
         return newState
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
@@ -116,7 +116,7 @@ object RevealedInHandTracker {
         // Only a card played *from hand* makes the known copies of its name ambiguous;
         // casting the same name from the graveyard/exile leaves the hand copy identifiable.
         if (castFromZone == Zone.HAND) {
-            newState = forgetSameNamedInHand(newState, event.casterId, event.semanticCardName)
+            newState = forgetSameNamedInHand(newState, event.casterId, event.underlyingCardName)
         }
         return newState
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.mechanics.layers.ContinuousEffectSourceComponent
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -38,8 +39,9 @@ import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
 import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.handlers.effects.library.ChooseCreatureTypePipelineExecutor
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.nameVisibleToAll
+import com.wingedsheep.engine.view.EventPresentationFactory
+import com.wingedsheep.engine.view.Visibility
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -106,6 +108,7 @@ class StackResolver(
     private val staticAbilityHandler: StaticAbilityHandler = StaticAbilityHandler(cardRegistry),
     private val predicateEvaluator: PredicateEvaluator = PredicateEvaluator()
 ) {
+    private val eventPresentationFactory = EventPresentationFactory(Visibility(cardRegistry))
 
     /**
      * Re-validates a spliced card's own targets as the spell resolves (CR 608.2b via 702.47d): the
@@ -472,9 +475,9 @@ class StackResolver(
         } else {
             cardComponent.name
         }
-        // For face-down creatures, use a generic name in the event (CR 708.2a)
+        // Preserve SpellCastEvent.cardName's historical public-name contract. The trusted
+        // presentation snapshot below separately retains semantic identity and private audiences.
         val eventName = if (castFaceDown) FACE_DOWN_DISPLAY_NAME else spellName
-
         // Collect target names for the cast event log
         val targetNames = effectiveTargets.mapNotNull { target ->
             when (target) {
@@ -515,6 +518,13 @@ class StackResolver(
                 casterId = casterId,
                 targetNames = targetNames,
                 xValue = boundXValue,
+                cardPresentation = eventPresentationFactory.castSpellIdentity(
+                    beforeCast = state,
+                    onStack = newState,
+                    castFromZone = castFromZone,
+                    entityId = cardId,
+                    semanticName = spellName,
+                ),
                 declaredCostSlot = declaredCostSlot,
                 totalManaSpent = totalManaSpent,
                 distinctColorsSpent =
@@ -534,14 +544,14 @@ class StackResolver(
         // Crime detection (CR Outlaws of Thunder Junction). Emit at most once per cast,
         // regardless of how many opponent-controlled targets the spell chose.
         if (CrimeDetector.isCrime(newState, casterId, effectiveTargets)) {
-            events.add(CommitCrimeEvent(casterId, cardId, eventName))
+            events.add(CommitCrimeEvent(casterId, cardId, spellName))
             newState = recordCrime(newState, casterId)
         }
 
         // "Whenever a player chooses one or more targets" (Psychic Battle). Emit once per cast
         // when the spell chose at least one target.
         if (effectiveTargets.isNotEmpty()) {
-            events.add(TargetsChosenEvent(casterId, cardId, eventName))
+            events.add(TargetsChosenEvent(casterId, cardId, spellName))
         }
 
         // Emit BecomesTargetEvent for each permanent, spell, or player target (Rule 601.2c)
@@ -1006,8 +1016,9 @@ class StackResolver(
             events.addAll(permanentResult.events)
             // CR 708.2a — a permanent that entered face down has no name, so neither the
             // "resolved" line nor the "entered the battlefield" line may carry the printed one.
-            // The cast line was already masked at `eventName` above; leaving these two unmasked
-            // made the log contradict it and told the opponent exactly what they were looking at.
+            // The cast line has its own event-time client presentation; leaving these two
+            // audience-agnostic log events unmasked made the log contradict it and told the
+            // opponent exactly what they were looking at.
             // Read the resolved entity rather than `spellComponent.castFaceDown` so every route
             // that lands a permanent face down is covered, not only a face-down cast.
             val permanentName = nameVisibleToAll(newState, spellId, cardComponent?.name ?: "Unknown")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/FaceDownNaming.kt
@@ -27,12 +27,13 @@ const val FACE_DOWN_CARD_DISPLAY_NAME: String = "Face-down card"
 /**
  * The name [entityId] may be shown under to *any* viewer, its controller included.
  *
- * Use this for flat strings with no audience attached — a game-log line, a decision summary. Those
- * reach both players, and [com.wingedsheep.engine.view.ClientEventTransformer] cannot redact them
- * downstream: it maps engine events to text with no `GameState` in hand, so it cannot tell a
- * face-down object from a face-up one. The decision has to be made where the event is emitted.
+ * Use this only for text whose contract genuinely has one public answer, such as an
+ * audience-agnostic decision summary. A typed event that will later be projected for one viewer
+ * must not collapse all viewers to that answer: capture an
+ * [com.wingedsheep.engine.core.EventCardPresentation] through
+ * [com.wingedsheep.engine.view.EventPresentationFactory] while the event-time state still exists.
  *
- * Where the text *does* have an audience, ask
+ * For other text that has an immediate audience, ask
  * [com.wingedsheep.engine.view.Visibility.isCardIdentityVisibleTo] instead and pick the label from
  * its answer. That query knows what this file cannot: explicit reveals, effect-granted access, and
  * the zones CR 708.5 does and does not let a controller look in.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -895,8 +895,9 @@ data class GameState(
      * itself; during a Mindslaver-style hijacked turn this resolves to the hijacker.
      *
      * Resource ownership (mana, cards, life) is unaffected — it always stays with
-     * [playerId]. This helper is only consulted at the input-routing seam: legal
-     * action enumeration, decision validation, and per-action seat checks.
+     * [playerId]. This helper is consulted at input and private-view routing seams: legal action
+     * enumeration, decision validation, per-action seat checks, and the information shown to the
+     * connection acting for that seat.
      *
      * A session-level [com.wingedsheep.engine.state.components.player.HotseatControlComponent]
      * (play-against-yourself) takes precedence over a per-turn hijack: it permanently routes

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1039,7 +1039,9 @@ object ClientEventTransformer {
 
             is SpellCastEvent -> ClientEvent.SpellCast(
                 spellId = event.spellEntityId,
-                spellName = event.cardName,
+                // Legacy events already stored an event-time public name. Current events select
+                // through the captured audience without consulting a later game state.
+                spellName = event.cardPresentation?.nameFor(viewingPlayerId) ?: event.cardName,
                 casterId = event.casterId,
                 isYours = event.casterId == viewingPlayerId,
                 targetNames = event.targetNames,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/EventPresentationFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/EventPresentationFactory.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.EventCardPresentation
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Captures cast identities while both sides of the authoritative state transition still exist.
+ *
+ * [Visibility] remains the sole authority for every viewer-specific answer. The resulting
+ * [EventCardPresentation] is immutable trusted event data: later projection selects one viewer's
+ * answer from it rather than consulting a potentially changed game state.
+ */
+class EventPresentationFactory(
+    private val visibility: Visibility,
+) {
+    fun castSpellIdentity(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+        semanticName: String,
+    ): EventCardPresentation {
+        if (isPublicThroughCast(beforeCast, onStack, castFromZone, entityId)) {
+            return EventCardPresentation(
+                semanticName = semanticName,
+                publicName = semanticName,
+            )
+        }
+
+        val identityViewers = onStack.turnOrder
+            .filter { viewerId ->
+                visibility.isCardIdentityVisibleThroughCast(
+                    beforeCast = beforeCast,
+                    onStack = onStack,
+                    castFromZone = castFromZone,
+                    entityId = entityId,
+                    viewingPlayerId = viewerId,
+                )
+            }
+            .toSet()
+        return EventCardPresentation(
+            semanticName = semanticName,
+            publicName = FACE_DOWN_DISPLAY_NAME,
+            identityViewers = identityViewers,
+        )
+    }
+
+    /** A spectator is entitled only to information [Visibility] calls public, never a seat's view. */
+    private fun isPublicThroughCast(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+    ): Boolean {
+        val representativeViewer = onStack.turnOrder.firstOrNull() ?: return false
+        return visibility.isCardIdentityVisibleThroughCast(
+            beforeCast = beforeCast,
+            onStack = onStack,
+            castFromZone = castFromZone,
+            entityId = entityId,
+            viewingPlayerId = representativeViewer,
+            isSpectator = true,
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -93,6 +93,57 @@ class Visibility(
     )
 
     /**
+     * Whether a recipient can carry [entityId]'s identity through the transition from its cast
+     * origin in [beforeCast] to the spell in [onStack].
+     *
+     * Looking only at the resulting stack object loses legitimate history: a card cast face down
+     * from face-up exile was public immediately before it became a nameless spell. Conversely, an
+     * individual [RevealedToComponent] on a card in an unordered hand does not prove which card
+     * left that hand face down. Existing cast handling deliberately clears those stale per-card
+     * hand reveals. Whole-hand visibility is different: while that effect remains active, the
+     * viewer sees the card actually leave.
+     *
+     * Keeping this distinction here makes [Visibility] the authority for both point-in-time
+     * identity and the one transition whose event presentation must retain it.
+     */
+    fun isCardIdentityVisibleThroughCast(
+        beforeCast: GameState,
+        onStack: GameState,
+        castFromZone: Zone?,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean {
+        val visibleOnStack = isCardIdentityVisibleTo(
+            state = onStack,
+            zoneType = Zone.STACK,
+            entityId = entityId,
+            viewingPlayerId = viewingPlayerId,
+            isSpectator = isSpectator,
+        )
+        if (visibleOnStack) return true
+
+        val origin = castFromZone ?: return false
+        if (origin == Zone.HAND) {
+            val ownerId = zoneOwnerOf(beforeCast, entityId, origin) ?: return false
+            return isZoneVisibleTo(
+                state = beforeCast,
+                zoneKey = ZoneKey(ownerId, origin),
+                viewingPlayerId = viewingPlayerId,
+                isSpectator = isSpectator,
+            )
+        }
+
+        return isCardIdentityVisibleTo(
+            state = beforeCast,
+            zoneType = origin,
+            entityId = entityId,
+            viewingPlayerId = viewingPlayerId,
+            isSpectator = isSpectator,
+        )
+    }
+
+    /**
      * Whether [viewingPlayerId] may know the identity of [entityId] in [zoneKey].
      *
      * A hidden zone is not all-or-nothing: [RevealedToComponent] and top-of-library effects can
@@ -116,8 +167,13 @@ class Visibility(
             // zone." Exile therefore gets no controller baseline: a card put there by a plain
             // "exile face down" rider is hidden from its owner too. Only an effect that grants
             // access opens one, and every such effect names its grantee — see below.
-            if (zoneKey.zoneType != Zone.EXILE &&
-                playerWhoMayLookAtFaceDown(state, entityId) == viewingPlayerId
+            // Private state is projected to the connection currently acting for a seat as well as
+            // to the seat itself, matching hand/sideboard visibility above. Spectator projection
+            // has already returned false, so acting authority never leaks into the public view.
+            val playerWhoMayLook = playerWhoMayLookAtFaceDown(state, entityId)
+            if (zoneKey.zoneType != Zone.EXILE && playerWhoMayLook != null &&
+                (playerWhoMayLook == viewingPlayerId ||
+                    state.actorFor(playerWhoMayLook) == viewingPlayerId)
             ) return true
             if (isCardRevealedTo(state, entityId, viewingPlayerId)) return true
             if (zoneKey.zoneType == Zone.BATTLEFIELD &&

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
@@ -336,7 +336,7 @@ class LookAtHandTest : FunSpec({
         result.isSuccess shouldBe true
         val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Test Morph"
+        castEvent.underlyingCardName shouldBe "Test Morph"
         castEvent.cardPresentation?.nameFor(viewer) shouldBe FACE_DOWN_DISPLAY_NAME
         driver.state.getEntity(castMorph)?.get<RevealedToComponent>() shouldBe null
         driver.state.getEntity(otherMorph)?.get<RevealedToComponent>() shouldBe null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LookAtHandTest.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.HandLookedAtEvent
 import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -332,6 +334,10 @@ class LookAtHandTest : FunSpec({
         )
 
         result.isSuccess shouldBe true
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Test Morph"
+        castEvent.cardPresentation?.nameFor(viewer) shouldBe FACE_DOWN_DISPLAY_NAME
         driver.state.getEntity(castMorph)?.get<RevealedToComponent>() shouldBe null
         driver.state.getEntity(otherMorph)?.get<RevealedToComponent>() shouldBe null
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/CardIdentityVisibilityTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.components.identity.ForetoldComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.HotseatControlComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
@@ -205,6 +206,60 @@ class CardIdentityVisibilityTest : ScenarioTestBase() {
             visibility.isCardIdentityVisibleTo(
                 game.state, Zone.STACK, game.spell, game.opponent,
             ) shouldBe false
+        }
+
+        test("event presentation captures each stack viewer's visibility at event time") {
+            val game = faceDownGame()
+            // An explicit reveal grants this opponent access, while a spectator remains outside
+            // that private audience. The factory delegates the answer to Visibility rather than
+            // recoding revealed-to or face-down rules locally.
+            val revealed = game.state.updateEntity(game.spell) {
+                it.with(RevealedToComponent.to(game.opponent))
+            }
+            val presentation = EventPresentationFactory(visibility).castSpellIdentity(
+                beforeCast = revealed,
+                onStack = revealed,
+                castFromZone = null,
+                entityId = game.spell,
+                semanticName = "Hill Giant",
+            )
+
+            presentation.nameFor(game.controller) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+            presentation.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+                "Face-down creature"
+
+            val laterState = revealed.updateEntity(game.spell) { it.without<RevealedToComponent>() }
+            visibility.isCardIdentityVisibleTo(
+                laterState, Zone.STACK, game.spell, game.opponent,
+            ) shouldBe false
+            // Event projection never reconsiders a later state in which that reveal disappeared.
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+        }
+
+        test("event presentation includes the input actor controlling a face-down spell's seat") {
+            val game = faceDownGame()
+            val controlled = game.state.updateEntity(game.controller) {
+                it.with(HotseatControlComponent(controllerId = game.opponent))
+            }
+
+            withClue("the controlling connection receives the same private identity as the seat") {
+                visibility.isCardIdentityVisibleTo(
+                    controlled, Zone.STACK, game.spell, game.opponent,
+                ) shouldBe true
+            }
+
+            val presentation = EventPresentationFactory(visibility).castSpellIdentity(
+                beforeCast = controlled,
+                onStack = controlled,
+                castFromZone = null,
+                entityId = game.spell,
+                semanticName = "Hill Giant",
+            )
+            presentation.nameFor(game.controller) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent) shouldBe "Hill Giant"
+            presentation.nameFor(game.opponent, isSpectator = true) shouldBe
+                "Face-down creature"
         }
 
         // CR 708.5: "At any time, you may look at a face-down spell you control on the stack or a

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -2,13 +2,20 @@ package com.wingedsheep.engine.view
 
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.EventCardPresentation
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.core.engineSerializersModule
 import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.state.components.battlefield.PhasedOutComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.FACE_DOWN_DISPLAY_NAME
 import com.wingedsheep.engine.state.nameVisibleToAll
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.permissions.MayPlayPermission
+import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -20,6 +27,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.assertions.withClue
@@ -28,12 +36,15 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 /**
  * The game log must never print the name of a card that is face down on the battlefield.
  *
- * CR 708.2a: a face-down permanent has no name. The cast line was masked from the start, but the
- * three lines that follow it were not, so a disguised creature announced itself the moment it
+ * CR 708.2a: a face-down permanent has no name. The public cast line is masked, but the three
+ * lines that follow it were not, so a disguised creature announced itself the moment it
  * resolved:
  *
  * ```
@@ -44,14 +55,14 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * Opponent's Aurelia's Vindicator triggered: ... unless ... pays {2} <- leak
  * ```
  *
- * [ClientEventTransformer] cannot fix this downstream — it maps engine events to log text with no
- * `GameState` in hand, so it cannot tell a face-down permanent from a face-up one. Every one of
- * these is therefore masked where the event is emitted, in `StackResolver`.
+ * [ClientEventTransformer] cannot reconstruct a past audience from a later `GameState`. The cast
+ * event therefore carries a viewer-aware presentation captured by `StackResolver`; the remaining
+ * audience-agnostic events are masked where they are emitted.
  *
- * The mask applies to *both* players' logs, as the cast line already did: the object genuinely has
- * no name, and a controller who wants to know what their own face-down permanent is looks at the
- * card (CR 708.5) — [ClientStateTransformer] keeps the real name in their card view, which is what
- * [FaceDownHelperCardVisibilityTest] covers.
+ * The later events mask every player's log: the object genuinely has no name after it resolves.
+ * The cast event is viewer-aware instead, so its controller may read the card identity while an
+ * opponent cannot. [ClientStateTransformer] likewise keeps the real name in the controller's card
+ * view, which [FaceDownHelperCardVisibilityTest] covers.
  */
 class FaceDownGameLogMaskingTest : FunSpec({
 
@@ -78,9 +89,15 @@ class FaceDownGameLogMaskingTest : FunSpec({
         }
     }
 
+    val openThoughts = card("Open Thoughts") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        staticAbility { ability = OpponentsPlayWithHandsRevealed }
+    }
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + listOf(disguisedAngel, tapper))
+        d.registerCards(TestCards.all + listOf(disguisedAngel, tapper, openThoughts))
         d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
         d.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return d
@@ -119,6 +136,13 @@ class FaceDownGameLogMaskingTest : FunSpec({
                 paymentStrategy = PaymentStrategy.FromPool,
             )
         )
+        val castEvent = d.events.filterIsInstance<SpellCastEvent>().single()
+        // Keep the historical public-name field safe while the trusted snapshot retains the
+        // semantic identity required by rules and knowledge code.
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe FACE_DOWN_DISPLAY_NAME
         d.bothPass()
 
         val opponentLog = d.logAsSeenBy(opponent)
@@ -130,9 +154,73 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val casterLog = d.logAsSeenBy(caster)
         withClue("caster's own log: $casterLog") {
-            casterLog.forEach { it shouldNotContain "Disguised Angel" }
+            casterLog.contains("You cast Disguised Angel") shouldBe true
             casterLog.contains("Your Face-down creature entered the battlefield") shouldBe true
         }
+
+        // The event-time snapshot is authoritative even after the stack object has changed zones.
+        ClientEventTransformer.transform(listOf(castEvent), opponent)
+            .single().description shouldBe "Opponent cast Face-down creature"
+    }
+
+    test("a face-down cast from face-up exile retains its public identity") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+        val cardId = d.putCardInExile(caster, "Disguised Angel")
+        d.replaceState(
+            d.state.addMayPlayPermission(
+                MayPlayPermission(
+                    id = EntityId.of("cast-disguised-angel-from-exile"),
+                    cardIds = setOf(cardId),
+                    controllerId = caster,
+                    timestamp = d.state.timestamp,
+                )
+            )
+        )
+        d.giveColorlessMana(caster, 3)
+
+        val result = d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
+        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+            "Disguised Angel"
+        d.logAsSeenBy(opponent).any { it.contains("cast Disguised Angel") } shouldBe true
+    }
+
+    test("continuous hand visibility survives a face-down cast") {
+        val d = driver()
+        val caster = d.activePlayer!!
+        val opponent = d.getOpponent(caster)
+        d.putPermanentOnBattlefield(opponent, openThoughts.name)
+        val cardId = d.putCardInHand(caster, "Disguised Angel")
+        d.giveColorlessMana(caster, 3)
+
+        val result = d.submitSuccess(
+            CastSpell(
+                playerId = caster,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+
+        val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
+        castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
+        castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe
+            FACE_DOWN_DISPLAY_NAME
     }
 
     test("the ward a disguised permanent triggers is not attributed to the hidden card") {
@@ -190,7 +278,10 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val log = d.logAsSeenBy(caster)
         withClue("log: $log") {
-            log.forEach { it shouldNotContain "Disguised Angel" }
+            // The caster's own event-time cast line may name their spell; the counter's target
+            // description remains audience-agnostic and must not repeat that identity.
+            log.filterNot { it == "You cast Disguised Angel" }
+                .forEach { it shouldNotContain "Disguised Angel" }
             log.contains("Opponent cast Counterspell targeting Face-down creature") shouldBe true
         }
     }
@@ -317,5 +408,46 @@ class FaceDownGameLogMaskingTest : FunSpec({
             opponentLog.contains("Disguised Angel resolved") shouldBe true
             opponentLog.contains("Opponent's Disguised Angel entered the battlefield") shouldBe true
         }
+    }
+
+    test("spell-cast presentation round-trips and legacy events retain their safe stored names") {
+        val json = Json { serializersModule = engineSerializersModule }
+        val current: GameEvent = SpellCastEvent(
+            spellEntityId = EntityId.of("spell"),
+            cardName = FACE_DOWN_DISPLAY_NAME,
+            casterId = EntityId.of("caster"),
+            cardPresentation = EventCardPresentation(
+                semanticName = "Disguised Angel",
+                publicName = FACE_DOWN_DISPLAY_NAME,
+                identityViewers = setOf(EntityId.of("caster")),
+            ),
+        )
+        json.decodeFromString<GameEvent>(json.encodeToString(current)) shouldBe current
+
+        // The raw event is trusted multi-recipient data. The transport-facing event contains only
+        // the one projected label and cannot carry the underlying identity or its audience set.
+        val opponentEvent: ClientEvent = ClientEventTransformer.transform(
+            listOf(current), EntityId.of("opponent")
+        ).single()
+        val encodedOpponentEvent = json.encodeToString(opponentEvent)
+        encodedOpponentEvent shouldNotContain "Disguised Angel"
+        encodedOpponentEvent shouldNotContain "identityViewers"
+
+        // Before viewer-specific capture, cardName was already the event-time public name. Keep
+        // ordinary face-up history readable and preserve the generic name stored for face-down
+        // casts rather than treating both legacy shapes as hidden.
+        val legacyFaceUp = """{"type":"SpellCastEvent","spellEntityId":"face-up","cardName":"Disguised Angel","casterId":"caster"}"""
+        val decodedFaceUp = json.decodeFromString<GameEvent>(legacyFaceUp) as SpellCastEvent
+        decodedFaceUp.cardPresentation shouldBe null
+        ClientEventTransformer.transform(listOf(decodedFaceUp), EntityId.of("opponent"))
+            .filterIsInstance<ClientEvent.SpellCast>()
+            .single().spellName shouldBe "Disguised Angel"
+
+        val legacyFaceDown = """{"type":"SpellCastEvent","spellEntityId":"face-down","cardName":"Face-down creature","casterId":"caster"}"""
+        val decodedFaceDown = json.decodeFromString<GameEvent>(legacyFaceDown) as SpellCastEvent
+        decodedFaceDown.cardPresentation shouldBe null
+        ClientEventTransformer.transform(listOf(decodedFaceDown), EntityId.of("opponent"))
+            .filterIsInstance<ClientEvent.SpellCast>()
+            .single().spellName shouldBe FACE_DOWN_DISPLAY_NAME
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownGameLogMaskingTest.kt
@@ -138,9 +138,9 @@ class FaceDownGameLogMaskingTest : FunSpec({
         )
         val castEvent = d.events.filterIsInstance<SpellCastEvent>().single()
         // Keep the historical public-name field safe while the trusted snapshot retains the
-        // semantic identity required by rules and knowledge code.
+        // underlying identity required by knowledge bookkeeping.
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.underlyingCardName shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(opponent) shouldBe FACE_DOWN_DISPLAY_NAME
         d.bothPass()
@@ -191,7 +191,7 @@ class FaceDownGameLogMaskingTest : FunSpec({
 
         val castEvent = result.events.filterIsInstance<SpellCastEvent>().single()
         castEvent.cardName shouldBe FACE_DOWN_DISPLAY_NAME
-        castEvent.semanticCardName shouldBe "Disguised Angel"
+        castEvent.underlyingCardName shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(caster) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(opponent) shouldBe "Disguised Angel"
         castEvent.cardPresentation?.nameFor(EntityId.of("spectator"), isSpectator = true) shouldBe


### PR DESCRIPTION
Face-down casting currently loses or leaks card identity depending on where the event is narrated.

A disguise spell can be correctly masked in the cast line and then disclose itself immediately afterward:

```text
Opponent cast Face-down creature
Disguised Angel resolved
Opponent's Disguised Angel entered the battlefield
You cast Lightning Bolt targeting Disguised Angel
Opponent's Disguised Angel triggered ward
```

A single global replacement is not correct either. The caster may look at their own face-down spell, an opponent may have continuing access to the caster's hand, and a card cast face down from face-up exile was already public. Those recipients should retain the identity they actually knew. An ordinary opponent to a hidden-hand disguise cast should not learn it.

The same transition therefore has several legitimate presentations:

| Cast situation | Caster | Ordinary opponent | Spectator |
| --- | --- | --- | --- |
| Face down from a hidden hand | `Disguised Angel` | `Face-down creature` | `Face-down creature` |
| Face down while the hand is continuously visible | `Disguised Angel` | `Disguised Angel` | `Face-down creature` |
| Face down after one card in an unordered hand was inspected | `Disguised Angel` | `Face-down creature` | `Face-down creature` |
| Face down from face-up exile | `Disguised Angel` | `Disguised Angel` | `Disguised Angel` |

This change captures that identity transition while both the origin state and the resulting stack state still exist.

## How identity is captured

`Visibility.isCardIdentityVisibleThroughCast` is the authority for whether a recipient can carry an identity across the cast:

- identity visible on the resulting stack remains visible;
- identity from a public or otherwise trackable origin remains visible;
- whole-hand visibility follows the card out of the hand;
- a one-card reveal in an unordered hand does not identify which card left face down.

`EventPresentationFactory` freezes those answers into an immutable `EventCardPresentation`. The snapshot stores one underlying card name, one public display name, and the set of seated viewers entitled to the underlying identity. Later client projection selects from that snapshot instead of consulting a state in which the spell may already have resolved or a temporary reveal may have disappeared.

The event keeps the two meanings explicit:

- `SpellCastEvent.cardName` retains its historical public-safe contract: an ordinary cast stores its name and a hidden face-down cast stores `Face-down creature`;
- `SpellCastEvent.underlyingCardName` exposes the underlying card-definition identity to trusted knowledge bookkeeping; it is explicitly not the name characteristic of a face-down spell;
- `ClientEventTransformer` selects only the display name captured for its recipient.

The audience-agnostic resolution, battlefield-entry, targeting, ward, and decision-summary paths now use the shared public naming authority, closing the later disclosures shown above.

## Historical events and transport scope

Events serialized before `cardPresentation` existed already contain a safe viewer-independent `cardName`. Their projection preserves that value:

```text
old ordinary cast:  Lightning Bolt      -> Lightning Bolt
old face-down cast: Face-down creature  -> Face-down creature
```

`GameEvent` remains trusted engine data. The game server converts it to `ClientEvent` before player transport or persisted player logs, and a serialization regression proves that an opponent-facing event contains neither the underlying name nor the audience set.

This establishes correct event presentation. It does not rotate stable engine `EntityId`s between hand and stack; a stateful client that previously saw a particular hand card may still correlate that separate state-delta channel. Closing that channel belongs at the client-identity or opaque-slot boundary rather than in event naming.

## Verification

Verified at `b6f4a3c0fd`, based on upstream `cc3080466a`:

- `just test-class FaceDownGameLogMaskingTest` — 12 passed
- `just test-class CardIdentityVisibilityTest` — 11 passed
- `just test-class LookAtHandTest` — 5 passed
- `git diff --check origin/main...HEAD`

The focused cases cover a real face-down cast from face-up exile under a play permission, continuing whole-hand visibility, stale one-card hand knowledge, caster/opponent/spectator projection, a connection acting for another seat, capture stability after later state changes, legacy face-up and face-down serialization, projected-event serialization, and the resolution/entry/target/ward leak family.
